### PR TITLE
Add <th> with scope='row' to Table component for screen readers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -6,7 +6,12 @@ const borderClasses =
   'vads-u-border-top--0 vads-u-border-right--0 vads-u-border-left--0 vads-u-font-family--sans vads-u-padding--0 vads-u-padding-y--0p5 medium-screen:vads-u-padding--2';
 const rowPaddingClass = 'vads-u-padding-y--2';
 
-const cellProps = ({ alignLeft, alignRight, label }, index, rowIndex) => {
+const cellProps = (
+  { alignLeft, alignRight, label },
+  index,
+  rowIndex,
+  scope = null,
+) => {
   return {
     'data-index': index,
     className: classNames(borderClasses, {
@@ -16,13 +21,7 @@ const cellProps = ({ alignLeft, alignRight, label }, index, rowIndex) => {
     'data-label': label,
     key: `${rowIndex}-${label}`,
     role: 'cell',
-  };
-};
-
-const thProps = (field, index, rowIndex) => {
-  return {
-    ...cellProps(field, index, rowIndex),
-    scope: 'row',
+    scope: scope,
   };
 };
 
@@ -70,7 +69,7 @@ function Table(props) {
           >
             {fields.map((field, index) =>
               index === 0 ? (
-                <th {...thProps(field, index, rowIndex)}>
+                <th {...cellProps(field, index, rowIndex, 'row')}>
                   {item[field.value] === null ? '---' : item[field.value]}
                 </th>
               ) : (

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -48,20 +48,36 @@ function Table(props) {
             className={`${borderClasses} ${rowPaddingClass}`}
             role="row"
           >
-            {fields.map((field, index) => (
-              <td
-                data-index={index}
-                className={classNames(borderClasses, {
-                  'vads-u-text-align--left': field.alignLeft,
-                  'medium-screen:vads-u-text-align--right': field.alignRight,
-                })}
-                data-label={field.label}
-                key={`${rowIndex}-${field.label}`}
-                role="cell"
-              >
-                {item[field.value] === null ? '---' : item[field.value]}
-              </td>
-            ))}
+            {fields.map((field, index) =>
+              index === 0 ? (
+                <th
+                  data-index={index}
+                  className={classNames(borderClasses, {
+                    'vads-u-text-align--left': field.alignLeft,
+                    'medium-screen:vads-u-text-align--right': field.alignRight,
+                  })}
+                  data-label={field.label}
+                  key={`${rowIndex}-${field.label}`}
+                  role="cell"
+                  scope="row"
+                >
+                  {item[field.value] === null ? '---' : item[field.value]}
+                </th>
+              ) : (
+                <td
+                  data-index={index}
+                  className={classNames(borderClasses, {
+                    'vads-u-text-align--left': field.alignLeft,
+                    'medium-screen:vads-u-text-align--right': field.alignRight,
+                  })}
+                  data-label={field.label}
+                  key={`${rowIndex}-${field.label}`}
+                  role="cell"
+                >
+                  {item[field.value] === null ? '---' : item[field.value]}
+                </td>
+              ),
+            )}
           </tr>
         ))}
       </tbody>

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -6,6 +6,26 @@ const borderClasses =
   'vads-u-border-top--0 vads-u-border-right--0 vads-u-border-left--0 vads-u-font-family--sans vads-u-padding--0 vads-u-padding-y--0p5 medium-screen:vads-u-padding--2';
 const rowPaddingClass = 'vads-u-padding-y--2';
 
+const cellProps = ({ alignLeft, alignRight, label }, index, rowIndex) => {
+  return {
+    'data-index': index,
+    className: classNames(borderClasses, {
+      'vads-u-text-align--left': alignLeft,
+      'medium-screen:vads-u-text-align--right': alignRight,
+    }),
+    'data-label': label,
+    key: `${rowIndex}-${label}`,
+    role: 'cell',
+  };
+};
+
+const thProps = (field, index, rowIndex) => {
+  return {
+    ...cellProps(field, index, rowIndex),
+    scope: 'row',
+  };
+};
+
 function Table(props) {
   const { currentSort, fields, data, ariaLabelledBy } = props;
 
@@ -50,30 +70,11 @@ function Table(props) {
           >
             {fields.map((field, index) =>
               index === 0 ? (
-                <th
-                  data-index={index}
-                  className={classNames(borderClasses, {
-                    'vads-u-text-align--left': field.alignLeft,
-                    'medium-screen:vads-u-text-align--right': field.alignRight,
-                  })}
-                  data-label={field.label}
-                  key={`${rowIndex}-${field.label}`}
-                  role="cell"
-                  scope="row"
-                >
+                <th {...thProps(field, index, rowIndex)}>
                   {item[field.value] === null ? '---' : item[field.value]}
                 </th>
               ) : (
-                <td
-                  data-index={index}
-                  className={classNames(borderClasses, {
-                    'vads-u-text-align--left': field.alignLeft,
-                    'medium-screen:vads-u-text-align--right': field.alignRight,
-                  })}
-                  data-label={field.label}
-                  key={`${rowIndex}-${field.label}`}
-                  role="cell"
-                >
+                <td {...cellProps(field, index, rowIndex)}>
                   {item[field.value] === null ? '---' : item[field.value]}
                 </td>
               ),

--- a/src/components/Table/Table.unit.spec.jsx
+++ b/src/components/Table/Table.unit.spec.jsx
@@ -36,11 +36,10 @@ describe('<Table />', () => {
 
     expect(wrapper.find('thead')).to.have.lengthOf(1);
     expect(wrapper.find('th')).to.have.lengthOf(15);
-    expect(wrapper.find('td')).to.have.lengthOf(45);
     wrapper.unmount();
   });
 
-  it('should render all of the rows', () => {
+  it('should render all of the rows with headers', () => {
     const wrapper = shallow(
       <Table
         fields={fields}
@@ -53,6 +52,13 @@ describe('<Table />', () => {
     );
 
     expect(wrapper.find('tr')).to.have.lengthOf(10); // includes header row
+
+    const bodyRows = wrapper.find('tbody').find('tr');
+    expect(bodyRows).to.have.lengthOf(9);
+    bodyRows.forEach(row => expect(row.childAt(0).type()).to.equal('th'));
+    bodyRows.forEach(row =>
+      expect(row.childAt(0).props()['scope']).to.eql('row'),
+    );
     wrapper.unmount();
   });
 

--- a/src/components/Table/Table.unit.spec.jsx
+++ b/src/components/Table/Table.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('<Table />', () => {
     );
 
     expect(wrapper.find('thead')).to.have.lengthOf(1);
-    expect(wrapper.find('th')).to.have.lengthOf(15); // Once for each field
+    expect(wrapper.find('th')).to.have.lengthOf(15);
     expect(wrapper.find('td')).to.have.lengthOf(45);
     wrapper.unmount();
   });

--- a/src/components/Table/Table.unit.spec.jsx
+++ b/src/components/Table/Table.unit.spec.jsx
@@ -35,7 +35,8 @@ describe('<Table />', () => {
     );
 
     expect(wrapper.find('thead')).to.have.lengthOf(1);
-    expect(wrapper.find('th')).to.have.lengthOf(6); // Once for each field
+    expect(wrapper.find('th')).to.have.lengthOf(15); // Once for each field
+    expect(wrapper.find('td')).to.have.lengthOf(45);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/489

## Testing done
Manual testing.

## Acceptance criteria
- [ ] Table component rows appear as described in the ticket.