### PR TITLE
Remove non-helpful done criteria

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,5 @@ Closes <ticket>
 - [ ]
 
 ## Definition of done
-- [ ] Events are logged appropriately
 - [ ] Documentation has been updated, if applicable
 - [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
-- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs


### PR DESCRIPTION
## Description

Remove items from PR template that aren't particularly useful for `component-library`. This template was originally copied from `vets-website`.

![so meta](https://media2.giphy.com/media/gY5sEujrJbCve/giphy-downsized.gif?cid=6104955e21e5e203bfef4b2e6477efe8d7c8c24d8516d590&rid=giphy-downsized.gif)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
