### PR TITLE
Build during the prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "generate": "stencil generate",
     "storybook": "start-storybook -p 6006",
     "serve": "stencil build --dev --watch --serve",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@stencil/core": "^2.0.1",


### PR DESCRIPTION
## Description
This builds the library when it's [installed via a git URL](https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts). With this addition, we won't have to require the downstream project to have that awful `postinstall` hook. 

## Testing done
Tested this on a local project installing this branch as a dependency via a [git URL](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#git-urls-as-dependencies).

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/125708816-de1bb586-3f64-41b6-92e7-95e66eff06e1.png)
