### PR TITLE
Update web-components dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
     "react-router": "3",
     "rimraf": "^3.0.2",
     "sinon": "^9.2.2",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11593,9 +11593,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0":
-  version "0.4.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#23d3c19611e4ce4704b213082b2c971c85b430ef"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.1":
+  version "0.4.1"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#f05bec344e73e03254f4ee2af1d8e322d4da893c"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

Storybook update for the changes in #82 

The Subheaders story for `<va-accordion>` now has improved spacing

## Testing done

Storybook :eyes: 


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/116460830-5c898880-a81c-11eb-81c2-02e1c70760ad.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
