### PR TITLE
Add third accordion item to Storybook

### DIFF
--- a/stories/va-accordion.stories.jsx
+++ b/stories/va-accordion.stories.jsx
@@ -28,6 +28,11 @@ const Template = args => {
         State, the right of the people to keep and bear Arms, shall not be
         infringed.
       </va-accordion-item>
+      <va-accordion-item level={level} header="Third Amendment">
+        No Soldier shall, in time of peace be quartered in any house, without
+        the consent of the Owner, nor in time of war, but in a manner to be
+        prescribed by law.
+      </va-accordion-item>
     </va-accordion>
   );
 };


### PR DESCRIPTION
## Description

Addresses @GnatalieH 's comment on https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/314 about having a third accordion item.

Item text taken from: https://constitution.congress.gov/constitution/amendment-3/

## Testing done

Storybook :eyes: 

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/133293225-8ab351b4-55bd-4853-8eae-fc353cd54fc1.png)

![image](https://user-images.githubusercontent.com/2008881/133293288-bfb0fc52-6a07-4917-92ab-ee6232789bd6.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
