### PR TITLE
Add formation to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "jest-cli": "^26.6.3",
     "lit-html": "^1.3.0",
     "puppeteer": "5.4.1"
+  },
+  "peerDependencies": {
+    "@department-of-veterans-affairs/formation": "^6.14.0"
   }
 }


### PR DESCRIPTION
Because whatever uses these web components currently needs formation too
for the styling. This isn't the goal, but that's where we're at right now.