### PR TITLE
Kelsonic 29069 banner refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -148,7 +148,7 @@ export class Banner extends Component {
             'vads-u-border-color--green-light':
               type === 'success' || type === 'continue',
             // 'warning', Yellow border, black triangle exclamation
-            'vads-u-border-color--warning-message': type === 'error',
+            'vads-u-border-color--warning-message': type === 'warning',
           },
         )}
         data-e2e-id="emergency-banner"


### PR DESCRIPTION
## Description
**Slack:** https://dsva.slack.com/archives/C52CL1PKQ/p1630607288190200

This PR changes the type for `vads-u-border-color--warning-message` to be `warning` instead of `error`.

## Testing done
Locally

## Screenshots
![image (4)](https://user-images.githubusercontent.com/12773166/131897995-1e682a6e-47bf-458a-9af9-0c7b29710ee9.png)

## Acceptance criteria
- [x] changes the type for `vads-u-border-color--warning-message` to be `warning` instead of `error`

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
