### PR TITLE
Add package version number to analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/AlertBox/AlertBox.unit.spec.jsx
+++ b/src/components/AlertBox/AlertBox.unit.spec.jsx
@@ -177,6 +177,7 @@ describe('<AlertBox />', () => {
               backgroundOnly: true,
               closeable: false,
             },
+            version: sinon.match.string,
           }),
         ),
       ).to.be.true;
@@ -211,6 +212,7 @@ describe('<AlertBox />', () => {
               backgroundOnly: true,
               closeable: false,
             },
+            version: sinon.match.string,
           }),
         ),
       ).to.be.true;

--- a/src/components/Breadcrumbs/Breadcrumbs.unit.spec.jsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.unit.spec.jsx
@@ -255,6 +255,7 @@ describe('<Breadcrumbs>', () => {
               totalLevels: 3,
               mobileFirstProp: undefined,
             },
+            version: sinon.match.string,
           }),
         ),
       ).to.be.true;

--- a/src/components/LoadingIndicator/LoadingIndicator.unit.spec.jsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.unit.spec.jsx
@@ -61,6 +61,7 @@ describe('<LoadingIndicator>', () => {
               displayTime: sinon.match.number,
               message: 'Loading',
             },
+            version: sinon.match.string,
           }),
         ),
       ).to.be.true;

--- a/src/components/Modal/Modal.unit.spec.jsx
+++ b/src/components/Modal/Modal.unit.spec.jsx
@@ -141,18 +141,7 @@ describe('<Modal/>', () => {
 
   describe('analytics event', function () {
     it('should be triggered when modal is visible', () => {
-      const handleAnalyticsEvent = e => {
-        expect(e.detail).to.eql({
-          componentName: 'Modal',
-          action: 'show',
-          details: {
-            status: undefined,
-            title: undefined,
-            primaryButtonText: undefined,
-            secondaryButtonText: undefined,
-          },
-        });
-      };
+      const handleAnalyticsEvent = sinon.spy();
 
       global.document.body.addEventListener(
         'component-library-analytics',
@@ -165,6 +154,22 @@ describe('<Modal/>', () => {
         </Modal>,
       );
 
+      expect(
+        handleAnalyticsEvent.calledWith(
+          sinon.match.has('detail', {
+            componentName: 'Modal',
+            action: 'show',
+            details: {
+              status: undefined,
+              title: undefined,
+              primaryButtonText: undefined,
+              secondaryButtonText: undefined,
+            },
+            version: sinon.match.string,
+          }),
+        ),
+      ).to.be.true;
+
       global.document.body.removeEventListener(
         'component-library-analytics',
         handleAnalyticsEvent,
@@ -174,18 +179,7 @@ describe('<Modal/>', () => {
     });
 
     it('should include title when present', () => {
-      const handleAnalyticsEvent = e => {
-        expect(e.detail).to.eql({
-          componentName: 'Modal',
-          action: 'show',
-          details: {
-            status: undefined,
-            title: 'My modal title',
-            primaryButtonText: undefined,
-            secondaryButtonText: undefined,
-          },
-        });
-      };
+      const handleAnalyticsEvent = sinon.spy();
 
       global.document.body.addEventListener(
         'component-library-analytics',
@@ -203,6 +197,22 @@ describe('<Modal/>', () => {
           Modal contents
         </Modal>,
       );
+
+      expect(
+        handleAnalyticsEvent.calledWith(
+          sinon.match.has('detail', {
+            componentName: 'Modal',
+            action: 'show',
+            details: {
+              status: undefined,
+              title: 'My modal title',
+              primaryButtonText: undefined,
+              secondaryButtonText: undefined,
+            },
+            version: sinon.match.string,
+          }),
+        ),
+      ).to.be.true;
 
       global.document.body.removeEventListener(
         'component-library-analytics',

--- a/src/components/ProgressBar/ProgressBar.unit.spec.jsx
+++ b/src/components/ProgressBar/ProgressBar.unit.spec.jsx
@@ -38,6 +38,7 @@ describe('<ProgressBar/>', () => {
               percent: 0,
               label: 'This is my ProgressBar.',
             },
+            version: sinon.match.string,
           }),
         ),
       ).to.be.true;
@@ -75,6 +76,7 @@ describe('<ProgressBar/>', () => {
               percent: 100,
               label: 'This is my ProgressBar.',
             },
+            version: sinon.match.string,
           }),
         ),
       ).to.be.true;

--- a/src/components/PromoBanner/PromoBanner.unit.spec.jsx
+++ b/src/components/PromoBanner/PromoBanner.unit.spec.jsx
@@ -68,6 +68,7 @@ describe('<PromoBanner>', () => {
               target: defaultProps.target,
               type: defaultProps.type,
             },
+            version: sinon.match.string,
           }),
         ),
       ).to.be.true;

--- a/src/components/SegmentedProgressBar/SegmentedProgressBar.unit.spec.jsx
+++ b/src/components/SegmentedProgressBar/SegmentedProgressBar.unit.spec.jsx
@@ -39,6 +39,7 @@ describe('<SegmentedProgressBar/>', () => {
               current: 0,
               total: 5,
             },
+            version: sinon.match.string,
           }),
         ),
       ).to.be.true;
@@ -72,6 +73,7 @@ describe('<SegmentedProgressBar/>', () => {
               current: 1,
               total: 5,
             },
+            version: sinon.match.string,
           }),
         ),
       ).to.be.true;

--- a/src/helpers/analytics.js
+++ b/src/helpers/analytics.js
@@ -1,3 +1,5 @@
+import packageJSON from '../../package.json';
+
 /**
  * Dispatch a custom JavaScript event on document.body for tracking analytics.
  * A separate event listener will be required to record the events to GA.
@@ -6,6 +8,8 @@
  * event.action {string} - The action that triggered the analytics event
  * event.details {object} - Contains any number of key-value pairs to further describe the analytics event
  */
+
+const version = packageJSON.version;
 
 export default function dispatchAnalyticsEvent({
   componentName,
@@ -17,6 +21,7 @@ export default function dispatchAnalyticsEvent({
       componentName,
       action,
       details,
+      version,
     },
   });
   document.body.dispatchEvent(event);


### PR DESCRIPTION
## Description
For: https://github.com/department-of-veterans-affairs/va.gov-team/issues/22168

Analytics and Insights would like the component-library version to be included in the analytics event.

I also fixed the modal tests to match the new flavor.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
