### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-components",
-  "version": "0.6.2",
+  "version": "0.7.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",


### PR DESCRIPTION
## Description
Gets v0.7.1 ready for release. [Changes](https://github.com/department-of-veterans-affairs/component-library/compare/wc-v0.7.0...bump-wc-0.7.1-cv) include:

- `<va-alert>` style updates
- Added `formation` to peer dependencies
  - This was just implicit before
- Removed "unknown" attribute spread to the underlying `input` element in `va-text-input` and `va-checkbox`
- Added a `prepare` script to install the dependencies in the downstream project when using a git URL