### PR TITLE
Automatically build package and attatch to release

### DIFF
--- a/.github/workflows/add-release-files.yml
+++ b/.github/workflows/add-release-files.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: 14.x
       - run: yarn
       - run: yarn build
+      - run: yarn build-bindings
       - run: yarn pack
       - run: ls
       - name: Upload the artifacts

--- a/.github/workflows/add-release-files.yml
+++ b/.github/workflows/add-release-files.yml
@@ -1,0 +1,31 @@
+on:
+  release:
+    types: [created, published, edited]
+name: Handle Release
+jobs:
+  generate:
+    name: Create release-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the web-components branch
+        uses: actions/checkout@v2
+        with:
+          ref: wc-automate-release-files
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - run: yarn
+      - run: yarn build
+      - run: yarn pack
+      - run: ls
+      - name: Upload the artifacts
+        uses: skx/github-action-publish-binaries@release-0.15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: '*.tgz'

--- a/.github/workflows/add-release-files.yml
+++ b/.github/workflows/add-release-files.yml
@@ -1,6 +1,6 @@
 on:
   release:
-    types: [created, published, edited]
+    types: [published]
 name: Handle Release
 jobs:
   generate:

--- a/.github/workflows/add-release-files.yml
+++ b/.github/workflows/add-release-files.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout the web-components branch
         uses: actions/checkout@v2
         with:
-          ref: wc-automate-release-files
+          ref: web-components
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'

--- a/.github/workflows/add-release-files.yml
+++ b/.github/workflows/add-release-files.yml
@@ -23,10 +23,9 @@ jobs:
       - run: yarn build
       - run: yarn build-bindings
       - run: yarn pack
-      - run: ls
       - name: Upload the artifacts
         uses: skx/github-action-publish-binaries@release-0.15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: '*.tgz'
+          args: 'web-components-*.tgz'


### PR DESCRIPTION
## Description
Closes #142.

This supercedes #143. In order for the action to run when a Release is tagged based on the `web-components` branch, this action will also need to be on that branch. Trying to change the base in the former PR messed things up, presumably due to no shared history.

We are doing this because using a `.git` url and building the package locally on different machines results in different checksums in the lockfile for yarn 2. Building the package remotely and attaching it to the release will solve this problem until we are able to actually unify `master` and `web-components`.

## Testing done

I monitored the `Actions` tab and made releases to trigger the action


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
