### PR TITLE
Fix incorrect removal of pre publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "node ./scripts/build.js",
     "build-storybook": "build-storybook",
     "postinstall": "husky install",
+    "prepublishOnly": "pinst --disable && node ./scripts/prepublish.js",
     "postpublish": "pinst --enable",
     "storybook": "start-storybook -p 6006",
     "test-debug": "karma start testing/karma.conf.js --browsers Chrome",


### PR DESCRIPTION
## Description
I mistakenly removed a script before committing my previous PR.

## Acceptance criteria
- [ ] Script is back

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
