### PR TITLE
Add Back to top Web Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/jest": "^26.0.20",
     "@types/puppeteer": "^5.4.3",
     "@types/react-dom": "16.0.9",
+    "animate.css": "^4.1.1",
     "babel-loader": "^8.2.2",
     "concurrently": "^5.3.0",
     "jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@stencil/core": "^2.0.1",
     "@stencil/postcss": "^2.0.0",
+    "classnames": "^2.3.1",
     "intersection-observer": "^0.12.0",
     "postcss-url": "^10.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepare": "npm run build && npm run build-bindings"
   },
   "dependencies": {
-    "@stencil/core": "^2.0.1",
+    "@stencil/core": "^2.8.1",
     "@stencil/postcss": "^2.0.0",
     "classnames": "^2.3.1",
     "intersection-observer": "^0.12.0",
@@ -54,7 +54,7 @@
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
     "lit-html": "^1.3.0",
-    "puppeteer": "5.4.1",
+    "puppeteer": "10.0.0",
     "react-dom": "^16.7.0",
     "typescript": "^4.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-components",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@stencil/core": "^2.0.1",
     "@stencil/postcss": "^2.0.0",
+    "intersection-observer": "^0.12.0",
     "postcss-url": "^10.1.1"
   },
   "license": "MIT",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -83,6 +83,10 @@ export namespace Components {
         "visible": boolean;
     }
     interface VaBackToTop {
+        /**
+          * Once the viewport is below this point, the button is revealed
+         */
+        "breakpoint": string;
     }
     interface VaCheckbox {
         /**
@@ -392,6 +396,10 @@ declare namespace LocalJSX {
         "visible"?: boolean;
     }
     interface VaBackToTop {
+        /**
+          * Once the viewport is below this point, the button is revealed
+         */
+        "breakpoint"?: string;
     }
     interface VaCheckbox {
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -84,7 +84,7 @@ export namespace Components {
     }
     interface VaBackToTop {
         /**
-          * Once the viewport is below this point, the button is revealed
+          * A vertical distance. Once the viewport is below this point, the button is revealed
          */
         "breakpoint": string;
     }
@@ -397,7 +397,7 @@ declare namespace LocalJSX {
     }
     interface VaBackToTop {
         /**
-          * Once the viewport is below this point, the button is revealed
+          * A vertical distance. Once the viewport is below this point, the button is revealed
          */
         "breakpoint"?: string;
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -82,6 +82,8 @@ export namespace Components {
          */
         "visible": boolean;
     }
+    interface VaBackToTop {
+    }
     interface VaCheckbox {
         /**
           * The aria-describedby attribute for the <intput> in the shadow DOM.
@@ -245,6 +247,12 @@ declare global {
         prototype: HTMLVaAlertElement;
         new (): HTMLVaAlertElement;
     };
+    interface HTMLVaBackToTopElement extends Components.VaBackToTop, HTMLStencilElement {
+    }
+    var HTMLVaBackToTopElement: {
+        prototype: HTMLVaBackToTopElement;
+        new (): HTMLVaBackToTopElement;
+    };
     interface HTMLVaCheckboxElement extends Components.VaCheckbox, HTMLStencilElement {
     }
     var HTMLVaCheckboxElement: {
@@ -286,6 +294,7 @@ declare global {
         "va-accordion": HTMLVaAccordionElement;
         "va-accordion-item": HTMLVaAccordionItemElement;
         "va-alert": HTMLVaAlertElement;
+        "va-back-to-top": HTMLVaBackToTopElement;
         "va-checkbox": HTMLVaCheckboxElement;
         "va-on-this-page": HTMLVaOnThisPageElement;
         "va-radio": HTMLVaRadioElement;
@@ -381,6 +390,8 @@ declare namespace LocalJSX {
           * If true, the alert will be visible.
          */
         "visible"?: boolean;
+    }
+    interface VaBackToTop {
     }
     interface VaCheckbox {
         /**
@@ -554,6 +565,7 @@ declare namespace LocalJSX {
         "va-accordion": VaAccordion;
         "va-accordion-item": VaAccordionItem;
         "va-alert": VaAlert;
+        "va-back-to-top": VaBackToTop;
         "va-checkbox": VaCheckbox;
         "va-on-this-page": VaOnThisPage;
         "va-radio": VaRadio;
@@ -570,6 +582,7 @@ declare module "@stencil/core" {
             "va-accordion": LocalJSX.VaAccordion & JSXBase.HTMLAttributes<HTMLVaAccordionElement>;
             "va-accordion-item": LocalJSX.VaAccordionItem & JSXBase.HTMLAttributes<HTMLVaAccordionItemElement>;
             "va-alert": LocalJSX.VaAlert & JSXBase.HTMLAttributes<HTMLVaAlertElement>;
+            "va-back-to-top": LocalJSX.VaBackToTop & JSXBase.HTMLAttributes<HTMLVaBackToTopElement>;
             "va-checkbox": LocalJSX.VaCheckbox & JSXBase.HTMLAttributes<HTMLVaCheckboxElement>;
             "va-on-this-page": LocalJSX.VaOnThisPage & JSXBase.HTMLAttributes<HTMLVaOnThisPageElement>;
             "va-radio": LocalJSX.VaRadio & JSXBase.HTMLAttributes<HTMLVaRadioElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -83,10 +83,6 @@ export namespace Components {
         "visible": boolean;
     }
     interface VaBackToTop {
-        /**
-          * A vertical distance. Once the viewport is below this point, the button is revealed
-         */
-        "breakpoint": string;
     }
     interface VaCheckbox {
         /**
@@ -396,10 +392,6 @@ declare namespace LocalJSX {
         "visible"?: boolean;
     }
     interface VaBackToTop {
-        /**
-          * A vertical distance. Once the viewport is below this point, the button is revealed
-         */
-        "breakpoint"?: string;
     }
     interface VaCheckbox {
         /**

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -121,8 +121,9 @@ describe('va-back-to-top', () => {
   it('passes an axe check when revealed', async () => {
     const page = await pageSetup();
     const button = await page.find('va-back-to-top >>> button');
+    const pastRevealPoint = 300;
 
-    await page.mouse.wheel({ deltaY: 300 });
+    await page.mouse.wheel({ deltaY: pastRevealPoint });
     await page.waitForChanges();
 
     expect(button).toHaveClass('reveal');
@@ -132,10 +133,13 @@ describe('va-back-to-top', () => {
 
   it('passes an axe check when docked', async () => {
     const page = await pageSetup();
+    const wrapper = await page.find('va-back-to-top >>> div');
+    const pastPlaceholder = 1000;
 
-    await page.mouse.wheel({ deltaY: 1400 });
+    await page.mouse.wheel({ deltaY: pastPlaceholder });
     await page.waitForChanges();
 
+    expect(wrapper).toHaveClass('docked');
     // The color contrast error appears to be a false negative
     await axeCheck(page, ['color-contrast']);
   });

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('va-back-to-top', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-back-to-top></va-back-to-top>');
+
+    const element = await page.find('va-back-to-top');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -83,9 +83,16 @@ describe('va-back-to-top', () => {
   it('stays docked even with really long footers', async () => {
     const page = await pageSetup();
     const wrapper = await page.find('va-back-to-top >>> div');
-    const pastDock = 1300; // Placeholder section is 1000px tall & viewport is 200
+    const pastPlaceholder = 1000;
+    // Placeholder section is 1000px tall. Accounting for the header,
+    // 2000px should put us well past the dock
+    const pastDock = 500;
 
-    // Scroll past the dock
+    // Scroll to the dock to give IntersectionObserver time to trigger
+    await page.mouse.wheel({ deltaY: pastPlaceholder });
+    await page.waitForChanges();
+
+    // Scroll past dock
     await page.mouse.wheel({ deltaY: pastDock });
     await page.waitForChanges();
 

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -1,81 +1,34 @@
 import { newE2EPage } from '@stencil/core/testing';
 import { axeCheck } from '../../../testing/test-helpers';
 
-const pageContent = `
-      <h1>The top</h1>
-      <p>Lorem ipsum</p>
-      <p>Some more</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Lorem ipsum</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>Some more</p>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-        mollit anim id est laborum.
-      </p>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-        mollit anim id est laborum.
-      </p>
-      <p>Some more</p>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
-        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-        mollit anim id est laborum.
-      </p>
-      <p>Some more</p>
-      <p>Some more</p>
-      `;
+const pageStyles = `
+:root { --reveal-breakpoint: 200px}
+div {
+  margin: 0;
+  padding: 0;
+  height: 1000px;
+}
+footer {
+  height: 500px;
+}
+`;
+
+const pageSetup = async () => {
+  const page = await newE2EPage();
+  await page.setViewport({ width: 800, height: 200 });
+  await page.setContent(`
+    <main>
+    <h1>The top</h1>
+    <div>Placeholder</div>
+    <va-back-to-top></va-back-to-top>
+    </main>
+    <footer>The footer</footer>
+    `);
+
+  await page.addStyleTag({ content: pageStyles });
+
+  return page;
+};
 
 describe('va-back-to-top', () => {
   it('renders', async () => {
@@ -87,82 +40,68 @@ describe('va-back-to-top', () => {
   });
 
   it('reveals when the viewport is below the reveal pixel', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <main>
-    ${pageContent}
-    <va-back-to-top></va-back-to-top>
-    </main>
-    `);
+    const page = await pageSetup();
     const button = await page.find('va-back-to-top >>> button');
+    const notQuitePastRevealPoint = 199;
 
     // Button shouldn't be revealed initially
     expect(button).not.toHaveClass('reveal');
 
-    await page.mouse.wheel({ deltaY: 100 });
+    // Scroll until the `<span class="reveal-point">` is just at
+    // the top of the viewport
+    await page.mouse.wheel({ deltaY: notQuitePastRevealPoint });
     await page.waitForChanges();
 
     // Button _still_ shouldn't be revealed after a bit of scrolling
     expect(button).not.toHaveClass('reveal');
 
-    await page.mouse.wheel({ deltaY: 1000 });
+    // Scroll a few pixels more to get past the `--reveal-breakpoint`
+    await page.mouse.wheel({ deltaY: 10 });
     await page.waitForChanges();
 
-    // We've scrolled a lot - button should be revealed
+    // Button should be revealed with `.reveal-point` above the viewport
     expect(button).toHaveClass('reveal');
   });
 
   it('docks when the "dock" is scrolled into view', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <main>
-    ${pageContent}
-    <va-back-to-top></va-back-to-top>
-    <footer style="height: 100px">The footer</footer>
-    </main>
-    `);
+    const page = await pageSetup();
     const wrapper = await page.find('va-back-to-top >>> div');
+    const pastPlaceholder = 1000;
 
     expect(wrapper).not.toHaveClass('docked');
 
-    await page.mouse.wheel({ deltaY: 1400 });
+    // 1000px scrolled + 200px viewport height means that the dock is in the viewport
+    await page.mouse.wheel({ deltaY: pastPlaceholder });
     await page.waitForChanges();
+
+    expect(await wrapper.isIntersectingViewport()).toEqual(true);
 
     // We've scrolled a lot - button should be docked
     expect(wrapper).toHaveClass('docked');
   });
 
   it('stays docked even with really long footers', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <main>
-    ${pageContent}
-    <va-back-to-top></va-back-to-top>
-    <footer style="height: 2400px">The footer</footer>
-    </main>
-    `);
+    const page = await pageSetup();
     const wrapper = await page.find('va-back-to-top >>> div');
+    const pastDock = 1300; // Placeholder section is 1000px tall & viewport is 200
 
-    await page.mouse.wheel({ deltaY: 3000 });
+    // Scroll past the dock
+    await page.mouse.wheel({ deltaY: pastDock });
     await page.waitForChanges();
 
-    // After scrolling this much, the dock is well above the viewport
+    // After scrolling this much, the dock is above the viewport
+    expect(await wrapper.isIntersectingViewport()).toEqual(false);
     expect(wrapper).toHaveClass('docked');
   });
 
   it('goes to top on click', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <main>
-    ${pageContent}
-    <va-back-to-top></va-back-to-top>
-    </main>
-    `);
+    const page = await pageSetup();
     const button = await page.find('va-back-to-top >>> button');
     const topHeading = await page.find('h1');
+    const pastRevealPoint = 300;
 
-    // Make the button visible
-    await page.mouse.wheel({ deltaY: 1000 });
+    // Scroll far enough to make the button visible
+    await page.mouse.wheel({ deltaY: pastRevealPoint });
     await page.waitForChanges();
 
     expect(await topHeading.isIntersectingViewport()).toEqual(false);
@@ -174,42 +113,25 @@ describe('va-back-to-top', () => {
   });
 
   it('passes an axe check', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <main>
-    ${pageContent}
-    <va-back-to-top></va-back-to-top>
-    </main>
-    `);
+    const page = await pageSetup();
 
     await axeCheck(page);
   });
 
   it('passes an axe check when revealed', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <main>
-    ${pageContent}
-    <va-back-to-top></va-back-to-top>
-    </main>
-    `);
+    const page = await pageSetup();
+    const button = await page.find('va-back-to-top >>> button');
 
-    await page.mouse.wheel({ deltaY: 1000 });
+    await page.mouse.wheel({ deltaY: 300 });
     await page.waitForChanges();
 
+    expect(button).toHaveClass('reveal');
     // The color contrast error appears to be a false negative
     await axeCheck(page, ['color-contrast']);
   });
 
   it('passes an axe check when docked', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <main>
-    ${pageContent}
-    <va-back-to-top></va-back-to-top>
-    <footer style="height: 100px">The footer</footer>
-    </main>
-    `);
+    const page = await pageSetup();
 
     await page.mouse.wheel({ deltaY: 1400 });
     await page.waitForChanges();

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -185,8 +185,7 @@ describe('va-back-to-top', () => {
     await axeCheck(page);
   });
 
-  // This is oddly failing on a color contrast error
-  it.skip('passes an axe check when revealed', async () => {
+  it('passes an axe check when revealed', async () => {
     const page = await newE2EPage();
     await page.setContent(`
     <main>
@@ -198,11 +197,11 @@ describe('va-back-to-top', () => {
     await page.mouse.wheel({ deltaY: 1000 });
     await page.waitForChanges();
 
-    await axeCheck(page);
+    // The color contrast error appears to be a false negative
+    await axeCheck(page, ['color-contrast']);
   });
 
-  // This is oddly failing on a color contrast error
-  it.skip('passes an axe check when docked', async () => {
+  it('passes an axe check when docked', async () => {
     const page = await newE2EPage();
     await page.setContent(`
     <main>
@@ -215,6 +214,7 @@ describe('va-back-to-top', () => {
     await page.mouse.wheel({ deltaY: 1400 });
     await page.waitForChanges();
 
-    await axeCheck(page);
+    // The color contrast error appears to be a false negative
+    await axeCheck(page, ['color-contrast']);
   });
 });

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -41,11 +41,11 @@ describe('va-back-to-top', () => {
 
   it('reveals when the viewport is below the reveal pixel', async () => {
     const page = await pageSetup();
-    const button = await page.find('va-back-to-top >>> button');
+    const wrapper = await page.find('va-back-to-top >>> div');
     const notQuitePastRevealPoint = 199;
 
     // Button shouldn't be revealed initially
-    expect(button).not.toHaveClass('reveal');
+    expect(wrapper).not.toHaveClass('reveal');
 
     // Scroll until the `<span class="reveal-point">` is just at
     // the top of the viewport
@@ -53,14 +53,14 @@ describe('va-back-to-top', () => {
     await page.waitForChanges();
 
     // Button _still_ shouldn't be revealed after a bit of scrolling
-    expect(button).not.toHaveClass('reveal');
+    expect(wrapper).not.toHaveClass('reveal');
 
     // Scroll a few pixels more to get past the `--reveal-breakpoint`
     await page.mouse.wheel({ deltaY: 10 });
     await page.waitForChanges();
 
     // Button should be revealed with `.reveal-point` above the viewport
-    expect(button).toHaveClass('reveal');
+    expect(wrapper).toHaveClass('reveal');
   });
 
   it('docks when the "dock" is scrolled into view', async () => {
@@ -127,13 +127,13 @@ describe('va-back-to-top', () => {
 
   it('passes an axe check when revealed', async () => {
     const page = await pageSetup();
-    const button = await page.find('va-back-to-top >>> button');
+    const wrapper = await page.find('va-back-to-top >>> div');
     const pastRevealPoint = 300;
 
     await page.mouse.wheel({ deltaY: pastRevealPoint });
     await page.waitForChanges();
 
-    expect(button).toHaveClass('reveal');
+    expect(wrapper).toHaveClass('reveal');
     // The color contrast error appears to be a false negative
     await axeCheck(page, ['color-contrast']);
   });

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -131,6 +131,24 @@ describe('va-back-to-top', () => {
     expect(wrapper).toHaveClass('docked');
   });
 
+  it('stays docked even with really long footers', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <main>
+    ${pageContent}
+    <va-back-to-top></va-back-to-top>
+    <footer style="height: 2400px">The footer</footer>
+    </main>
+    `);
+    const wrapper = await page.find('va-back-to-top >>> div');
+
+    await page.mouse.wheel({ deltaY: 3000 });
+    await page.waitForChanges();
+
+    // After scrolling this much, the dock is well above the viewport
+    expect(wrapper).toHaveClass('docked');
+  });
+
   it('goes to top on click', async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -109,4 +109,24 @@ describe('va-back-to-top', () => {
     // We've scrolled a lot - button should be revealed
     expect(button).toHaveClass('reveal');
   });
+
+  it('docks when the "dock" is scrolled into view', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <main>
+    ${pageContent}
+    <va-back-to-top></va-back-to-top>
+    <footer style="height: 100px">The footer</footer>
+    </main>
+    `);
+    const wrapper = await page.find('va-back-to-top >>> div');
+
+    expect(wrapper).not.toHaveClass('docked');
+
+    await page.mouse.wheel({ deltaY: 1400 });
+    await page.waitForChanges();
+
+    // We've scrolled a lot - button should be revealed
+    expect(wrapper).toHaveClass('docked');
+  });
 });

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from '@stencil/core/testing';
 
 const pageContent = `
+      <h1>The top</h1>
       <p>Lorem ipsum</p>
       <p>Some more</p>
       <p>Lorem ipsum</p>
@@ -128,5 +129,28 @@ describe('va-back-to-top', () => {
 
     // We've scrolled a lot - button should be revealed
     expect(wrapper).toHaveClass('docked');
+  });
+
+  it('goes to top on click', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <main>
+    ${pageContent}
+    <va-back-to-top></va-back-to-top>
+    </main>
+    `);
+    const button = await page.find('va-back-to-top >>> button');
+    const topHeading = await page.find('h1');
+
+    // Make the button visible
+    await page.mouse.wheel({ deltaY: 1000 });
+    await page.waitForChanges();
+
+    expect(await topHeading.isIntersectingViewport()).toEqual(false);
+
+    button.click();
+    await page.waitForChanges();
+
+    expect(await topHeading.isIntersectingViewport()).toEqual(true);
   });
 });

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -184,4 +184,37 @@ describe('va-back-to-top', () => {
 
     await axeCheck(page);
   });
+
+  // This is oddly failing on a color contrast error
+  it.skip('passes an axe check when revealed', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <main>
+    ${pageContent}
+    <va-back-to-top></va-back-to-top>
+    </main>
+    `);
+
+    await page.mouse.wheel({ deltaY: 1000 });
+    await page.waitForChanges();
+
+    await axeCheck(page);
+  });
+
+  // This is oddly failing on a color contrast error
+  it.skip('passes an axe check when docked', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <main>
+    ${pageContent}
+    <va-back-to-top></va-back-to-top>
+    <footer style="height: 100px">The footer</footer>
+    </main>
+    `);
+
+    await page.mouse.wheel({ deltaY: 1400 });
+    await page.waitForChanges();
+
+    await axeCheck(page);
+  });
 });

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { axeCheck } from '../../../testing/test-helpers';
 
 const pageContent = `
       <h1>The top</h1>
@@ -127,7 +128,7 @@ describe('va-back-to-top', () => {
     await page.mouse.wheel({ deltaY: 1400 });
     await page.waitForChanges();
 
-    // We've scrolled a lot - button should be revealed
+    // We've scrolled a lot - button should be docked
     expect(wrapper).toHaveClass('docked');
   });
 
@@ -170,5 +171,17 @@ describe('va-back-to-top', () => {
     await page.waitForChanges();
 
     expect(await topHeading.isIntersectingViewport()).toEqual(true);
+  });
+
+  it('passes an axe check', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <main>
+    ${pageContent}
+    <va-back-to-top></va-back-to-top>
+    </main>
+    `);
+
+    await axeCheck(page);
   });
 });

--- a/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -1,5 +1,80 @@
 import { newE2EPage } from '@stencil/core/testing';
 
+const pageContent = `
+      <p>Lorem ipsum</p>
+      <p>Some more</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Lorem ipsum</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>Some more</p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </p>
+      <p>Some more</p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </p>
+      <p>Some more</p>
+      <p>Some more</p>
+      `;
+
 describe('va-back-to-top', () => {
   it('renders', async () => {
     const page = await newE2EPage();
@@ -7,5 +82,31 @@ describe('va-back-to-top', () => {
 
     const element = await page.find('va-back-to-top');
     expect(element).toHaveClass('hydrated');
+  });
+
+  it('reveals when the viewport is below the reveal pixel', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <main>
+    ${pageContent}
+    <va-back-to-top></va-back-to-top>
+    </main>
+    `);
+    const button = await page.find('va-back-to-top >>> button');
+
+    // Button shouldn't be revealed initially
+    expect(button).not.toHaveClass('reveal');
+
+    await page.mouse.wheel({ deltaY: 100 });
+    await page.waitForChanges();
+
+    // Button _still_ shouldn't be revealed after a bit of scrolling
+    expect(button).not.toHaveClass('reveal');
+
+    await page.mouse.wheel({ deltaY: 1000 });
+    await page.waitForChanges();
+
+    // We've scrolled a lot - button should be revealed
+    expect(button).toHaveClass('reveal');
   });
 });

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -2,10 +2,10 @@
 :host {
   display: block;
   bottom: 0;
-  /* pointer-events: none; */
-  /* position: fixed; */
   width: 100%;
   height: 44px;
+  margin-top: 4rem;
+  margin-bottom: 2rem;
 }
 
 div {

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -30,11 +30,9 @@ button {
   right: 0;
   width: 44px;
 }
-
-/* div.docked, */
-/* div.docked button { */
-/*   position: relative; */
-/* } */
+button:hover {
+  background-color: var(--color-black);
+}
 
 div.docked {
   position: relative;

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -15,6 +15,14 @@ div {
   width: 100%;
 }
 
+.reveal-point {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  top: var(--reveal-breakpoint, 60rem);
+  left: 0;
+}
+
 button {
   bottom: 0;
   background-color: var(--color-gray-dark);

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -27,23 +27,35 @@ div {
 
 button {
   bottom: 0;
+  right: 0;
   background-color: var(--color-gray-dark);
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
   height: 44px;
+  width: 44px;
   margin: 0;
+  margin-bottom: 0.5rem;
   opacity: 0;
   padding: 0;
   pointer-events: none;
   pointer-events: auto;
   position: absolute;
-  right: 0;
-  width: 44px;
   transition: all 0.25s ease-in;
-  margin-bottom: 0.5rem;
 }
 button:hover {
   background-color: var(--color-black);
+}
+button.reveal {
+  pointer-events: auto;
+  opacity: 1;
+  animation: slideInUp 0.25s;
+}
+button:not(.reveal) {
+  animation: slideOutDown 0.25s;
+}
+
+button span {
+  display: none;
 }
 
 div.docked {
@@ -51,7 +63,6 @@ div.docked {
   display: flex;
   flex-direction: row-reverse;
 }
-
 div:not(.docked) {
   max-width: var(--undocked-width);
 }
@@ -60,31 +71,9 @@ div.docked button {
   position: relative;
 }
 
-button span {
-  display: none;
-}
-
 i {
   font-size: 2rem;
 }
-
-@media (min-width: 768px) {
-  button {
-    padding: 0 1.6rem;
-    width: auto;
-  }
-
-  i {
-    padding-right: 8px;
-    padding-top: 12px;
-    font-size: 1em;
-  }
-
-  button span {
-    display: inline-block;
-  }
-}
-
 i {
   font-family: 'Font Awesome 5 Free';
   font-style: normal;
@@ -94,12 +83,19 @@ i::before {
   content: '\F062'; /* fa-arrow-up*/
 }
 
-button.reveal {
-  pointer-events: auto;
-  opacity: 1;
-  animation: slideInUp 0.25s;
-}
+@media (min-width: 768px) {
+  button {
+    padding: 0 1.6rem;
+    width: auto;
+  }
 
-button:not(.reveal) {
-  animation: slideOutDown 0.25s;
+  button span {
+    display: inline-block;
+  }
+
+  i {
+    padding-right: 8px;
+    padding-top: 12px;
+    font-size: 1em;
+  }
 }

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -21,9 +21,9 @@ button {
   border-top-right-radius: 0;
   height: 44px;
   margin: 0;
-  /* opacity: 0; */
+  opacity: 0;
   padding: 0;
-  /* pointer-events: none; */
+  pointer-events: none;
   pointer-events: auto;
   position: absolute;
   right: 0;
@@ -58,7 +58,7 @@ i {
   font-size: 2rem;
 }
 
-.reveal {
-  background: blue;
-  color: white;
+button.reveal {
+  pointer-events: auto;
+  opacity: 1;
 }

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -64,7 +64,6 @@ button span {
 
 @media (min-width: 768px) {
   button {
-    border-radius: 5px;
     padding-left: 17px;
     padding-right: 19px;
     width: auto;

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -1,0 +1,44 @@
+:host {
+  display: block;
+  bottom: 0;
+  /* pointer-events: none; */
+  /* position: fixed; */
+  width: 100%;
+  height: 44px;
+}
+
+div {
+  position: fixed;
+  bottom: 0;
+  display: block;
+  width: 100%;
+}
+
+button {
+  bottom: 0;
+  background-color: var(--color-gray-dark);
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  height: 44px;
+  margin: 0;
+  /* opacity: 0; */
+  padding: 0;
+  /* pointer-events: none; */
+  pointer-events: auto;
+  position: absolute;
+  right: 0;
+  width: 44px;
+}
+
+/* @media(max-width: ) { */
+button {
+  padding-left: 17px;
+  padding-right: 19px;
+  width: auto;
+}
+/* } */
+
+i {
+  margin-right: 0;
+  font-size: 2rem;
+}

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -41,6 +41,10 @@ div.docked {
   flex-direction: row-reverse;
 }
 
+div:not(.docked) {
+  max-width: var(--undocked-width);
+}
+
 div.docked button {
   position: relative;
 }

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -23,6 +23,8 @@ div {
   height: 1px;
   top: var(--reveal-breakpoint, 60rem);
   left: 0;
+  /* background: black; /1* For debugging in browser *1/ */
+  /* width: 100%;  /1* For debugging in browser *1/ */
 }
 
 button {

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -50,17 +50,40 @@ div.docked button {
   position: relative;
 }
 
-/* @media(max-width: ) { */
-button {
-  padding-left: 17px;
-  padding-right: 19px;
-  width: auto;
+button span {
+  display: none;
 }
-/* } */
+
+@media (min-width: 768px) {
+  button {
+    border-radius: 5px;
+    padding-left: 17px;
+    padding-right: 19px;
+    width: auto;
+  }
+
+  i {
+    padding-right: 8px;
+    padding-top: 12px;
+    font-size: 1em;
+  }
+
+  button span {
+    display: inline-block;
+  }
+}
 
 i {
   margin-right: 0;
   font-size: 2rem;
+}
+i {
+  font-family: 'Font Awesome 5 Free';
+  font-style: normal;
+  font-weight: 900;
+}
+i::before {
+  content: '\F062'; /* fa-arrow-up*/
 }
 
 button.reveal {

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -3,7 +3,6 @@
 @import '../../mixins/buttons.css';
 :host {
   display: block;
-  bottom: 0;
   width: 100%;
   height: 44px;
   margin-top: 4rem;
@@ -35,12 +34,10 @@ button {
   border-top-right-radius: 0;
   height: 44px;
   width: 44px;
-  margin: 0;
   margin-bottom: 0.5rem;
   opacity: 0;
   padding: 0;
   pointer-events: none;
-  pointer-events: auto;
   position: absolute;
   transition: all 0.25s ease-in;
 }

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -64,10 +64,13 @@ button span {
   display: none;
 }
 
+i {
+  font-size: 2rem;
+}
+
 @media (min-width: 768px) {
   button {
-    padding-left: 17px;
-    padding-right: 19px;
+    padding: 0 1.6rem;
     width: auto;
   }
 
@@ -82,10 +85,6 @@ button span {
   }
 }
 
-i {
-  margin-right: 0;
-  font-size: 2rem;
-}
 i {
   font-family: 'Font Awesome 5 Free';
   font-style: normal;

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -52,6 +52,18 @@ button:not(.reveal) {
   animation: slideOutDown 0.25s;
 }
 
+@media (prefers-reduced-motion) {
+  button {
+    transition: none;
+  }
+  button.reveal {
+    animation: none;
+  }
+  button:not(.reveal) {
+    animation: none;
+  }
+}
+
 button span {
   display: none;
 }

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -29,6 +29,8 @@ button {
   position: absolute;
   right: 0;
   width: 44px;
+  transition: all 0.25s ease-in;
+  margin-bottom: 0.5rem;
 }
 button:hover {
   background-color: var(--color-black);
@@ -87,4 +89,33 @@ i::before {
 button.reveal {
   pointer-events: auto;
   opacity: 1;
+  animation: slideInUp;
+  animation-duration: 0.25s;
+}
+
+button:not(.reveal) {
+  animation: slideOutDown;
+  animation-duration: 0.25s;
+}
+
+@keyframes slideInUp {
+  from {
+    transform: translate3d(0, 100%, 0);
+    visibility: visible;
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes slideOutDown {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+
+  to {
+    visibility: hidden;
+    transform: translate3d(0, 100%, 0);
+  }
 }

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -43,12 +43,12 @@ button {
 button:hover {
   background-color: var(--color-black);
 }
-button.reveal {
+div.reveal button {
   pointer-events: auto;
   opacity: 1;
   animation: slideInUp 0.25s;
 }
-button:not(.reveal) {
+div:not(.reveal) button {
   animation: slideOutDown 0.25s;
 }
 
@@ -56,10 +56,10 @@ button:not(.reveal) {
   button {
     transition: none;
   }
-  button.reveal {
+  div.reveal button {
     animation: none;
   }
-  button:not(.reveal) {
+  div:not(.reveal) button {
     animation: none;
   }
 }
@@ -75,6 +75,9 @@ div.docked {
 }
 div:not(.docked) {
   max-width: var(--undocked-width);
+}
+div:not(.docked):not(.reveal) {
+  position: relative;
 }
 
 div.docked button {

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -1,3 +1,4 @@
+@import '../../mixins/buttons.css';
 :host {
   display: block;
   bottom: 0;

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -85,6 +85,8 @@ i::before {
   button {
     padding: 0 1.6rem;
     width: auto;
+    border-bottom-right-radius: 5px;
+    border-top-right-radius: 5px;
   }
 
   button span {

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -30,6 +30,21 @@ button {
   width: 44px;
 }
 
+/* div.docked, */
+/* div.docked button { */
+/*   position: relative; */
+/* } */
+
+div.docked {
+  position: relative;
+  display: flex;
+  flex-direction: row-reverse;
+}
+
+div.docked button {
+  position: relative;
+}
+
 /* @media(max-width: ) { */
 button {
   padding-left: 17px;
@@ -46,8 +61,4 @@ i {
 .reveal {
   background: blue;
   color: white;
-}
-
-.docked {
-  position: relative;
 }

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -12,7 +12,6 @@
 div {
   position: fixed;
   bottom: 0;
-  display: block;
   width: 100%;
 }
 
@@ -93,8 +92,8 @@ i::before {
   }
 
   i {
-    padding-right: 8px;
-    padding-top: 12px;
+    padding-right: 0.8rem;
+    padding-top: 1.2rem;
     font-size: 1em;
   }
 }

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -1,3 +1,5 @@
+@import '../../../node_modules/animate.css/source/sliding_entrances/slideInUp.css';
+@import '../../../node_modules/animate.css/source/sliding_exits/slideOutDown.css';
 @import '../../mixins/buttons.css';
 :host {
   display: block;
@@ -96,33 +98,9 @@ i::before {
 button.reveal {
   pointer-events: auto;
   opacity: 1;
-  animation: slideInUp;
-  animation-duration: 0.25s;
+  animation: slideInUp 0.25s;
 }
 
 button:not(.reveal) {
-  animation: slideOutDown;
-  animation-duration: 0.25s;
-}
-
-@keyframes slideInUp {
-  from {
-    transform: translate3d(0, 100%, 0);
-    visibility: visible;
-  }
-
-  to {
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes slideOutDown {
-  from {
-    transform: translate3d(0, 0, 0);
-  }
-
-  to {
-    visibility: hidden;
-    transform: translate3d(0, 100%, 0);
-  }
+  animation: slideOutDown 0.25s;
 }

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -47,3 +47,7 @@ i {
   background: blue;
   color: white;
 }
+
+.docked {
+  position: relative;
+}

--- a/src/components/va-back-to-top/va-back-to-top.css
+++ b/src/components/va-back-to-top/va-back-to-top.css
@@ -42,3 +42,8 @@ i {
   margin-right: 0;
   font-size: 2rem;
 }
+
+.reveal {
+  background: blue;
+  color: white;
+}

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -1,0 +1,40 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'va-back-to-top',
+  styleUrl: 'va-back-to-top.css',
+  shadow: true,
+})
+export class VaBackToTop {
+  navigateToTop() {
+    console.log('Clicking button');
+    // Focus the h1 tag on the page.
+    const el = document.querySelector('h1');
+    if (el) {
+      // Prepare the element so that it can accept focus properly.
+      el.setAttribute('tabindex', '-1');
+      el.focus();
+
+      // Cleanup the tabindex on blur.
+      el.addEventListener('blur', () => el.removeAttribute('tabindex'));
+    }
+
+    // Scroll to the top.
+    return window.scrollTo(0, 0);
+  }
+
+  render() {
+    return (
+      <Host>
+        <div>
+          <button onClick={this.navigateToTop.bind(this)}>
+            <span>
+              <i aria-hidden="true" class="fa-arrow-up" role="img"></i>
+            </span>
+            <span>Back to top</span>
+          </button>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -1,4 +1,6 @@
-import { Component, Host, Listen, State, h } from '@stencil/core';
+import { Component, Element, Host, Listen, State, h } from '@stencil/core';
+
+import { isInViewport } from '../../utils/utils';
 
 @Component({
   tag: 'va-back-to-top',
@@ -7,13 +9,28 @@ import { Component, Host, Listen, State, h } from '@stencil/core';
 })
 export class VaBackToTop {
   breakpoint = 600;
+  bttButton!: HTMLButtonElement;
   @State() hasHitBreakpoint = false;
+  @State() isDocked = false;
+
+  @Element() el: HTMLElement;
 
   @Listen('scroll', { target: 'window' })
   handleScroll(ev) {
     if (this.breakpointCheck() !== this.hasHitBreakpoint) {
       this.hasHitBreakpoint = !this.hasHitBreakpoint;
     }
+
+    if (this.readyToDock() !== this.isDocked) {
+      this.isDocked = !this.isDocked;
+    }
+  }
+
+  readyToDock() {
+    return (
+      this.el.getBoundingClientRect().top <=
+        this.bttButton.getBoundingClientRect().top && isInViewport(this.el)
+    );
   }
 
   breakpointCheck() {
@@ -38,12 +55,18 @@ export class VaBackToTop {
   }
 
   render() {
+    let buttonClasses = '';
+
+    if (this.hasHitBreakpoint) buttonClasses += 'reveal ';
+    if (this.isDocked) buttonClasses += 'docked';
+
     return (
       <Host>
-        <div>
+        <div class={this.isDocked ? 'docked' : ''}>
           <button
             onClick={this.navigateToTop.bind(this)}
-            class={this.hasHitBreakpoint ? 'reveal' : ''}
+            class={buttonClasses}
+            ref={el => (this.bttButton = el as HTMLButtonElement)}
           >
             <span>
               <i aria-hidden="true" class="fa-arrow-up" role="img"></i>

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Host, State, h } from '@stencil/core';
+import { Component, Element, Host, State, Prop, h } from '@stencil/core';
 import classnames from 'classnames';
 
 import 'intersection-observer';
@@ -9,10 +9,15 @@ import 'intersection-observer';
   shadow: true,
 })
 export class VaBackToTop {
-  breakpoint = 600;
   dockObserver = null;
   revealObserver = null;
   revealPixel!: HTMLSpanElement;
+
+  /**
+   * A vertical distance. Once the viewport is below this point,
+   * the button is revealed
+   */
+  @Prop() breakpoint = '60rem';
 
   @State() hasHitBreakpoint = false;
   @State() isDocked = false;
@@ -54,7 +59,10 @@ export class VaBackToTop {
 
   render() {
     const undockedWidth = this.el.getBoundingClientRect().width;
+
+    // These won't work on IE11 - there is a default value for --reveal-breakpoint
     this.el.style.setProperty('--undocked-width', `${undockedWidth}px`);
+    this.el.style.setProperty('--reveal-breakpoint', this.breakpoint);
 
     return (
       <Host>

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -66,9 +66,7 @@ export class VaBackToTop {
             class={this.hasHitBreakpoint ? 'reveal' : ''}
             ref={el => (this.bttButton = el as HTMLButtonElement)}
           >
-            <span>
-              <i aria-hidden="true" class="fa-arrow-up" role="img"></i>
-            </span>
+            <i aria-hidden="true" role="img"></i>
             <span>Back to top</span>
           </button>
         </div>

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -16,7 +16,7 @@ export class VaBackToTop {
   @Element() el: HTMLElement;
 
   @Listen('scroll', { target: 'window' })
-  handleScroll(ev) {
+  handleScroll() {
     if (this.breakpointCheck() !== this.hasHitBreakpoint) {
       this.hasHitBreakpoint = !this.hasHitBreakpoint;
     }
@@ -55,17 +55,12 @@ export class VaBackToTop {
   }
 
   render() {
-    let buttonClasses = '';
-
-    if (this.hasHitBreakpoint) buttonClasses += 'reveal ';
-    if (this.isDocked) buttonClasses += 'docked';
-
     return (
       <Host>
         <div class={this.isDocked ? 'docked' : ''}>
           <button
             onClick={this.navigateToTop.bind(this)}
-            class={buttonClasses}
+            class={this.hasHitBreakpoint ? 'reveal' : ''}
             ref={el => (this.bttButton = el as HTMLButtonElement)}
           >
             <span>

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Host, State, Prop, h } from '@stencil/core';
+import { Component, Element, Host, State, h } from '@stencil/core';
 import classnames from 'classnames';
 
 import 'intersection-observer';
@@ -10,12 +10,6 @@ import 'intersection-observer';
 })
 export class VaBackToTop {
   revealPixel!: HTMLSpanElement;
-
-  /**
-   * A vertical distance. Once the viewport is below this point,
-   * the button is revealed
-   */
-  @Prop() breakpoint = '60rem';
 
   @State() hasHitBreakpoint = false;
   @State() isDocked = false;
@@ -57,10 +51,7 @@ export class VaBackToTop {
 
   render() {
     const undockedWidth = this.el.getBoundingClientRect().width;
-
-    // These won't work on IE11 - there is a default value for --reveal-breakpoint
     this.el.style.setProperty('--undocked-width', `${undockedWidth}px`);
-    this.el.style.setProperty('--reveal-breakpoint', this.breakpoint);
 
     return (
       <Host>

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -24,11 +24,7 @@ export class VaBackToTop {
     };
 
     const handleDock = entries => {
-      if (entries[0].isIntersecting && !this.isDocked) {
-        this.isDocked = true;
-      } else if (!entries[0].isIntersecting && this.isDocked) {
-        this.isDocked = false;
-      }
+      this.isDocked = entries[0].isIntersecting;
     };
 
     const handleReveal = entries => {

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -20,7 +20,10 @@ export class VaBackToTop {
     // Setup observer to handle docking behavior
     const dockObserver = new IntersectionObserver(
       entries => {
-        this.isDocked = entries[0].isIntersecting;
+        // The second half of the || ensures that the button
+        // stays docked even if the viewport is scrolled below the dock
+        this.isDocked =
+          entries[0].isIntersecting || entries[0].boundingClientRect.y < 0;
       },
       { threshold: 1.0 },
     );

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -9,8 +9,6 @@ import 'intersection-observer';
   shadow: true,
 })
 export class VaBackToTop {
-  dockObserver = null;
-  revealObserver = null;
   revealPixel!: HTMLSpanElement;
 
   /**
@@ -26,19 +24,19 @@ export class VaBackToTop {
 
   componentDidLoad() {
     // Setup observer to handle docking behavior
-    this.dockObserver = new IntersectionObserver(
+    const dockObserver = new IntersectionObserver(
       entries => {
         this.isDocked = entries[0].isIntersecting;
       },
       { threshold: 1.0 },
     );
-    this.dockObserver.observe(this.el);
+    dockObserver.observe(this.el);
 
     // Setup observer to handle reveal behavior
-    this.revealObserver = new IntersectionObserver(entries => {
+    const revealObserver = new IntersectionObserver(entries => {
       this.hasHitBreakpoint = entries[0].boundingClientRect.y < 0;
     });
-    this.revealObserver.observe(this.revealPixel);
+    revealObserver.observe(this.revealPixel);
   }
 
   navigateToTop() {

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -75,12 +75,10 @@ export class VaBackToTop {
           ref={el => (this.revealPixel = el as HTMLSpanElement)}
         ></span>
 
-        <div class={classnames({ docked: this.isDocked })}>
-          <button
-            type="button"
-            onClick={this.navigateToTop.bind(this)}
-            class={classnames({ reveal: this.revealed })}
-          >
+        <div
+          class={classnames({ docked: this.isDocked, reveal: this.revealed })}
+        >
+          <button type="button" onClick={this.navigateToTop.bind(this)}>
             <i aria-hidden="true" role="img"></i>
             <span>Back to top</span>
           </button>

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -10,8 +10,8 @@ import 'intersection-observer';
  * 3. "Docking" when the dock becomes visible
  *
  * The span.reveal-point determines when the reveal happens.
- * It is positioned on the page in an absolute manner, and the
- * button will reveal when the span is above the viewport.
+ * It uses `position: absolute` so the button will reveal when
+ * the `span` is above the viewport.
  */
 @Component({
   tag: 'va-back-to-top',

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -3,6 +3,16 @@ import classnames from 'classnames';
 
 import 'intersection-observer';
 
+/**
+ * This component has three main behaviors:
+ * 1. Going to the top of the page when the button is clicked
+ * 2. "Revealing" after scrolling down far enough
+ * 3. "Docking" when the dock becomes visible
+ *
+ * The span.reveal-point determines when the reveal happens.
+ * It is positioned on the page in an absolute manner, and the
+ * button will reveal when the span is above the viewport.
+ */
 @Component({
   tag: 'va-back-to-top',
   styleUrl: 'va-back-to-top.css',
@@ -53,6 +63,8 @@ export class VaBackToTop {
   }
 
   render() {
+    // This ensures that when the button is revealed but not docked,
+    // its width is the same as its parent.
     const undockedWidth = this.el.getBoundingClientRect().width;
     this.el.style.setProperty('--undocked-width', `${undockedWidth}px`);
 

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -29,7 +29,7 @@ export class VaBackToTop {
       threshold: 1.0,
     };
 
-    const handleDock = (entries, observer) => {
+    const handleDock = entries => {
       console.log('Intersection callback', this.isDocked);
       console.log(entries[0].isIntersecting);
       if (entries[0].isIntersecting && !this.isDocked) {

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, Host, Listen, State, h } from '@stencil/core';
 
 @Component({
   tag: 'va-back-to-top',
@@ -6,6 +6,20 @@ import { Component, Host, h } from '@stencil/core';
   shadow: true,
 })
 export class VaBackToTop {
+  breakpoint = 600;
+  @State() hasHitBreakpoint = false;
+
+  @Listen('scroll', { target: 'window' })
+  handleScroll(ev) {
+    if (this.breakpointCheck() !== this.hasHitBreakpoint) {
+      this.hasHitBreakpoint = !this.hasHitBreakpoint;
+    }
+  }
+
+  breakpointCheck() {
+    return (window.scrollY || window.pageYOffset) > this.breakpoint;
+  }
+
   navigateToTop() {
     console.log('Clicking button');
     // Focus the h1 tag on the page.
@@ -27,7 +41,10 @@ export class VaBackToTop {
     return (
       <Host>
         <div>
-          <button onClick={this.navigateToTop.bind(this)}>
+          <button
+            onClick={this.navigateToTop.bind(this)}
+            class={this.hasHitBreakpoint ? 'reveal' : ''}
+          >
             <span>
               <i aria-hidden="true" class="fa-arrow-up" role="img"></i>
             </span>

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Host, Listen, State, h } from '@stencil/core';
 
-import { isInViewport } from '../../utils/utils';
+import 'intersection-observer';
 
 @Component({
   tag: 'va-back-to-top',
@@ -9,6 +9,7 @@ import { isInViewport } from '../../utils/utils';
 })
 export class VaBackToTop {
   breakpoint = 600;
+  observer = null;
   bttButton!: HTMLButtonElement;
   @State() hasHitBreakpoint = false;
   @State() isDocked = false;
@@ -20,17 +21,26 @@ export class VaBackToTop {
     if (this.breakpointCheck() !== this.hasHitBreakpoint) {
       this.hasHitBreakpoint = !this.hasHitBreakpoint;
     }
-
-    if (this.readyToDock() !== this.isDocked) {
-      this.isDocked = !this.isDocked;
-    }
   }
 
-  readyToDock() {
-    return (
-      this.el.getBoundingClientRect().top <=
-        this.bttButton.getBoundingClientRect().top && isInViewport(this.el)
-    );
+  componentWillLoad() {
+    console.log(this.el, this.el.getBoundingClientRect());
+    const options = {
+      threshold: 1.0,
+    };
+
+    const handleDock = (entries, observer) => {
+      console.log('Intersection callback', this.isDocked);
+      console.log(entries[0].isIntersecting);
+      if (entries[0].isIntersecting && !this.isDocked) {
+        this.isDocked = true;
+      } else if (!entries[0].isIntersecting && this.isDocked) {
+        this.isDocked = false;
+      }
+    };
+
+    this.observer = new IntersectionObserver(handleDock, options);
+    this.observer.observe(this.el);
   }
 
   breakpointCheck() {

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -55,6 +55,9 @@ export class VaBackToTop {
   }
 
   render() {
+    const undockedWidth = this.el.getBoundingClientRect().width;
+    this.el.style.setProperty('--undocked-width', `${undockedWidth}px`);
+
     return (
       <Host>
         <div class={this.isDocked ? 'docked' : ''}>

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -18,7 +18,7 @@ export class VaBackToTop {
 
   @Element() el: HTMLElement;
 
-  componentWillLoad() {
+  componentDidLoad() {
     // Setup observer to handle docking behavior
     this.dockObserver = new IntersectionObserver(
       entries => {
@@ -32,10 +32,6 @@ export class VaBackToTop {
     this.revealObserver = new IntersectionObserver(entries => {
       this.hasHitBreakpoint = entries[0].boundingClientRect.y < 0;
     });
-  }
-
-  componentDidLoad() {
-    console.log(this.revealPixel);
     this.revealObserver.observe(this.revealPixel);
   }
 

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -77,6 +77,7 @@ export class VaBackToTop {
 
         <div class={classnames({ docked: this.isDocked })}>
           <button
+            type="button"
             onClick={this.navigateToTop.bind(this)}
             class={classnames({ reveal: this.revealed })}
           >

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -21,7 +21,7 @@ import 'intersection-observer';
 export class VaBackToTop {
   revealPixel!: HTMLSpanElement;
 
-  @State() hasHitBreakpoint = false;
+  @State() revealed = false;
   @State() isDocked = false;
 
   @Element() el: HTMLElement;
@@ -41,7 +41,7 @@ export class VaBackToTop {
 
     // Setup observer to handle reveal behavior
     const revealObserver = new IntersectionObserver(entries => {
-      this.hasHitBreakpoint = entries[0].boundingClientRect.y < 0;
+      this.revealed = entries[0].boundingClientRect.y < 0;
     });
     revealObserver.observe(this.revealPixel);
   }
@@ -78,7 +78,7 @@ export class VaBackToTop {
         <div class={classnames({ docked: this.isDocked })}>
           <button
             onClick={this.navigateToTop.bind(this)}
-            class={classnames({ reveal: this.hasHitBreakpoint })}
+            class={classnames({ reveal: this.revealed })}
           >
             <i aria-hidden="true" role="img"></i>
             <span>Back to top</span>

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -19,22 +19,19 @@ export class VaBackToTop {
   @Element() el: HTMLElement;
 
   componentWillLoad() {
-    const options = {
-      threshold: 1.0,
-    };
-
-    const handleDock = entries => {
-      this.isDocked = entries[0].isIntersecting;
-    };
-
-    const handleReveal = entries => {
-      this.hasHitBreakpoint = entries[0].boundingClientRect.y < 0;
-    };
-
-    this.dockObserver = new IntersectionObserver(handleDock, options);
+    // Setup observer to handle docking behavior
+    this.dockObserver = new IntersectionObserver(
+      entries => {
+        this.isDocked = entries[0].isIntersecting;
+      },
+      { threshold: 1.0 },
+    );
     this.dockObserver.observe(this.el);
 
-    this.revealObserver = new IntersectionObserver(handleReveal);
+    // Setup observer to handle reveal behavior
+    this.revealObserver = new IntersectionObserver(entries => {
+      this.hasHitBreakpoint = entries[0].boundingClientRect.y < 0;
+    });
   }
 
   componentDidLoad() {

--- a/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/src/components/va-back-to-top/va-back-to-top.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Host, State, h } from '@stencil/core';
+import classnames from 'classnames';
 
 import 'intersection-observer';
 
@@ -62,10 +63,10 @@ export class VaBackToTop {
           ref={el => (this.revealPixel = el as HTMLSpanElement)}
         ></span>
 
-        <div class={this.isDocked ? 'docked' : ''}>
+        <div class={classnames({ docked: this.isDocked })}>
           <button
             onClick={this.navigateToTop.bind(this)}
-            class={this.hasHitBreakpoint ? 'reveal' : ''}
+            class={classnames({ reveal: this.hasHitBreakpoint })}
           >
             <i aria-hidden="true" role="img"></i>
             <span>Back to top</span>

--- a/src/global/variables.css
+++ b/src/global/variables.css
@@ -4,6 +4,7 @@
 /*   https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/8d39616e957cb44b6664a658b2c51dca8076fe7e/packages/formation/sass/base/_b-variables.scss#L16-L17 */
 :root {
   --color-base: #212121;
+  --color-black: #000000;
   --color-white: #ffffff;
   --color-gray: #5b616b;
   --color-gray-medium: #757575;

--- a/src/mixins/buttons.css
+++ b/src/mixins/buttons.css
@@ -1,0 +1,18 @@
+@import './focusable.css';
+button {
+  appearance: none;
+  border: 0;
+  border-radius: 5px;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  color: var(--color-white);
+  cursor: pointer;
+  display: inline-block;
+  font-family: var(--font-source-sans);
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 1rem 2rem;
+  text-align: center;
+  text-decoration: none;
+}

--- a/src/mixins/buttons.css
+++ b/src/mixins/buttons.css
@@ -3,8 +3,6 @@ button {
   appearance: none;
   border: 0;
   border-radius: 5px;
-  border-top-right-radius: 5px;
-  border-bottom-right-radius: 5px;
   color: var(--color-white);
   cursor: pointer;
   display: inline-block;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -28,3 +28,14 @@ export function getSlottedNodes(
     item => item.nodeName.toLowerCase() === nodeName,
   );
 }
+
+export function isInViewport(element) {
+  const rect = element.getBoundingClientRect();
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <=
+      (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+  );
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -28,14 +28,3 @@ export function getSlottedNodes(
     item => item.nodeName.toLowerCase() === nodeName,
   );
 }
-
-export function isInViewport(element) {
-  const rect = element.getBoundingClientRect();
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <=
-      (window.innerHeight || document.documentElement.clientHeight) &&
-    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  );
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3737,6 +3737,11 @@ classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,6 +2520,11 @@ ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+animate.css@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/animate.css/-/animate.css-4.1.1.tgz#614ec5a81131d7e4dc362a58143f7406abd68075"
+  integrity sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ==
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6092,6 +6092,11 @@ interpret@^2.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+intersection-observer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.0.tgz#6c84628f67ce8698e5f9ccf857d97718745837aa"
+  integrity sha512-2Vkz8z46Dv401zTWudDGwO7KiGHNDkMv417T5ItcNYfmvHR/1qCTVBO9vwH8zZmQ0WkA/1ARwpysR9bsnop4NQ==
+
 invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,10 +1414,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stencil/core@^2.0.1":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.4.0.tgz#17b45629c8986e35dcbce3f7dab7d64beede83f2"
-  integrity sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg==
+"@stencil/core@^2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.8.1.tgz#21b15c115d9a5e2f56379774fcbd9bc947bf336f"
+  integrity sha512-iv9J6oLO/lv7/aO45M05yw3pp1J7olY400vlOZgdMVs3s5zHfalY1ZPYM0KyqU4+7DZuadKYbd0aQZ/g2PInZw==
 
 "@stencil/postcss@^2.0.0":
   version "2.0.0"
@@ -2257,9 +2257,9 @@
     "@types/yargs-parser" "*"
 
 "@types/yauzl@^2.9.1":
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
-  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.2.tgz#c48e5d56aff1444409e39fa164b0b4d4552a7b7a"
+  integrity sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==
   dependencies:
     "@types/node" "*"
 
@@ -2464,10 +2464,12 @@ address@1.1.2, address@^1.0.1:
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
 
-agent-base@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
-  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -4278,7 +4280,14 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1:
+debug@4:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -4412,10 +4421,10 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
-devtools-protocol@0.0.809251:
-  version "0.0.809251"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.809251.tgz#300b3366be107d5c46114ecb85274173e3999518"
-  integrity sha512-pf+2OY6ghMDPjKkzSWxHMq+McD+9Ojmq5XVRYpv/kPd9sTMQxzEt21592a31API8qRjro0iYYOc3ag46qF/1FA==
+devtools-protocol@0.0.883894:
+  version "0.0.883894"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.883894.tgz#d403f2c75cd6d71c916aee8dde9258da988a4da9"
+  integrity sha512-33idhm54QJzf3Q7QofMgCvIVSd2o9H3kQPWaKT/fhoZh+digc+WSiMhbkeG3iN79WY4Hwr9G05NpbhEVrsOYAg==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -5013,7 +5022,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@^2.0.0:
+extract-zip@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -5902,12 +5911,12 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
-  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+https-proxy-agent@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   dependencies:
-    agent-base "5"
+    agent-base "6"
     debug "4"
 
 human-signals@^1.1.1:
@@ -7584,11 +7593,6 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp-classic@^0.5.2:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
-  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
-
 mkdirp@^0.5.1, mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
@@ -7698,7 +7702,7 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -8268,19 +8272,19 @@ pirates@^4.0.0, pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
+pkg-dir@4.2.0, pkg-dir@^4.1.0, pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
 pkg-dir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
-
-pkg-dir@^4.1.0, pkg-dir@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
 
 pkg-up@3.1.0, pkg-up@^3.1.0:
   version "3.1.0"
@@ -8459,10 +8463,10 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+progress@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+  integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -8522,7 +8526,7 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -8589,23 +8593,23 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.4.1.tgz#f2038eb23a0f593ed2cce0d6e7cd5c43aecd6756"
-  integrity sha512-8u6r9tFm3gtMylU4uCry1W/CeAA8uczKMONvGvivkTsGqKA7iB7DWO2CBFYlB9GY6/IEoq9vkI5slJWzUBkwNw==
+puppeteer@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-10.0.0.tgz#1b597c956103e2d989ca17f41ba4693b20a3640c"
+  integrity sha512-AxHvCb9IWmmP3gMW+epxdj92Gglii+6Z4sb+W+zc2hTTu10HF0yg6hGXot5O74uYkVqG3lfDRLfnRpi6WOwi5A==
   dependencies:
-    debug "^4.1.0"
-    devtools-protocol "0.0.809251"
-    extract-zip "^2.0.0"
-    https-proxy-agent "^4.0.0"
-    node-fetch "^2.6.1"
-    pkg-dir "^4.2.0"
-    progress "^2.0.1"
-    proxy-from-env "^1.0.0"
-    rimraf "^3.0.2"
-    tar-fs "^2.0.0"
-    unbzip2-stream "^1.3.3"
-    ws "^7.2.3"
+    debug "4.3.1"
+    devtools-protocol "0.0.883894"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.0"
+    node-fetch "2.6.1"
+    pkg-dir "4.2.0"
+    progress "2.0.1"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.0.0"
+    unbzip2-stream "1.3.3"
+    ws "7.4.6"
 
 qs@6.7.0:
   version "6.7.0"
@@ -9226,17 +9230,17 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -9984,17 +9988,17 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar-fs@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+tar-fs@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
+  integrity sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==
   dependencies:
     chownr "^1.1.1"
-    mkdirp-classic "^0.5.2"
+    mkdirp "^0.5.1"
     pump "^3.0.0"
-    tar-stream "^2.1.4"
+    tar-stream "^2.0.0"
 
-tar-stream@^2.1.4:
+tar-stream@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
   integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
@@ -10339,10 +10343,10 @@ typescript@^4.3.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
-unbzip2-stream@^1.3.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
-  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+unbzip2-stream@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz#d156d205e670d8d8c393e1c02ebd506422873f6a"
+  integrity sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
@@ -10913,6 +10917,11 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 ws@^7.2.3:
   version "7.4.3"


### PR DESCRIPTION
## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/29785

This adds a `<va-back-to-top>` Web Component. This will replace our current "Back to top" button. It solves some problems with the old version:

- The button doesn't need to pay attention to the footer, and it will stop once it reaches its "dock"
- The dock ensures that space is reserved for the button
    - The button will no longer appear on the same "line" as pagination buttons, etc.
- When the button is visible & undocked, its width is dynamically set to be that of its parent

## Testing done

Local dev server, storybook, and E2E tests

## Screenshots

See #171 


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
