### PR TITLE
Wrap sidenav in a story so we can use the iframe

### DIFF
--- a/stories/process-list.stories.mdx
+++ b/stories/process-list.stories.mdx
@@ -3,7 +3,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 <Meta title="Components/Process list" />
 
 <Canvas>
-  <Story name="default">
+  <Story name="Default">
     <ol class="process">
       <li class="process-step list-one">
         <b>Heading for step one.</b><br/>

--- a/stories/process-list.stories.mdx
+++ b/stories/process-list.stories.mdx
@@ -1,20 +1,22 @@
-import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 <Meta title="Components/Process list" />
 
 <Canvas>
-  <ol class="process">
-    <li class="process-step list-one">
-      <b>Heading for step one.</b><br/>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-   </li>
-    <li class="process-step list-two">
-      <b>Heading for step two.</b><br/>
-      Sed sed mi mattis orci posuere suscipit. Nunc eu sapien sit amet nibh finibus rutrum. Duis sit amet libero sapien. Nam cursus lobortis tincidunt.
-    </li>
-    <li class="process-step list-three">
-      <b>Heading for step three.</b><br/>
-      Fusce sit amet egestas elit, id suscipit dolor. Nam sed augue nibh. In euismod aliquam lacinia
-   </li>
-  </ol>
+  <Story name="default">
+    <ol class="process">
+      <li class="process-step list-one">
+        <b>Heading for step one.</b><br/>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </li>
+      <li class="process-step list-two">
+        <b>Heading for step two.</b><br/>
+        Sed sed mi mattis orci posuere suscipit. Nunc eu sapien sit amet nibh finibus rutrum. Duis sit amet libero sapien. Nam cursus lobortis tincidunt.
+      </li>
+      <li class="process-step list-three">
+        <b>Heading for step three.</b><br/>
+        Fusce sit amet egestas elit, id suscipit dolor. Nam sed augue nibh. In euismod aliquam lacinia
+      </li>
+    </ol>
+  </Story>
 </Canvas>

--- a/stories/sidenav.stories.mdx
+++ b/stories/sidenav.stories.mdx
@@ -5,7 +5,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 <!-- Do we even need this? -->
 
 <Canvas>
-  <Story name="default">
+  <Story name="Default">
     <div>
       <button type="button" class="va-btn-sidebarnav-trigger" aria-controls="va-detailpage-sidebar">
         <span>

--- a/stories/sidenav.stories.mdx
+++ b/stories/sidenav.stories.mdx
@@ -1,11 +1,11 @@
-import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
 <Meta title="Components/Sidenav" />
 
 <!-- Do we even need this? -->
 
 <Canvas>
-  <>
+  <Story name="default">
     <div>
       <button type="button" class="va-btn-sidebarnav-trigger" aria-controls="va-detailpage-sidebar">
         <span>
@@ -93,5 +93,5 @@ import { Canvas, Meta } from '@storybook/addon-docs/blocks';
         </div>
       </div>
     </div>
-  </>
+  </Story>
 </Canvas>


### PR DESCRIPTION
## Description

This is for a PR for the design site which will use a Storybook iframe for the sidenav and process list interactive "components": https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/458

Wrap the following components in a `<Story>` tag:
- Process list
- Sidenav 

## Testing done

Local storybook :eyes: 


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/117495131-158d4880-af2a-11eb-80cf-a5fae7d4edbd.png)

![image](https://user-images.githubusercontent.com/2008881/117499371-ff828680-af2f-11eb-9ca3-a7188c1e389a.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
