### PR TITLE
Add dependency caching to Chromatic workflow on GitHub Actions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn
         # 👇 Adds Chromatic as a step in the workflow


### PR DESCRIPTION
## Description
This PR adds dependency caching to the Chromatic workflow on GitHub Actions, which will reduce CI times.

## Acceptance criteria
- [ ] CI passes.