### PR TITLE
Telephone doc fixes

### DIFF
--- a/src/components/Telephone/Telephone.jsx
+++ b/src/components/Telephone/Telephone.jsx
@@ -85,7 +85,7 @@ const deriveContactPattern = (pattern, parsedNumber) => {
   return PATTERNS.DEFAULT;
 };
 
-/**
+/***
  * Telephone component
  * @param {string|number} contact (required) - telephone number, with or without
  *  formatting; all non-digit characters will be stripped out
@@ -217,6 +217,11 @@ Telephone.propTypes = {
    * Custom onClick function
    */
   onClick: PropTypes.func,
+
+  /**
+   * Custom link content
+   */
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 export default Telephone;

--- a/src/components/Telephone/Telephone.stories.jsx
+++ b/src/components/Telephone/Telephone.stories.jsx
@@ -8,7 +8,7 @@ import {
   Stories,
 } from '@storybook/addon-docs/blocks';
 
-import Telephone, { CONTACTS } from './Telephone';
+import Telephone, { CONTACTS, PATTERNS } from './Telephone';
 import { contactsMap } from './contacts';
 import Table from '../Table/Table';
 
@@ -28,24 +28,61 @@ const Contacts = () => (
   />
 );
 
+const patternFields = [
+  { label: 'Pattern name (PATTERN.x)', value: 'key' },
+  { label: 'Pattern', value: 'value' },
+  { label: 'Description', value: 'description' },
+];
+const patternDescriptions = {
+  '3_DIGIT':
+    'Used for 3-digit numbers (e.g. 711 & 911); automatically set for 3-digit numbers',
+  DEFAULT: (
+    <>
+      Standard telephone format. See the{' '}
+      <a href="https://design.va.gov/content-style-guide/dates-and-numbers#phone-numbers">
+        phone number design specification
+      </a>
+      .
+    </>
+  ),
+  OUTSIDE_US:
+    'Pattern used for numbers where the Veteran is located outside the United States',
+};
+const Patterns = () => (
+  <Table
+    fields={patternFields}
+    data={Object.entries(PATTERNS).map(p => ({
+      key: p[0],
+      value: p[1],
+      description: (
+        <div style={{ maxWidth: '30em' }}>{patternDescriptions[p[0]]}</div>
+      ),
+    }))}
+  />
+);
+
+const Page = () => (
+  <>
+    <Title />
+    <Subtitle />
+    <Description />
+    <Primary />
+    <ArgsTable />
+    <Contacts />
+    <br />
+    <Patterns />
+    <br />
+    <Stories />
+  </>
+);
+
 export default {
   title: 'Components/Telephone',
   component: Telephone,
   parameters: {
     docs: {
-      // Add the contacts table to the docs page
-      page: () => (
-        <>
-          <Title />
-          <Subtitle />
-          <Description />
-          <Primary />
-          <ArgsTable />
-          <Contacts />
-          <br />
-          <Stories />
-        </>
-      ),
+      // Add the contacts & pattern table to the docs page
+      page: Page,
     },
   },
 };
@@ -62,5 +99,14 @@ Default.args = { ...defaultArgs };
 export const DisplayOnly = Template.bind({});
 DisplayOnly.args = { ...defaultArgs, notClickable: true };
 
+export const ThreeDigitNumber = Template.bind({});
+ThreeDigitNumber.args = { contact: '711' };
+
 export const Extension = Template.bind({});
 Extension.args = { ...defaultArgs, extension: '123' };
+
+export const CustomContent = Template.bind({});
+CustomContent.args = {
+  contact: CONTACTS['222_VETS'],
+  children: '877-222-VETS (8387)',
+};

--- a/src/components/Telephone/contacts.js
+++ b/src/components/Telephone/contacts.js
@@ -27,6 +27,11 @@ export const contactsMap = Object.freeze({
     phoneNumber: '6127136415',
     description: 'Debt Management Center (Overseas)',
   },
+  DMDC_DEERS: {
+    phoneNumber: '8663632883',
+    description:
+      'Defense Manpower Data Center (DMDC) | Defense Enrollment Eligibility Reporting System (DEERS) Support Office',
+  },
   DS_LOGON: {
     phoneNumber: '8005389552',
     description: 'Defense Manpower Data Center',
@@ -34,6 +39,10 @@ export const contactsMap = Object.freeze({
   DS_LOGON_TTY: {
     phoneNumber: '8663632883',
     description: 'Defense Manpower Data Center TTY',
+  },
+  FEDERAL_RELAY_SERVICE: {
+    phoneNumber: '8008778339',
+    description: 'Federal Relay Service',
   },
   GI_BILL: {
     phoneNumber: '8884424551',
@@ -57,6 +66,10 @@ export const contactsMap = Object.freeze({
     phoneNumber: '8005351117',
     description: 'National Cemetery Scheduling Office',
   },
+  SUICIDE_PREVENTION_LIFELINE: {
+    phoneNumber: '8007994889',
+    description: 'Suicide Prevention Line',
+  },
   TESC: {
     phoneNumber: '8882242950',
     description: 'U.S. Treasury Electronic Payment Solution Center',
@@ -65,20 +78,9 @@ export const contactsMap = Object.freeze({
     phoneNumber: '8888263127',
     description: 'U.S. Department of the Treasury (Debt Management Services)',
   },
-  FEDERAL_RELAY_SERVICE: {
-    phoneNumber: '8008778339',
-    description: 'Federal Relay Service',
-  },
-  SUICIDE_PREVENTION_LIFELINE: {
-    phoneNumber: '8007994889',
-    description: 'Suicide Prevention Line',
-  },
-  DMDC_DEERS: {
-    phoneNumber: '8663632883',
-    description:
-      'Defense Manpower Data Center (DMDC) | Defense Enrollment Eligibility Reporting System (DEERS) Support Office',
-  },
-  VA_311: { phoneNumber: '8006982411', description: 'VA Help desk (VA311)' },
+  // VA_311 used before the number changed to include 411
+  VA_311: { phoneNumber: '8006982411', description: 'VA Help desk (VA411)' },
+  VA_411: { phoneNumber: '8006982411', description: 'VA Help desk (VA411)' },
   VA_BENEFITS: {
     phoneNumber: '8008271000',
     description: 'Veterans Benefits Assistance',


### PR DESCRIPTION
## Description

This PR does 4 things to the Telephone component:
- Made contact list alphabetical
- Added a third `*` to the JSDocs (line 88) to stop render of the unformatted JSDoc block below the title
- Added `PATTERN` values to table
- Added more stories: 3-digit number & custom content

## Testing done

Unit tests

## Screenshots

<details><summary>Unformatted JSDoc under title (before)</summary>

<!-- leave a blank line above -->
<img width="313" alt="Screen Shot 2021-03-09 at 9 59 27 AM" src="https://user-images.githubusercontent.com/136959/110514811-4b9a8180-80cd-11eb-91a8-ffc601a9ec18.png"></details>

<details><summary>Title then example (after)</summary>

<!-- leave a blank line above -->
<img width="209" alt="Screen Shot 2021-03-09 at 11 47 44 AM" src="https://user-images.githubusercontent.com/136959/110514807-4b9a8180-80cd-11eb-8607-44a658836220.png"></details>

## Acceptance criteria
- [x] Telephone docs cleaned up
- [x] Available patterns shown
- [x] More Telephone stories

## Definition of done
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
