### PR TITLE
Link to issue template & fix storybook section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ system](https://department-of-veterans-affairs.github.io/veteran-facing-services
 or
 [Storybook](https://design.va.gov/storybook/?path=/story/about-introduction--page).
 
+## Contributing
+
+The issue tracker is disabled on this repo. To request a new component or a feature enhancement, please [open an issue here](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/new?assignees=&labels=vsp-design-system-team&template=feature_request.md)
+
 ## Running Storybook locally
 
 From the project root, run the following commands:
 
 1. `yarn install`
-1. `cd packages/formation-react`
-1. `yarn install`
-   - It's a Lerna thing. For some reason, it doesn't work without _both_
-     installs. ¯\_(ツ)\_/¯
 1. `yarn storybook`
 
 ## Publishing Module to NPM


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/19062

Adds a link to the README which will open an issue in the `vets-design-system-documentation` repo, since issue tracking has been disabled in `component-library`.

## Testing done


## Screenshots

![Peek 2021-01-26 14-56](https://user-images.githubusercontent.com/2008881/105917140-d4aa9d00-5fe6-11eb-99c3-da6ff333d887.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
