### PR TITLE
Exclude files in testing folder from build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
   ],
   "exclude": [
     "node_modules",
-    "src/**/*.stories.*"
+    "src/**/*.stories.*",
+    "src/testing"
   ]
 }


### PR DESCRIPTION
## Description

This is related to #43 and #48, but wasn't caught since they were never tested together. #43 added a file in a new `src/testing` directory meant for holding helpers for testing. #48 changed how the dependencies were organized so that a `npm install --only=prod` would lead to a successful build by consumers.

By adding the `test-helpers.jsx` file which imports from `axe-core`, we ended up in a situation where we were trying to include that file as part of the build but it would fail, since `axe-core` wasn't installed. This will prevent that.

The problem was noticed locally when trying to upgrade the `web-components` dependency.

## Testing done

Testing on the PR for `storybook-wc`: https://github.com/department-of-veterans-affairs/component-library/pull/31/commits/faa5c3cae5d4c5c6dbf50ed694c4ce0eca08546b


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
