### PR TITLE
Make the address block a story

### DIFF
--- a/stories/address-block.stories.mdx
+++ b/stories/address-block.stories.mdx
@@ -3,10 +3,12 @@ import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 <Meta title="Components/Address block" />
 
 <Canvas>
-  <p class="va-address-block">
-    Department of Veterans Affairs Claims Intake Center <br/>
-    Attention: C-123 Claims<br/>
-    PO Box 5088<br/>
-    Janesville, WI 53547-5088<br/>
-  </p>
+  <Story name="Default">
+    <p class="va-address-block">
+      Department of Veterans Affairs Claims Intake Center <br/>
+      Attention: C-123 Claims<br/>
+      PO Box 5088<br/>
+      Janesville, WI 53547-5088<br/>
+    </p>
+  </Story>
 </Canvas>


### PR DESCRIPTION
## Description
Adds a `<Story>` to the address block so design.va.gov/components/address-block can point to it in the iframe. Doing so will remove the unsightly canvas box on that page.

## Testing done
Storybook :eyes: 

## Screenshots
**Storybook**
![image](https://user-images.githubusercontent.com/12970166/117204970-d7ffb280-ada5-11eb-9211-082d9ce7c36e.png)

**design.va.gov: Before**
![image](https://user-images.githubusercontent.com/12970166/117205029-e9e15580-ada5-11eb-9480-2d1a1691cb0c.png)

**design.va.gov: After**
![image](https://user-images.githubusercontent.com/12970166/117204881-c0c0c500-ada5-11eb-8bc5-19ba63a1d6cc.png)