### PR TITLE
Refresh `yarn.lock` file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10492,7 +10492,7 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-focus-lock@^2.4.0, react-focus-lock@^2.5.0:
+react-focus-lock@^2.5.0, react-focus-lock@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.2.tgz#f1e4db5e25cd8789351f2bd5ebe91e9dcb9c2922"
   integrity sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==


### PR DESCRIPTION
## Description
An updated `yarn.lock` file is being generated when running `yarn install` locally and on CI. This PR refreshes the file so that it does not have to be updated.

## Testing done
Tests pass locally.

## Acceptance criteria
- [ ] CI passes.
- [ ] New `yarn.lock` file is not generated on CI.