### PR TITLE
va-text-input stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "sass-loader": "^8.0.2",
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.2"
   },
   "resolutions": {
     "trim-newlines": "^4.0.2"

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -6,6 +6,9 @@ import { makeField } from '../../helpers/fields';
 import dispatchAnalyticsEvent from '../../helpers/analytics';
 
 /**
+ * **Note:** This component is deprecated in favor of the <va-text-input> web
+ * component.
+ *
  * A form input with a label that can display error messages.
  *
  * Props:

--- a/src/components/TextInput/TextInput.stories.jsx
+++ b/src/components/TextInput/TextInput.stories.jsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import TextInput from './TextInput';
 
 export default {
-  title: 'Components/TextInput',
+  title: 'Components/TextInput (deprecated)',
   component: TextInput,
 };
 

--- a/stories/va-text-input.stories.jsx
+++ b/stories/va-text-input.stories.jsx
@@ -18,11 +18,12 @@ const defaultArgs = {
   name: 'my-input',
   label: 'My input',
   autocomplete: false,
-  'disable-analytics': true,
-  // Fun fact: This should really be false, but that passes required="false" to
-  // the web component, which correctly interprets this as a truthy value.
-  // See also:
+  // Fun fact: This should really be false, but that passes
+  // enable-analytics="false" to the web component, which correctly interprets
+  // this as a truthy value. See also:
   // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute
+  'enable-analytics': null,
+  // Same story here
   required: null,
   error: null,
   maxlength: null,
@@ -63,4 +64,4 @@ Autocomplete.args = {
 };
 
 export const WithAnalytics = Template.bind({});
-WithAnalytics.args = { ...defaultArgs, 'disable-analytics': false };
+WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };

--- a/stories/va-text-input.stories.jsx
+++ b/stories/va-text-input.stories.jsx
@@ -19,7 +19,11 @@ const defaultArgs = {
   label: 'My input',
   autocomplete: false,
   'disable-analytics': true,
-  required: false,
+  // Fun fact: This should really be false, but that passes required="false" to
+  // the web component, which correctly interprets this as a truthy value.
+  // See also:
+  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute
+  required: null,
   error: null,
   maxlength: null,
   placeholder: null,

--- a/stories/va-text-input.stories.jsx
+++ b/stories/va-text-input.stories.jsx
@@ -1,0 +1,38 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { getWebComponentDocs, StoryDocs, propStructure } from './wc-helpers';
+
+const textInputDocs = getWebComponentDocs('va-text-input');
+
+export default {
+  title: 'Components/va-text-input',
+  parameters: {
+    docs: {
+      /* eslint-disable-next-line react/display-name */
+      page: () => <StoryDocs docs={textInputDocs.docs} />,
+    },
+  },
+};
+
+const defaultArgs = {
+  name: 'my-input',
+  label: 'My input',
+  autocomplete: false,
+  'disable-analytics': true,
+  required: false,
+  error: null,
+  maxlength: null,
+  placeholder: null,
+  value: null,
+};
+
+const Template = props => {
+  return <va-text-input {...props} />;
+};
+
+export const Default = Template.bind({});
+Default.args = { ...defaultArgs };
+Default.argTypes = propStructure(textInputDocs);
+
+export const Error = Template.bind({});
+Error.args = { ...defaultArgs, error: 'This is an error message' };

--- a/stories/va-text-input.stories.jsx
+++ b/stories/va-text-input.stories.jsx
@@ -36,3 +36,27 @@ Default.argTypes = propStructure(textInputDocs);
 
 export const Error = Template.bind({});
 Error.args = { ...defaultArgs, error: 'This is an error message' };
+
+export const Required = Template.bind({});
+Required.args = { ...defaultArgs, required: true };
+
+export const WithPlaceholder = Template.bind({});
+WithPlaceholder.args = { ...defaultArgs, placeholder: 'This is a placeholder' };
+
+export const MaxLength = Template.bind({});
+MaxLength.args = {
+  ...defaultArgs,
+  maxlength: '16',
+  placeholder: 'No more than 16 characters',
+};
+
+export const Autocomplete = Template.bind({});
+Autocomplete.args = {
+  ...defaultArgs,
+  name: 'email',
+  autocomplete: 'email',
+  placeholder: 'This should complete using email addresses',
+};
+
+export const WithAnalytics = Template.bind({});
+WithAnalytics.args = { ...defaultArgs, 'disable-analytics': false };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12956,9 +12956,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1":
-  version "0.6.1"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#b892c5ba2252fbe8800c0e1e7fdc9fdaa90846f5"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.2":
+  version "0.6.2"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#9fdda8c6b4e325194b2a7c1fccacdd42a24664f2"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description
Adds the stories for `va-text-input`.

After much struggling with getting the funky default value to work like I wanted to, I gave up and settled on adding every bloody prop to the `defaultArgs`. :roll_eyes: It's still a bit funky, but it's not _awful._

## Testing done
:eyes: 

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/123040265-53deaa00-d3a8-11eb-97b6-319d05013a3c.png)
And more! But they're basically all like that. Very exciting.