### PR TITLE
Add error class to Date fieldset

### DIFF
--- a/src/components/Date/Date.jsx
+++ b/src/components/Date/Date.jsx
@@ -82,7 +82,9 @@ class Date extends React.Component {
 
     let errorSpanId;
     let errorSpan = '';
+    let fieldsetClass;
     if (!isValid) {
+      fieldsetClass = 'input-error-date usa-input-error';
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
         <span className="usa-input-error-message" role="alert" id={errorSpanId}>
@@ -92,7 +94,7 @@ class Date extends React.Component {
     }
 
     return (
-      <fieldset className={!isValid ? 'input-error-date' : undefined}>
+      <fieldset className={fieldsetClass}>
         <legend className="vads-u-font-size--base vads-u-font-weight--normal">
           {this.props.label || 'Date of birth'}
           {this.props.required && (


### PR DESCRIPTION
## Description

When the date widget has an error, the left-sided red border doesn't extend up into the `legend`

Including the `usa-input-error` class in the `fieldset`

Design spec: https://design.va.gov/patterns/form-feedback

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/394

## Testing done

Visual

## Screenshots

Source page: https://staging.va.gov/disability/file-disability-claim-form-21-526ez/introduction

![Screen Shot 2021-02-11 at 4 00 17 PM](https://user-images.githubusercontent.com/136959/107704498-f6608100-6c82-11eb-977a-668d64e44558.png)
![Screen Shot 2021-02-11 at 3 59 51 PM](https://user-images.githubusercontent.com/136959/107704501-f6f91780-6c82-11eb-9412-f9e0e0abddc3.png)

\* Note: I'm not sure how to get that last bit of border to be above the text.

## Acceptance criteria
- [x] Red border extends up into the `fieldset`/`legend`

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
