### PR TITLE
Add section heading to va-accordion web component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -33,6 +33,10 @@ export namespace Components {
           * True if only a single item can be opened at once
          */
         "openSingle": boolean;
+        /**
+          * Optional accordion section heading text. Only used in analytics event. Default is null.
+         */
+        "sectionheading": string;
     }
     interface VaAccordionItem {
         /**
@@ -265,6 +269,10 @@ declare namespace LocalJSX {
           * True if only a single item can be opened at once
          */
         "openSingle"?: boolean;
+        /**
+          * Optional accordion section heading text. Only used in analytics event. Default is null.
+         */
+        "sectionheading"?: string;
     }
     interface VaAccordionItem {
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -36,7 +36,7 @@ export namespace Components {
         /**
           * Optional accordion section heading text. Only used in analytics event. Default is null.
          */
-        "sectionheading": string;
+        "sectionHeading": string;
     }
     interface VaAccordionItem {
         /**
@@ -272,7 +272,7 @@ declare namespace LocalJSX {
         /**
           * Optional accordion section heading text. Only used in analytics event. Default is null.
          */
-        "sectionheading"?: string;
+        "sectionHeading"?: string;
     }
     interface VaAccordionItem {
         /**

--- a/src/components/va-accordion/va-accordion.e2e.ts
+++ b/src/components/va-accordion/va-accordion.e2e.ts
@@ -103,6 +103,7 @@ describe('va-accordion', () => {
         header: "First item",
         subheader: "First subheader",
         level: 2,
+        sectionHeading: null,
       },
     });
   });

--- a/src/components/va-accordion/va-accordion.stories.tsx
+++ b/src/components/va-accordion/va-accordion.stories.tsx
@@ -36,6 +36,18 @@ const TemplateSubheader = ({ subheader1, subheader2, level }) => html`
   </va-accordion>
 `;
 
+const TemplateSectionHeading = ({ sectionheading, level }) => html`
+  <va-accordion sectionheading=${sectionheading}>
+    <va-accordion-item header="First Amendment" level=${level}>
+      Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the
+      right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
+    </va-accordion-item>
+    <va-accordion-item header="Second Amendment" level=${level}>
+      A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
+    </va-accordion-item>
+  </va-accordion>
+`;
+
 
 export const Default = Template.bind({});
 
@@ -52,3 +64,8 @@ Bordered.args = { ...defaultArgs, bordered: true };
 export const Subheaders = TemplateSubheader.bind({});
 
 Subheaders.args = { ...defaultArgs, subheader1: 'First Amendment Subheader', subheader2: 'Second Amendment Subheader' };
+
+export const SectionHeading = TemplateSectionHeading.bind({});
+
+SectionHeading.args = { ...defaultArgs, sectionheading: "This is a section heading." };
+

--- a/src/components/va-accordion/va-accordion.stories.tsx
+++ b/src/components/va-accordion/va-accordion.stories.tsx
@@ -9,7 +9,8 @@ const defaultArgs = {
   multi: false,
   bordered: false,
   subheader: false,
-  level: 2
+  level: 2,
+  sectionHeading: null
 };
 
 const Template = ({ multi, bordered, level }) => html`
@@ -36,8 +37,8 @@ const TemplateSubheader = ({ subheader1, subheader2, level }) => html`
   </va-accordion>
 `;
 
-const TemplateSectionHeading = ({ sectionheading, level }) => html`
-  <va-accordion sectionheading=${sectionheading}>
+const TemplateSectionHeading = ({ sectionHeading, level }) => html`
+  <va-accordion section-heading=${sectionHeading}>
     <va-accordion-item header="First Amendment" level=${level}>
       Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the
       right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
@@ -67,5 +68,5 @@ Subheaders.args = { ...defaultArgs, subheader1: 'First Amendment Subheader', sub
 
 export const SectionHeading = TemplateSectionHeading.bind({});
 
-SectionHeading.args = { ...defaultArgs, sectionheading: "This is a section heading." };
+SectionHeading.args = { ...defaultArgs, sectionHeading: "This is a section heading." };
 

--- a/src/components/va-accordion/va-accordion.tsx
+++ b/src/components/va-accordion/va-accordion.tsx
@@ -68,6 +68,8 @@ export class VaAccordion {
           header: clickedItem.header,
           subheader: clickedItem.subheader,
           level: clickedItem.level,
+          sectionHeading: this.sectionheading,
+          bordered: this.bordered
         },
       };
       this.componentLibraryAnalytics.emit(detail);
@@ -90,6 +92,12 @@ export class VaAccordion {
    * If true, doesn't fire the CustomEvent which can be used for analytics tracking.
    */
   @Prop() disableAnalytics: boolean = false;
+
+  /**
+   * Optional accordion section heading text. Only used in analytics event. Default is null.
+   */
+  @Prop() sectionheading: string = null;
+
 
   render() {
     return (

--- a/src/components/va-accordion/va-accordion.tsx
+++ b/src/components/va-accordion/va-accordion.tsx
@@ -68,7 +68,7 @@ export class VaAccordion {
           header: clickedItem.header,
           subheader: clickedItem.subheader,
           level: clickedItem.level,
-          sectionHeading: this.sectionheading,
+          sectionHeading: this.sectionHeading,
           bordered: this.bordered
         },
       };
@@ -96,7 +96,7 @@ export class VaAccordion {
   /**
    * Optional accordion section heading text. Only used in analytics event. Default is null.
    */
-  @Prop() sectionheading: string = null;
+  @Prop() sectionHeading: string = null;
 
 
   render() {


### PR DESCRIPTION
## Description
For https://github.com/department-of-veterans-affairs/va.gov-team/issues/27847

> The transition from us-accordion to the va-accordion has revealed a gap in the latter.
> 
> We need to add the 'section-label' as a component parameter (for analytics only) and back out the dataLayer injection Ryan Leahy added to vets-website.

## Testing done

Added "Accordion Section Heading" story.

## Screenshots

![image](https://user-images.githubusercontent.com/62304138/127235112-c46d16ae-006e-41f1-8a27-58bf5fd54e9c.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
