### PR TITLE
Update icon accessibility documentation

### DIFF
--- a/src/components/IconBase/IconBase.jsx
+++ b/src/components/IconBase/IconBase.jsx
@@ -3,9 +3,18 @@ import React from 'react';
 
 class IconBase extends React.Component {
   render() {
-    const { focusable, role, ...svgProps } = this.props;
+    const { focusable, role, ariaLabel, ...svgProps } = this.props;
 
-    return (
+    return ariaLabel ? (
+      <svg
+        focusable={focusable}
+        role={role}
+        {...svgProps}
+        aria-label={ariaLabel}
+      >
+        {this.props.children}
+      </svg>
+    ) : (
       <svg focusable={focusable} role={role} {...svgProps}>
         {this.props.children}
       </svg>
@@ -16,6 +25,8 @@ class IconBase extends React.Component {
 IconBase.propTypes = {
   focusable: PropTypes.bool.isRequired,
   role: PropTypes.string,
+  ariaLabel: PropTypes.string,
+  children: PropTypes.node.isRequired,
 };
 
 IconBase.defaultProps = {

--- a/src/components/IconBase/IconBase.stories.jsx
+++ b/src/components/IconBase/IconBase.stories.jsx
@@ -19,7 +19,9 @@ export const Description = () => (
     <p>
       <strong>Icon being used alone</strong>
       <br />
-      Example goes here...
+      <code>{`
+      <IconHelp color={'#000000'} cssClass={'a-class'} id={'favorite'} role={'img'} ariaLabel={'Favorite'} />
+    `}</code>
     </p>
     <p>
       <strong>Icon being used with supporting text</strong>

--- a/src/components/IconBase/IconBase.stories.jsx
+++ b/src/components/IconBase/IconBase.stories.jsx
@@ -42,40 +42,28 @@ export const Description = () => (
     <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'presentation'} ariaLabel={'Help'} />
     `}</code>
     <br />
-    <code>{`
-    Help
-    `}</code>
+    <code>{`Help`}</code>
     <h4>
       Icon being used alone inside an <code>{'<a>'}</code> tag
     </h4>
-    <code>{`
-      <a href="#>
-    `}</code>
+    <code>{`<a href="#>`}</code>
     <br />
     <code>{`
-        <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
+      <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
     `}</code>
     <br />
-    <code>{`
-      </a>
-    `}</code>
+    <code>{`</a>`}</code>
     <h4>
       Icon being used with supporting text inside an <code>{'<a>'}</code> tag
     </h4>
-    <code>{`
-      <a href="#>
-    `}</code>
+    <code>{`<a href="#>`}</code>
     <br />
     <code>{`
         <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'presentation'} ariaLabel={'Help'} />
     `}</code>
     <br />
-    <code>{`
-        Help
-    `}</code>
+    <code>{`Help`}</code>
     <br />
-    <code>{`
-      </a>
-    `}</code>
+    <code>{`</a>`}</code>
   </div>
 );

--- a/src/components/IconBase/IconBase.stories.jsx
+++ b/src/components/IconBase/IconBase.stories.jsx
@@ -16,54 +16,12 @@ export const Description = () => (
     <p>
       For examples of how this is used, see the other <code>Icon</code> stories.
     </p>
-    <h2>Accessibility</h2>
-    <h3>
-      When to use <code>{'role="img"'}</code>
-    </h3>
     <p>
-      If an icon is being used alone (without support text), it should have a{' '}
-      <code>{'role="img"'}</code> AND appropriate ARIA markup OR screen reader
-      only descriptive text.
+      For more information, see the Design System{' '}
+      <a href="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/blob/master/src/_design/icons.md">
+        icon documentation
+      </a>
+      .
     </p>
-    <h3>
-      When to use <code>{'role="presentation"'}</code>
-    </h3>
-    <p>
-      If an icon is being used with visual (and assistive device) text, it
-      should have <code>{'role="presentation"'}</code>.
-    </p>
-    <h3>Accessibility Examples</h3>
-    <h4>Icon being used alone</h4>
-    <code>{`
-      <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
-    `}</code>
-    <h4>Icon being used with supporting text</h4>
-    <code>{`
-    <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'presentation'} ariaLabel={'Help'} />
-    `}</code>
-    <br />
-    <code>{`Help`}</code>
-    <h4>
-      Icon being used alone inside an <code>{'<a>'}</code> tag
-    </h4>
-    <code>{`<a href="#>`}</code>
-    <br />
-    <code>{`
-      <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
-    `}</code>
-    <br />
-    <code>{`</a>`}</code>
-    <h4>
-      Icon being used with supporting text inside an <code>{'<a>'}</code> tag
-    </h4>
-    <code>{`<a href="#>`}</code>
-    <br />
-    <code>{`
-        <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'presentation'} ariaLabel={'Help'} />
-    `}</code>
-    <br />
-    <code>{`Help`}</code>
-    <br />
-    <code>{`</a>`}</code>
   </div>
 );

--- a/src/components/IconBase/IconBase.stories.jsx
+++ b/src/components/IconBase/IconBase.stories.jsx
@@ -41,6 +41,7 @@ export const Description = () => (
     <code>{`
     <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'presentation'} ariaLabel={'Help'} />
     `}</code>
+    <br />
     <code>{`
     Help
     `}</code>
@@ -49,7 +50,13 @@ export const Description = () => (
     </h4>
     <code>{`
       <a href="#>
+    `}</code>
+    <br />
+    <code>{`
         <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
+    `}</code>
+    <br />
+    <code>{`
       </a>
     `}</code>
     <h4>
@@ -57,8 +64,17 @@ export const Description = () => (
     </h4>
     <code>{`
       <a href="#>
+    `}</code>
+    <br />
+    <code>{`
         <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'presentation'} ariaLabel={'Help'} />
+    `}</code>
+    <br />
+    <code>{`
         Help
+    `}</code>
+    <br />
+    <code>{`
       </a>
     `}</code>
   </div>

--- a/src/components/IconBase/IconBase.stories.jsx
+++ b/src/components/IconBase/IconBase.stories.jsx
@@ -39,7 +39,9 @@ export const Description = () => (
     `}</code>
     <h4>Icon being used with supporting text</h4>
     <code>{`
-    <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
+    <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'presentation'} ariaLabel={'Help'} />
+    `}</code>
+    <code>{`
     Help
     `}</code>
     <h4>
@@ -55,7 +57,7 @@ export const Description = () => (
     </h4>
     <code>{`
       <a href="#>
-        <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
+        <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'presentation'} ariaLabel={'Help'} />
         Help
       </a>
     `}</code>

--- a/src/components/IconBase/IconBase.stories.jsx
+++ b/src/components/IconBase/IconBase.stories.jsx
@@ -16,5 +16,29 @@ export const Description = () => (
     <p>
       For examples of how this is used, see the other <code>Icon</code> stories.
     </p>
+    <p>
+      <strong>Icon being used alone</strong>
+      <br />
+      Example goes here...
+    </p>
+    <p>
+      <strong>Icon being used with supporting text</strong>
+      <br />
+      Example goes here...
+    </p>
+    <p>
+      <strong>
+        Icon being used alone inside an <code>{'<a>'}</code> tag
+      </strong>
+      <br />
+      Example goes here...
+    </p>
+    <p>
+      <strong>
+        icon being used with supporting text inside an <code>{'<a>'}</code> tag
+      </strong>
+      <br />
+      Example goes here...
+    </p>
   </div>
 );

--- a/src/components/IconBase/IconBase.stories.jsx
+++ b/src/components/IconBase/IconBase.stories.jsx
@@ -16,31 +16,33 @@ export const Description = () => (
     <p>
       For examples of how this is used, see the other <code>Icon</code> stories.
     </p>
+    <h2>Accessibility</h2>
+    <h3>
+      When to use <code>{'role="img"'}</code>
+    </h3>
     <p>
-      <strong>Icon being used alone</strong>
-      <br />
-      <code>{`
+      If an icon is being used alone (without support text), it should have a{' '}
+      <code>{'role="img"'}</code> AND appropriate ARIA markup OR screen reader
+      only descriptive text.
+    </p>
+    <h3>
+      When to use <code>{'role="presentation"'}</code>
+    </h3>
+    <p>
+      If an icon is being used with visual (and assistive device) text, it
+      should have <code>{'role="presentation"'}</code>.
+    </p>
+    <h3>Accessibility Examples</h3>
+    <h4>Icon being used alone</h4>
+    <code>{`
       <IconHelp color={'#000000'} cssClass={'a-class'} id={'favorite'} role={'img'} ariaLabel={'Favorite'} />
     `}</code>
-    </p>
-    <p>
-      <strong>Icon being used with supporting text</strong>
-      <br />
-      Example goes here...
-    </p>
-    <p>
-      <strong>
-        Icon being used alone inside an <code>{'<a>'}</code> tag
-      </strong>
-      <br />
-      Example goes here...
-    </p>
-    <p>
-      <strong>
-        icon being used with supporting text inside an <code>{'<a>'}</code> tag
-      </strong>
-      <br />
-      Example goes here...
-    </p>
+    <h4>Icon being used with supporting text</h4>
+    <h4>
+      Icon being used alone inside an <code>{'<a>'}</code> tag
+    </h4>
+    <h4>
+      Icon being used with supporting text inside an <code>{'<a>'}</code> tag
+    </h4>
   </div>
 );

--- a/src/components/IconBase/IconBase.stories.jsx
+++ b/src/components/IconBase/IconBase.stories.jsx
@@ -35,14 +35,25 @@ export const Description = () => (
     <h3>Accessibility Examples</h3>
     <h4>Icon being used alone</h4>
     <code>{`
-      <IconHelp color={'#000000'} cssClass={'a-class'} id={'favorite'} role={'img'} ariaLabel={'Favorite'} />
+      <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
     `}</code>
     <h4>Icon being used with supporting text</h4>
     <h4>
       Icon being used alone inside an <code>{'<a>'}</code> tag
     </h4>
+    <code>{`
+      <a href="#>
+        <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
+      </a>
+    `}</code>
     <h4>
       Icon being used with supporting text inside an <code>{'<a>'}</code> tag
     </h4>
+    <code>{`
+      <a href="#>
+        <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
+        Help
+      </a>
+    `}</code>
   </div>
 );

--- a/src/components/IconBase/IconBase.stories.jsx
+++ b/src/components/IconBase/IconBase.stories.jsx
@@ -38,6 +38,10 @@ export const Description = () => (
       <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
     `}</code>
     <h4>Icon being used with supporting text</h4>
+    <code>{`
+    <IconHelp color={'#000000'} cssClass={'a-class'} id={'icon-help'} role={'img'} ariaLabel={'Help'} />
+    Help
+    `}</code>
     <h4>
       Icon being used alone inside an <code>{'<a>'}</code> tag
     </h4>

--- a/src/components/IconHelp/IconHelp.jsx
+++ b/src/components/IconHelp/IconHelp.jsx
@@ -13,7 +13,7 @@ class IconHelp extends React.Component {
         id={id}
         pointerEvents="none"
         role={role}
-        aria-label={ariaLabel}
+        ariaLabel={ariaLabel}
         viewBox="0 0 62 63"
         width="62"
       >

--- a/src/components/IconHelp/IconHelp.jsx
+++ b/src/components/IconHelp/IconHelp.jsx
@@ -4,7 +4,7 @@ import IconBase from '../IconBase/IconBase';
 
 class IconHelp extends React.Component {
   render() {
-    const { color, cssClass, id, role } = this.props;
+    const { color, cssClass, id, role, ariaLabel } = this.props;
 
     return (
       <IconBase
@@ -13,6 +13,7 @@ class IconHelp extends React.Component {
         id={id}
         pointerEvents="none"
         role={role}
+        aria-label={ariaLabel}
         viewBox="0 0 62 63"
         width="62"
       >
@@ -46,6 +47,11 @@ IconHelp.propTypes = {
    * `role` attribute for the `<svg>` element
    */
   role: PropTypes.string,
+
+  /**
+   * `aria-label` attribute for the `<svg>` element
+   */
+  ariaLabel: PropTypes.string,
 };
 
 export default IconHelp;

--- a/src/components/IconHelp/IconHelp.stories.jsx
+++ b/src/components/IconHelp/IconHelp.stories.jsx
@@ -20,4 +20,6 @@ const defaultArgs = {
 export const Default = Template.bind({});
 Default.args = {
   ...defaultArgs,
+  role: 'image',
+  ariaLabel: 'Favorite',
 };

--- a/src/components/IconHelp/IconHelp.stories.jsx
+++ b/src/components/IconHelp/IconHelp.stories.jsx
@@ -21,5 +21,5 @@ export const Default = Template.bind({});
 Default.args = {
   ...defaultArgs,
   role: 'image',
-  ariaLabel: 'Favorite',
+  ariaLabel: 'Help',
 };

--- a/src/components/IconHelp/IconHelp.unit.spec.jsx
+++ b/src/components/IconHelp/IconHelp.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import IconHelp from './IconHelp.jsx';
 import { axeCheck } from '../../helpers/test-helpers';
@@ -18,6 +18,26 @@ describe('<IconHelp />', () => {
     );
 
     expect(wrapper.exists('.a-class')).to.equal(true);
+
+    wrapper.unmount();
+  });
+
+  it('sets aria-label when a valid value for the ariaLabel prop is provided', () => {
+    const ariaLabel = 'Help';
+    const wrapper = mount(
+      <IconHelp
+        cssClass="a-class"
+        color="#000000"
+        id="help"
+        role="img"
+        ariaLabel={ariaLabel}
+      />,
+    );
+    const IconHelpComponent = wrapper.find('IconHelp');
+    expect(IconHelpComponent.props().ariaLabel).to.equal(ariaLabel);
+
+    const IconBaseComponent = wrapper.find('IconBase');
+    expect(IconBaseComponent.props().ariaLabel).to.equal(ariaLabel);
 
     wrapper.unmount();
   });

--- a/src/components/IconHelp/IconHelp.unit.spec.jsx
+++ b/src/components/IconHelp/IconHelp.unit.spec.jsx
@@ -10,7 +10,7 @@ describe('<IconHelp />', () => {
         color="#000000"
         id="help"
         role="img"
-        ariaLabel="Favorite"
+        ariaLabel="Help"
       />,
     ));
 });

--- a/src/components/IconHelp/IconHelp.unit.spec.jsx
+++ b/src/components/IconHelp/IconHelp.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import IconHelp from './IconHelp.jsx';
 import { axeCheck } from '../../helpers/test-helpers';
@@ -19,26 +19,6 @@ describe('<IconHelp />', () => {
     );
 
     expect(wrapper.exists('.a-class')).to.equal(true);
-
-    wrapper.unmount();
-  });
-
-  it('passes the ariaLabel prop to IconBase', () => {
-    const ariaLabel = 'Help';
-    const wrapper = mount(
-      <IconHelp
-        cssClass="a-class"
-        color="#000000"
-        id="help"
-        role="img"
-        ariaLabel={ariaLabel}
-      />,
-    );
-    const IconHelpComponent = wrapper.find('IconHelp');
-    expect(IconHelpComponent.props().ariaLabel).to.equal(ariaLabel);
-
-    const IconBaseComponent = wrapper.find('IconBase');
-    expect(IconBaseComponent.props().ariaLabel).to.equal(ariaLabel);
 
     wrapper.unmount();
   });

--- a/src/components/IconHelp/IconHelp.unit.spec.jsx
+++ b/src/components/IconHelp/IconHelp.unit.spec.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
+
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 
@@ -22,7 +24,7 @@ describe('<IconHelp />', () => {
     wrapper.unmount();
   });
 
-  it('sets aria-label when a valid value for the ariaLabel prop is provided', () => {
+  it('passes the ariaLabel prop to IconBase', () => {
     const ariaLabel = 'Help';
     const wrapper = mount(
       <IconHelp
@@ -40,6 +42,22 @@ describe('<IconHelp />', () => {
     expect(IconBaseComponent.props().ariaLabel).to.equal(ariaLabel);
 
     wrapper.unmount();
+  });
+
+  it('sets the aria-label attribute when the ariaLabel prop is given', () => {
+    const ariaLabel = 'Help';
+
+    const icon = ReactTestUtils.renderIntoDocument(
+      <IconHelp
+        cssClass="a-class"
+        color="#000000"
+        id="help"
+        role="img"
+        ariaLabel={ariaLabel}
+      />,
+    );
+    var svg = ReactTestUtils.findRenderedDOMComponentWithTag(icon, 'svg');
+    expect(svg.getAttribute('aria-label')).to.equal(ariaLabel);
   });
 
   it('should pass a basic aXe check', () =>

--- a/src/components/IconHelp/IconHelp.unit.spec.jsx
+++ b/src/components/IconHelp/IconHelp.unit.spec.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import IconHelp from './IconHelp.jsx';
+import { axeCheck } from '../../helpers/test-helpers';
+
+describe('<IconHelp />', () => {
+  it('should pass a basic aXe check', () =>
+    axeCheck(
+      <IconHelp
+        cssClass="a-class"
+        color="#000000"
+        id="help"
+        role="img"
+        ariaLabel="Favorite"
+      />,
+    ));
+});

--- a/src/components/IconHelp/IconHelp.unit.spec.jsx
+++ b/src/components/IconHelp/IconHelp.unit.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 

--- a/src/components/IconHelp/IconHelp.unit.spec.jsx
+++ b/src/components/IconHelp/IconHelp.unit.spec.jsx
@@ -60,6 +60,14 @@ describe('<IconHelp />', () => {
     expect(svg.getAttribute('aria-label')).to.equal(ariaLabel);
   });
 
+  it('does not include the aria-label attribute when the ariaLabel prop is not given', () => {
+    const icon = ReactTestUtils.renderIntoDocument(
+      <IconHelp cssClass="a-class" color="#000000" id="help" role="img" />,
+    );
+    var svg = ReactTestUtils.findRenderedDOMComponentWithTag(icon, 'svg');
+    expect(svg.getAttribute('aria-label')).to.equal(null);
+  });
+
   it('should pass a basic aXe check', () =>
     axeCheck(
       <IconHelp

--- a/src/components/IconHelp/IconHelp.unit.spec.jsx
+++ b/src/components/IconHelp/IconHelp.unit.spec.jsx
@@ -1,8 +1,27 @@
 import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
 import IconHelp from './IconHelp.jsx';
 import { axeCheck } from '../../helpers/test-helpers';
 
 describe('<IconHelp />', () => {
+  it('Should Render', () => {
+    const wrapper = shallow(
+      <IconHelp
+        cssClass="a-class"
+        color="#000000"
+        id="help"
+        role="img"
+        ariaLabel="Help"
+      />,
+    );
+
+    expect(wrapper.exists('.a-class')).to.equal(true);
+
+    wrapper.unmount();
+  });
+
   it('should pass a basic aXe check', () =>
     axeCheck(
       <IconHelp

--- a/src/components/IconSearch/IconSearch.jsx
+++ b/src/components/IconSearch/IconSearch.jsx
@@ -4,7 +4,7 @@ import IconBase from '../IconBase/IconBase';
 
 class IconSearch extends React.Component {
   render() {
-    const { color, cssClass, id, role, title } = this.props;
+    const { color, cssClass, id, role, ariaLabel, title } = this.props;
 
     let svgTitle;
 
@@ -19,6 +19,7 @@ class IconSearch extends React.Component {
         id={id}
         pointerEvents="none"
         role={role}
+        aria-label={ariaLabel}
         viewBox="0 0 216 146"
         width="24"
       >
@@ -58,6 +59,11 @@ IconSearch.propTypes = {
    * `role` attribute for the `<svg>` element
    */
   role: PropTypes.string,
+
+  /**
+   * `aria-label` attribute for the `<svg>` element
+   */
+  ariaLabel: PropTypes.string,
 };
 
 export default IconSearch;

--- a/src/components/IconSearch/IconSearch.jsx
+++ b/src/components/IconSearch/IconSearch.jsx
@@ -19,7 +19,7 @@ class IconSearch extends React.Component {
         id={id}
         pointerEvents="none"
         role={role}
-        aria-label={ariaLabel}
+        ariaLabel={ariaLabel}
         viewBox="0 0 216 146"
         width="24"
       >

--- a/src/components/IconSearch/IconSearch.stories.jsx
+++ b/src/components/IconSearch/IconSearch.stories.jsx
@@ -22,5 +22,5 @@ export const Default = Template.bind({});
 Default.args = {
   ...defaultArgs,
   role: 'image',
-  ariaLabel: 'Favorite',
+  ariaLabel: 'Search',
 };

--- a/src/components/IconSearch/IconSearch.stories.jsx
+++ b/src/components/IconSearch/IconSearch.stories.jsx
@@ -21,4 +21,6 @@ const defaultArgs = {
 export const Default = Template.bind({});
 Default.args = {
   ...defaultArgs,
+  role: 'image',
+  ariaLabel: 'Favorite',
 };

--- a/src/components/IconSearch/IconSearch.unit.spec.jsx
+++ b/src/components/IconSearch/IconSearch.unit.spec.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import IconSearch from './IconSearch.jsx';
+import { axeCheck } from '../../helpers/test-helpers';
+
+describe('<IconSearch />', () => {
+  it('should pass a basic aXe check', () =>
+    axeCheck(
+      <IconSearch
+        cssClass="a-class"
+        color="#000000"
+        id="help"
+        role="img"
+        ariaLabel="Favorite"
+      />,
+    ));
+});

--- a/src/components/IconSearch/IconSearch.unit.spec.jsx
+++ b/src/components/IconSearch/IconSearch.unit.spec.jsx
@@ -1,14 +1,78 @@
 import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
 import IconSearch from './IconSearch.jsx';
 import { axeCheck } from '../../helpers/test-helpers';
 
 describe('<IconSearch />', () => {
+  it('Should Render', () => {
+    const wrapper = shallow(
+      <IconSearch
+        cssClass="a-class"
+        color="#000000"
+        id="search"
+        role="img"
+        ariaLabel="Search"
+      />,
+    );
+
+    expect(wrapper.exists('.a-class')).to.equal(true);
+
+    wrapper.unmount();
+  });
+
+  it('passes the ariaLabel prop to IconBase', () => {
+    const ariaLabel = 'Search';
+    const wrapper = mount(
+      <IconSearch
+        cssClass="a-class"
+        color="#000000"
+        id="search"
+        role="img"
+        ariaLabel={ariaLabel}
+      />,
+    );
+    const IconSearchComponent = wrapper.find('IconSearch');
+    expect(IconSearchComponent.props().ariaLabel).to.equal(ariaLabel);
+
+    const IconBaseComponent = wrapper.find('IconBase');
+    expect(IconBaseComponent.props().ariaLabel).to.equal(ariaLabel);
+
+    wrapper.unmount();
+  });
+
+  it('sets the aria-label attribute when the ariaLabel prop is given', () => {
+    const ariaLabel = 'Search';
+
+    const icon = ReactTestUtils.renderIntoDocument(
+      <IconSearch
+        cssClass="a-class"
+        color="#000000"
+        id="search"
+        role="img"
+        ariaLabel={ariaLabel}
+      />,
+    );
+    var svg = ReactTestUtils.findRenderedDOMComponentWithTag(icon, 'svg');
+    expect(svg.getAttribute('aria-label')).to.equal(ariaLabel);
+  });
+
+  it('does not include the aria-label attribute when the ariaLabel prop is not given', () => {
+    const icon = ReactTestUtils.renderIntoDocument(
+      <IconSearch cssClass="a-class" color="#000000" id="search" role="img" />,
+    );
+    var svg = ReactTestUtils.findRenderedDOMComponentWithTag(icon, 'svg');
+    expect(svg.getAttribute('aria-label')).to.equal(null);
+  });
+
   it('should pass a basic aXe check', () =>
     axeCheck(
       <IconSearch
         cssClass="a-class"
         color="#000000"
-        id="help"
+        id="search"
         role="img"
         ariaLabel="Search"
       />,

--- a/src/components/IconSearch/IconSearch.unit.spec.jsx
+++ b/src/components/IconSearch/IconSearch.unit.spec.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
+
 import IconSearch from './IconSearch.jsx';
 import { axeCheck } from '../../helpers/test-helpers';
 

--- a/src/components/IconSearch/IconSearch.unit.spec.jsx
+++ b/src/components/IconSearch/IconSearch.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import IconSearch from './IconSearch.jsx';
 import { axeCheck } from '../../helpers/test-helpers';
@@ -19,26 +19,6 @@ describe('<IconSearch />', () => {
     );
 
     expect(wrapper.exists('.a-class')).to.equal(true);
-
-    wrapper.unmount();
-  });
-
-  it('passes the ariaLabel prop to IconBase', () => {
-    const ariaLabel = 'Search';
-    const wrapper = mount(
-      <IconSearch
-        cssClass="a-class"
-        color="#000000"
-        id="search"
-        role="img"
-        ariaLabel={ariaLabel}
-      />,
-    );
-    const IconSearchComponent = wrapper.find('IconSearch');
-    expect(IconSearchComponent.props().ariaLabel).to.equal(ariaLabel);
-
-    const IconBaseComponent = wrapper.find('IconBase');
-    expect(IconBaseComponent.props().ariaLabel).to.equal(ariaLabel);
 
     wrapper.unmount();
   });

--- a/src/components/IconSearch/IconSearch.unit.spec.jsx
+++ b/src/components/IconSearch/IconSearch.unit.spec.jsx
@@ -10,7 +10,7 @@ describe('<IconSearch />', () => {
         color="#000000"
         id="help"
         role="img"
-        ariaLabel="Favorite"
+        ariaLabel="Search"
       />,
     ));
 });

--- a/src/components/IconUser/IconUser.jsx
+++ b/src/components/IconUser/IconUser.jsx
@@ -13,7 +13,7 @@ class IconUser extends React.Component {
         id={id}
         pointerEvents="none"
         role={role}
-        aria-label={ariaLabel}
+        ariaLabel={ariaLabel}
         viewBox="308 246 57 63"
         width="57"
       >

--- a/src/components/IconUser/IconUser.jsx
+++ b/src/components/IconUser/IconUser.jsx
@@ -4,7 +4,7 @@ import IconBase from '../IconBase/IconBase';
 
 class IconUser extends React.Component {
   render() {
-    const { color, cssClass, id, role } = this.props;
+    const { color, cssClass, id, role, ariaLabel } = this.props;
 
     return (
       <IconBase
@@ -13,6 +13,7 @@ class IconUser extends React.Component {
         id={id}
         pointerEvents="none"
         role={role}
+        aria-label={ariaLabel}
         viewBox="308 246 57 63"
         width="57"
       >
@@ -66,6 +67,16 @@ IconUser.propTypes = {
   color: PropTypes.string /* Should be a CSS color */,
   cssClass: PropTypes.string,
   id: PropTypes.string,
+
+  /**
+   * `role` attribute for the `<svg>` element
+   */
+  role: PropTypes.string,
+
+  /**
+   * `aria-label` attribute for the `<svg>` element
+   */
+  ariaLabel: PropTypes.string,
 };
 
 export default IconUser;

--- a/src/components/IconUser/IconUser.stories.jsx
+++ b/src/components/IconUser/IconUser.stories.jsx
@@ -15,4 +15,8 @@ const Template = args => <IconUser {...args} />;
 const defaultArgs = {};
 
 export const Default = Template.bind({});
-Default.args = { ...defaultArgs };
+Default.args = {
+  ...defaultArgs,
+  role: 'image',
+  ariaLabel: 'Favorite',
+};

--- a/src/components/IconUser/IconUser.stories.jsx
+++ b/src/components/IconUser/IconUser.stories.jsx
@@ -18,5 +18,5 @@ export const Default = Template.bind({});
 Default.args = {
   ...defaultArgs,
   role: 'image',
-  ariaLabel: 'Favorite',
+  ariaLabel: 'User',
 };

--- a/src/components/IconUser/IconUser.unit.spec.jsx
+++ b/src/components/IconUser/IconUser.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import IconUser from './IconUser.jsx';
 import { axeCheck } from '../../helpers/test-helpers';
@@ -19,26 +19,6 @@ describe('<IconUser />', () => {
     );
 
     expect(wrapper.exists('.a-class')).to.equal(true);
-
-    wrapper.unmount();
-  });
-
-  it('passes the ariaLabel prop to IconBase', () => {
-    const ariaLabel = 'user';
-    const wrapper = mount(
-      <IconUser
-        cssClass="a-class"
-        color="#000000"
-        id="user"
-        role="img"
-        ariaLabel={ariaLabel}
-      />,
-    );
-    const IconUserComponent = wrapper.find('IconUser');
-    expect(IconUserComponent.props().ariaLabel).to.equal(ariaLabel);
-
-    const IconBaseComponent = wrapper.find('IconBase');
-    expect(IconBaseComponent.props().ariaLabel).to.equal(ariaLabel);
 
     wrapper.unmount();
   });

--- a/src/components/IconUser/IconUser.unit.spec.jsx
+++ b/src/components/IconUser/IconUser.unit.spec.jsx
@@ -1,8 +1,72 @@
 import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
 import IconUser from './IconUser.jsx';
 import { axeCheck } from '../../helpers/test-helpers';
 
 describe('<IconUser />', () => {
+  it('Should Render', () => {
+    const wrapper = shallow(
+      <IconUser
+        cssClass="a-class"
+        color="#000000"
+        id="user"
+        role="img"
+        ariaLabel="user"
+      />,
+    );
+
+    expect(wrapper.exists('.a-class')).to.equal(true);
+
+    wrapper.unmount();
+  });
+
+  it('passes the ariaLabel prop to IconBase', () => {
+    const ariaLabel = 'user';
+    const wrapper = mount(
+      <IconUser
+        cssClass="a-class"
+        color="#000000"
+        id="user"
+        role="img"
+        ariaLabel={ariaLabel}
+      />,
+    );
+    const IconUserComponent = wrapper.find('IconUser');
+    expect(IconUserComponent.props().ariaLabel).to.equal(ariaLabel);
+
+    const IconBaseComponent = wrapper.find('IconBase');
+    expect(IconBaseComponent.props().ariaLabel).to.equal(ariaLabel);
+
+    wrapper.unmount();
+  });
+
+  it('sets the aria-label attribute when the ariaLabel prop is given', () => {
+    const ariaLabel = 'user';
+
+    const icon = ReactTestUtils.renderIntoDocument(
+      <IconUser
+        cssClass="a-class"
+        color="#000000"
+        id="user"
+        role="img"
+        ariaLabel={ariaLabel}
+      />,
+    );
+    var svg = ReactTestUtils.findRenderedDOMComponentWithTag(icon, 'svg');
+    expect(svg.getAttribute('aria-label')).to.equal(ariaLabel);
+  });
+
+  it('does not include the aria-label attribute when the ariaLabel prop is not given', () => {
+    const icon = ReactTestUtils.renderIntoDocument(
+      <IconUser cssClass="a-class" color="#000000" id="user" role="img" />,
+    );
+    var svg = ReactTestUtils.findRenderedDOMComponentWithTag(icon, 'svg');
+    expect(svg.getAttribute('aria-label')).to.equal(null);
+  });
+
   it('should pass a basic aXe check', () =>
     axeCheck(
       <IconUser
@@ -10,7 +74,7 @@ describe('<IconUser />', () => {
         color="#000000"
         id="help"
         role="img"
-        ariaLabel="User"
+        ariaLabel="user"
       />,
     ));
 });

--- a/src/components/IconUser/IconUser.unit.spec.jsx
+++ b/src/components/IconUser/IconUser.unit.spec.jsx
@@ -10,7 +10,7 @@ describe('<IconUser />', () => {
         color="#000000"
         id="help"
         role="img"
-        ariaLabel="Favorite"
+        ariaLabel="User"
       />,
     ));
 });

--- a/src/components/IconUser/IconUser.unit.spec.jsx
+++ b/src/components/IconUser/IconUser.unit.spec.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import IconUser from './IconUser.jsx';
+import { axeCheck } from '../../helpers/test-helpers';
+
+describe('<IconUser />', () => {
+  it('should pass a basic aXe check', () =>
+    axeCheck(
+      <IconUser
+        cssClass="a-class"
+        color="#000000"
+        id="help"
+        role="img"
+        ariaLabel="Favorite"
+      />,
+    ));
+});


### PR DESCRIPTION
## Description
Closes <https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/221>

## Testing done
New unit tests to run aXe checks against `IconHelp`, `IconSearch`, and `IconUser` components.

## Acceptance criteria
- [x] Documentation is updated to highlight when developers should use different roles
- [x] If an icon is being used alone (without support text), it should have a `role="img"` AND appropriate ARIA markup OR screen reader only descriptive text
- [x] If an icon is being used with visual (and assistive device) text, it should have `role="presentation"`
- [x] Documentation should show more explicit use cases:
  * Icon being used alone
  * Icon being used with supporting text
  * Icon being used alone inside an `<a>` tag
  * icon being used with supporting text inside an `<a>` tag
 - [x] Create and/or modify unit tests for this component to include an aXe scan

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
