### PR TITLE
Mark AlertBox as deprecated in storybook

### DIFF
--- a/src/components/AlertBox/AlertBox.jsx
+++ b/src/components/AlertBox/AlertBox.jsx
@@ -12,6 +12,9 @@ export const ALERT_TYPE = Object.freeze({
   CONTINUE: 'continue', // Green border, green lock
 });
 
+/**
+ * This component is no longer supported, please use `<va-alert>` instead.
+ */
 class AlertBox extends Component {
   constructor(props) {
     super(props);

--- a/src/components/AlertBox/AlertBox.stories.jsx
+++ b/src/components/AlertBox/AlertBox.stories.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import AlertBox, { ALERT_TYPE } from './AlertBox';
 
 export default {
-  title: 'Components/AlertBox',
+  title: 'Components/AlertBox (deprecated)',
   component: AlertBox,
   argTypes: {
     status: {


### PR DESCRIPTION
## Description
This is a follow-up to https://github.com/department-of-veterans-affairs/component-library/pull/74

Now that we have `<va-alert>` we should guide teams towards that and away from `<AlertBox>`.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
