### PR TITLE
Apply same CSS fix to :hover state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-library",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components/va-accordion/va-accordion-item.css
+++ b/src/components/va-accordion/va-accordion-item.css
@@ -42,6 +42,9 @@ button {
 
 button:hover {
   background-color: var(--color-gray-lighter);
+  /* This color assignment is for IE11 compatibility - the one in */
+  /* the `<va-accordion>`'s CSS with `:host` doesn't work well */
+  color: var(--color-base);
 }
 
 #content {


### PR DESCRIPTION

## Description
Related to #53. This PR is [this CSS](https://github.com/department-of-veterans-affairs/component-library/commit/400c2541ed8dc5e1e433ceecc07ccaf9c6135a3a#diff-f7e0ba5886671b1b6e4a8e1e9c98a76a3f2aac69b66b4c3f5fe4f827fcf60d23R38-R40) applied when the button has the `:hover` pseudoselector as well.


## Testing done

Local testing in IE11


## Screenshots

Before, with the visual bug:

![Peek 2021-03-12 15-54 (1)](https://user-images.githubusercontent.com/2008881/111010886-a392eb80-834c-11eb-9fbe-6fc307dc105e.gif)


After, with the hover bug fixed:

![Peek 2021-03-12 15-45 (1)](https://user-images.githubusercontent.com/2008881/111010812-72b2b680-834c-11eb-8dc7-09127dec002d.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
