### PR TITLE
Remove designer documentation & add stories

### DIFF
--- a/stories/buttons.stories.mdx
+++ b/stories/buttons.stories.mdx
@@ -1,119 +1,74 @@
 import { Meta, Canvas } from '@storybook/addon-docs/blocks';
 
-<Meta title="Designer Documentation/Buttons" parameters={{ previewTabs: { 'canvas': { hidden: true }}}} />
-
-# Buttons
-
-Use buttons to signal actions.
+<Meta title="Components/Buttons" />
 
 ## Default buttons
 
-The default buttons are the most commonly-used button on the site.
-
 <Canvas>
-  <div>
-    <button type="button" className="usa-button">Button</button>
-    <button type="button" className="usa-button usa-button-active">Active</button>
-    <button type="button" className="usa-button usa-button-hover">Hover</button>
-    <br/>
-    <a href="#" className="usa-button">Link button</a>
-    <a href="#" className="usa-button usa-button-active">Link button active</a>
-    <a href="#" className="usa-button usa-button-hover">Link button hover</a>
-  </div>
+  <Story name="Default">
+    <div>
+      <button type="button" className="usa-button">Button</button>
+      <button type="button" className="usa-button usa-button-active">Active</button>
+      <button type="button" className="usa-button usa-button-hover">Hover</button>
+      <br/>
+      <a href="#" className="usa-button">Link button</a>
+      <a href="#" className="usa-button usa-button-active">Link button active</a>
+      <a href="#" className="usa-button usa-button-hover">Link button hover</a>
+    </div>
+  </Story>
 </Canvas>
 
 ## Primary buttons
 
-Use the **primary** button for the primary action on a page.
-
-
 <Canvas>
-  <div>
-    <button type="button" class="usa-button-primary va-button-primary">Button</button>
-    <br/>
-    <a class="usa-button-primary va-button-primary" href="#">Link button</a>
-  </div>
+  <Story name="Primary">
+    <div>
+      <button type="button" class="usa-button-primary va-button-primary">Button</button>
+      <br/>
+      <a class="usa-button-primary va-button-primary" href="#">Link button</a>
+    </div>
+  </Story>
 </Canvas>
 
-
-### Research insight
-
-Our researchers learned that users were missing calls to action on some pages because the blue buttons did not stand out, so a green **primary** button was created, tested and determined to be successful.
-
-## Secondary button
-
-Use **secondary** buttons for any actions that need to be _downplayed_ against other actions.
-
+## Secondary buttons
 
 <Canvas>
-  <div>
-    <button class="usa-button-secondary">Button</button>
-    <button class="usa-button-secondary usa-button-active">Active</button>
-    <button class="usa-button-secondary usa-button-hover">Hover</button>
-    <br/>
-    <a href="#" class="usa-button usa-button-secondary">Link button</a>
-    <a href="#" class="usa-button usa-button-secondary usa-button-active">Link button active</a>
-    <a href="#" class="usa-button usa-button-secondary usa-button-hover">Link button hover</a>
-  </div>
+  <Story name="Secondary">
+    <div>
+      <button class="usa-button-secondary">Button</button>
+      <button class="usa-button-secondary usa-button-active">Active</button>
+      <button class="usa-button-secondary usa-button-hover">Hover</button>
+      <br/>
+      <a href="#" class="usa-button usa-button-secondary">Link button</a>
+      <a href="#" class="usa-button usa-button-secondary usa-button-active">Link button active</a>
+      <a href="#" class="usa-button usa-button-secondary usa-button-hover">Link button hover</a>
+    </div>
+  </Story>
 </Canvas>
 
 ## Big buttons
 
-Any button can be made bigger by adding a class name of `usa-button-big` to the button.
-
-
 <Canvas>
