### PR TITLE
Accordion color fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-components",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components/va-accordion/va-accordion-item.css
+++ b/src/components/va-accordion/va-accordion-item.css
@@ -37,14 +37,14 @@ button {
   display: block;
   /* This color assignment is for IE11 compatibility - the one in */
   /* the `<va-accordion>`'s CSS with `:host` doesn't work well */
-  color: var(--color-base);
+  color: var(--color-gray-dark);
 }
 
 button:hover {
   background-color: var(--color-gray-lighter);
   /* This color assignment is for IE11 compatibility - the one in */
   /* the `<va-accordion>`'s CSS with `:host` doesn't work well */
-  color: var(--color-base);
+  color: var(--color-gray-dark);
 }
 
 #content {

--- a/src/components/va-accordion/va-accordion.css
+++ b/src/components/va-accordion/va-accordion.css
@@ -1,7 +1,7 @@
 :host {
   display: block;
   width: 100%;
-  color: var(--color-base);
+  color: var(--color-gray-dark);
   --item-border: none; /* This is to overwrite any previous inherited value */
 }
 

--- a/src/global/variables.css
+++ b/src/global/variables.css
@@ -5,6 +5,7 @@
 :root {
   --color-base: #212121;
   --color-white: #ffffff;
+  --color-gray-dark: #323a45;
   --color-gray-light: #aeb0b5;
   --color-gray-lighter: #d6d7d9;
   --color-gray-lightest: #f1f1f1;


### PR DESCRIPTION
## Description
Addresses the issue mentioned by @rtwell: https://dsva.slack.com/archives/G01BJ3ESXL4/p1620912808066400

## Testing done

Storybook :eyes: 


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/118165110-c7b88a80-b3d8-11eb-8760-4bfa36d9fae3.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
