### PR TITLE
Add aria-describedby to Date, Select & NumberInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/Date/Date.jsx
+++ b/src/components/Date/Date.jsx
@@ -27,7 +27,7 @@ class Date extends React.Component {
   }
 
   UNSAFE_componentWillMount() {
-    this.id = _.uniqueId('date-input-');
+    this.inputId = _.uniqueId('date-input-');
   }
 
   handleChange(path, update) {

--- a/src/components/Date/Date.jsx
+++ b/src/components/Date/Date.jsx
@@ -92,6 +92,10 @@ class Date extends React.Component {
       );
     }
 
+    const ariaDescribedby =
+      [errorSpanId, this.props.ariaDescribedby || ''].join(' ').trim() ||
+      undefined;
+
     return (
       <fieldset className={fieldsetClass}>
         <legend className="vads-u-font-size--base vads-u-font-weight--normal">
@@ -115,7 +119,7 @@ class Date extends React.Component {
                 onValueChange={update => {
                   this.handleChange('month', update);
                 }}
-                ariaDescribedby={this.props.ariaDescribedby}
+                ariaDescribedby={ariaDescribedby}
               />
             </div>
             <div className="form-datefield-day">
@@ -128,7 +132,7 @@ class Date extends React.Component {
                 onValueChange={update => {
                   this.handleChange('day', update);
                 }}
-                ariaDescribedby={this.props.ariaDescribedby}
+                ariaDescribedby={ariaDescribedby}
               />
             </div>
             <div className="usa-datefield usa-form-group usa-form-group-year">
@@ -143,7 +147,7 @@ class Date extends React.Component {
                 onValueChange={update => {
                   this.handleChange('year', update);
                 }}
-                ariaDescribedby={this.props.ariaDescribedby}
+                ariaDescribedby={ariaDescribedby}
               />
             </div>
           </div>

--- a/src/components/Date/Date.jsx
+++ b/src/components/Date/Date.jsx
@@ -2,7 +2,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import moment from 'moment';
 
 import Select from '../Select/Select';
 import NumberInput from '../NumberInput/NumberInput';
@@ -116,6 +115,7 @@ class Date extends React.Component {
                 onValueChange={update => {
                   this.handleChange('month', update);
                 }}
+                ariaDescribedby={this.props.ariaDescribedby}
               />
             </div>
             <div className="form-datefield-day">
@@ -128,6 +128,7 @@ class Date extends React.Component {
                 onValueChange={update => {
                   this.handleChange('day', update);
                 }}
+                ariaDescribedby={this.props.ariaDescribedby}
               />
             </div>
             <div className="usa-datefield usa-form-group usa-form-group-year">
@@ -142,6 +143,7 @@ class Date extends React.Component {
                 onValueChange={update => {
                   this.handleChange('year', update);
                 }}
+                ariaDescribedby={this.props.ariaDescribedby}
               />
             </div>
           </div>
@@ -194,6 +196,12 @@ Date.propTypes = {
   onValueChange: PropTypes.func.isRequired,
   requiredMessage: PropTypes.string,
   invalidMessage: PropTypes.string,
+  /**
+   * Add additional aria-describedby to the month, day & year elements.
+   * Note: make sure the ID exists on the page before adding this, or you'll
+   * have an WCAG violation
+   */
+  ariaDescribedby: PropTypes.string,
 };
 
 Date.defaultProps = {

--- a/src/components/Date/Date.mdx
+++ b/src/components/Date/Date.mdx
@@ -42,6 +42,7 @@ import Date from '@department-of-veterans-affairs/component-library/Date'
   date={this.state.date}
   requiredMessage='Please provide a response'
   invalidMessage='Please provide a valid date'
+  ariaDescribedby='some-id'
 />;
 ```
 

--- a/src/components/Date/Date.stories.jsx
+++ b/src/components/Date/Date.stories.jsx
@@ -9,11 +9,7 @@ export default {
 const Template = args => {
   const [date, setDate] = useState(args.date);
   return (
-    <Date
-      {...args}
-      date={date}
-      onValueChange={newDate => setDate(newDate)}
-    />
+    <Date {...args} date={date} onValueChange={newDate => setDate(newDate)} />
   );
 };
 
@@ -60,4 +56,10 @@ Error.args = {
       dirty: true,
     },
   },
+};
+
+export const AriaDescribedby = Template.bind({});
+AriaDescribedby.args = {
+  ...defaultArgs,
+  ariaDescribedby: 'some-id',
 };

--- a/src/components/Date/Date.unit.spec.jsx
+++ b/src/components/Date/Date.unit.spec.jsx
@@ -209,6 +209,38 @@ describe('<Date>', () => {
     });
     tree.unmount();
   });
+  it('renders aria-describedby and invalid message id on all elements', () => {
+    const date = {
+      day: makeField(''),
+      month: makeField(''),
+      year: makeField('1890'),
+    };
+    date.year.dirty = true;
+    date.month.dirty = true;
+    date.day.dirty = true;
+
+    const tree = shallow(
+      <Date
+        date={date}
+        name=""
+        onValueChange={() => {}}
+        ariaDescribedby="test-id"
+      />,
+    );
+
+    const numberAria = tree.find('NumberInput').props().ariaDescribedby;
+    // "date-input-##-error-message test-id"
+    expect(numberAria).to.contain('date-input-');
+    expect(numberAria).to.contain('-error-message');
+    expect(numberAria).to.contain('test-id');
+    tree.find('Select').forEach(select => {
+      const selectAria = select.props().ariaDescribedby;
+      expect(numberAria).to.contain('date-input-');
+      expect(numberAria).to.contain('-error-message');
+      expect(selectAria).to.contain('test-id');
+    });
+    tree.unmount();
+  });
   it('should pass aXe check when multiple aria-describedby ids are set', () => {
     const date = {
       day: makeField(''),

--- a/src/components/Date/Date.unit.spec.jsx
+++ b/src/components/Date/Date.unit.spec.jsx
@@ -15,9 +15,7 @@ describe('<Date>', () => {
       month: makeField(12),
       year: makeField(2010),
     };
-    const tree = shallow(
-      <Date date={date} onValueChange={_update => {}} />,
-    );
+    const tree = shallow(<Date date={date} onValueChange={() => {}} />);
     expect(tree.find('fieldset')).to.have.lengthOf(1);
     const legend = tree.find('legend');
     expect(legend).to.have.lengthOf(1);
@@ -30,9 +28,7 @@ describe('<Date>', () => {
       month: makeField(12),
       year: makeField(2010),
     };
-    const tree = shallow(
-      <Date date={date} onValueChange={_update => {}} />,
-    );
+    const tree = shallow(<Date date={date} onValueChange={() => {}} />);
     expect(tree.find('NumberInput')).to.have.lengthOf(1);
     expect(tree.find('Select')).to.have.lengthOf(2);
     tree.unmount();
@@ -48,7 +44,7 @@ describe('<Date>', () => {
     date.day.dirty = true;
 
     const tree = shallow(
-      <Date required date={date} onValueChange={_update => {}} />,
+      <Date required date={date} onValueChange={() => {}} />,
     );
 
     expect(tree.find('.usa-input-error').exists()).to.be.true;
@@ -67,9 +63,7 @@ describe('<Date>', () => {
     date.month.dirty = true;
     date.day.dirty = true;
 
-    const tree = shallow(
-      <Date date={date} onValueChange={_update => {}} />,
-    );
+    const tree = shallow(<Date date={date} onValueChange={() => {}} />);
 
     expect(tree.find('.usa-input-error').exists()).to.be.true;
     expect(tree.find('.usa-input-error-message').text()).to.equal(
@@ -86,9 +80,7 @@ describe('<Date>', () => {
     date.year.dirty = true;
     date.month.dirty = false;
     date.day.dirty = false;
-    const tree = shallow(
-      <Date date={date} onValueChange={_update => {}} />,
-    );
+    const tree = shallow(<Date date={date} onValueChange={() => {}} />);
 
     expect(tree.find('.usa-input-error').exists()).to.be.true;
     expect(tree.find('.usa-input-error-message').text()).to.contain(
@@ -105,9 +97,7 @@ describe('<Date>', () => {
     date.year.dirty = true;
     date.month.dirty = false;
     date.day.dirty = false;
-    const tree = shallow(
-      <Date date={date} onValueChange={_update => {}} />,
-    );
+    const tree = shallow(<Date date={date} onValueChange={() => {}} />);
 
     expect(tree.find('.usa-input-error').exists()).to.be.true;
     expect(tree.find('.usa-input-error-message').text()).to.contain(
@@ -115,7 +105,6 @@ describe('<Date>', () => {
     );
     tree.unmount();
   });
-
 
   it('does not show invalid message for month year date', () => {
     const date = {
@@ -127,9 +116,7 @@ describe('<Date>', () => {
     date.month.dirty = true;
     date.day.dirty = true;
 
-    const tree = shallow(
-      <Date date={date} onValueChange={_update => {}} />,
-    );
+    const tree = shallow(<Date date={date} onValueChange={() => {}} />);
     expect(tree.find('.usa-input-error')).to.have.length(0);
     tree.unmount();
   });
@@ -148,7 +135,7 @@ describe('<Date>', () => {
       <Date
         date={date}
         validation={{ valid: false, message: 'Test' }}
-        onValueChange={_update => {}}
+        onValueChange={() => {}}
       />,
     );
 
@@ -173,7 +160,7 @@ describe('<Date>', () => {
           { valid: true, message: 'NotShownMessage' },
           { valid: false, message: 'Test' },
         ]}
-        onValueChange={_update => {}}
+        onValueChange={() => {}}
       />,
     );
 
@@ -189,9 +176,7 @@ describe('<Date>', () => {
       year: makeField('1890'),
     };
 
-    return axeCheck(
-      <Date date={date} onValueChange={_update => {}} />,
-    );
+    return axeCheck(<Date date={date} onValueChange={() => {}} />);
   });
 
   it('should pass aXe check when errorMessage is set', () => {
@@ -204,8 +189,6 @@ describe('<Date>', () => {
     date.month.dirty = true;
     date.day.dirty = true;
 
-    return axeCheck(
-      <Date date={date} onValueChange={_update => {}} />,
-    );
+    return axeCheck(<Date date={date} onValueChange={() => {}} />);
   });
 });

--- a/src/components/Date/Date.unit.spec.jsx
+++ b/src/components/Date/Date.unit.spec.jsx
@@ -191,4 +191,36 @@ describe('<Date>', () => {
 
     return axeCheck(<Date date={date} onValueChange={() => {}} />);
   });
+
+  it('renders aria-describedby on elements', () => {
+    const date = {
+      day: makeField(1),
+      month: makeField(12),
+      year: makeField(2010),
+    };
+    const tree = shallow(
+      <Date date={date} onValueChange={() => {}} ariaDescribedby="test-id" />,
+    );
+    expect(tree.find('NumberInput').props().ariaDescribedby).to.equal(
+      'test-id',
+    );
+    tree.find('Select').forEach(select => {
+      expect(select.props().ariaDescribedby).to.equal('test-id');
+    });
+    tree.unmount();
+  });
+  it('should pass aXe check when multiple aria-describedby ids are set', () => {
+    const date = {
+      day: makeField(''),
+      month: makeField(''),
+      year: makeField('1890'),
+    };
+    date.year.dirty = true;
+    date.month.dirty = true;
+    date.day.dirty = true;
+
+    return axeCheck(
+      <Date date={date} onValueChange={() => {}} ariaDescribedby="test-id" />,
+    );
+  });
 });

--- a/src/components/NumberInput/NumberInput.jsx
+++ b/src/components/NumberInput/NumberInput.jsx
@@ -53,6 +53,10 @@ class NumberInput extends React.Component {
       requiredSpan = <span className="form-required-span">(*Required)</span>;
     }
 
+    const ariaDescribedby =
+      [errorSpanId, this.props.ariaDescribedby || ''].join(' ').trim() ||
+      undefined;
+
     return (
       <div className={this.props.errorMessage ? 'usa-input-error' : undefined}>
         <label
@@ -69,7 +73,7 @@ class NumberInput extends React.Component {
         {errorSpan}
         <input
           className={this.props.additionalClass}
-          aria-describedby={errorSpanId}
+          aria-describedby={ariaDescribedby}
           id={this.inputId}
           name={this.props.name}
           max={this.props.max}
@@ -138,6 +142,11 @@ NumberInput.propTypes = {
    * Will be applied as a class name on the `<input>`
    */
   additionalClass: PropTypes.string,
+
+  /**
+   * Add additional aria-describedby to the `<input>`
+   */
+  ariaDescribedby: PropTypes.string,
 };
 
 export default NumberInput;

--- a/src/components/NumberInput/NumberInput.mdx
+++ b/src/components/NumberInput/NumberInput.mdx
@@ -30,6 +30,7 @@ import NumberInput from '@department-of-veterans-affairs/component-library/Numbe
   min={1}
   max={10}
   field={this.state.field}
+  ariaDescribedby={''}
 />
 ```
 

--- a/src/components/NumberInput/NumberInput.stories.jsx
+++ b/src/components/NumberInput/NumberInput.stories.jsx
@@ -13,13 +13,7 @@ const Template = args => {
     setField(newField);
   };
 
-  return (
-    <NumberInput
-      {...args}
-      field={field}
-      onValueChange={onValueChange}
-    />
-  );
+  return <NumberInput {...args} field={field} onValueChange={onValueChange} />;
 };
 
 const defaultArgs = {
@@ -57,4 +51,11 @@ export const Required = Template.bind({});
 Required.args = {
   ...defaultArgs,
   required: true,
+};
+
+export const AriaDescribedby = Template.bind({});
+AriaDescribedby.args = {
+  ...defaultArgs,
+  errorMessage: 'This is also an error',
+  ariaDescribedby: 'testing-id',
 };

--- a/src/components/NumberInput/NumberInput.unit.spec.jsx
+++ b/src/components/NumberInput/NumberInput.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('<NumberInput>', () => {
   it('ensure value changes propagate', () => {
     let errorableInput;
 
-    const updatePromise = new Promise((resolve, _reject) => {
+    const updatePromise = new Promise(resolve => {
       errorableInput = ReactTestUtils.renderIntoDocument(
         <NumberInput
           field={testValue}
@@ -42,7 +42,7 @@ describe('<NumberInput>', () => {
   it('ensure blur makes field dirty', () => {
     let errorableInput;
 
-    const updatePromise = new Promise((resolve, _reject) => {
+    const updatePromise = new Promise(resolve => {
       errorableInput = ReactTestUtils.renderIntoDocument(
         <NumberInput
           field={testValue}
@@ -68,7 +68,7 @@ describe('<NumberInput>', () => {
       <NumberInput
         field={testValue}
         label="my label"
-        onValueChange={_update => {}}
+        onValueChange={() => {}}
       />,
     );
 
@@ -95,7 +95,7 @@ describe('<NumberInput>', () => {
         field={testValue}
         label="my label"
         errorMessage="error message"
-        onValueChange={_update => {}}
+        onValueChange={() => {}}
       />,
     );
 
@@ -123,7 +123,7 @@ describe('<NumberInput>', () => {
       <NumberInput
         field={testValue}
         label="my label"
-        onValueChange={_update => {}}
+        onValueChange={() => {}}
       />,
     );
     expect(tree.find('label').text()).to.equal('my label');
@@ -136,7 +136,7 @@ describe('<NumberInput>', () => {
         field={testValue}
         label="my label"
         required
-        onValueChange={_update => {}}
+        onValueChange={() => {}}
       />,
     );
 
@@ -150,7 +150,7 @@ describe('<NumberInput>', () => {
       <NumberInput
         field={testValue}
         label="my label"
-        onValueChange={_update => {}}
+        onValueChange={() => {}}
       />,
     );
 
@@ -172,7 +172,7 @@ describe('<NumberInput>', () => {
       <NumberInput
         field={testValue}
         label="my label"
-        onValueChange={_update => {}}
+        onValueChange={() => {}}
       />,
     );
     return check;

--- a/src/components/NumberInput/NumberInput.unit.spec.jsx
+++ b/src/components/NumberInput/NumberInput.unit.spec.jsx
@@ -167,12 +167,70 @@ describe('<NumberInput>', () => {
     tree.unmount();
   });
 
+  it('has aria-describedby attribute when ariaDescribedby is set', () => {
+    const tree = shallow(
+      <NumberInput
+        field={testValue}
+        label="my label"
+        ariaDescribedby="some-id"
+        onValueChange={() => {}}
+      />,
+    );
+
+    // Ensure no error.
+    expect(tree.find('.usa-input-error')).to.have.lengthOf(0);
+
+    // No error means no aria-describedby to not confuse screen readers.
+    const inputs = tree.find('input');
+    expect(inputs).to.have.lengthOf(1);
+    expect(inputs.prop('aria-describedby')).to.equal('some-id');
+    tree.unmount();
+  });
+
+  it('has aria-described by attribute with id & errorMessage when set', () => {
+    const tree = shallow(
+      <NumberInput
+        field={testValue}
+        label="my label"
+        ariaDescribedby="some-id"
+        errorMessage="error message"
+        onValueChange={() => {}}
+      />,
+    );
+
+    // Ensure all error classes set.
+    expect(tree.find('.usa-input-error')).to.have.lengthOf(1);
+
+    const errorMessages = tree.find('.usa-input-error-message');
+    expect(errorMessages).to.have.lengthOf(1);
+    expect(errorMessages.text()).to.equal('Error error message');
+
+    const inputs = tree.find('input');
+    expect(inputs.prop('aria-describedby')).to.contain('some-id');
+    expect(inputs.prop('aria-describedby')).to.contain(
+      errorMessages.prop('id'),
+    );
+    tree.unmount();
+  });
+
   it('passes aXe check', () => {
     const check = axeCheck(
       <NumberInput
         field={testValue}
         label="my label"
         onValueChange={() => {}}
+      />,
+    );
+    return check;
+  });
+  it('passes aXe check with aria-describedby attribute containing 2 IDs', () => {
+    const check = axeCheck(
+      <NumberInput
+        field={testValue}
+        label="my label"
+        onValueChange={() => {}}
+        ariaDescribedby="some-id"
+        errorMessage="error message"
       />,
     );
     return check;

--- a/src/components/NumberInput/NumberInput.unit.spec.jsx
+++ b/src/components/NumberInput/NumberInput.unit.spec.jsx
@@ -180,7 +180,8 @@ describe('<NumberInput>', () => {
     // Ensure no error.
     expect(tree.find('.usa-input-error')).to.have.lengthOf(0);
 
-    // No error means no aria-describedby to not confuse screen readers.
+    // No error, but ariaDescribedby contains an ID. It should exactly equal the
+    // ID
     const inputs = tree.find('input');
     expect(inputs).to.have.lengthOf(1);
     expect(inputs.prop('aria-describedby')).to.equal('some-id');
@@ -206,6 +207,7 @@ describe('<NumberInput>', () => {
     expect(errorMessages.text()).to.equal('Error error message');
 
     const inputs = tree.find('input');
+    // expect both the error span ID and the ariaDescribedby prop ID
     expect(inputs.prop('aria-describedby')).to.contain('some-id');
     expect(inputs.prop('aria-describedby')).to.contain(
       errorMessages.prop('id'),
@@ -223,7 +225,7 @@ describe('<NumberInput>', () => {
     );
     return check;
   });
-  it('passes aXe check with aria-describedby attribute containing 2 IDs', () => {
+  it('passes aXe check with aria-describedby attribute', () => {
     const check = axeCheck(
       <NumberInput
         field={testValue}

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -62,6 +62,10 @@ class Select extends React.Component {
       requiredSpan = <span className="form-required-span">(*Required)</span>;
     }
 
+    const ariaDescribedby =
+      [errorSpanId, this.props.ariaDescribedby || ''].join(' ').trim() ||
+      undefined;
+
     // Calculate options for select
     let reactKey = 0;
     // TODO(awong): Remove this hack to handle options prop and use invariants instead.
@@ -99,7 +103,7 @@ class Select extends React.Component {
         {errorSpan}
         <select
           className={this.props.additionalClass}
-          aria-describedby={errorSpanId}
+          aria-describedby={ariaDescribedby}
           id={this.selectId}
           name={this.props.name}
           value={selectedValue}
@@ -214,6 +218,11 @@ Select.propTypes = {
    * are disabled by default due to PII/PHI concerns.
    */
   enableAnalytics: PropTypes.bool,
+
+  /**
+   * Add additional aria-describedby to the `<select>`
+   */
+  ariaDescribedby: PropTypes.string,
 };
 
 Select.defaultProps = {

--- a/src/components/Select/Select.mdx
+++ b/src/components/Select/Select.mdx
@@ -34,6 +34,7 @@ import Select from '@department-of-veterans-affairs/component-library/Select'
   additionalClass='additional-class'
   emptyDescription='this is empty'
   ariaLiveRegionText='The following option was selected: '
+  ariaDescribedby='some-id'
 />
 ```
 
@@ -64,6 +65,7 @@ export class RenderedComponent extends React.Component {
           additionalClass='additional-class'
           emptyDescription='this is empty'
           ariaLiveRegionText='The following option was selected: '
+          ariaDescribedby=''
         />
       </div>
     );

--- a/src/components/Select/Select.mdx
+++ b/src/components/Select/Select.mdx
@@ -33,7 +33,7 @@ import Select from '@department-of-veterans-affairs/component-library/Select'
   onValueChange={value => this.setState({ value })}
   additionalClass='additional-class'
   emptyDescription='this is empty'
-  ariaLiveRegionText: 'The following option was selected: ',
+  ariaLiveRegionText='The following option was selected: '
 />
 ```
 
@@ -63,7 +63,7 @@ export class RenderedComponent extends React.Component {
           onValueChange={value => this.setState({ value })}
           additionalClass='additional-class'
           emptyDescription='this is empty'
-          ariaLiveRegionText: 'The following option was selected: ',
+          ariaLiveRegionText='The following option was selected: '
         />
       </div>
     );

--- a/src/components/Select/Select.stories.jsx
+++ b/src/components/Select/Select.stories.jsx
@@ -55,6 +55,13 @@ AriaLiveRegion.args = {
   ariaLiveRegionText: 'The following branch was selected: ',
 };
 
+export const AriaDescribedby = Template.bind({});
+AriaDescribedby.args = {
+  ...defaultArgs,
+  errorMessage: 'This is also an error',
+  ariaDescribedby: 'testing-id',
+};
+
 export const WithAnalytics = Template.bind({});
 WithAnalytics.args = {
   ...defaultArgs,

--- a/src/components/Select/Select.unit.spec.jsx
+++ b/src/components/Select/Select.unit.spec.jsx
@@ -239,6 +239,55 @@ describe('<Select>', () => {
     tree.unmount();
   });
 
+  it('has error styles when errorMessage is set', () => {
+    const tree = shallow(
+      <Select
+        label="my label"
+        options={options}
+        value={testValue}
+        onValueChange={() => {}}
+        ariaDescribedby="test-id"
+      />,
+    );
+
+    // Ensure all error classes set.
+    expect(tree.find('.usa-input-error')).to.have.lengthOf(0);
+
+    // No error means no aria-describedby to not confuse screen readers.
+    const selects = tree.find('select');
+    expect(selects).to.have.lengthOf(1);
+
+    expect(selects.prop('aria-describedby')).to.equal('test-id');
+    tree.unmount();
+  });
+
+  it('has error styles when errorMessage is set', () => {
+    const tree = shallow(
+      <Select
+        label="my label"
+        options={options}
+        errorMessage="error message"
+        value={testValue}
+        onValueChange={() => {}}
+        ariaDescribedby="test-id"
+      />,
+    );
+
+    // Ensure all error classes set.
+    expect(tree.find('.usa-input-error')).to.have.lengthOf(1);
+
+    // No error means no aria-describedby to not confuse screen readers.
+    const selects = tree.find('select');
+    expect(selects).to.have.lengthOf(1);
+
+    const idNum = selects.props().id.split('-')[2];
+    expect(selects.prop('aria-describedby')).to.contain('test-id');
+    expect(selects.prop('aria-describedby')).to.contain(
+      `errorable-select-${idNum}-error-message`,
+    );
+    tree.unmount();
+  });
+
   describe('analytics event', function () {
     it('should NOT be triggered when enableAnalytics is not true', () => {
       const wrapper = shallow(


### PR DESCRIPTION
## Description

This PR adds an `aria-describedby` attribute to `Date`, `Select` and `NumberInput` components to allow screenreaders to target content related to form element.

This value should only be added when the target ID exists within the DOM.

Related:

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/22569
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/22612

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] `aria-describedby` added to the `Date`, `Select` and `NumberInput`

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