-  <div>
-    <button type="button" class="usa-button usa-button-big">Default button</button>
-    <button type="button" class="usa-button-primary va-button-primary usa-button-big">Button</button>
-    <button class="usa-button-secondary usa-button-big">Secondary button</button>
-    <br/>
-    <a href="#" class="usa-button usa-button-big">Default link button</a>
-    <a href="#" class="usa-button-primary va-button-primary usa-button-big">Primary link</a>
-    <a href="#" class="usa-button usa-button-secondary usa-button-big">Secondary link</a>
-  </div>
+  <Story name="Big">
+    <div>
+      <button type="button" class="usa-button usa-button-big">Default button</button>
+      <button type="button" class="usa-button-primary va-button-primary usa-button-big">Button</button>
+      <button class="usa-button-secondary usa-button-big">Secondary button</button>
+      <br/>
+      <a href="#" class="usa-button usa-button-big">Default link button</a>
+      <a href="#" class="usa-button-primary va-button-primary usa-button-big">Primary link</a>
+      <a href="#" class="usa-button usa-button-secondary usa-button-big">Secondary link</a>
+    </div>
+  </Story>
 </Canvas>
 
 ## Disabled buttons
 
-Only `<button>` elements can be disabled with a `disabled` attribute. To make a `<a>` element disabled, you must use `.usa-button.usa-button-disabled` on the element.
-
-
 <Canvas>
-  <div>
-    <button type="button" class="usa-button" disabled>Disabled button</button>
-    <a href="#" class="usa-button usa-button-disabled">Disabled link</a>
-  </div>
+  <Story name="Disabled">
+    <div>
+      <button type="button" class="usa-button" disabled>Disabled button</button>
+      <a href="#" class="usa-button usa-button-disabled">Disabled link</a>
+    </div>
+  </Story>
 </Canvas>
-
-
-## Guidance
-
-* Buttons can be applied to `<button>`, which are used for actions,  or `<a>`, which is used for hyperlinks to destinations. Read more about usage under [accessibility](#accessibility).
-* Generally, use primary buttons for actions that go to the next step and use secondary buttons for actions that happen on the current page.
-* When to use default (blue) versus primary (green) buttons: If there is only one button on the page, use a pimary (green) button. Especially if the button is surrounded by a lot of content. Primary (green) buttons are always isolated from other UI, and meant to draw attention to themselves. In most other cases, use a default (blue) button.
-* Style the button most users should click in a way that distinguishes from other buttons on the page. Try using the “large button” or the most visually distinct fill color.
-* Make sure buttons should look clickable—use color variations to distinguish static, hover and active states.
-* Avoid using too many buttons on a page.
-* Use sentence case for button labels.
-* Button labels should be as short as possible with “trigger words” that your users will recognize to clearly explain what will happen when the button is clicked (for example, “download,” “view” or “sign up”).
-* Make the first word of the button’s label a verb. For example, instead of “Complaint Filing” label the button “File a complaint.”
-* At times, consider adding an icon to signal specific actions (“download”, “open in a new window”, etc).
-* Read more about writing for buttons in the [content style guide](../content-style-guide/buttons.html)
-
-### When to use
-
-* Use buttons for the most important actions you want users to take on your site, such as "download," "sign up," or "sign out."
-
-### When to consider something else
-
-* If you want to lead users between pages of a website. Use links instead.
-* Less popular or less important actions may be visually styled as links.
-
-### Accessibility
-
-* When using the `<button>` element, always specify a `type`.
-* When using the `<a>` element, you may want to consider using `role="button"`.
-* Buttons should display a visible focus state when users tab to them.
-* Avoid using `<div>` or `<img>` tags to create buttons. Screen readers don't automatically know either is a usable button.
-* When styling links to look like buttons, remember that screen readers handle links slightly differently than they do buttons. Pressing the Space key triggers a button, but pressing the Enter key triggers a link.


### PR DESCRIPTION
Like it says on the tin, I
- Removed the designer-facing documentation
- Moved the stories under the `Components` sub-section
- Added `<Story>`s for use in iframes on design.va.gov
![image](https://user-images.githubusercontent.com/12970166/117894712-d173ae00-b271-11eb-8e29-a3c1d5465ff1.png)
![image](https://user-images.githubusercontent.com/12970166/117894733-da647f80-b271-11eb-98bd-7dc5228c9f11.png)
![image](https://user-images.githubusercontent.com/12970166/117894754-e2242400-b271-11eb-8209-6de81c26879a.png)
