### PR TITLE
Resolve trim-newlines vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "node ./scripts/build.js",
     "build-storybook": "build-storybook",
     "prepublishOnly": "pinst --disable && node ./scripts/prepublish.js",
-    "postinstall": "husky install && cd node_modules/web-components && npm install --only=prod && npm run-script build",
+    "postinstall": "husky install && cd node_modules/web-components && yarn install --production && npm run-script build",
     "postpublish": "pinst --enable",
     "storybook": "start-storybook -p 6006",
     "test-debug": "karma start testing/karma.conf.js --browsers Chrome",

--- a/package.json
+++ b/package.json
@@ -98,5 +98,8 @@
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1"
+  },
+  "resolutions": {
+    "trim-newlines": "^4.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12384,10 +12384,10 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+trim-newlines@^1.0.0, trim-newlines@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-4.0.2.tgz#d6aaaf6a0df1b4b536d183879a6b939489808c7c"
+  integrity sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==
 
 trim-trailing-lines@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
## Description
Like it says on the tin, there was a vulnerability with the version of `trim-newlines` we were using, so this pins it to `^4.0.2`, which is not vulnerable to the RegExp DOS attack that `1.0.0` is.

`trim-newlines` is a dependency of `meow` which is a dependency of `node-sass`. I looked into updating `node-sass`, but it uses the same version of `meow` as the version we're on now, so that was a dead end.

## Testing done
None :see_no_evil:
If this doesn't work as expected, I'm not sure how we'd figure it out unless it breaks spectacularly. :shrug: 