### PR TITLE
Remove the Template pattern

### DIFF
--- a/src/components/DropDownPanel/DropDownPanel.stories.jsx
+++ b/src/components/DropDownPanel/DropDownPanel.stories.jsx
@@ -6,13 +6,12 @@ export default {
   component: DropDownPanel,
 };
 
-const Template = (args) => {
-  const [isOpen, setOpen] = useState(args.isOpen);
-
+export const Default = () => {
+  const [isOpen, setOpen] = useState(false);
   return (
     <div style={{ backgroundColor: '#112e51' }}>
       <DropDownPanel
-        {...args}
+        buttonText="Helpdesk"
         isOpen={isOpen}
         clickHandler={() => setOpen(!isOpen)}
       >
@@ -22,11 +21,3 @@ const Template = (args) => {
     </div>
   );
 };
-
-const defaultArgs = {
-  buttonText: 'Helpdesk',
-  isOpen: false,
-};
-
-export const Default = Template.bind({});
-Default.args = { ...defaultArgs };


### PR DESCRIPTION
## Description

The `Show code` button on the story for `<DropDownPanel>` is a bit misleading. It doesn't show the actual function for `clickHandler`, and the `isOpen` prop is ommited entirely (see screenshots). This PR removes the template/bind pattern that was apparently causing this. Solution is based on [this storybook issue comment](https://github.com/storybookjs/storybook/issues/11542#issuecomment-665193303)

Additional context in [a slack thread](https://dsva.slack.com/archives/CBU0KDSB1/p1621271386492300?thread_ts=1621268979.486700&cid=CBU0KDSB1).

## Testing done

Local storybook :eyes: 


## Screenshots

### Before

![image](https://user-images.githubusercontent.com/2008881/118534477-22662500-b6fe-11eb-9e9b-68b38a9b6712.png)


### After

![image](https://user-images.githubusercontent.com/2008881/118534520-2e51e700-b6fe-11eb-99e4-e00e023893ae.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
