### PR TITLE
Add aria-describedby to RadioButtons

### DIFF
--- a/src/components/RadioButtons/RadioButtons.jsx
+++ b/src/components/RadioButtons/RadioButtons.jsx
@@ -13,17 +13,19 @@ import dispatchAnalyticsEvent from '../../helpers/analytics';
  * A radio button group with a label.
  *
  * Validation has the following props.
-
- * `additionalFieldsetClass` - String for any additional fieldset classes.
- * `additionalLegendClass` - String for any additional legend classes.
- * `errorMessage' - String Error message for the radio button group
- * `label` - String for the group field label.
- * `name` - String for the name attribute.
- * `tabIndex` - Number for keyboard tab order.
- * `options` - Array of options to populate group.
- * `required` - is this field required.
- * `value` - string. Value of the select field.
- * `onValueChange` - a function with this prototype: (newValue)
+ *
+ * - `additionalFieldsetClass` String for any additional fieldset classes.
+ * - `additionalLegendClass` String for any additional legend classes.
+ * - `errorMessage` String Error message for the radio button group
+ * - `label` String for the group field label.
+ * - `name` String for the name attribute.
+ * - `tabIndex` Number for keyboard tab order.
+ * - `options` Array of options to populate group.
+ * - `required` is this field required.
+ * - `value` string. Value of the select field.
+ * - `onValueChange` a function with this prototype: (newValue)
+ * - `ariaDescribedby` Array matching the options, added when the option is
+ *   selected
  */
 class RadioButtons extends React.Component {
   constructor() {
@@ -112,6 +114,8 @@ class RadioButtons extends React.Component {
         optionValue === storedValue,
         optionValue,
       );
+      const ariaDescribedby =
+        (checked && this.props.ariaDescribedby?.[optionIndex]) || null;
 
       const radioButton = (
         <div
@@ -128,6 +132,7 @@ class RadioButtons extends React.Component {
               onKeyDown={this.props.onKeyDown}
               value={optionValue}
               onChange={this.handleChange}
+              aria-describedby={ariaDescribedby}
             />
 
             <label
@@ -273,6 +278,10 @@ RadioButtons.propTypes = {
    * are disabled by default due to PII/PHI concerns.
    */
   enableAnalytics: PropTypes.bool,
+  /**
+   * aria-describedby labels array based on the option index
+   */
+  ariaDescribedby: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default RadioButtons;

--- a/src/components/RadioButtons/RadioButtons.mdx
+++ b/src/components/RadioButtons/RadioButtons.mdx
@@ -34,12 +34,17 @@ import RadioButtons from '@department-of-veterans-affairs/component-library/Radi
     {
       label: 'option 3 label',
       value: 'expanding option 3',
-      additional: 'expanded option 3',
+      additional: <span id="option3">expanded option 3<span>,
     },
   ]}
   value={this.state.value}
   required={false}
   toolTipText= 'this triggers a tooltip'
+  ariaDescribedby={[
+    null,
+    null,
+    'option3',
+  ]}
 />
 ```
 
@@ -70,12 +75,17 @@ export class RenderedComponent extends React.Component {
             {
               label: 'option 3 label',
               value: 'expanding option 3',
-              additional: 'expanded option 3',
+              additional: <span id="option3">expanded option 3<span>,
             },
           ]}
           value={this.state.value}
           required={false}
-          toolTipText= 'this triggers a tooltip'
+          toolTipText='this triggers a tooltip'
+          ariaDescribedby={[
+            null,
+            null,
+            'option3',
+          ]}
         />
       </div>
     );

--- a/src/components/RadioButtons/RadioButtons.stories.jsx
+++ b/src/components/RadioButtons/RadioButtons.stories.jsx
@@ -51,6 +51,17 @@ Error.args = {
   },
 };
 
+export const AriaDescribedby = Template.bind({});
+AriaDescribedby.args = {
+  ...defaultArgs,
+  value: { value: 'First option' },
+  ariaDescribedby: [
+    'test1',
+    'test2',
+    null, // nothing to point to
+  ],
+};
+
 export const WithAnalytics = Template.bind({});
 WithAnalytics.args = {
   ...defaultArgs,

--- a/src/components/RadioButtons/RadioButtons.unit.spec.jsx
+++ b/src/components/RadioButtons/RadioButtons.unit.spec.jsx
@@ -18,6 +18,11 @@ describe('<RadioButtons>', () => {
     { value: 'no', label: 'No', additional: 'No additional' },
     'maybe',
   ];
+  const someExpandingOptionsWithId = [
+    'yes',
+    { value: 'no', label: 'No', additional: <span id="nope">Nope</span> },
+    'maybe',
+  ];
 
   it('calls onValueChange with value and dirty state', () => {
     let valueChanged;
@@ -82,6 +87,25 @@ describe('<RadioButtons>', () => {
     wrapper.unmount();
   });
 
+  it('renders a aria-describedby when option is selected', () => {
+    const wrapper = shallow(
+      <RadioButtons
+        label="test"
+        options={someExpandingOptionsWithId}
+        value={makeField('no')}
+        onValueChange={value => value}
+        ariaDescribedby={['yep', 'nope', 'maybep']}
+      />,
+    );
+
+    // Only the selected radio should have an aria-describedby defined
+    const result = [null, 'nope', null];
+    wrapper.find('input').forEach((input, index) => {
+      expect(input.prop('aria-describedby')).to.eql(result[index]);
+    });
+    wrapper.unmount();
+  });
+
   it('passes aXe check when only non-expanding options are rendered', () => {
     const check = axeCheck(
       <RadioButtons
@@ -113,6 +137,31 @@ describe('<RadioButtons>', () => {
         options={someExpandingOptions}
         value={makeField('test')}
         onValueChange={value => value}
+      />,
+    );
+    return check;
+  });
+
+  it('passes aXe check when aria-describedby targets expanding id', () => {
+    const check = axeCheck(
+      <RadioButtons
+        label="test"
+        options={someExpandingOptionsWithId}
+        value={makeField('no')}
+        onValueChange={value => value}
+        ariaDescribedby={[null, 'nope', null]}
+      />,
+    );
+    return check;
+  });
+  it('passes aXe check when aria-describedby does not target expanding id', () => {
+    const check = axeCheck(
+      <RadioButtons
+        label="test"
+        options={someExpandingOptionsWithId}
+        value={makeField('maybe')}
+        onValueChange={value => value}
+        ariaDescribedby={[null, 'nope', null]}
       />,
     );
     return check;


### PR DESCRIPTION
## Description

This PR adds an `aria-describedby` attribute to selected radio buttons to allow screenreaders to target content related to the selected choice. Only the selected option will include an `aria-describedby` label (see screenshot).

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/22569
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/22612

## Testing done

Updated unit tests

## Screenshots

<details><summary><code>aria-describedby</code> with ID not in DOM</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-03 at 11 14 46 AM](https://user-images.githubusercontent.com/136959/120677825-1946b900-c45d-11eb-9b7c-8f191be41cbd.png)</details>

## Acceptance criteria
- [x] `aria-describedby` added to selected radio buttons when defined

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
