### PR TITLE
Add disableAnalytics flag to PromoBanner analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/PromoBanner/PromoBanner.jsx
+++ b/src/components/PromoBanner/PromoBanner.jsx
@@ -15,7 +15,15 @@ const PROMO_BANNER_ICONS = new Map([
   [PROMO_BANNER_TYPES.emailSignup, 'fa-envelope'],
 ]);
 
-function PromoBanner({ type, onClose, render, href, target, text }) {
+function PromoBanner({
+  type,
+  onClose,
+  render,
+  href,
+  target,
+  text,
+  disableAnalytics,
+}) {
   const iconClasses = classnames(
     'fas',
     'fa-stack-1x',
@@ -23,16 +31,19 @@ function PromoBanner({ type, onClose, render, href, target, text }) {
   );
 
   const onCloseWithAnalytics = () => {
-    dispatchAnalyticsEvent({
-      componentName: 'PromoBanner',
-      action: 'linkClick',
-      details: {
-        text,
-        href,
-        target,
-        type,
-      },
-    });
+    // Conditionally track the event.
+    if (!disableAnalytics) {
+      dispatchAnalyticsEvent({
+        componentName: 'PromoBanner',
+        action: 'linkClick',
+        details: {
+          text,
+          href,
+          target,
+          type,
+        },
+      });
+    }
     return onClose && onClose();
   };
 
@@ -106,6 +117,10 @@ PromoBanner.propTypes = {
    * Content for the `<a>` tag. Only gets used if `render` is _not_ used
    */
   text: PropTypes.string,
+  /**
+   * Analytics tracking function(s) will not be called
+   */
+  disableAnalytics: PropTypes.bool,
 };
 
 export default PromoBanner;


### PR DESCRIPTION
## Description
Sorry - forgot to add the standard disable bool to [this PR](https://github.com/department-of-veterans-affairs/component-library/pull/60). :roll_eyes: 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
