### PR TITLE
Use branch with color fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "sass-loader": "^8.0.2",
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-accordion-color-fix"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "sass-loader": "^8.0.2",
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.5.0"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-accordion-color-fix"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12956,9 +12956,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.5.0":
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-accordion-color-fix":
   version "0.5.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#f2250ee009e8feb811a9cd8b75457f849b6ed8be"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#2b74f2938339c81bd0f6f87007edd1842c13de50"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12956,9 +12956,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-accordion-color-fix":
-  version "0.5.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#2b74f2938339c81bd0f6f87007edd1842c13de50"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1":
+  version "0.6.1"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#b892c5ba2252fbe8800c0e1e7fdc9fdaa90846f5"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

Do not merge until https://github.com/department-of-veterans-affairs/component-library/pull/94 is merged and there is a release.

This updates storybook to show the accordion web component with the correct color.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
