### PR TITLE
add optional accordion subheader to storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
     "react-router": "3",
     "rimraf": "^3.0.2",
     "sinon": "^9.2.2",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.3.0"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0"
   }
 }

--- a/stories/va-accordion.stories.jsx
+++ b/stories/va-accordion.stories.jsx
@@ -39,6 +39,33 @@ const Template = args => {
   );
 };
 
+const TemplateSubheader = args => {
+  const { level, ...rest } = args;
+  return (
+    <va-accordion {...rest}>
+      <va-accordion-item
+        level={level}
+        header="First Amendment"
+        subheader="First Amendment Subheader"
+      >
+        Congress shall make no law respecting an establishment of religion, or
+        prohibiting the free exercise thereof; or abridging the freedom of
+        speech, or of the press; or the right of the people peaceably to
+        assemble, and to petition the Government for a redress of grievances.
+      </va-accordion-item>
+      <va-accordion-item
+        level={level}
+        header="Second Amendment"
+        subheader="Second Amendment Subheader"
+      >
+        A well regulated Militia, being necessary to the security of a free
+        State, the right of the people to keep and bear Arms, shall not be
+        infringed.
+      </va-accordion-item>
+    </va-accordion>
+  );
+};
+
 const defaultArgs = {
   multi: false,
   bordered: false,
@@ -66,4 +93,9 @@ export const ChangeHeaderLevel = Template.bind({});
 ChangeHeaderLevel.args = {
   ...defaultArgs,
   level: 4,
+};
+
+export const Subheader = TemplateSubheader.bind({});
+Subheader.args = {
+  ...defaultArgs,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -11593,9 +11593,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.3.0":
-  version "0.3.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#92a40a745b5616432ddff0815b4db8f9d930c349"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0":
+  version "0.4.0"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#23d3c19611e4ce4704b213082b2c971c85b430ef"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description
Closes https://app.zenhub.com/workspaces/vsp-design-system-5f8de67192551b0012ebb802/issues/department-of-veterans-affairs/vets-design-system-documentation/412

## Testing done
Visual in storybook

## Screenshots
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/12739849/114414616-f98dc580-9b7c-11eb-98c3-71763756791b.png">


## Acceptance criteria
- [ ] adds subheader section to va-accordion story

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
