### PR TITLE
Remove unknown attributes spread cv

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -79,6 +79,7 @@ export namespace Components {
         "visible": boolean;
     }
     interface VaCheckbox {
+        "ariaDescribedby": string;
         /**
           * Whether the checkbox is checked or not.  Note: Because this isn't reflective, vaCheckbox.getAttribute('checked') will not reflect the correct value. Use the property vaCheckbox.checked instead.
          */
@@ -309,6 +310,7 @@ declare namespace LocalJSX {
         "visible"?: boolean;
     }
     interface VaCheckbox {
+        "ariaDescribedby"?: string;
         /**
           * Whether the checkbox is checked or not.  Note: Because this isn't reflective, vaCheckbox.getAttribute('checked') will not reflect the correct value. Use the property vaCheckbox.checked instead.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -79,6 +79,9 @@ export namespace Components {
         "visible": boolean;
     }
     interface VaCheckbox {
+        /**
+          * The aria-describedby attribute for the <intput> in the shadow DOM.
+         */
         "ariaDescribedby": string;
         /**
           * Whether the checkbox is checked or not.  Note: Because this isn't reflective, vaCheckbox.getAttribute('checked') will not reflect the correct value. Use the property vaCheckbox.checked instead.
@@ -134,6 +137,10 @@ export namespace Components {
         "value": string;
     }
     interface VaTextInput {
+        /**
+          * The aria-describedby attribute for the <intput> in the shadow DOM.
+         */
+        "ariaDescribedby"?: string;
         /**
           * What to tell the browser to auto-complete the field with.
          */
@@ -310,6 +317,9 @@ declare namespace LocalJSX {
         "visible"?: boolean;
     }
     interface VaCheckbox {
+        /**
+          * The aria-describedby attribute for the <intput> in the shadow DOM.
+         */
         "ariaDescribedby"?: string;
         /**
           * Whether the checkbox is checked or not.  Note: Because this isn't reflective, vaCheckbox.getAttribute('checked') will not reflect the correct value. Use the property vaCheckbox.checked instead.
@@ -369,6 +379,10 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface VaTextInput {
+        /**
+          * The aria-describedby attribute for the <intput> in the shadow DOM.
+         */
+        "ariaDescribedby"?: string;
         /**
           * What to tell the browser to auto-complete the field with.
          */

--- a/src/components/va-checkbox/test/va-checkbox.e2e.ts
+++ b/src/components/va-checkbox/test/va-checkbox.e2e.ts
@@ -166,13 +166,4 @@ describe('va-checkbox', () => {
     await inputEl.click();
     expect(await inputEl.getProperty('checked')).toBeTruthy();
   });
-
-  it('passes unknown props to the input element in the shadow DOM', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-checkbox foo="bar" />');
-
-    // Render the error message text
-    const element = await page.find('va-checkbox >>> input');
-    expect(element.getAttribute('foo')).toEqual('bar');
-  });
 });

