### PR TITLE
Do not call onClose when link clicked

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/PromoBanner/PromoBanner.jsx
+++ b/src/components/PromoBanner/PromoBanner.jsx
@@ -30,7 +30,7 @@ function PromoBanner({
     PROMO_BANNER_ICONS.get(type),
   );
 
-  const onCloseWithAnalytics = () => {
+  const handleLinkClick = () => {
     // Conditionally track the event.
     if (!disableAnalytics) {
       dispatchAnalyticsEvent({
@@ -44,7 +44,6 @@ function PromoBanner({
         },
       });
     }
-    return onClose && onClose();
   };
 
   return (
@@ -65,7 +64,7 @@ function PromoBanner({
               className="vads-c-promo-banner__content-link"
               href={href}
               target={target}
-              onClick={onCloseWithAnalytics}
+              onClick={handleLinkClick}
             >
               {text} <i className="fas fa-angle-right" />
             </a>

--- a/src/components/PromoBanner/PromoBanner.unit.spec.jsx
+++ b/src/components/PromoBanner/PromoBanner.unit.spec.jsx
@@ -76,25 +76,21 @@ describe('<PromoBanner>', () => {
   });
 
   describe('onClose', () => {
-    let wrapper;
-    const onCloseSpy = sinon.spy();
-    const props = {
-      type: PROMO_BANNER_TYPES.announcement,
-      href: 'https://missionact.va.gov/',
-      text: TEXT,
-      onClose: onCloseSpy,
+    const renderBanner = () => {
+      const onCloseSpy = sinon.spy();
+      const wrapper = shallow(
+        <PromoBanner
+          type={PROMO_BANNER_TYPES.announcement}
+          href="https://missionact.va.gov/"
+          text={TEXT}
+          onClose={onCloseSpy}
+        />,
+      );
+      return { onCloseSpy, wrapper };
     };
 
-    beforeEach(() => {
-      wrapper = shallow(<PromoBanner {...props} />);
-    });
-
-    afterEach(() => {
-      onCloseSpy.resetHistory();
-      wrapper.unmount();
-    });
-
     it('should call onClose when the "x" button is clicked', () => {
+      const { wrapper, onCloseSpy } = renderBanner();
       // Click close button in content
       const closeButton = wrapper.find('.vads-c-promo-banner__close button');
       closeButton.simulate('click');
@@ -103,6 +99,7 @@ describe('<PromoBanner>', () => {
     });
 
     it('should not call onClose when the link is clicked', () => {
+      const { wrapper, onCloseSpy } = renderBanner();
       // Click link in content
       const testLink = wrapper.find('.vads-c-promo-banner__content-link');
       testLink.simulate('click');

--- a/src/components/PromoBanner/PromoBanner.unit.spec.jsx
+++ b/src/components/PromoBanner/PromoBanner.unit.spec.jsx
@@ -74,4 +74,40 @@ describe('<PromoBanner>', () => {
       ).to.be.true;
     });
   });
+
+  describe('onClose', () => {
+    let wrapper;
+    const onCloseSpy = sinon.spy();
+    const props = {
+      type: PROMO_BANNER_TYPES.announcement,
+      href: 'https://missionact.va.gov/',
+      text: TEXT,
+      onClose: onCloseSpy,
+    };
+
+    beforeEach(() => {
+      wrapper = shallow(<PromoBanner {...props} />);
+    });
+
+    afterEach(() => {
+      onCloseSpy.resetHistory();
+      wrapper.unmount();
+    });
+
+    it('should call onClose when the "x" button is clicked', () => {
+      // Click close button in content
+      const closeButton = wrapper.find('.vads-c-promo-banner__close button');
+      closeButton.simulate('click');
+
+      expect(onCloseSpy.called).to.be.true;
+    });
+
+    it('should not call onClose when the link is clicked', () => {
+      // Click link in content
+      const testLink = wrapper.find('.vads-c-promo-banner__content-link');
+      testLink.simulate('click');
+
+      expect(onCloseSpy.called).not.to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29824

Currently clicking a link in a Promo Banner dismisses the banner when only clicking the x should do that.

## Testing done
local, unit

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
