### PR TITLE
Fixed icon accessibility error in AlertBox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/AlertBox/AlertBox.jsx
+++ b/src/components/AlertBox/AlertBox.jsx
@@ -93,7 +93,7 @@ class AlertBox extends Component {
         aria-label={this.props.closeBtnAriaLabel}
         onClick={this.props.onCloseAlert}
       >
-        <i className="fas fa-times-circle" aria-label="Close icon" />
+        <i className="fas fa-times-circle" aria-hidden="true" />
       </button>
     );
 


### PR DESCRIPTION
## Description
This was throwing an error in CI nightwatch for a misplaces aria attribute.

```
 src/site/tests/home/00-required.e2e.spec   ✖ Failed [fail]: (
          Description:  Elements must only use allowed ARIA attributes
          Impact:       serious
          Rule ID:      aria-allowed-attr
          URL:          [n/a]
          DOM node:     
<i class="fas fa-times-circle" aria-label="Close icon"></i>
i[aria-label="Close\ icon"]
          More help:    https://dequeuniversity.com/rules/axe/4.3/aria-allowed-attr?application=axeAPI
        )
```