--- a/src/components/va-checkbox/va-checkbox.tsx
+++ b/src/components/va-checkbox/va-checkbox.tsx
@@ -58,7 +58,10 @@ export class VaCheckbox {
    */
   @Prop({ mutable: true }) checked: boolean = false;
 
-  @Prop() ariaDescribedby: string;
+  /**
+   * The aria-describedby attribute for the <intput> in the shadow DOM.
+   */
+  @Prop() ariaDescribedby: string = '';
 
   private fireAnalyticsEvent = () => {
     // Either the description prop or the text content of the description slots

--- a/src/components/va-checkbox/va-checkbox.tsx
+++ b/src/components/va-checkbox/va-checkbox.tsx
@@ -8,15 +8,6 @@ import {
   Prop,
 } from '@stencil/core';
 
-import { assembleAttributes } from '../../utils/utils';
-
-// The props passed to the web component which we don't want to pass to the
-// input element. Note: The following attributes are deliberately left out so
-// they get passed to the input:
-//   - required
-//   - checked
-const wcOnlyProps = ['label', 'error', 'enableAnalytics'];
-
 @Component({
   tag: 'va-checkbox',
   styleUrl: 'va-checkbox.css',
@@ -67,6 +58,8 @@ export class VaCheckbox {
    */
   @Prop({ mutable: true }) checked: boolean = false;
 
+  @Prop() ariaDescribedby: string;
+
   private fireAnalyticsEvent = () => {
     // Either the description prop or the text content of the description slots
     const description =
@@ -101,13 +94,10 @@ export class VaCheckbox {
   };
 
   render() {
-    const atts = assembleAttributes(this.el.attributes, wcOnlyProps);
-    atts['aria-describedby'] = (
-      (atts['aria-describedby'] || '') + ' description'
-    ).trim();
-    if (this.error) {
-      atts['aria-describedby'] += ' error-message';
-    }
+    const describedBy = `${this.ariaDescribedby} description ${
+      this.error && 'error-message'
+    }`.trim();
+
     return (
       <Host>
         <div id="description">
@@ -120,7 +110,8 @@ export class VaCheckbox {
         <input
           type="checkbox"
           id="checkbox-element"
-          {...atts}
+          checked={this.checked}
+          aria-describedby={describedBy}
           onChange={this.handleChange}
         />
         <label htmlFor="checkbox-element">

--- a/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -64,7 +64,7 @@ describe('va-text-input', () => {
       <va-text-input class="hydrated" label="This is a field" required="">
         <mock:shadow-root>
           <label for="inputField">This is a field <span class="required">(*Required)</span></label>
-          <input id="inputField" type="text" required="" />
+          <input id="inputField" type="text" />
         </mock:shadow-root>
       </va-text-input>
     `);
@@ -162,25 +162,5 @@ describe('va-text-input', () => {
     expect((await page.find('va-text-input >>> small')).innerText).toContain(
       '(Max. 3 characters)',
     );
-  });
-
-  it('passes unknown props to the input element in the shadow DOM', async () => {
-    // This is primarily so we don't have to make a new prop for each aria-* attribute
-    const page = await newE2EPage();
-
-    await page.setContent(
-      '<va-text-input label="Hello, world" unprop="Not a real prop" />',
-    );
-    const element = await page.find('va-text-input');
-
-    // Filters out label, passes unprop
-    expect(element).toEqualHtml(`
-      <va-text-input class="hydrated" label="Hello, world" unprop="Not a real prop">
-        <mock:shadow-root>
-          <label for="inputField">Hello, world</label>
-          <input id="inputField" type="text" unprop="Not a real prop"/>
-        </mock:shadow-root>
-      </va-text-input>
-    `);
   });
 });

--- a/src/components/va-text-input/va-text-input.tsx
+++ b/src/components/va-text-input/va-text-input.tsx
@@ -75,6 +75,11 @@ export class VaTextInput {
    */
   @Prop() name?: string;
 
+  /**
+   * The aria-describedby attribute for the <intput> in the shadow DOM.
+   */
+  @Prop() ariaDescribedby?: string = '';
+
   /*
    * The value for the input.
    */
@@ -107,12 +112,9 @@ export class VaTextInput {
   };
 
   render() {
-    const atts = assembleAttributes(this.el.attributes, wcOnlyProps);
-    if (this.error) {
-      atts['aria-describedby'] = (
-        (atts['aria-describedby'] || '') + ' error-message'
-      ).trim();
-    }
+    const describedBy =
+      `${this.ariaDescribedby} ${this.error ? 'error-message' : ''}`.trim() ||
+      null; // Null so we don't add the attribute if we have an empty string
     return (
       <Host>
         {this.label && (
@@ -125,9 +127,12 @@ export class VaTextInput {
         <input
           id="inputField"
           type="text"
-          {...atts}
+          value={this.value}
           onInput={this.handleChange}
           onBlur={this.handleBlur}
+          aria-describedby={describedBy}
+          placeholder={this.placeholder}
+          maxlength={this.maxlength}
         />
         {this.maxlength && this.value.length >= this.maxlength && (
           <small>(Max. {this.maxlength} characters)</small>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -28,23 +28,3 @@ export function getSlottedNodes(
     item => item.nodeName.toLowerCase() === nodeName,
   );
 }
-
-/**
- * Transform the NamedNodeMap into an object we can spread as attributes on an
- * HTMLElement.
- */
-export const assembleAttributes = (atts: NamedNodeMap, ignoreList: string[]) =>
-  Array.from(atts)
-    .filter(a => !ignoreList.some(p => a.nodeName === p))
-    .reduce(
-      (all, a) => ({
-        ...all,
-        [a.nodeName]:
-          // a.nodeValue will be an empty string when the attribute value isn't
-          // specified such as when using a boolean true like for the required prop.
-          // ...except for value. We want to keep value="" because that's
-          // meaningful.
-          a.nodeValue || (a.nodeName !== 'value' && a.nodeValue === ''),
-      }),
-      {},
-    );


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/27033

I also removed the `required` from the `input` on the `va-text-input` test. We may add it back in there, but it doesn't technically do that in the React version. I don't know whether or not it should, but I've asked our a11y specialists and will write up an issue to add it back in if we need it.

## Testing done
Unit tests pass.