### PR TITLE
Use fullwidth alert component in Banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "sass-loader": "^8.0.2",
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.6"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-alert-full"
   },
   "resolutions": {
     "trim-newlines": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -99,13 +99,13 @@
     "sass-loader": "^8.0.2",
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-alert-full"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.10.0"
   },
   "resolutions": {
     "trim-newlines": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^16.13.1",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.6"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -99,12 +99,13 @@
     "sass-loader": "^8.0.2",
     "sinon": "^9.2.2",
     "uswds": "1.6.10",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.0"
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.6"
   },
   "resolutions": {
     "trim-newlines": "^4.0.2"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.6"
   }
 }

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 // Relative imports.
-import AlertBox from '../AlertBox/AlertBox';
+import { VaAlert } from 'web-components/react-bindings';
 
 const DISMISSED_BANNERS_KEY = 'DISMISSED_BANNERS';
 
@@ -154,14 +154,15 @@ export class Banner extends Component {
         data-e2e-id="emergency-banner"
         onClick={this.onClick}
       >
-        <AlertBox
-          // eslint-disable-next-line react/no-danger
-          content={<div dangerouslySetInnerHTML={{ __html: content }} />}
-          headline={title}
-          isVisible
+        <VaAlert
+          visible
+          closeable={showClose}
           onCloseAlert={onCloseAlert}
           status={type}
-        />
+        >
+          <h3 slot="headline">{title}</h3>
+          <div dangerouslySetInnerHTML={{ __html: content }} />
+        </VaAlert>
       </div>
     );
   }

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -1,7 +1,6 @@
 // Node modules.
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 // Relative imports.
 import { VaAlert } from 'web-components/react-bindings';
 
@@ -132,30 +131,10 @@ export class Banner extends Component {
     const onCloseAlert = showClose && storage ? this.dismiss : undefined;
 
     return (
-      <div
-        className={classnames(
-          'usa-alert-full-width',
-          'vads-u-border-top--5px',
-          'medium-screen:vads-u-border-top--10px',
-          'vads-c-emergency-banner',
-          {
-            // 'info', primary-alt border, black circled 'i'
-            'vads-u-border-color--primary-alt': type === 'info' || !type,
-            // 'error', Red border, red circled exclamation
-            'vads-u-border-color--secondary': type === 'error',
-            // 'success', Green border, green checkmark
-            // 'continue', Green border, green lock
-            'vads-u-border-color--green-light':
-              type === 'success' || type === 'continue',
-            // 'warning', Yellow border, black triangle exclamation
-            'vads-u-border-color--warning-message': type === 'warning',
-          },
-        )}
-        data-e2e-id="emergency-banner"
-        onClick={this.onClick}
-      >
+      <div data-e2e-id="emergency-banner" onClick={this.onClick}>
         <VaAlert
           visible
+          fullwidth
           closeable={showClose}
           onCloseAlert={onCloseAlert}
           status={type}

--- a/src/components/Banner/Banner.jsx
+++ b/src/components/Banner/Banner.jsx
@@ -134,7 +134,7 @@ export class Banner extends Component {
       <div data-e2e-id="emergency-banner" onClick={this.onClick}>
         <VaAlert
           visible
-          fullwidth
+          full-width
           closeable={showClose}
           onCloseAlert={onCloseAlert}
           status={type}

--- a/stories/va-alert.stories.jsx
+++ b/stories/va-alert.stories.jsx
@@ -13,15 +13,24 @@ const defaultArgs = {
   status: 'info',
   backgroundOnly: false,
   closeable: false,
+  fullwidth: false,
   onClose: () => {},
 };
 
-const Template = ({ headline, status, backgroundOnly, closeable, onClose }) => {
+const Template = ({
+  headline,
+  fullwidth,
+  status,
+  backgroundOnly,
+  closeable,
+  onClose,
+}) => {
   return (
     <va-alert
       status={status}
       background-only={backgroundOnly}
       closeable={closeable}
+      fullwidth={fullwidth}
       onClose={onClose}
     >
       {headline}
@@ -57,6 +66,13 @@ Closeable.args = {
   ...defaultArgs,
   closeable: true,
   onClose: () => console.log('Close event triggered'),
+};
+
+export const Fullwidth = Template.bind({});
+Fullwidth.args = {
+  ...defaultArgs,
+  fullwidth: true,
+  status: 'warning',
 };
 
 export const BackgroundOnly = Template.bind({});

--- a/stories/va-alert.stories.jsx
+++ b/stories/va-alert.stories.jsx
@@ -13,13 +13,13 @@ const defaultArgs = {
   status: 'info',
   backgroundOnly: false,
   closeable: false,
-  fullwidth: false,
+  fullWidth: false,
   onClose: () => {},
 };
 
 const Template = ({
   headline,
-  fullwidth,
+  fullWidth,
   status,
   backgroundOnly,
   closeable,
@@ -30,7 +30,7 @@ const Template = ({
       status={status}
       background-only={backgroundOnly}
       closeable={closeable}
-      fullwidth={fullwidth}
+      full-width={fullWidth}
       onClose={onClose}
     >
       {headline}
@@ -71,7 +71,7 @@ Closeable.args = {
 export const Fullwidth = Template.bind({});
 Fullwidth.args = {
   ...defaultArgs,
-  fullwidth: true,
+  fullWidth: true,
   status: 'warning',
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13031,9 +13031,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.0":
-  version "0.9.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#ac558c3c97129ad1acdf60b08966359b2d5139f4"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.6":
+  version "0.9.6"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#cfffd5588044c7c2f37a5bae0be625aa50f8c1af"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13031,9 +13031,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-alert-full":
-  version "0.9.6"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#9534a9a6eb819871f1bd14f0b2579caef50f5f5c"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.10.0":
+  version "0.10.0"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#ccd5f49b327edfbfb814153be5a75b4e45257161"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13031,9 +13031,9 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.6":
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-alert-full":
   version "0.9.6"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#cfffd5588044c7c2f37a5bae0be625aa50f8c1af"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#9534a9a6eb819871f1bd14f0b2579caef50f5f5c"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

This is meant to address an a11y issue with the `<AlertBox>` component @timwright12 mentioned in https://github.com/department-of-veterans-affairs/component-library/pull/179. In an effort to further the migration away from React components and towards Web Components, the `<Banner>` will use `<va-alert>` instead of its deprecated React counterpart.

If this gets merged, we should be able to delete [this file](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/a50f7304cfbb9824b75fd8af215769f1cf595c67/packages/formation/sass/modules/_m-emergency-banner.scss#L1).

## Testing done

Storybook :eyes: 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
