### PR TITLE
Update date display & storybook args for banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
+    "date-fns": "^2.17.0",
+    "date-fns-tz": "^1.1.1",
     "lodash": "^4.17.15",
     "moment": "^2.23.0",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/MaintenanceBanner/MaintenanceBanner.jsx
+++ b/src/components/MaintenanceBanner/MaintenanceBanner.jsx
@@ -74,7 +74,7 @@ export class MaintenanceBanner extends Component {
       return (
         <>
           <p>
-            <strong>Date:</strong> {startsAtET.format('dddd MMMM D, YYYY')}
+            <strong>Date:</strong> {startsAtET.format('dddd, MMMM D, YYYY')}
           </p>
           <p>
             <strong>Start/End time:</strong> {startsAtET.format('h:mm a')} to{' '}
@@ -88,11 +88,11 @@ export class MaintenanceBanner extends Component {
       <>
         <p>
           <strong>Start:</strong>{' '}
-          {startsAtET.format('dddd MMMM D, YYYY, [at] h:mm a')} ET
+          {startsAtET.format('dddd, MMMM D, YYYY, [at] h:mm a')} ET
         </p>
         <p>
           <strong>End:</strong>{' '}
-          {expiresAtET.format('dddd MMMM D, YYYY, [at] h:mm a')} ET
+          {expiresAtET.format('dddd, MMMM D, YYYY, [at] h:mm a')} ET
         </p>
       </>
     );

--- a/src/components/MaintenanceBanner/MaintenanceBanner.jsx
+++ b/src/components/MaintenanceBanner/MaintenanceBanner.jsx
@@ -32,7 +32,7 @@ export class MaintenanceBanner extends Component {
      */
     content: PropTypes.string.isRequired,
     /**
-     * A Date object used when downtime expires. Should be in UTC.
+     * A Date object used when downtime expires.
      */
     expiresAt: PropTypes.object.isRequired,
     /**
@@ -47,7 +47,7 @@ export class MaintenanceBanner extends Component {
       setItem: PropTypes.func.isRequired,
     }),
     /**
-     * A Date object used when downtime starts. Should be in UTC.
+     * A Date object used when downtime starts.
      */
     startsAt: PropTypes.object.isRequired,
     /**
@@ -59,7 +59,7 @@ export class MaintenanceBanner extends Component {
      */
     warnContent: PropTypes.string,
     /**
-     * A Date object used when pre-downtime starts. Should be in UTC.
+     * A Date object used when pre-downtime starts.
      */
     warnStartsAt: PropTypes.object,
     /**

--- a/src/components/MaintenanceBanner/MaintenanceBanner.jsx
+++ b/src/components/MaintenanceBanner/MaintenanceBanner.jsx
@@ -88,8 +88,9 @@ export class MaintenanceBanner extends Component {
             {formatEastern(startsAt, 'EEEE, MMMM d, yyyy')}
           </p>
           <p>
-            <strong>Start/End time:</strong> {formatEastern(startsAt, 'h:mm a')}{' '}
-            to {formatEastern(expiresAt, 'h:mm a')} ET
+            <strong>Start/End time:</strong>{' '}
+            {formatEastern(startsAt, 'h:mm aaaa')} to{' '}
+            {formatEastern(expiresAt, 'h:mm aaaa')} ET
           </p>
         </>
       );
@@ -99,11 +100,11 @@ export class MaintenanceBanner extends Component {
       <>
         <p>
           <strong>Start:</strong>{' '}
-          {formatEastern(startsAt, "EEEE, MMMM d, yyyy, 'at' h:mm a")} ET
+          {formatEastern(startsAt, "EEEE, MMMM d, yyyy, 'at' h:mm aaaa")} ET
         </p>
         <p>
           <strong>End:</strong>{' '}
-          {formatEastern(expiresAt, "EEEE, MMMM d, yyyy, 'at' h:mm a")} ET
+          {formatEastern(expiresAt, "EEEE, MMMM d, yyyy, 'at' h:mm aaaa")} ET
         </p>
       </>
     );

--- a/src/components/MaintenanceBanner/MaintenanceBanner.jsx
+++ b/src/components/MaintenanceBanner/MaintenanceBanner.jsx
@@ -2,11 +2,24 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import moment from 'moment';
+import { isAfter, isBefore, isSameDay } from 'date-fns';
+import { format, utcToZonedTime } from 'date-fns-tz';
+
 // Relative imports.
 import AlertBox from '../AlertBox/AlertBox';
 
 export const MAINTENANCE_BANNER = 'MAINTENANCE_BANNER';
+
+const easternZone = 'America/New_York';
+
+/**
+ * Simple helper which takes a UTC time and formats it to be in the Eastern (New York) timezone
+ */
+function formatEastern(datetimeUTC, formatString) {
+  return format(utcToZonedTime(datetimeUTC, easternZone), formatString, {
+    timeZone: easternZone,
+  });
+}
 
 // @WARNING: This is currently only used once in vets-website.
 /**
@@ -19,7 +32,7 @@ export class MaintenanceBanner extends Component {
      */
     content: PropTypes.string.isRequired,
     /**
-     * A 'moment' object used when downtime expires. Use `moment.utc()` to get the correct display time.
+     * A Date object used when downtime expires. Should be in UTC.
      */
     expiresAt: PropTypes.object.isRequired,
     /**
@@ -34,7 +47,7 @@ export class MaintenanceBanner extends Component {
       setItem: PropTypes.func.isRequired,
     }),
     /**
-     * A 'moment' object used when downtime starts. Use `moment.utc()` to get the correct display time.
+     * A Date object used when downtime starts. Should be in UTC.
      */
     startsAt: PropTypes.object.isRequired,
     /**
@@ -46,7 +59,7 @@ export class MaintenanceBanner extends Component {
      */
     warnContent: PropTypes.string,
     /**
-     * A 'moment' object used when pre-downtime starts. Use `moment.utc()` to get the correct display time.
+     * A Date object used when pre-downtime starts. Should be in UTC.
      */
     warnStartsAt: PropTypes.object,
     /**
@@ -67,18 +80,16 @@ export class MaintenanceBanner extends Component {
   derivePostContent = () => {
     const { startsAt, expiresAt } = this.props;
 
-    const startsAtET = startsAt.clone().subtract(4, 'hours');
-    const expiresAtET = expiresAt.clone().subtract(4, 'hours');
-
-    if (startsAt.isSame(expiresAt, 'day')) {
+    if (isSameDay(startsAt, expiresAt)) {
       return (
         <>
           <p>
-            <strong>Date:</strong> {startsAtET.format('dddd, MMMM D, YYYY')}
+            <strong>Date:</strong>{' '}
+            {formatEastern(startsAt, 'EEEE, MMMM d, yyyy')}
           </p>
           <p>
-            <strong>Start/End time:</strong> {startsAtET.format('h:mm a')} to{' '}
-            {expiresAtET.format('h:mm a')} ET
+            <strong>Start/End time:</strong> {formatEastern(startsAt, 'h:mm a')}{' '}
+            to {formatEastern(expiresAt, 'h:mm a')} ET
           </p>
         </>
       );
@@ -88,11 +99,11 @@ export class MaintenanceBanner extends Component {
       <>
         <p>
           <strong>Start:</strong>{' '}
-          {startsAtET.format('dddd, MMMM D, YYYY, [at] h:mm a')} ET
+          {formatEastern(startsAt, "EEEE, MMMM d, yyyy, 'at' h:mm a")} ET
         </p>
         <p>
           <strong>End:</strong>{' '}
-          {expiresAtET.format('dddd, MMMM D, YYYY, [at] h:mm a')} ET
+          {formatEastern(expiresAt, "EEEE, MMMM d, yyyy, 'at' h:mm a")} ET
         </p>
       </>
     );
@@ -120,7 +131,7 @@ export class MaintenanceBanner extends Component {
     } = this.props;
 
     // Derive dates.
-    const now = moment();
+    const now = Date.now();
     const postContent = derivePostContent();
 
     // Escape early if the banner is dismissed.
@@ -129,17 +140,17 @@ export class MaintenanceBanner extends Component {
     }
 
     // Escape early if it's before when it should show.
-    if (now.isBefore(warnStartsAt)) {
+    if (isBefore(now, warnStartsAt)) {
       return null;
     }
 
     // Escape early if it's after when it should show.
-    if (now.isAfter(expiresAt)) {
+    if (isAfter(now, expiresAt)) {
       return null;
     }
 
     // Show pre-downtime.
-    if (now.isBefore(startsAt)) {
+    if (isBefore(now, startsAt)) {
       return (
         <div
           className="usa-alert-full-width vads-u-border-top--5px medium-screen:vads-u-border-top--10px vads-u-border-color--warning-message maintenance-banner"

--- a/src/components/MaintenanceBanner/MaintenanceBanner.mdx
+++ b/src/components/MaintenanceBanner/MaintenanceBanner.mdx
@@ -3,18 +3,17 @@ title: MaintenanceBanner
 name: MaintenanceBanner
 ---
 
-import moment from 'moment';
 import MaintenanceBanner from './MaintenanceBanner'
 
 
 ### Code:
 ```javascript
-import moment from 'moment';
+import { addHours, subHours } from 'date-fns';
 import MaintenanceBanner from '@department-of-veterans-affairs/component-library/MaintenanceBanner'
 
 // Derive startsAt and expiresAt.
-const startsAt = moment();
-const expiresAt = startsAt.clone().add(24, 'hours');
+const startsAt = new Date(Date.now())
+const expiresAt = addHours(Date.now(), 24);
 
 <MaintenanceBanner
   content="We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we're finished. Thank you for your patience."
@@ -23,7 +22,7 @@ const expiresAt = startsAt.clone().add(24, 'hours');
   startsAt={startsAt}
   title="Site maintenance"
   warnContent="We’ll be doing some work on VA.gov. If you have trouble signing in or using tools, check back after we're finished. Thank you for your patience."
-  warnStartsAt={startsAt.clone().subtract(12, 'hours')}
+  warnStartsAt={subHours(startsAt, 12)}
   warnTitle="Upcoming site maintenance"
 />
 ```
@@ -32,12 +31,12 @@ const expiresAt = startsAt.clone().add(24, 'hours');
 <div className="site-c-reactcomp__rendered">
   <MaintenanceBanner
     content="We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we're finished. Thank you for your patience."
-    expiresAt={moment().add(24, 'hours')}
+    expiresAt={addHours(Date.now(), 24)}
     id="1"
-    startsAt={moment()}
+    startsAt={new Date(Date.now())}
     title="Site maintenance"
     warnContent="We’ll be doing some work on VA.gov. If you have trouble signing in or using tools, check back after we're finished. Thank you for your patience."
-    warnStartsAt={moment().subtract(12, 'hours')}
+    warnStartsAt={subHours(Date.now(), 12)}
     warnTitle="Upcoming site maintenance"
   />
 </div>

--- a/src/components/MaintenanceBanner/MaintenanceBanner.stories.jsx
+++ b/src/components/MaintenanceBanner/MaintenanceBanner.stories.jsx
@@ -35,10 +35,12 @@ const Template = args => {
 
 const defaultArgs = {
   id: 'maintenence-banner-id',
-  title: 'Current maintenance notice',
-  warnTitle: 'Future maintenance notice',
-  content: 'The site is currently under maintenance.',
-  warnContent: 'The site will be undergoing maintenance shortly.',
+  title: 'Site maintenance',
+  warnTitle: 'Upcoming site maintenance',
+  content:
+    'We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.',
+  warnContent:
+    'We’ll be doing some work on VA.gov. The maintenance will last 1 hour. During that time, you won’t be able to sign in or use tools.',
   startsAt: moment().valueOf(),
   expiresAt: moment().add(1, 'hour').valueOf(),
   warnStartsAt: moment().subtract(30, 'minutes').valueOf(),

--- a/src/components/MaintenanceBanner/MaintenanceBanner.stories.jsx
+++ b/src/components/MaintenanceBanner/MaintenanceBanner.stories.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import React from 'react';
-import moment from 'moment';
+import { addHours, subMinutes, format } from 'date-fns';
 
 import MaintenanceBanner from './MaintenanceBanner';
 
@@ -14,23 +14,16 @@ export default {
   },
 };
 
-const Template = args => {
-  const startTime = moment.utc(moment(args.startsAt));
-  const endTime = moment.utc(moment(args.expiresAt));
-  const warnStart = moment.utc(moment(args.warnStartsAt));
+const Template = (args) => {
+  const startTime = args.startsAt;
+  const endTime = args.expiresAt;
+  const warnStart = args.warnStartsAt;
   console.group('Times passed to Template');
-  console.log('startTime:', startTime.format('MM/DD/YY HH:mm'));
-  console.log('endTime', endTime.format('MM/DD/YY HH:mm'));
-  console.log('warnStart', warnStart.format('MM/DD/YY HH:mm'));
+  console.log('startTime:', format(startTime, 'MM/dd/yy p'));
+  console.log('endTime', format(endTime, 'MM/dd/yy p'));
+  console.log('warnStart', format(warnStart, 'MM/dd/yy p'));
   console.groupEnd();
-  return (
-    <MaintenanceBanner
-      {...args}
-      startsAt={startTime}
-      expiresAt={endTime}
-      warnStartsAt={warnStart}
-    />
-  );
+  return <MaintenanceBanner {...args} />;
 };
 
 const defaultArgs = {
@@ -41,9 +34,9 @@ const defaultArgs = {
     'We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.',
   warnContent:
     'We’ll be doing some work on VA.gov. The maintenance will last 1 hour. During that time, you won’t be able to sign in or use tools.',
-  startsAt: moment().valueOf(),
-  expiresAt: moment().add(1, 'hour').valueOf(),
-  warnStartsAt: moment().subtract(30, 'minutes').valueOf(),
+  startsAt: new Date(Date.now()),
+  expiresAt: addHours(Date.now(), 1),
+  warnStartsAt: subMinutes(Date.now(), 30),
 };
 
 export const DuringMaintenance = Template.bind({});
@@ -52,7 +45,7 @@ DuringMaintenance.args = { ...defaultArgs };
 export const BeforeMaintenance = Template.bind({});
 BeforeMaintenance.args = {
   ...defaultArgs,
-  startsAt: moment().add(1, 'hour').valueOf(),
-  expiresAt: moment().add(2, 'hours').valueOf(),
-  warnStartsAt: moment().valueOf(),
+  startsAt: addHours(Date.now(), 1),
+  expiresAt: addHours(Date.now(), 2),
+  warnStartsAt: new Date(Date.now()),
 };

--- a/src/components/MaintenanceBanner/MaintenanceBanner.unit.spec.jsx
+++ b/src/components/MaintenanceBanner/MaintenanceBanner.unit.spec.jsx
@@ -2,14 +2,15 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import moment from 'moment';
+import { addHours, format, subHours } from 'date-fns';
+
 // Relative imports.
 import MaintenanceBanner, { MAINTENANCE_BANNER } from './MaintenanceBanner.jsx';
 
-const deriveDefaultProps = (startsAt = moment()) => {
-  const expiresAt = startsAt.clone().add(2, 'hours');
-  const formattedStartsAt = startsAt.format('dddd M/D, h:mm a');
-  const formattedExpiresAt = expiresAt.format('dddd M/D, h:mm a');
+const deriveDefaultProps = (startsAt = Date.now()) => {
+  const expiresAt = addHours(startsAt, 2);
+  const formattedStartsAt = format(startsAt, 'EEEE M/d, h:mm a');
+  const formattedExpiresAt = format(expiresAt, 'EEEE M/d, h:mm a');
 
   return {
     id: '1',
@@ -18,7 +19,7 @@ const deriveDefaultProps = (startsAt = moment()) => {
     title: 'DS Logon is down for maintenance.',
     content:
       'DS Logon is down for maintenance. Please use ID.me or MyHealtheVet to sign in or use online tools.',
-    warnStartsAt: startsAt.clone().subtract(12, 'hours'),
+    warnStartsAt: subHours(startsAt, 12),
     warnTitle: 'DS Logon will be down for maintenance',
     warnContent: `DS Logon will be unavailable from ${formattedStartsAt} to ${formattedExpiresAt} Please use ID.me or MyHealtheVet to sign in or use online tools during this time.`,
   };
@@ -27,7 +28,7 @@ const deriveDefaultProps = (startsAt = moment()) => {
 describe('<MaintenanceBanner>', () => {
   it("Escapes early if it's before when it should show.", () => {
     const wrapper = mount(
-      <MaintenanceBanner {...deriveDefaultProps(moment().add(13, 'hours'))} />,
+      <MaintenanceBanner {...deriveDefaultProps(addHours(Date.now(), 13))} />,
     );
     expect(wrapper.html()).to.equal(null);
     wrapper.unmount();
@@ -35,7 +36,7 @@ describe('<MaintenanceBanner>', () => {
 
   it('Shows pre-downtime.', () => {
     const wrapper = mount(
-      <MaintenanceBanner {...deriveDefaultProps(moment().add(2, 'hours'))} />,
+      <MaintenanceBanner {...deriveDefaultProps(addHours(Date.now(), 2))} />,
     );
     expect(wrapper.html()).to.not.equal(null);
     expect(wrapper.html()).to.include('vads-u-border-color--warning-message');
@@ -51,9 +52,7 @@ describe('<MaintenanceBanner>', () => {
 
   it("Escapes early if it's after when it should show.", () => {
     const wrapper = mount(
-      <MaintenanceBanner
-        {...deriveDefaultProps(moment().subtract(3, 'hours'))}
-      />,
+      <MaintenanceBanner {...deriveDefaultProps(subHours(Date.now(), 3))} />,
     );
     expect(wrapper.html()).to.equal(null);
     wrapper.unmount();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4275,6 +4275,16 @@ damerau-levenshtein@^1.0.6:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
   integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
 
+date-fns-tz@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.1.1.tgz#2e0dfcc62cc5b7b5fa7ea620f11a5e7f63a7ed75"
+  integrity sha512-5PR604TlyvpiNXtvn+PZCcCazsI8fI1am3/aimNFN8CMqHQ0KRl+6hB46y4mDbB7bk3+caEx3qHhS7Ewac/FIg==
+
+date-fns@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
+  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
+
 date-format@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"


### PR DESCRIPTION
## Description

Related to https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/198

This updates the `MaintenanceBanner` stories with some new content, and also puts a comma after the formatted day. It also replaces `moment` with `date-fns` _only in `MaintenanceBanner`_. This allows us to properly format the `a.m.`/`p.m.` according to [our own guidelines](https://design.va.gov/content-style-guide/dates-and-numbers#times-and-time-zones).

I also found a bug that _might_ be related to daylight savings time. The displayed time was an hour off from the time that was passed in as a prop. This has been fixed.

## Testing done

- Local Storybook
- Unit testing


## Screenshots

### Before banner

![image](https://user-images.githubusercontent.com/2008881/107820399-94118a00-6d2f-11eb-98c4-5f19df1514f7.png)


### During banner

![image](https://user-images.githubusercontent.com/2008881/107820360-86f49b00-6d2f-11eb-8bff-4d20a928ef4b.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
