### PR TITLE
Show out of range year error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/Date/Date.jsx
+++ b/src/components/Date/Date.jsx
@@ -8,6 +8,8 @@ import Select from '../Select/Select';
 import NumberInput from '../NumberInput/NumberInput';
 
 import {
+  minYear,
+  maxYear,
   isDirtyDate,
   isValidPartialDate,
   isNotBlankDateField,
@@ -70,6 +72,12 @@ class Date extends React.Component {
         isValid = validationResult.valid;
         errorMessage = validationResult.message;
       }
+    } else if (year.value.length >= 4) {
+      const yr = parseInt(year.value, 10);
+      if (yr < minYear || yr > maxYear) {
+        isValid = false;
+        errorMessage = `Please enter a year between ${minYear} and ${maxYear}`;
+      }
     }
 
     let errorSpanId;
@@ -125,8 +133,8 @@ class Date extends React.Component {
                 errorMessage={isValid ? undefined : ''}
                 label="Year"
                 name={`${this.props.name}Year`}
-                max={moment().add(100, 'year').year()}
-                min="1900"
+                max={maxYear}
+                min={minYear}
                 pattern="[0-9]{4}"
                 field={year}
                 onValueChange={update => {

--- a/src/components/Date/Date.unit.spec.jsx
+++ b/src/components/Date/Date.unit.spec.jsx
@@ -6,6 +6,8 @@ import { axeCheck } from '../../helpers/test-helpers';
 import Date from './Date';
 import { makeField } from '../../helpers/fields.js';
 
+import { minYear, maxYear } from '../../helpers/validations';
+
 describe('<Date>', () => {
   it('renders input elements', () => {
     const date = {
@@ -60,6 +62,45 @@ describe('<Date>', () => {
     );
     tree.unmount();
   });
+  it('displays invalid year message for years < min', () => {
+    const date = {
+      day: makeField(''),
+      month: makeField(''),
+      year: makeField((minYear - 20).toString()),
+    };
+    date.year.dirty = true;
+    date.month.dirty = false;
+    date.day.dirty = false;
+    const tree = shallow(
+      <Date date={date} onValueChange={_update => {}} />,
+    );
+
+    expect(tree.find('.usa-input-error').exists()).to.be.true;
+    expect(tree.find('.usa-input-error-message').text()).to.contain(
+      `Please enter a year between ${minYear} and ${maxYear}`,
+    );
+    tree.unmount();
+  });
+  it('displays invalid year message for years > max', () => {
+    const date = {
+      day: makeField(''),
+      month: makeField(''),
+      year: makeField((maxYear + 20).toString()),
+    };
+    date.year.dirty = true;
+    date.month.dirty = false;
+    date.day.dirty = false;
+    const tree = shallow(
+      <Date date={date} onValueChange={_update => {}} />,
+    );
+
+    expect(tree.find('.usa-input-error').exists()).to.be.true;
+    expect(tree.find('.usa-input-error-message').text()).to.contain(
+      `Please enter a year between ${minYear} and ${maxYear}`,
+    );
+    tree.unmount();
+  });
+
 
   it('does not show invalid message for month year date', () => {
     const date = {

--- a/src/components/MonthYear/MonthYear.jsx
+++ b/src/components/MonthYear/MonthYear.jsx
@@ -8,6 +8,8 @@ import Select from '../Select/Select';
 import NumberInput from '../NumberInput/NumberInput';
 
 import {
+  minYear,
+  maxYear,
   isValidPartialMonthYear,
   validateCustomFormComponent,
 } from '../../helpers/validations';
@@ -58,6 +60,12 @@ class MonthYear extends React.Component {
         isValid = validationResult.valid;
         errorMessage = validationResult.message;
       }
+    } else if (year.value.length >= 4) {
+      const yr = parseInt(year.value, 10);
+      if (yr < minYear || yr > maxYear) {
+        isValid = false;
+        errorMessage = `Please enter a year between ${minYear} and ${maxYear}`;
+      }
     }
 
     let errorSpanId;
@@ -101,10 +109,8 @@ class MonthYear extends React.Component {
                 errorMessage={isValid ? undefined : ''}
                 label="Year"
                 name={`${this.props.name}Year`}
-                max={moment()
-                  .add(100, 'year')
-                  .year()}
-                min="1900"
+                max={maxYear}
+                min={minYear}
                 pattern="[0-9]{4}"
                 field={year}
                 onValueChange={update => {

--- a/src/components/MonthYear/MonthYear.unit.spec.jsx
+++ b/src/components/MonthYear/MonthYear.unit.spec.jsx
@@ -6,6 +6,8 @@ import { axeCheck } from '../../helpers/test-helpers';
 import MonthYear from './MonthYear';
 import { makeField } from '../../helpers/fields.js';
 
+import { minYear, maxYear } from '../../helpers/validations';
+
 describe('<MonthYear>', () => {
   it('renders input elements', () => {
     const date = {
@@ -74,6 +76,40 @@ describe('<MonthYear>', () => {
     );
 
     expect(tree.find('.usa-input-error').length).to.equal(0);
+    tree.unmount();
+  });
+  it('displays invalid year message for years < min', () => {
+    const date = {
+      month: makeField(''),
+      year: makeField((minYear - 20).toString()),
+    };
+    date.year.dirty = true;
+    date.month.dirty = false;
+    const tree = shallow(
+      <MonthYear date={date} onValueChange={_update => {}} />,
+    );
+
+    expect(tree.find('.usa-input-error').exists()).to.be.true;
+    expect(tree.find('.usa-input-error-message').text()).to.contain(
+      `Please enter a year between ${minYear} and ${maxYear}`,
+    );
+    tree.unmount();
+  });
+  it('displays invalid year message for years > max', () => {
+    const date = {
+      month: makeField(''),
+      year: makeField((maxYear + 20).toString()),
+    };
+    date.year.dirty = true;
+    date.month.dirty = false;
+    const tree = shallow(
+      <MonthYear date={date} onValueChange={_update => {}} />,
+    );
+
+    expect(tree.find('.usa-input-error').exists()).to.be.true;
+    expect(tree.find('.usa-input-error-message').text()).to.contain(
+      `Please enter a year between ${minYear} and ${maxYear}`,
+    );
     tree.unmount();
   });
 

--- a/src/helpers/validations.js
+++ b/src/helpers/validations.js
@@ -1,6 +1,9 @@
 import _ from 'lodash';
 import moment from 'moment';
 
+const minYear = 1900;
+const maxYear = moment().add(100, 'year').year();
+
 function dateToMoment(dateField) {
   return moment({
     year: dateField.year.value,
@@ -331,6 +334,8 @@ function isValidRoutingNumber(value) {
 }
 
 export {
+  minYear,
+  maxYear,
   isBlank,
   isBlankDateField,
   isBlankMonthYear,


### PR DESCRIPTION
## Description

In the `Date` and `MonthYear` components do not show a validation error when an out-of-range year is input. This is a launchblocker accessibility issue (see related issue). This PR shows a year-specific error message when an out-of-range year is input - see the screenshot for an example.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18578

## Testing done

Updated unit tests

## Screenshots

![year](https://user-images.githubusercontent.com/136959/106508186-ad921680-6491-11eb-84ac-70c457033046.gif)

## Acceptance criteria
- [x] Out-of-range year input shows a range specific year validation error message 

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
