### PR TITLE
feat(TextInput): Add new ariaDescribedBy prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "sass-loader": "^8.0.2",
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.5.0"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1"
   }
 }

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -57,14 +57,14 @@ class TextInput extends React.Component {
   }
 
   render() {
+    let ariaDescribedBy = this.props.ariaDescribedBy;
     // Calculate error state.
     let errorSpan = '';
     let maxCharacters;
-    let errorSpanId = undefined;
     let inputErrorClass = undefined;
     let labelErrorClass = undefined;
     if (this.props.errorMessage) {
-      errorSpanId = `${this.inputId}-error-message`;
+      const errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
         <span className="usa-input-error-message" role="alert" id={errorSpanId}>
           <span className="sr-only">Error</span> {this.props.errorMessage}
@@ -72,6 +72,9 @@ class TextInput extends React.Component {
       );
       inputErrorClass = 'usa-input-error';
       labelErrorClass = 'usa-input-error-label';
+      ariaDescribedBy = ariaDescribedBy
+        ? `${ariaDescribedBy} ${errorSpanId}`
+        : errorSpanId;
     }
 
     // Calculate max characters and display '(Max. XX characters)' when max is hit.
@@ -98,7 +101,7 @@ class TextInput extends React.Component {
         {errorSpan}
         <input
           className={this.props.additionalClass}
-          aria-describedby={errorSpanId}
+          aria-describedby={ariaDescribedBy}
           id={this.inputId}
           placeholder={this.props.placeholder}
           name={this.props.name}
@@ -160,6 +163,11 @@ TextInput.propTypes = {
    * Called when input value is changed
    */
   onValueChange: PropTypes.func.isRequired,
+  /**
+   * Sets the aria-describedby attribute
+   */
+  /* eslint-disable consistent-return */
+  ariaDescribedBy: PropTypes.string,
   /**
    * `<input>` type attribute
    */

--- a/src/components/TextInput/TextInput.unit.spec.jsx
+++ b/src/components/TextInput/TextInput.unit.spec.jsx
@@ -239,6 +239,61 @@ describe('<TextInput>', () => {
     return check;
   });
 
+  it('passes aXe check when error and ariaDescribedBy present', () => {
+    const check = axeCheck(
+      <TextInput
+        field={makeField('')}
+        label="test"
+        placeholder="Placeholder"
+        errorMessage="error"
+        onValueChange={value => value}
+        ariaDescribedBy="described-by-this-id"
+      />,
+    );
+
+    return check;
+  });
+
+  it('renders ariaDescribedBy as aria-describedby attribute when errorMessage attribute is not present', () => {
+    const describedById = 'described-by-this-id';
+    const wrapper = shallow(
+      <TextInput
+        field={makeField('')}
+        label="test"
+        onValueChange={value => value}
+        ariaDescribedBy={describedById}
+      />,
+    );
+
+    const attribute = wrapper.find('input').prop('aria-describedby');
+    expect(attribute).to.exist;
+    expect(attribute).to.eql(describedById);
+    wrapper.unmount();
+  });
+
+  it('renders concatenated aria-describedby attribute when errorMessage attribute and ariaDescribedBy is present', () => {
+    const describedById = 'described-by-this-id';
+    const wrapper = shallow(
+      <TextInput
+        field={makeField('')}
+        label="test"
+        errorMessage="errorMessage"
+        onValueChange={value => value}
+        ariaDescribedBy={describedById}
+      />,
+    );
+
+    const input = wrapper.find('input');
+    const errorMessageId = wrapper
+      .find('.usa-input-error-message')
+      .first()
+      .prop('id');
+    const concatenatedAriaDescribedByIds = `${describedById} ${errorMessageId}`;
+    const ariaDescribedBy = input.prop('aria-describedby');
+    expect(ariaDescribedBy).to.eql(concatenatedAriaDescribedByIds);
+    wrapper.unmount();
+  });
+
   describe('analytics event', function () {
     it('should NOT be triggered when enableAnalytics is not true', () => {
       const wrapper = mount(

--- a/src/components/TextInput/TextInput.unit.spec.jsx
+++ b/src/components/TextInput/TextInput.unit.spec.jsx
@@ -266,7 +266,6 @@ describe('<TextInput>', () => {
     );
 
     const attribute = wrapper.find('input').prop('aria-describedby');
-    expect(attribute).to.exist;
     expect(attribute).to.eql(describedById);
     wrapper.unmount();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12956,9 +12956,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.5.0":
-  version "0.5.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#f2250ee009e8feb811a9cd8b75457f849b6ed8be"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1":
+  version "0.6.1"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#b892c5ba2252fbe8800c0e1e7fdc9fdaa90846f5"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description
Addresses the need for aria-describedby for TextInput.
[Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23616)
[Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23222)

## Testing done
Manual Storybook With axe
Unit Test added

## Screenshots
Only ariaDescribedBy:
![image](https://user-images.githubusercontent.com/83595736/118186579-e4ba8100-b40b-11eb-84fc-dc3afe50412e.png)
Both error and ariaDescribedBy:
![image](https://user-images.githubusercontent.com/83595736/118186715-0ae02100-b40c-11eb-896f-3c754a1f43d0.png)
No error or ariaDescribedBy:
![image](https://user-images.githubusercontent.com/83595736/118187258-b5584400-b40c-11eb-9b43-a1a338a08f2b.png)


## Acceptance criteria
- [ ] Allow additional prop ariaDescribedBy to be passed to TextInput

## Definition of done
[Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23616)
[Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23222)

