### PR TITLE
Hide icons from screen readers

### DIFF
--- a/src/components/PromoBanner/PromoBanner.jsx
+++ b/src/components/PromoBanner/PromoBanner.jsx
@@ -52,8 +52,12 @@ function PromoBanner({
       <div className="vads-c-promo-banner__body">
         <div className="vads-c-promo-banner__icon">
           <span className="fa-stack fa-lg">
-            <i className="vads-u-color--white fa fa-circle fa-stack-2x" />
-            <i className={iconClasses} />
+            <i
+              aria-hidden="true"
+              className="vads-u-color--white fa fa-circle fa-stack-2x"
+              role="presentation"
+            />
+            <i aria-hidden="true" className={iconClasses} role="presentation" />
           </span>
         </div>
 
@@ -67,7 +71,12 @@ function PromoBanner({
               target={target}
               onClick={onCloseWithAnalytics}
             >
-              {text} <i className="fas fa-angle-right" />
+              {text}{' '}
+              <i
+                aria-hidden="true"
+                className="fas fa-angle-right"
+                role="presentation"
+              />
             </a>
           )}
         </div>
@@ -79,7 +88,11 @@ function PromoBanner({
             onClick={onClose}
             className="va-button-link vads-u-margin-top--1"
           >
-            <i className="fas fa-times-circle vads-u-font-size--lg" />
+            <i
+              aria-hidden="true"
+              className="fas fa-times-circle vads-u-font-size--lg"
+              role="presentation"
+            />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/250
Adds `aria-hidden="true"` and `role="presentation"` properties to icon elements for improved accessibility with JAWS. 

## Testing done
Passes all karma & linting tests.

## Acceptance criteria
- [x]  Icons are not being announced to screen readers. JAWS in particular.
- [x]  Create and/or modify unit tests for this component to include an aXe scan

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
