### PR TITLE
Unmount components in analytics tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.5.1",
+  "version": "2.5.3",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/Checkbox/Checkbox.unit.spec.jsx
+++ b/src/components/Checkbox/Checkbox.unit.spec.jsx
@@ -163,6 +163,8 @@ describe('<Checkbox/>', () => {
       });
 
       expect(spy.called).to.be.false;
+
+      wrapper.unmount();
     });
 
     it('should be triggered when Checkbox is checked', () => {
@@ -195,6 +197,8 @@ describe('<Checkbox/>', () => {
           }),
         ),
       ).to.be.true;
+
+      wrapper.unmount();
     });
   });
 });

--- a/src/components/CheckboxGroup/CheckboxGroup.unit.spec.jsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.unit.spec.jsx
@@ -91,6 +91,8 @@ describe('<CheckboxGroup>', () => {
       });
 
       expect(spy.called).to.be.false;
+
+      wrapper.unmount();
     });
 
     it('should be triggered when field is checked', () => {
@@ -133,6 +135,8 @@ describe('<CheckboxGroup>', () => {
           }),
         ),
       ).to.be.true;
+
+      wrapper.unmount();
     });
   });
 });

--- a/src/components/RadioButtons/RadioButtons.unit.spec.jsx
+++ b/src/components/RadioButtons/RadioButtons.unit.spec.jsx
@@ -134,6 +134,8 @@ describe('<RadioButtons>', () => {
       });
 
       expect(spy.called).to.be.false;
+
+      wrapper.unmount();
     });
 
     it('should be triggered when RadioButton is selected', () => {
@@ -166,6 +168,8 @@ describe('<RadioButtons>', () => {
           }),
         ),
       ).to.be.true;
+
+      wrapper.unmount();
     });
   });
 });

--- a/src/components/Select/Select.unit.spec.jsx
+++ b/src/components/Select/Select.unit.spec.jsx
@@ -258,6 +258,8 @@ describe('<Select>', () => {
       });
 
       expect(spy.called).to.be.false;
+
+      wrapper.unmount();
     });
 
     it('should be triggered when Select option is changed', () => {
@@ -291,6 +293,8 @@ describe('<Select>', () => {
           }),
         ),
       ).to.be.true;
+
+      wrapper.unmount();
     });
   });
 });

--- a/src/components/TextArea/TextArea.unit.spec.jsx
+++ b/src/components/TextArea/TextArea.unit.spec.jsx
@@ -223,6 +223,8 @@ describe('<TextArea>', () => {
       });
 
       expect(spy.called).to.be.false;
+
+      wrapper.unmount();
     });
 
     it('should be triggered when field is blurred', () => {
@@ -254,6 +256,8 @@ describe('<TextArea>', () => {
           }),
         ),
       ).to.be.true;
+
+      wrapper.unmount();
     });
   });
 });


### PR DESCRIPTION
## Description
Correct me if I'm wrong, but I should be unmounting these components even if they are shallow render.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
