### PR TITLE
Issue with RadioButtons tests on vets-website

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/RadioButtons/RadioButtons.jsx
+++ b/src/components/RadioButtons/RadioButtons.jsx
@@ -52,7 +52,7 @@ class RadioButtons extends React.Component {
 
   handleChange(domEvent) {
     const optionValue = domEvent.target.value;
-    const optionLabel = domEvent.target.parentElement.querySelector(
+    const optionLabel = domEvent.target.parentElement?.querySelector(
       `label[for="${domEvent.target.id}"`,
     ).innerText;
 


### PR DESCRIPTION
## Description

@cvalarida - Some issues with the new RadioButton analytics snuck by me.  I published and panic unpublished (sorry).

![image](https://user-images.githubusercontent.com/62304138/117392572-56e90e00-aec0-11eb-9b81-87a178bd6857.png)

The issue is with test like this:

https://github.com/department-of-veterans-affairs/vets-website/blob/0c29a0b4dac10e7b2876d7314c19aedf25c2830c/src/applications/edu-benefits/tests/components/EducationWizard.unit.spec.jsx

```js
function answerQuestion(tree, name, value) {
  getQuestion(tree, name).simulate('change', { target: { value } });
}
```

When `target` is set like this, our `target.parentElement` value is undefined...
```
domEvent.target:                { value: 'yes' }
domEvent.target.parentElement:  undefined
```
...and the label querySelector fails.

Any ideas on how to address this?  Should we...

1. Optional Chain the selector `domEvent.target.parentElement?.querySelector` to avoid the error?
2. Revert to my `data-label` attribute and update all these tests to pass it in?
3. ???


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
