### PR TITLE
Rename events in va-select

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -378,8 +378,8 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
-        "onKeyDown"?: (event: CustomEvent<any>) => void;
-        "onSelect"?: (event: CustomEvent<any>) => void;
+        "onVaKeyDown"?: (event: CustomEvent<any>) => void;
+        "onVaSelect"?: (event: CustomEvent<any>) => void;
         /**
           * Whether or not this is a required field.
          */

--- a/src/components/va-select/test/va-select.e2e.ts
+++ b/src/components/va-select/test/va-select.e2e.ts
@@ -119,7 +119,7 @@ describe('va-select', () => {
       </va-select>
     `);
 
-    const selectSpy = await page.spyOnEvent('select');
+    const selectSpy = await page.spyOnEvent('vaSelect');
 
     const handle = await page.$('pierce/select');
     await handle.select('bar');
@@ -137,7 +137,7 @@ describe('va-select', () => {
       </va-select>
     `);
 
-    const keyDownSpy = await page.spyOnEvent('keyDown');
+    const keyDownSpy = await page.spyOnEvent('vaKeyDown');
 
     const handle = await page.$('pierce/select');
     await handle.press('ArrowDown');

--- a/src/components/va-select/va-select.tsx
+++ b/src/components/va-select/va-select.tsx
@@ -48,9 +48,9 @@ export class VaSelect {
    */
   @Prop() enableAnalytics: boolean;
 
-  @Event() keyDown: EventEmitter;
+  @Event() vaKeyDown: EventEmitter;
 
-  @Event() select: EventEmitter;
+  @Event() vaSelect: EventEmitter;
 
   @Event({
     eventName: 'component-library-analytics',
@@ -62,7 +62,7 @@ export class VaSelect {
   @State() options: Array<Node>;
 
   private handleKeyDown() {
-    this.keyDown.emit();
+    this.vaKeyDown.emit();
   }
 
   private handleChange(e: Event) {
@@ -80,7 +80,7 @@ export class VaSelect {
       };
       this.componentLibraryAnalytics.emit(detail);
     }
-    this.select.emit({ value: this.value });
+    this.vaSelect.emit({ value: this.value });
   }
 
   /**


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/27163

Previously the build would give warnings due to the custom event names being the same as some native events:

![image](https://user-images.githubusercontent.com/2008881/126819808-e205700c-8b28-4da1-89a7-0a12110b5853.png)


Changing the names removes those warnings.

## Testing done

E2e tests


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
