### PR TITLE
Removed aria-live from breakcrumbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.jsx
@@ -63,7 +63,6 @@ class Breadcrumbs extends Component {
     return (
       <nav
         aria-label={ariaLabel}
-        aria-live="polite"
         className={classnames({
           'va-nav-breadcrumbs': true,
           'va-nav-breadcrumbs--mobile': !!mobileFirstProp,

--- a/src/components/Breadcrumbs/Breadcrumbs.unit.spec.jsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.unit.spec.jsx
@@ -78,7 +78,6 @@ describe('<Breadcrumbs>', () => {
 
     expect(navElem.props().className).to.equal('va-nav-breadcrumbs');
     expect(navElem.props()['aria-label']).to.equal('Breadcrumb');
-    expect(navElem.props()['aria-live']).to.equal('polite');
     tree.unmount();
   });
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/241

## Testing done

Tested that removing aria-polite stopped screen readers from announcing breadcrumbs when re-rendering

## Screenshots

N/A

## Acceptance criteria
- [ ] Breadcrumbs do not not announce their state when re-rendering

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
