### PR TITLE
Make react a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "node-sass": "4.14.1",
     "pinst": "^2.1.4",
     "prettier": "^2.2.1",
+    "react": "^16.13.1",
     "react-dom": "^16.7.0",
     "react-html-parser": "^2.0.2",
     "react-router": "3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "lodash": "^4.17.15",
     "moment": "^2.23.0",
     "prop-types": "^15.6.2",
-    "react": "^16.7.0",
     "react-focus-lock": "^2.4.0",
     "react-focus-on": "^3.5.1",
     "react-scroll": "^1.7.16",
@@ -101,5 +100,8 @@
   },
   "resolutions": {
     "trim-newlines": "^4.0.2"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10687,7 +10687,7 @@ react-transition-group@1:
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-react@^16.7.0:
+react@^16.13.1:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
## Description
Closes department-of-veterans-affairs/va.gov-team/issues/26810

This should move `react` to be a peer dependency so we can avoid problems with conflicting versions of React.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
