### PR TITLE
Update to 3-digit telephone numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/Telephone/Telephone.jsx
+++ b/src/components/Telephone/Telephone.jsx
@@ -136,8 +136,9 @@ function Telephone({
     }`;
 
   // Add a "+1" to the tel for all included patterns, except 3-digit
-  const isIncludedPattern = Object.values(PATTERNS).includes(contactPattern) &&
-    contactPattern !== PATTERNS['3_DIGIT'];
+  const isIncludedPattern = Object.values(PATTERNS)
+    .filter(pattern => pattern !== PATTERNS['3_DIGIT'])
+    .includes(contactPattern);
   const href = `tel:${isIncludedPattern ? `+1${phoneNumber}` : phoneNumber}${
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better

--- a/src/components/Telephone/Telephone.jsx
+++ b/src/components/Telephone/Telephone.jsx
@@ -12,12 +12,6 @@ export const PATTERNS = {
   OUTSIDE_US: '+1-###-###-####',
 };
 
-// Custom aria labels (only used internally)
-const LABELS = {
-  711: 'TTY: 7 1 1.',
-  911: '1. 9 1 1.',
-};
-
 /**
  * Parse the raw phone number string. And strip out leading "1" and any
  * non-digits
@@ -137,13 +131,13 @@ function Telephone({
 
   const formattedAriaLabel =
     ariaLabel ||
-    LABELS[parsedNumber] || // custom 911 aria-label
     `${formatTelLabel(formattedNumber)}${
       extension ? `. extension ${formatTelLabelBlock(extension)}.` : '.'
     }`;
 
-  // Add a "+1" to the tel for all included patterns
-  const isIncludedPattern = Object.values(PATTERNS).includes(contactPattern);
+  // Add a "+1" to the tel for all included patterns, except 3-digit
+  const isIncludedPattern = Object.values(PATTERNS).includes(contactPattern) &&
+    contactPattern !== PATTERNS['3_DIGIT'];
   const href = `tel:${isIncludedPattern ? `+1${phoneNumber}` : phoneNumber}${
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better

--- a/src/components/Telephone/Telephone.mdx
+++ b/src/components/Telephone/Telephone.mdx
@@ -52,7 +52,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/c
 <Telephone contact={CONTACTS['911']} />
 
 /* Renders as
-<a href="tel:+1911" aria-label="1. 9 1 1." class="no-wrap">911</a>
+<a href="tel:911" aria-label="9 1 1." class="no-wrap">911</a>
 */
 
 // Showing all options

--- a/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/src/components/Telephone/Telephone.unit.spec.jsx
@@ -63,14 +63,6 @@ describe('Widget <Telephone />', () => {
     expect(wrapper.text()).to.equal('800-698-2411');
     wrapper.unmount();
   });
-  it('should render 911 (a known number)', () => {
-    const wrapper = shallow(<Telephone contact={CONTACTS['911']} />);
-    const props = wrapper.props();
-    expect(props.href).to.equal('tel:+1911');
-    expect(props['aria-label']).to.equal('1. 9 1 1.');
-    expect(wrapper.text()).to.equal('911');
-    wrapper.unmount();
-  });
 
   // extension
   it('should render a known number + extension', () => {
@@ -155,6 +147,24 @@ describe('Widget <Telephone />', () => {
     expect(props.href).to.equal('tel:+18884424551');
     expect(props['aria-label']).to.equal(ariaLabel);
     expect(wrapper.text()).to.equal('888-442-4551');
+    wrapper.unmount();
+  });
+  it('should render 911', () => {
+    const wrapper = shallow(<Telephone contact={CONTACTS['911']} />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:911');
+    expect(props['aria-label']).to.equal('9 1 1.');
+    expect(wrapper.text()).to.equal('911');
+    wrapper.unmount();
+  });
+  it('should render 711 without a custom label', () => {
+    const wrapper = shallow(
+      <Telephone contact={711} />,
+    );
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:711');
+    expect(props['aria-label']).to.equal('7 1 1.');
+    expect(wrapper.text()).to.equal('711');
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Description

Three-digit phone numbers, e.g. `911` and `711` do not need specific labels added by the Telephone component, nor should they be preceeded by a `+1` as they are with other numbers.

In this PR:

- The `TTY` within the `711` aria-label is repetitive and has been removed.
- For all 3-digit numbers, the `+1` in the number causes the phone call to not complete as dialed

This PR combines the work of the two tickets because removing the TTY label and adding a new unit test would include a `+1` in the number, and it was just as easy to combine the work.

Closes tickets
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/338 (remove `+1`)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/18274 (remove `tty`)

## Testing done

Unit tests updated

## Screenshots

N/A

## Acceptance criteria
- [x] Three-digit phone numbers should not include a `+1` in the dialed number
- [x] The extra `TTY` in the aria-label has been removed

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
