### PR TITLE
Add white action link to storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@babel/plugin-proposal-throw-expressions": "^7.12.1",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/preset-env": "^7.12.10",
-    "@department-of-veterans-affairs/formation": "6.14.0",
+    "@department-of-veterans-affairs/formation": "6.15.0",
     "@storybook/addon-a11y": "6.1.21",
     "@storybook/addon-actions": "6.1.21",
     "@storybook/addon-essentials": "6.1.21",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@babel/plugin-proposal-throw-expressions": "^7.12.1",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/preset-env": "^7.12.10",
-    "@department-of-veterans-affairs/formation": "6.15.0",
+    "@department-of-veterans-affairs/formation": "6.15.1",
     "@storybook/addon-a11y": "6.1.21",
     "@storybook/addon-actions": "6.1.21",
     "@storybook/addon-essentials": "6.1.21",

--- a/stories/action-link.stories.mdx
+++ b/stories/action-link.stories.mdx
@@ -9,3 +9,9 @@ import { Meta, Canvas } from '@storybook/addon-docs/blocks';
 <Canvas>
   <a className="va-action-link--green" href="#">Call to action</a>
 </Canvas>
+
+<Canvas>
+  <div class="usa-background-dark" style={{ padding: '10px 0 20px' }}>
+    <a className="va-action-link--white" href="#">Call to action</a>
+  </div>
+</Canvas>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,10 +1239,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@department-of-veterans-affairs/formation@6.14.0":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.14.0.tgz#6a58f95920dd596d5ec0815155fe3b927c8b0736"
-  integrity sha512-gJVyk8eaiSgFc7mvmn8tIoE04CTL6Q6IW4ri66Brx72OqvS7nAj82/aK+GQ2uJMfIUaS591YFw3F07ZAhVorWQ==
+"@department-of-veterans-affairs/formation@6.15.0":
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.15.1.tgz#17eef0b979d9ccf18a756141d8d8431e1bfe8268"
+  integrity sha512-hYLaR6IDN4Wk0PW8phD7LnrwYFp0L20ehJCbusEmPa2lJwujQRmQP52SDYlR+VutGswkvDfD5sv5RgJ97VIIMQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,7 +1239,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@department-of-veterans-affairs/formation@6.15.0":
+"@department-of-veterans-affairs/formation@6.15.1":
   version "6.15.1"
   resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.15.1.tgz#17eef0b979d9ccf18a756141d8d8431e1bfe8268"
   integrity sha512-hYLaR6IDN4Wk0PW8phD7LnrwYFp0L20ehJCbusEmPa2lJwujQRmQP52SDYlR+VutGswkvDfD5sv5RgJ97VIIMQ==


### PR DESCRIPTION
## Description
Along with this PR in veteran-facing-services-tools, closes https://app.zenhub.com/workspaces/vsp-design-system-5f8de67192551b0012ebb802/issues/department-of-veterans-affairs/va.gov-team/22151

## Testing done
Visual testing using the `feat/22151--white-action-link` branch on [veteran-facing-services-tools](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/602)

## Screenshots
<img width="459" alt="image" src="https://user-images.githubusercontent.com/12739849/113335016-66d66680-92f2-11eb-9f61-ccc394f66dee.png">

![white-link-hover](https://user-images.githubusercontent.com/12739849/113335989-b8cbbc00-92f3-11eb-80a9-29cc0ca31e1a.gif)

## Acceptance criteria
- [ ] White action link is shown on storybook action links page
- [ ] hover and focus behaviors match details from https://design.va.gov/components/action-links

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
