### PR TITLE
ProgressBar and LoadingIndicator axe fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/LoadingIndicator/LoadingIndicator.jsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.jsx
@@ -42,5 +42,5 @@ LoadingIndicator.propTypes = {
 
 LoadingIndicator.defaultProps = {
   setFocus: false,
-  label: "loading-indicator",
+  label: "Loading",
 };

--- a/src/components/LoadingIndicator/LoadingIndicator.jsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.jsx
@@ -42,4 +42,5 @@ LoadingIndicator.propTypes = {
 
 LoadingIndicator.defaultProps = {
   setFocus: false,
+  label: "loading-indicator",
 };

--- a/src/components/ProgressBar/ProgressBar.jsx
+++ b/src/components/ProgressBar/ProgressBar.jsx
@@ -25,5 +25,5 @@ ProgressBar.propTypes = {
 };
 
 ProgressBar.defaultProps = {
-  label: "progress-bar",
+  label: "Working",
 };

--- a/src/components/ProgressBar/ProgressBar.jsx
+++ b/src/components/ProgressBar/ProgressBar.jsx
@@ -23,3 +23,7 @@ ProgressBar.propTypes = {
    */
   percent: PropTypes.number.isRequired,
 };
+
+ProgressBar.defaultProps = {
+  label: "progress-bar",
+};

--- a/src/components/SegmentedProgressBar/SegmentedProgressBar.jsx
+++ b/src/components/SegmentedProgressBar/SegmentedProgressBar.jsx
@@ -12,7 +12,7 @@ export default function SegmentedProgressBar({ current, total, label }) {
   return (
     <div
       className="progress-bar-segmented"
-      role="progressbar"
+      // role="progressbar"
       aria-valuenow={current}
       aria-valuemin="0"
       aria-valuemax={total}
@@ -40,4 +40,8 @@ SegmentedProgressBar.propTypes = {
    * The total number of segments in the progress bar
    */
   total: PropTypes.number.isRequired,
+};
+
+SegmentedProgressBar.defaultProps = {
+  label: "progress-bar-segmented",
 };

--- a/src/components/SegmentedProgressBar/SegmentedProgressBar.jsx
+++ b/src/components/SegmentedProgressBar/SegmentedProgressBar.jsx
@@ -12,7 +12,7 @@ export default function SegmentedProgressBar({ current, total, label }) {
   return (
     <div
       className="progress-bar-segmented"
-      // role="progressbar"
+      role="progressbar"
       aria-valuenow={current}
       aria-valuemin="0"
       aria-valuemax={total}

--- a/src/components/SegmentedProgressBar/SegmentedProgressBar.jsx
+++ b/src/components/SegmentedProgressBar/SegmentedProgressBar.jsx
@@ -8,7 +8,7 @@ import _ from 'lodash';
  * @param {number} current - The index of the current chapter
  * @param {number} total   - The total number of chapters in the form
  */
-export default function SegmentedProgressBar({ current, total, label }) {
+export default function SegmentedProgressBar({ current, total }) {
   return (
     <div
       className="progress-bar-segmented"
@@ -17,7 +17,7 @@ export default function SegmentedProgressBar({ current, total, label }) {
       aria-valuemin="0"
       aria-valuemax={total}
       tabIndex="0"
-      aria-label={label}
+      aria-label={`Step ${current} of ${total}`}
     >
       {_.range(total).map(step => (
         <div
@@ -40,8 +40,4 @@ SegmentedProgressBar.propTypes = {
    * The total number of segments in the progress bar
    */
   total: PropTypes.number.isRequired,
-};
-
-SegmentedProgressBar.defaultProps = {
-  label: "progress-bar-segmented",
 };


### PR DESCRIPTION
## Description
This PR adds default `aria-label` values to the `ProgressBar`, `SegmentedProgressBar`, and `LoadingIndicator`. This fixes axe failures caused by an `aria-label` value not being set for these components.

This is the simplest solution to the axe failures, but I'm not sure if a default, generic name is sufficient for accessibility standards. @1Copenut

Closes two tickets: [`ProgressBar` axe failure](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/357) and [`LoadingIndicator` axe failure](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/366).

## Testing done
- No failures observed when running the axe browser plugin on pages that use these components.
- Ran the entire Cypress test suite locally using these changes and the latest versions of `axe-core` and `cypress-axe`. No axe failures observed for any `ProgressBar`s or `LoadingIndicator`s.

## Acceptance criteria
- [ ] No axe failures seen in the axe browser plugin for pages that use these components
- [ ] No axe failures in the `vets-website` Cypress test suite.
