### PR TITLE
disableAnalytics -> enableAnalytics on va-text-input

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -86,9 +86,9 @@ export namespace Components {
          */
         "autocomplete"?: string;
         /**
-          * Don't emit any component-library-analytics events.
+          * Emit component-library-analytics events on the blur event.
          */
-        "disableAnalytics"?: boolean;
+        "enableAnalytics"?: boolean;
         /**
           * The error message to render.
          */
@@ -250,9 +250,9 @@ declare namespace LocalJSX {
          */
         "autocomplete"?: string;
         /**
-          * Don't emit any component-library-analytics events.
+          * Emit component-library-analytics events on the blur event.
          */
-        "disableAnalytics"?: boolean;
+        "enableAnalytics"?: boolean;
         /**
           * The error message to render.
          */

--- a/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -84,7 +84,7 @@ describe('va-text-input', () => {
     await axeCheck(page);
   });
 
-  it('fires an analytics event', async () => {
+  it('fires an analytics event when enableAnalytics is true', async () => {
     const page = await newE2EPage();
 
     await page.setContent(

--- a/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -87,7 +87,9 @@ describe('va-text-input', () => {
   it('fires an analytics event', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<va-text-input label="Input Field"/>');
+    await page.setContent(
+      '<va-text-input label="Input Field" enable-analytics/>',
+    );
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
@@ -119,12 +121,10 @@ describe('va-text-input', () => {
     expect(blurSpy).toHaveReceivedEvent();
   });
 
-  it("doesn't fire analytics events when disableAnalytics is true", async () => {
+  it("doesn't fire analytics events", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(
-      '<va-text-input label="Input Field" disable-analytics />',
-    );
+    await page.setContent('<va-text-input label="Input Field"/>');
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
     const inputEl = await page.find('va-text-input >>> input');

--- a/src/components/va-text-input/va-text-input.tsx
+++ b/src/components/va-text-input/va-text-input.tsx
@@ -54,9 +54,9 @@ export class VaTextInput {
   @Prop() autocomplete?: string;
 
   /**
-   * Don't emit any component-library-analytics events.
+   * Emit component-library-analytics events on the blur event.
    */
-  @Prop() disableAnalytics?: boolean;
+  @Prop() enableAnalytics?: boolean;
 
   /**
    * The name to pass to the input element.
@@ -82,7 +82,7 @@ export class VaTextInput {
   };
 
   private handleBlur = () => {
-    if (this.disableAnalytics) return;
+    if (!this.enableAnalytics) return;
 
     this.componentLibraryAnalytics.emit({
       componentName: 'va-text-input',


### PR DESCRIPTION
## Description
Changes the disableAnalytics prop to enableAnalytics so it doesn't fire the events by default. This matches the current behavior of `TextInput`.

## Testing done
Automated tests.

## Screenshots
N/A

## Acceptance criteria
- [x] The events don't fire by default
- [x] The events do fire when the `enableAnalytics` prop is passed to the component