### PR TITLE
Add more storybook iframes

### DIFF
--- a/src/components/CheckboxGroup/CheckboxGroup.stories.jsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.jsx
@@ -19,8 +19,34 @@ const Template = args => (
 
 const defaultArgs = {
   label: 'Checkbox Group',
-  errorMessage: 'This is an error message',
   required: true,
+  options: [
+    {
+      label: 'Option one',
+      value: 'value',
+    },
+    {
+      label: 'Option two',
+      value: 'value',
+    },
+  ],
+  values: { key: 'value' },
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  ...defaultArgs,
+  errorMessage: 'This is an error message',
+};
+
+export const AdditionalContent = Template.bind({});
+AdditionalContent.args = {
+  ...defaultArgs,
   options: [
     {
       label: 'Checkbox label',
@@ -35,11 +61,4 @@ const defaultArgs = {
       additional: 'and another thing',
     },
   ],
-  values: { key: 'value' },
-};
-
-export const Default = Template.bind({});
-
-Default.args = {
-  ...defaultArgs,
 };

--- a/stories/featured-content.stories.mdx
+++ b/stories/featured-content.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks';
 
 <Meta title="Components/Featured content" />
 
@@ -9,16 +9,18 @@ Call attention to important blocks of content.
 Features are typically used to describe eligibility requirements.
 
 <Canvas>
-  <div class="feature">
-    <h3>If I’m a Veteran, can I get VR&amp;E benefits and services?</h3>
-    <p>You may be eligible for VR&amp;E benefits and services if you’re a Veteran, and you meet all of the requirements listed below.</p>
-    <p><strong>All of these must be true. You:</strong></p>
-    <ul>
-      <li>Didn’t receive a dishonorable discharge, <strong>and</strong></li>
-      <li>Have a service-connected disability rating of at least 10% from VA, <strong>and</strong></li>
-      <li><a href="#">Apply for VR&amp;E services</a></li>
-    </ul>
-  </div>
+  <Story name="Default">
+    <div class="feature">
+      <h3>If I’m a Veteran, can I get VR&amp;E benefits and services?</h3>
+      <p>You may be eligible for VR&amp;E benefits and services if you’re a Veteran, and you meet all of the requirements listed below.</p>
+      <p><strong>All of these must be true. You:</strong></p>
+      <ul>
+        <li>Didn’t receive a dishonorable discharge, <strong>and</strong></li>
+        <li>Have a service-connected disability rating of at least 10% from VA, <strong>and</strong></li>
+        <li><a href="#">Apply for VR&amp;E services</a></li>
+      </ul>
+    </div>
+  </Story>
 </Canvas>
 
 ## Guidance

--- a/stories/horizontal-rules.stories.mdx
+++ b/stories/horizontal-rules.stories.mdx
@@ -5,5 +5,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 # Stars
 
 <Canvas>
+  <Story name="Default">
     <div class="va-h-ruled--stars"></div>
+  </Story>
 </Canvas>

--- a/stories/labels.stories.mdx
+++ b/stories/labels.stories.mdx
@@ -3,5 +3,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 <Meta title="Components/Labels" />
 
 <Canvas>
-  <span class="usa-label">New</span>
+  <Story name="Default">
+    <span class="usa-label">New</span>
+  </Story>
 </Canvas>


### PR DESCRIPTION
## Description

Add some more `<Story>` wrappers so we can get iframes.

This should be merged before: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/464

This PR:

- simplifies the default story for `CheckboxGroup>` for documentation purposes
  - breaks the all-in-one appproach up into multiple stories
- wraps featured-content in a `<Story>` so we get an iframe
- wraps horizontal-rule in a `<Story>` so we get an iframe
- wraps labels in a `<Story>` so we get an iframe

## Testing done

Storybook :eyes: 


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
