### PR TITLE
Fix the spacing around the subheader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-library",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components/va-accordion/va-accordion-item.css
+++ b/src/components/va-accordion/va-accordion-item.css
@@ -62,4 +62,6 @@ button[aria-expanded='false'] {
 
 p {
   font-weight: 400;
+  line-height: 26px;
+  margin: 0;
 }


### PR DESCRIPTION
## Description
@rtwell pointed out some spacing weirdness with the `<va-accordion>` component with a subheader, so this aims to fix it.

Related to https://github.com/department-of-veterans-affairs/component-library/pull/73

## Testing done

Storybook :eyes: 


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/116456353-09f99d80-a817-11eb-910e-70015a649c96.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
