### PR TITLE
Change how React bindings are built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ Thumbs.db
 UserInterfaceState.xcuserstate
 .env
 
-generated/
+react-bindings/

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dist/",
     "loader/",
     "component-docs.json",
-    "react-bindings.js"
+    "react-bindings.js",
+    "generated/"
   ],
   "scripts": {
     "build": "stencil build --docs-json component-docs.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-components",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "dist/",
     "loader/",
     "component-docs.json",
-    "react-bindings.js",
-    "generated/"
+    "react-bindings/"
   ],
   "scripts": {
     "build": "stencil build --docs-json component-docs.json",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "files": [
     "dist/",
     "loader/",
-    "component-docs.json"
+    "component-docs.json",
+    "react-bindings.js"
   ],
   "scripts": {
     "build": "stencil build --docs-json component-docs.json",

--- a/react-bindings.js
+++ b/react-bindings.js
@@ -1,1 +1,0 @@
-export * from './generated/bindings/components';

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -26,8 +26,8 @@ export const config: Config = {
   },
   outputTargets: [
     reactOutputTarget({
-      componentCorePackage: '../../dist/types',
-      proxiesFile: './generated/react-bindings/components.ts',
+      componentCorePackage: '../dist/types',
+      proxiesFile: './react-bindings/index.ts',
       includeDefineCustomElements: false,
     }),
     {

--- a/tsconfig.bindings.json
+++ b/tsconfig.bindings.json
@@ -13,16 +13,12 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "outDir": "generated/bindings",
     "removeComments": false,
     "sourceMap": true,
     "jsx": "react",
     "target": "es2015"
   },
-  "include": [
-    "generated/react-bindings/**/*.ts",
-    "generated/react-bindings/**/*.tsx"
-  ],
+  "include": ["react-bindings/**/*.ts", "react-bindings/**/*.tsx"],
   "compileOnSave": false,
   "buildOnSave": false
 }


### PR DESCRIPTION
## Description
This is a followup for #131. We needed the bindings to be includes in the `files` property in `package.json` so that they remain after installation.

The directory structure has also been reworked slightly so that inside of the `react-bindings` directory we have an `index.js` file and an `index.d.ts` file after building the bindings. This allows typescript _and_ javascript projects to import from `component-library/react-bindings`

## Testing done

Local using https://github.com/department-of-veterans-affairs/formulate/pull/16

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
