### PR TITLE
Fix LoadingIndicator a11y error

### DIFF
--- a/src/components/LoadingIndicator/LoadingIndicator.jsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.jsx
@@ -9,7 +9,6 @@ export default class LoadingIndicator extends React.Component {
   }
   render() {
     const { message } = this.props;
-    const { label } = this.props;
 
     return (
       <div className="loading-indicator-container">
@@ -19,7 +18,7 @@ export default class LoadingIndicator extends React.Component {
           }}
           className="loading-indicator"
           role="progressbar"
-          aria-label={label}
+          aria-label="Please wait while we load the application for you."
           aria-valuetext={message}
           tabIndex="0"
         />


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/366

This fixes an accesibility error by adding an `aria-label` attribute to all instances of `<LoadingIndicator>`


## Screenshots

<details>

<summary>Before</summary>

![image](https://user-images.githubusercontent.com/2008881/105525137-810e1b80-5c95-11eb-9e12-ffeba45bf2bb.png)

</details>

<details>

<summary>After</summary>

![image](https://user-images.githubusercontent.com/2008881/105525271-b450aa80-5c95-11eb-93cf-cc613caad3cb.png)

</details>