### PR TITLE
refactor: use react-focus-on to manage focus trap for modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-focus-lock": "^2.4.0",
+    "react-focus-on": "^3.5.1",
     "react-scroll": "^1.7.16",
     "react-transition-group": "1",
     "recast": "^0.14.4"

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -9,7 +9,6 @@ const ESCAPE_KEY = 27;
 class Modal extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { lastFocus: null, isTabbingBackwards: false };
 
     this.handleDocumentKeyDown = this.handleDocumentKeyDown.bind(this);
     this.handleClose = this.handleClose.bind(this);

--- a/src/components/Modal/Modal.stories.jsx
+++ b/src/components/Modal/Modal.stories.jsx
@@ -6,19 +6,23 @@ export default {
   component: Modal,
 };
 
-const Template = (args) => {
+const Template = args => {
   const [visible, setVisible] = useState(args.visible);
   const onClose = () => setVisible(!visible);
+  const openModal = () => setVisible(true);
   return (
-    <Modal {...args} visible={visible} onClose={onClose}>
-      {args.children}
-    </Modal>
+    <div style={{ height: '500px' }}>
+      <button onClick={openModal}>Click here to open modal</button>
+      <Modal {...args} visible={visible} onClose={onClose}>
+        {args.children}
+      </Modal>
+    </div>
   );
 };
 
 const defaultArgs = {
   ...Modal.defaultProps,
-  visible: true,
+  visible: false,
   // Note: This is not a prop of Modal. This is to demonstrate the use of children in the Modal.
   children: (
     <>
@@ -36,12 +40,12 @@ const defaultArgs = {
   primaryButton: {
     text: 'Primary button',
     // eslint-disable-next-line no-console
-    action: (e) => console.log('Primary button clicked. Event fired:', e),
+    action: e => console.log('Primary button clicked. Event fired:', e),
   },
   secondaryButton: {
     text: 'Secondary button',
     // eslint-disable-next-line no-console
-    action: (e) => console.log('Secondary button clicked. Event fired:', e),
+    action: e => console.log('Secondary button clicked. Event fired:', e),
   },
   title: 'Modal title goes here',
 };
@@ -84,4 +88,8 @@ export const WithoutTitle = Template.bind({});
 WithoutTitle.args = { ...defaultArgs, title: undefined };
 
 export const HideCloseButton = Template.bind({});
-HideCloseButton.args = { ...defaultArgs, hideCloseButton: true };
+HideCloseButton.args = {
+  ...defaultArgs,
+  hideCloseButton: true,
+  clickToClose: true,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2918,6 +2918,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-hidden@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.2.tgz#5354315a29bffdaced3993fccd826817dc8c5272"
+  integrity sha512-WAMH9q3vRimVqP+B0q2eDvx7IPDoY17A2fWwj5atTA/zTYJCNcS6HJ5YErZ5FO3PUHhrV0y0yR1NA0dRNm913A==
+  dependencies:
+    tslib "^1.0.0"
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -6155,6 +6162,11 @@ get-intrinsic@^1.0.2:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -9520,7 +9532,7 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-focus-lock@^2.4.0:
+react-focus-lock@^2.3.1, react-focus-lock@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.0.tgz#12e3a3940e897c26e2c2a0408cd25ea3c99b3709"
   integrity sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==
@@ -9530,6 +9542,18 @@ react-focus-lock@^2.4.0:
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.2"
     use-callback-ref "^1.2.1"
+    use-sidecar "^1.0.1"
+
+react-focus-on@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.5.1.tgz#b459309cbee1b0a42dac92253e434d2860a509f6"
+  integrity sha512-6iE56nYNwVU6Pke362TjqRLz/G7DBGnEugkxhPAhpXEZW5og3vhc9qDPlyiHgxoiY9kYTWjdAEFz4nJgSluANg==
+  dependencies:
+    aria-hidden "^1.1.1"
+    react-focus-lock "^2.3.1"
+    react-remove-scroll "^2.4.0"
+    react-style-singleton "^2.1.0"
+    use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
 react-helmet-async@^1.0.2:
@@ -9598,6 +9622,25 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
+react-remove-scroll-bar@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz#d4d545a7df024f75d67e151499a6ab5ac97c8cdd"
+  integrity sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==
+  dependencies:
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+
+react-remove-scroll@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.4.1.tgz#e0af6126621083a5064591d367291a81b2d107f5"
+  integrity sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==
+  dependencies:
+    react-remove-scroll-bar "^2.1.0"
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+    use-callback-ref "^1.2.3"
+    use-sidecar "^1.0.1"
+
 react-router@3:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.6.tgz#cad202796a7bba3efc2100da453b3379c9d4aeb4"
@@ -9629,6 +9672,15 @@ react-sizeme@^2.5.2, react-sizeme@^2.6.7:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
+
+react-style-singleton@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.1.1.tgz#ce7f90b67618be2b6b94902a30aaea152ce52e66"
+  integrity sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^1.0.0"
 
 react-syntax-highlighter@^12.0.0:
   version "12.2.1"
@@ -11099,7 +11151,7 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.0.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -11374,6 +11426,11 @@ use-callback-ref@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.4.tgz#d86d1577bfd0b955b6e04aaf5971025f406bea3c"
   integrity sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==
+
+use-callback-ref@^1.2.3:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.5.tgz#6115ed242cfbaed5915499c0a9842ca2912f38a5"
+  integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
 
 use-composed-ref@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## Description
Closes [18727](https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/18727)

Refactored the modal component to use react-focus-on in order to solve memory leak issue in Storybook.
Added buttons to open modals on the Storybook default page so that the user can scroll on the page (open modals disable page scrolling).
Increased size of iframe windows for modals on the Storybook default page so that the user can use the close button to close the modals.

## Testing done
All tests are passing.
All scenarios in Storybook are working and the memory leak issue is no longer present
**Need to find a way to test with existing modals in vets-website**

## Screenshots
From Storybook
<img width="1021" alt="image" src="https://user-images.githubusercontent.com/12739849/112009214-928c6c00-8afc-11eb-80c9-b680f9d225cb.png">

From http://localhost:3001/gi-bill-comparison-tool/profile/149A1405
(linked vets-website to component-library, ran vets-website with `yarn watch --env.api https://dev-api.va.gov`)
<img width="982" alt="image" src="https://user-images.githubusercontent.com/12739849/112026025-2ca7e080-8b0c-11eb-830f-e2399ed1d93e.png">


## Acceptance criteria
- [ ] Opening the modal component in Storybook no longer causes Storybook to hang or tab to become unresponsive
- [ ] The user is able to scroll on the Storybook modal page to see all modal options
- [ ] All modal options still work
- [ ] All tests are passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
