### PR TITLE
Change ProgressBar, SegmentedProgressBar, and LoadingIndicator analytics to opt-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/LoadingIndicator/LoadingIndicator.jsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.jsx
@@ -18,14 +18,16 @@ export default class LoadingIndicator extends React.Component {
   }
 
   componentWillUnmount() {
-    dispatchAnalyticsEvent({
-      componentName: 'LoadingIndicator',
-      action: 'displayed',
-      details: {
-        displayTime: Date.now() - this.state.loadingStartTime,
-        message: this.props.message,
-      },
-    });
+    if (this.props.enableAnalytics) {
+      dispatchAnalyticsEvent({
+        componentName: 'LoadingIndicator',
+        action: 'displayed',
+        details: {
+          displayTime: Date.now() - this.state.loadingStartTime,
+          message: this.props.message,
+        },
+      });
+    }
   }
 
   render() {
@@ -63,6 +65,11 @@ LoadingIndicator.propTypes = {
    * An aXe label
    */
   label: PropTypes.string,
+  /**
+   * Analytics tracking function(s) will be called. Form components
+   * are disabled by default due to PII/PHI concerns.
+   */
+  enableAnalytics: PropTypes.bool,
 };
 
 LoadingIndicator.defaultProps = {

--- a/src/components/LoadingIndicator/LoadingIndicator.unit.spec.jsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.unit.spec.jsx
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 import React from 'react';
 import sinon from 'sinon';
-import { axeCheck, mountToDiv } from '../../helpers/test-helpers';
+import {
+  axeCheck,
+  mountToDiv,
+  testAnalytics,
+} from '../../helpers/test-helpers';
 
 import LoadingIndicator from './LoadingIndicator.jsx';
 
@@ -40,24 +44,14 @@ describe('<LoadingIndicator>', () => {
           enableAnalytics
         />
       );
-      const handleAnalyticsEvent = sinon.spy();
 
       const mountedComponent = mountToDiv(component, 'loadingContainer');
-
-      global.document.body.addEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
-
-      mountedComponent.unmount();
-
-      global.document.body.removeEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
+      const spy = testAnalytics(mountedComponent, () => {
+        mountedComponent.unmount();
+      });
 
       expect(
-        handleAnalyticsEvent.calledWith(
+        spy.calledWith(
           sinon.match.has('detail', {
             componentName: 'LoadingIndicator',
             action: 'displayed',

--- a/src/components/LoadingIndicator/LoadingIndicator.unit.spec.jsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.unit.spec.jsx
@@ -34,7 +34,11 @@ describe('<LoadingIndicator>', () => {
   describe('analytics event', function () {
     it('should be triggered when component is unmounted', () => {
       const component = (
-        <LoadingIndicator message="Loading" label="aria label here" />
+        <LoadingIndicator
+          message="Loading"
+          label="aria label here"
+          enableAnalytics
+        />
       );
       const handleAnalyticsEvent = sinon.spy();
 

--- a/src/components/ProgressBar/ProgressBar.jsx
+++ b/src/components/ProgressBar/ProgressBar.jsx
@@ -2,9 +2,9 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import dispatchAnalyticsEvent from '../../helpers/analytics';
 
-export default function ProgressBar({ percent, label, disableAnalytics }) {
+export default function ProgressBar({ percent, label, enableAnalytics }) {
   useEffect(() => {
-    if (!disableAnalytics && (percent === 0 || percent === 100)) {
+    if (enableAnalytics && (percent === 0 || percent === 100)) {
       dispatchAnalyticsEvent({
         componentName: 'ProgressBar',
         action: 'change',
@@ -42,9 +42,10 @@ ProgressBar.propTypes = {
    */
   label: PropTypes.string,
   /**
-   * Analytics tracking function(s) will not be called
+   * Analytics tracking function(s) will be called. Form components
+   * are disabled by default due to PII/PHI concerns.
    */
-  disableAnalytics: PropTypes.bool,
+  enableAnalytics: PropTypes.bool,
 };
 
 ProgressBar.defaultProps = {

--- a/src/components/ProgressBar/ProgressBar.unit.spec.jsx
+++ b/src/components/ProgressBar/ProgressBar.unit.spec.jsx
@@ -5,6 +5,7 @@ import { axeCheck } from '../../helpers/test-helpers';
 import sinon from 'sinon';
 
 import ProgressBar from './ProgressBar.jsx';
+import { testAnalytics } from '../../helpers/test-helpers';
 
 describe('<ProgressBar/>', () => {
   it('should render', () => {
@@ -18,23 +19,20 @@ describe('<ProgressBar/>', () => {
 
   describe('analytics event', function () {
     it('should be triggered when a ProgressBar is mounted at 0%', () => {
-      const handleAnalyticsEvent = sinon.spy();
+      let tree;
 
-      global.document.body.addEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
-
-      const tree = mount(
-        <ProgressBar
-          percent={0}
-          label="This is my ProgressBar."
-          enableAnalytics
-        />,
-      );
+      const spy = testAnalytics(tree, () => {
+        tree = mount(
+          <ProgressBar
+            percent={0}
+            label="This is my ProgressBar."
+            enableAnalytics
+          />,
+        );
+      });
 
       expect(
-        handleAnalyticsEvent.calledWith(
+        spy.calledWith(
           sinon.match.has('detail', {
             componentName: 'ProgressBar',
             action: 'change',
@@ -47,22 +45,10 @@ describe('<ProgressBar/>', () => {
         ),
       ).to.be.true;
 
-      global.document.body.removeEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
-
       tree.unmount();
     });
 
     it('should be triggered when a ProgressBar updates to 100%', () => {
-      const handleAnalyticsEvent = sinon.spy();
-
-      global.document.body.addEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
-
       const tree = mount(
         <ProgressBar
           percent={42}
@@ -71,12 +57,14 @@ describe('<ProgressBar/>', () => {
         />,
       );
 
-      tree.setProps({ percent: 100 });
+      const spy = testAnalytics(tree, () => {
+        tree.setProps({ percent: 100 });
+      });
 
       // We should onnly see the 100% event
 
       expect(
-        handleAnalyticsEvent.calledOnceWith(
+        spy.calledOnceWith(
           sinon.match.has('detail', {
             componentName: 'ProgressBar',
             action: 'change',
@@ -88,11 +76,6 @@ describe('<ProgressBar/>', () => {
           }),
         ),
       ).to.be.true;
-
-      global.document.body.removeEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
 
       tree.unmount();
     });

--- a/src/components/ProgressBar/ProgressBar.unit.spec.jsx
+++ b/src/components/ProgressBar/ProgressBar.unit.spec.jsx
@@ -26,7 +26,11 @@ describe('<ProgressBar/>', () => {
       );
 
       const tree = mount(
-        <ProgressBar percent={0} label="This is my ProgressBar." />,
+        <ProgressBar
+          percent={0}
+          label="This is my ProgressBar."
+          enableAnalytics
+        />,
       );
 
       expect(
@@ -60,7 +64,11 @@ describe('<ProgressBar/>', () => {
       );
 
       const tree = mount(
-        <ProgressBar percent={42} label="This is my ProgressBar." />,
+        <ProgressBar
+          percent={42}
+          label="This is my ProgressBar."
+          enableAnalytics
+        />,
       );
 
       tree.setProps({ percent: 100 });

--- a/src/components/SegmentedProgressBar/SegmentedProgressBar.jsx
+++ b/src/components/SegmentedProgressBar/SegmentedProgressBar.jsx
@@ -12,11 +12,11 @@ import dispatchAnalyticsEvent from '../../helpers/analytics';
 export default function SegmentedProgressBar({
   current,
   total,
-  disableAnalytics,
+  enableAnalytics,
 }) {
   useEffect(() => {
     // Conditionally track events
-    if (!disableAnalytics) {
+    if (enableAnalytics) {
       dispatchAnalyticsEvent({
         componentName: 'SegmentedProgressBar',
         action: 'change',
@@ -60,7 +60,8 @@ SegmentedProgressBar.propTypes = {
    */
   total: PropTypes.number.isRequired,
   /**
-   * Analytics tracking function(s) will not be called
+   * Analytics tracking function(s) will be called. Form components
+   * are disabled by default due to PII/PHI concerns.
    */
-  disableAnalytics: PropTypes.bool,
+  enableAnalytics: PropTypes.bool,
 };

--- a/src/components/SegmentedProgressBar/SegmentedProgressBar.unit.spec.jsx
+++ b/src/components/SegmentedProgressBar/SegmentedProgressBar.unit.spec.jsx
@@ -5,6 +5,7 @@ import { axeCheck } from '../../helpers/test-helpers';
 import sinon from 'sinon';
 
 import SegmentedProgressBar from './SegmentedProgressBar.jsx';
+import { testAnalytics } from '../../helpers/test-helpers';
 
 describe('<SegmentedProgressBar/>', () => {
   it('should render', () => {
@@ -21,19 +22,16 @@ describe('<SegmentedProgressBar/>', () => {
 
   describe('analytics event', function () {
     it('should be triggered when a SegmentedProgressBar is mounted', () => {
-      const handleAnalyticsEvent = sinon.spy();
+      let tree;
 
-      global.document.body.addEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
-
-      const tree = mount(
-        <SegmentedProgressBar current={0} total={5} enableAnalytics />,
-      );
+      const spy = testAnalytics(tree, () => {
+        tree = mount(
+          <SegmentedProgressBar current={0} total={5} enableAnalytics />,
+        );
+      });
 
       expect(
-        handleAnalyticsEvent.calledWith(
+        spy.calledWith(
           sinon.match.has('detail', {
             componentName: 'SegmentedProgressBar',
             action: 'change',
@@ -46,30 +44,20 @@ describe('<SegmentedProgressBar/>', () => {
         ),
       ).to.be.true;
 
-      global.document.body.removeEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
-
       tree.unmount();
     });
 
     it('should be triggered when a SegmentedProgressBar is updated', () => {
-      const handleAnalyticsEvent = sinon.spy();
-
-      global.document.body.addEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
-
       const tree = mount(
         <SegmentedProgressBar current={0} total={5} enableAnalytics />,
       );
 
-      tree.setProps({ current: 1 });
+      const spy = testAnalytics(tree, () => {
+        tree.setProps({ current: 1 });
+      });
 
       expect(
-        handleAnalyticsEvent.calledWith(
+        spy.calledWith(
           sinon.match.has('detail', {
             componentName: 'SegmentedProgressBar',
             action: 'change',
@@ -81,11 +69,6 @@ describe('<SegmentedProgressBar/>', () => {
           }),
         ),
       ).to.be.true;
-
-      global.document.body.removeEventListener(
-        'component-library-analytics',
-        handleAnalyticsEvent,
-      );
 
       tree.unmount();
     });

--- a/src/components/SegmentedProgressBar/SegmentedProgressBar.unit.spec.jsx
+++ b/src/components/SegmentedProgressBar/SegmentedProgressBar.unit.spec.jsx
@@ -28,7 +28,9 @@ describe('<SegmentedProgressBar/>', () => {
         handleAnalyticsEvent,
       );
 
-      const tree = mount(<SegmentedProgressBar current={0} total={5} />);
+      const tree = mount(
+        <SegmentedProgressBar current={0} total={5} enableAnalytics />,
+      );
 
       expect(
         handleAnalyticsEvent.calledWith(
@@ -60,7 +62,9 @@ describe('<SegmentedProgressBar/>', () => {
         handleAnalyticsEvent,
       );
 
-      const tree = mount(<SegmentedProgressBar current={0} total={5} />);
+      const tree = mount(
+        <SegmentedProgressBar current={0} total={5} enableAnalytics />,
+      );
 
       tree.setProps({ current: 1 });
 


### PR DESCRIPTION
## Description
For: https://github.com/department-of-veterans-affairs/va.gov-team/issues/24499

Our event counts on ProgressBar, SegmentedProgressBar, and LoadingIndicator are waaaaay higher than expected.  We will need to make these opt-in to avoid hitting our monthly GA quota.

## TODO: write tests for disable state

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
