### PR TITLE
Wrap Date in a fieldset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/Date/Date.jsx
+++ b/src/components/Date/Date.jsx
@@ -84,18 +84,18 @@ class Date extends React.Component {
     }
 
     return (
-      <div className={!isValid ? 'input-error-date' : undefined}>
-        <label>
-          {this.props.label ? this.props.label : 'Date of birth'}
+      <fieldset className={!isValid ? 'input-error-date' : undefined}>
+        <legend className="vads-u-font-size--base vads-u-font-weight--normal">
+          {this.props.label || 'Date of birth'}
           {this.props.required && (
             <span className="form-required-span">(*Required)</span>
           )}
-        </label>
+        </legend>
         {errorSpan}
         <div
           className={isValid ? undefined : 'usa-input-error form-error-date'}
         >
-          <div className="usa-date-of-birth">
+          <div className="usa-date-of-birth usa-datefields clearfix-text">
             <div className="form-datefield-month">
               <Select
                 errorMessage={isValid ? undefined : ''}
@@ -136,7 +136,7 @@ class Date extends React.Component {
             </div>
           </div>
         </div>
-      </div>
+      </fieldset>
     );
   }
 }

--- a/src/components/Date/Date.jsx
+++ b/src/components/Date/Date.jsx
@@ -95,7 +95,7 @@ class Date extends React.Component {
         <div
           className={isValid ? undefined : 'usa-input-error form-error-date'}
         >
-          <div className="usa-date-of-birth usa-datefields clearfix-text">
+          <div className="usa-date-of-birth usa-datefields clearfix">
             <div className="form-datefield-month">
               <Select
                 errorMessage={isValid ? undefined : ''}

--- a/src/components/Date/Date.unit.spec.jsx
+++ b/src/components/Date/Date.unit.spec.jsx
@@ -7,6 +7,21 @@ import Date from './Date';
 import { makeField } from '../../helpers/fields.js';
 
 describe('<Date>', () => {
+  it('wraps input elements in a fieldset', () => {
+    const date = {
+      day: makeField(1),
+      month: makeField(12),
+      year: makeField(2010),
+    };
+    const tree = shallow(
+      <Date date={date} onValueChange={_update => {}} />,
+    );
+    expect(tree.find('fieldset')).to.have.lengthOf(1);
+    const legend = tree.find('legend');
+    expect(legend).to.have.lengthOf(1);
+    expect(legend.text()).to.equal('Date of birth');
+    tree.unmount();
+  });
   it('renders input elements', () => {
     const date = {
       day: makeField(1),

--- a/src/components/MonthYear/MonthYear.jsx
+++ b/src/components/MonthYear/MonthYear.jsx
@@ -72,18 +72,18 @@ class MonthYear extends React.Component {
     }
 
     return (
-      <div className={!isValid ? 'input-error-date' : undefined}>
-        <label>
-          {this.props.label}
+      <fieldset className={!isValid ? 'input-error-date' : undefined}>
+        <legend className="vads-u-font-size--base vads-u-font-weight--normal">
+          {this.props.label || 'Date'}
           {this.props.required && (
             <span className="form-required-span">(*Required)</span>
           )}
-        </label>
+        </legend>
         {errorSpan}
         <div
           className={isValid ? undefined : 'usa-input-error form-error-date'}
         >
-          <div className="usa-date-of-birth">
+          <div className="usa-date-of-birth usa-datefields clearfix-text">
             <div className="form-datefield-month">
               <Select
                 errorMessage={isValid ? undefined : ''}
@@ -114,7 +114,7 @@ class MonthYear extends React.Component {
             </div>
           </div>
         </div>
-      </div>
+      </fieldset>
     );
   }
 }

--- a/src/components/MonthYear/MonthYear.jsx
+++ b/src/components/MonthYear/MonthYear.jsx
@@ -83,7 +83,7 @@ class MonthYear extends React.Component {
         <div
           className={isValid ? undefined : 'usa-input-error form-error-date'}
         >
-          <div className="usa-date-of-birth usa-datefields clearfix-text">
+          <div className="usa-date-of-birth usa-datefields clearfix">
             <div className="form-datefield-month">
               <Select
                 errorMessage={isValid ? undefined : ''}

--- a/src/components/MonthYear/MonthYear.unit.spec.jsx
+++ b/src/components/MonthYear/MonthYear.unit.spec.jsx
@@ -7,6 +7,20 @@ import MonthYear from './MonthYear';
 import { makeField } from '../../helpers/fields.js';
 
 describe('<MonthYear>', () => {
+  it('wraps input elements in a fieldset', () => {
+    const date = {
+      month: makeField(12),
+      year: makeField(2010),
+    };
+    const tree = shallow(
+      <MonthYear date={date} onValueChange={_update => {}} />,
+    );
+    expect(tree.find('fieldset')).to.have.lengthOf(1);
+    const legend = tree.find('legend');
+    expect(legend).to.have.lengthOf(1);
+    expect(legend.text()).to.equal('Date');
+    tree.unmount();
+  });
   it('renders input elements', () => {
     const date = {
       month: makeField(12),


### PR DESCRIPTION
## Description

To improve accessibility, the `Date` component should be wrapped in a `<fieldset>` and include a `<legend>`.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15364

## Testing done

Unit tests updated

## Screenshots

N/A - appearance is the same, but did require some classes to make it the same

## Acceptance criteria

- [x] Date component wrapped in a `fieldset`, and includes a `legend`

## Definition of done

- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs