### PR TITLE
Fix accordion after staging review

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-library",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -36,6 +36,10 @@ export namespace Components {
          */
         "header": string;
         /**
+          * Header level for button wrapper. Must be between 1 and 6
+         */
+        "level": number;
+        /**
           * True if the item is open
          */
         "open": boolean;
@@ -96,6 +100,10 @@ declare namespace LocalJSX {
           * The accordion item header text
          */
         "header"?: string;
+        /**
+          * Header level for button wrapper. Must be between 1 and 6
+         */
+        "level"?: number;
         /**
           * This event is fired so that `<va-accordion>` can manage which items are opened or closed
          */

--- a/src/components/va-accordion/va-accordion-item.css
+++ b/src/components/va-accordion/va-accordion-item.css
@@ -10,6 +10,15 @@
   display: none;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+}
+
 button {
   cursor: pointer;
   width: 100%;

--- a/src/components/va-accordion/va-accordion-item.css
+++ b/src/components/va-accordion/va-accordion-item.css
@@ -5,6 +5,11 @@
   margin-bottom: 0.5rem;
 }
 
+:host(:not([open])) #content,
+:host([open='false']) #content {
+  display: none;
+}
+
 button {
   cursor: pointer;
   width: 100%;
@@ -34,10 +39,6 @@ button:hover {
   border-left: var(--item-border);
   border-right: var(--item-border);
   border-bottom: var(--item-border);
-}
-
-button[aria-expanded='false'] + div {
-  display: none;
 }
 
 button[aria-expanded='false'] {

--- a/src/components/va-accordion/va-accordion-item.css
+++ b/src/components/va-accordion/va-accordion-item.css
@@ -20,7 +20,7 @@ button {
   background-position: right 2rem center;
   background-repeat: no-repeat;
   background-size: 1.5rem;
-  display: inline-block;
+  display: block;
 }
 
 button:hover {

--- a/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -11,12 +11,31 @@ describe('va-accordion-item', () => {
     expect(element).toEqualHtml(`
     <va-accordion-item class="hydrated">
       <mock:shadow-root>
-        <button aria-controls="content" aria-expanded="false"></button>
+        <h2>
+          <button aria-controls="content" aria-expanded="false"></button>
+        </h2>
         <div id="content">
           <slot></slot>
         </div>
       </mock:shadow-root>
     </va-accordion-item>`);
+  });
+
+  it('allows the heading level to be changed via prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-accordion-item header="The header">Content inside</va-accordion-item>',
+    );
+    const element = await page.find('va-accordion-item');
+    let header = element.shadowRoot.childNodes[0];
+
+    expect(header.nodeName).toEqual('H2');
+
+    element.setProperty('level', 4);
+    await page.waitForChanges();
+    header = element.shadowRoot.childNodes[0];
+
+    expect(header.nodeName).toEqual('H4');
   });
 
   it('passes an axe check when open', async () => {

--- a/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -58,7 +58,9 @@ describe('va-accordion-item', () => {
 
   it('sets aria-expanded to true based on prop', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-accordion-item header="The header">Content inside</va-accordion-item>');
+    await page.setContent(
+      '<va-accordion-item header="The header">Content inside</va-accordion-item>',
+    );
     const component = await page.find('va-accordion-item');
     const button = await page.find('va-accordion-item >>> button');
 
@@ -72,7 +74,9 @@ describe('va-accordion-item', () => {
 
   it('fires a custom event when the button is clicked', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-accordion-item header="The header">Content inside</va-accordion-item>');
+    await page.setContent(
+      '<va-accordion-item header="The header">Content inside</va-accordion-item>',
+    );
 
     const accordionItemToggled = await page.spyOnEvent('accordionItemToggled');
 

--- a/src/components/va-accordion/va-accordion-item.tsx
+++ b/src/components/va-accordion/va-accordion-item.tsx
@@ -25,16 +25,32 @@ export class VaAccordionItem {
    */
   @Prop() open: boolean = false;
 
+  /**
+   * Header level for button wrapper. Must be between 1 and 6
+   */
+  @Prop() level: number = 2;
+
   private toggleOpen(e: MouseEvent): void {
     this.accordionItemToggled.emit(e);
   }
 
   render() {
+    const Header = () =>
+      h(
+        `h${this.level}`,
+        null,
+        <button
+          onClick={this.toggleOpen.bind(this)}
+          aria-expanded={this.open ? 'true' : 'false'}
+          aria-controls="content"
+        >
+          {this.header}
+        </button>,
+      );
+
     return (
       <Host>
-        <button onClick={this.toggleOpen.bind(this)} aria-expanded={this.open ? 'true' : 'false'} aria-controls="content">
-          {this.header}
-        </button>
+        <Header />
         <div id="content">
           <slot />
         </div>

--- a/src/components/va-accordion/va-accordion.e2e.ts
+++ b/src/components/va-accordion/va-accordion.e2e.ts
@@ -37,7 +37,9 @@ describe('va-accordion', () => {
         <va-accordion-item header="Second item">A bit more</va-accordion-item>
       </va-accordion>`);
 
-    const buttons = await page.findAll('va-accordion-item >>> button[aria-expanded="false"]');
+    const buttons = await page.findAll(
+      'va-accordion-item >>> button[aria-expanded="false"]',
+    );
     expect(buttons.length).toEqual(2);
 
     await buttons[0].click();
@@ -61,7 +63,9 @@ describe('va-accordion', () => {
         <va-accordion-item header="Second item">A bit more</va-accordion-item>
       </va-accordion>`);
 
-    const buttons = await page.findAll('va-accordion-item >>> button[aria-expanded="false"]');
+    const buttons = await page.findAll(
+      'va-accordion-item >>> button[aria-expanded="false"]',
+    );
     expect(buttons.length).toEqual(2);
 
     await buttons[0].click();

--- a/src/components/va-accordion/va-accordion.tsx
+++ b/src/components/va-accordion/va-accordion.tsx
@@ -27,7 +27,7 @@ export class VaAccordion {
 
   @Listen('accordionItemToggled')
   itemToggledHandler(event: CustomEvent) {
-    const clickedItem = event.detail.target.parentNode.host;
+    const clickedItem = event.detail.target.parentNode.parentNode.host;
     // Close the other items if this accordion isn't multi-selectable
     if (!this.multi) {
       this.getSlottedNodes(this.el, 'va-accordion-item')

--- a/src/components/va-accordion/va-accordion.tsx
+++ b/src/components/va-accordion/va-accordion.tsx
@@ -27,6 +27,10 @@ export class VaAccordion {
 
   @Listen('accordionItemToggled')
   itemToggledHandler(event: CustomEvent) {
+    // The event target is the button, and it has a parent which is a header.
+    // It is the parent of the header (the root item) that we need to access
+    // The final parentNode will be a shadowRoot, and from there we get the host.
+    // https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/host
     const clickedItem = event.detail.target.parentNode.parentNode.host;
     // Close the other items if this accordion isn't multi-selectable
     if (!this.multi) {


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/20479
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/20485

The staging review for the accordion web component found 2 a11y issues. This addresses them by:
- Setting the `<button>` to `display: block`
- Wrapping the button in a header that defaults to an `<h2>`
  - A `level` prop can be used to adjust the header level from 1 to 6

## Testing done

- Local e2e tests
- Storybook validation


## Screenshots

This is from [another PR](https://github.com/department-of-veterans-affairs/component-library/pull/31/commits/51bad68f30cf09c981ea46bc835b915639d57f03):

![image](https://user-images.githubusercontent.com/2008881/109237006-a22ac600-7785-11eb-86f3-6cdb03680c09.png)



## Acceptance criteria
- [ ]  MacOS + Safari + VoiceOver maintain focus on the correct button when users interact with it
- [x]  Users can advance to the next text node correctly when a button is expanded
- [x]  Buttons are wrapped in a heading, defaulting to an H2
- [x]  Headings have a `level` prop that can be overridden to nest the heading properly
- [x]  Current styling and behavior are retained

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
