### PR TITLE
Only find tests in src/

### DIFF
--- a/testing/tests.js
+++ b/testing/tests.js
@@ -5,5 +5,5 @@ const Adapter = require('enzyme-adapter-react-16');
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const testsContext = require.context('..', true, /\.spec\.js[x]{0,1}$/);
+const testsContext = require.context('../src/', true, /\.spec\.js[x]{0,1}$/);
 testsContext.keys().forEach(testsContext);


### PR DESCRIPTION
This fixes the `chokidar` watcher error as well as the failing tests we were seeing.

Just don't ask me _why._ I find this `karma` setup positively baffling. :see_no_evil: 