### PR TITLE
Add radio web component to storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "sass-loader": "^8.0.2",
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-radio-button"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.0"
   },
   "resolutions": {
     "trim-newlines": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "sass-loader": "^8.0.2",
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.8.0"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-radio-button"
   },
   "resolutions": {
     "trim-newlines": "^4.0.2"

--- a/stories/va-radio.stories.jsx
+++ b/stories/va-radio.stories.jsx
@@ -48,3 +48,9 @@ Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(radioDocs);
+
+export const Error = Template.bind({});
+Error.args = {
+  ...defaultArgs,
+  error: 'There has been an error',
+};

--- a/stories/va-radio.stories.jsx
+++ b/stories/va-radio.stories.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  getWebComponentDocs,
+  componentStructure,
+  propStructure,
+  StoryDocs,
+} from './wc-helpers';
+
+const radioDocs = getWebComponentDocs('va-radio');
+const radioItem = getWebComponentDocs('va-radio-option');
+
+export default {
+  title: 'Components/va-radio',
+  subcomponents: componentStructure(radioItem),
+  parameters: {
+    docs: {
+      /* eslint-disable-next-line react/display-name */
+      page: () => <StoryDocs docs={radioDocs.docs} />,
+    },
+  },
+};
+
+const Template = args => {
+  return (
+    <va-radio {...args}>
+      <va-radio-option
+        label="Option one"
+        name="one"
+        value="1"
+      ></va-radio-option>
+      <va-radio-option
+        label="Option two"
+        name="two"
+        value="2"
+      ></va-radio-option>
+    </va-radio>
+  );
+};
+
+const defaultArgs = {
+  label: 'This is a label',
+  required: false,
+  error: null,
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+Default.argTypes = propStructure(radioDocs);

--- a/stories/va-radio.stories.jsx
+++ b/stories/va-radio.stories.jsx
@@ -23,16 +23,8 @@ export default {
 const Template = args => {
   return (
     <va-radio {...args}>
-      <va-radio-option
-        label="Option one"
-        name="one"
-        value="1"
-      ></va-radio-option>
-      <va-radio-option
-        label="Option two"
-        name="two"
-        value="2"
-      ></va-radio-option>
+      <va-radio-option label="Option one" name="one" value="1" />
+      <va-radio-option label="Option two" name="two" value="2" />
     </va-radio>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12944,7 +12944,7 @@ watchpack@^1.7.4:
 
 "web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-radio-button":
   version "0.8.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#f3fb475f71493f43edd6014705f229bf3a5303c4"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#c666445fe3a8b77cd8c42af89898a1461610f65e"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12942,9 +12942,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-radio-button":
-  version "0.8.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#c666445fe3a8b77cd8c42af89898a1461610f65e"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.0":
+  version "0.9.0"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#ac558c3c97129ad1acdf60b08966359b2d5139f4"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12942,9 +12942,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.8.0":
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-radio-button":
   version "0.8.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#4ee6bb1b0dfe33f029d13b8ec5cd10b61bffdcb3"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#f3fb475f71493f43edd6014705f229bf3a5303c4"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

Related to #120 

Add storybook story for the new `<va-radio>` Web Component.

Note: This should not be merged until the component has a tagged release.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
