### PR TITLE
Add full month names to date select

### DIFF
--- a/src/helpers/options-for-select.js
+++ b/src/helpers/options-for-select.js
@@ -39,18 +39,18 @@ export const genders = [
 ];
 
 export const months = [
-  { label: 'Jan', value: 1 },
-  { label: 'Feb', value: 2 },
-  { label: 'Mar', value: 3 },
-  { label: 'Apr', value: 4 },
+  { label: 'January', value: 1 },
+  { label: 'February', value: 2 },
+  { label: 'March', value: 3 },
+  { label: 'April', value: 4 },
   { label: 'May', value: 5 },
-  { label: 'Jun', value: 6 },
-  { label: 'Jul', value: 7 },
-  { label: 'Aug', value: 8 },
-  { label: 'Sep', value: 9 },
-  { label: 'Oct', value: 10 },
-  { label: 'Nov', value: 11 },
-  { label: 'Dec', value: 12 },
+  { label: 'June', value: 6 },
+  { label: 'July', value: 7 },
+  { label: 'August', value: 8 },
+  { label: 'September', value: 9 },
+  { label: 'October', value: 10 },
+  { label: 'November', value: 11 },
+  { label: 'December', value: 12 },
 ];
 
 export const twentyNineDays = [


### PR DESCRIPTION
## Description

Use full month names inside the Date & MonthYear components to remove inconsistent screenreader interpretation of the abbreviations.

Related:
- https://github.com/department-of-veterans-affairs/component-library/pull/16#discussion_r568320847
- https://github.com/department-of-veterans-affairs/vets-website/pull/15935 (Form system date widget update)

## Testing done

Checked results in storybook instance

## Screenshots

<details><summary>Date</summary>

<!-- leave a blank line above -->
<img width="375" alt="Screen Shot 2021-03-09 at 9 43 26 AM" src="https://user-images.githubusercontent.com/136959/110497368-fe61e400-80bb-11eb-98fd-460b416ab18e.png"></details>

<details><summary>Month/Year</summary>

<!-- leave a blank line above -->
<img width="343" alt="Screen Shot 2021-03-09 at 9 43 39 AM" src="https://user-images.githubusercontent.com/136959/110497449-12a5e100-80bc-11eb-9db8-e88348266d8e.png"></details>

## Acceptance criteria
- [x] Full month names are displayed within the Date & MonthYear month select

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
