### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,9 @@ workflows:
   publish-dev:
     jobs:
       - publish-storybook:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           bucket: dev-design.va.gov
           context:
             - Platform


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/17250

Copy the [CircleCI config from `veteran-facing-services-tools`](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/8109019860cb623805293ddacb361e6bd54fc7a1/.circleci/config.yml)

The copied config was considerably simplified since we no loner need to check if we should publish storybook or not. If this repo gets updated, it's safe to say that we should re-publish storybook.


## Results

We can successfully use CircleCI to build & publish storybook:

https://app.circleci.com/pipelines/github/department-of-veterans-affairs/component-library/17/workflows/7bd2e857-cab3-426c-815a-c2192d044917/jobs/13