### PR TITLE
Add full-width variant for `<va-alert>`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-components",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -74,6 +74,10 @@ export namespace Components {
          */
         "disableAnalytics": boolean;
         /**
+          * If true, the alert will be full width. Should be for emergency communication only.
+         */
+        "fullwidth": boolean;
+        /**
           * Determines the icon and border/background color. One of `info`, `error`, `success`, `warning`, or `continue`
          */
         "status": string;
@@ -367,6 +371,10 @@ declare namespace LocalJSX {
           * If true, doesn't fire the CustomEvent which can be used for analytics tracking.
          */
         "disableAnalytics"?: boolean;
+        /**
+          * If true, the alert will be full width. Should be for emergency communication only.
+         */
+        "fullwidth"?: boolean;
         "onClose"?: (event: CustomEvent<any>) => void;
         "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -76,7 +76,7 @@ export namespace Components {
         /**
           * If true, the alert will be full width. Should be for emergency communication only.
          */
-        "fullwidth": boolean;
+        "fullWidth": boolean;
         /**
           * Determines the icon and border/background color. One of `info`, `error`, `success`, `warning`, or `continue`
          */
@@ -374,7 +374,7 @@ declare namespace LocalJSX {
         /**
           * If true, the alert will be full width. Should be for emergency communication only.
          */
-        "fullwidth"?: boolean;
+        "fullWidth"?: boolean;
         "onClose"?: (event: CustomEvent<any>) => void;
         "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
         /**

--- a/src/components/va-alert/va-alert.css
+++ b/src/components/va-alert/va-alert.css
@@ -26,12 +26,12 @@ div.alert {
   box-sizing: border-box;
 }
 
-div.alert:not(.fullwidth):not(.bg-only) {
+div.alert:not(.full-width):not(.bg-only) {
   border-left-style: solid;
   border-left-width: 10px;
 }
-div.alert.fullwidth.info,
-div.alert.fullwidth.warning {
+div.alert.full-width.info,
+div.alert.full-width.warning {
   border-top-style: solid;
   border-top-width: 10px;
 }

--- a/src/components/va-alert/va-alert.css
+++ b/src/components/va-alert/va-alert.css
@@ -23,9 +23,16 @@ div.alert {
   padding: 3.2rem 6.4rem 3.2rem 2.4rem;
   width: 100%;
   vertical-align: middle;
+  box-sizing: border-box;
+}
+
+div.alert:not(.fullwidth):not(.bg-only) {
   border-left-style: solid;
   border-left-width: 10px;
-  box-sizing: border-box;
+}
+div.alert.fullwidth {
+  border-top-style: solid;
+  border-top-width: 10px;
 }
 
 div.alert > i::before {
@@ -80,7 +87,7 @@ div.bg-only {
 }
 
 .info {
-  border-left-color: var(--color-primary-alt-dark);
+  border-color: var(--color-primary-alt-dark);
 }
 .info.bg-only {
   background-color: var(--color-primary-alt-lightest);
@@ -88,7 +95,7 @@ div.bg-only {
 
 .continue,
 .success {
-  border-left-color: var(--color-green);
+  border-color: var(--color-green);
 }
 
 .continue.bg-only {
@@ -99,7 +106,7 @@ div.bg-only {
 }
 
 .warning {
-  border-left-color: var(--color-gold);
+  border-color: var(--color-gold);
 }
 
 .warning.bg-only {
@@ -107,7 +114,7 @@ div.bg-only {
 }
 
 .error {
-  border-left-color: var(--color-secondary-dark);
+  border-color: var(--color-secondary-dark);
 }
 
 .error.bg-only {

--- a/src/components/va-alert/va-alert.css
+++ b/src/components/va-alert/va-alert.css
@@ -30,7 +30,8 @@ div.alert:not(.fullwidth):not(.bg-only) {
   border-left-style: solid;
   border-left-width: 10px;
 }
-div.alert.fullwidth {
+div.alert.fullwidth.info,
+div.alert.fullwidth.warning {
   border-top-style: solid;
   border-top-width: 10px;
 }

--- a/src/components/va-alert/va-alert.stories.tsx
+++ b/src/components/va-alert/va-alert.stories.tsx
@@ -10,14 +10,22 @@ const defaultArgs = {
   status: 'info',
   backgroundOnly: false,
   closeable: false,
+  fullwidth: false,
 };
 
-const Template = ({ backgroundOnly, headline, status, closeable }) => html`
+const Template = ({
+  backgroundOnly,
+  fullwidth,
+  headline,
+  status,
+  closeable,
+}) => html`
   <div>
     <va-alert
       background-only="${backgroundOnly}"
       status="${status}"
       closeable="${closeable}"
+      fullwidth="${fullwidth}"
     >
       <h3 slot="headline">${headline}</h3>
       <div>
@@ -59,6 +67,12 @@ export const Closeable = Template.bind({});
 Closeable.args = {
   ...defaultArgs,
   closeable: true,
+};
+
+export const Fullwidth = Template.bind({});
+Fullwidth.args = {
+  ...defaultArgs,
+  fullwidth: true,
 };
 
 export const BackgroundOnly = Template.bind({});

--- a/src/components/va-alert/va-alert.stories.tsx
+++ b/src/components/va-alert/va-alert.stories.tsx
@@ -10,12 +10,12 @@ const defaultArgs = {
   status: 'info',
   backgroundOnly: false,
   closeable: false,
-  fullwidth: false,
+  fullWidth: false,
 };
 
 const Template = ({
   backgroundOnly,
-  fullwidth,
+  fullWidth,
   headline,
   status,
   closeable,
@@ -25,7 +25,7 @@ const Template = ({
       background-only="${backgroundOnly}"
       status="${status}"
       closeable="${closeable}"
-      fullwidth="${fullwidth}"
+      full-width="${fullWidth}"
     >
       <h3 slot="headline">${headline}</h3>
       <div>
@@ -72,7 +72,7 @@ Closeable.args = {
 export const Fullwidth = Template.bind({});
 Fullwidth.args = {
   ...defaultArgs,
-  fullwidth: true,
+  fullWidth: true,
 };
 
 export const BackgroundOnly = Template.bind({});

--- a/src/components/va-alert/va-alert.tsx
+++ b/src/components/va-alert/va-alert.tsx
@@ -52,7 +52,7 @@ export class VaAlert {
    * If true, the alert will be full width.
    * Should be for emergency communication only.
    */
-  @Prop() fullwidth: boolean = false;
+  @Prop() fullWidth: boolean = false;
 
   /**
    * Fires when the component has successfully finished rendering for the first
@@ -127,8 +127,8 @@ export class VaAlert {
   }
 
   render() {
-    const { backgroundOnly, status, fullwidth, visible, closeable } = this;
-    const classes = `alert ${status} ${fullwidth ? 'fullwidth' : ''} ${
+    const { backgroundOnly, status, fullWidth, visible, closeable } = this;
+    const classes = `alert ${status} ${fullWidth ? 'full-width' : ''} ${
       backgroundOnly ? 'bg-only' : ''
     }`;
     const role = status === 'error' ? 'alert' : null;

--- a/src/components/va-alert/va-alert.tsx
+++ b/src/components/va-alert/va-alert.tsx
@@ -49,6 +49,12 @@ export class VaAlert {
   @Prop() closeable: boolean = false;
 
   /**
+   * If true, the alert will be full width.
+   * Should be for emergency communication only.
+   */
+  @Prop() fullwidth: boolean = false;
+
+  /**
    * Fires when the component has successfully finished rendering for the first
    * time.
    */
@@ -121,8 +127,10 @@ export class VaAlert {
   }
 
   render() {
-    const { backgroundOnly, status, visible, closeable } = this;
-    const classes = `alert ${status} ${backgroundOnly ? 'bg-only' : ''}`;
+    const { backgroundOnly, status, fullwidth, visible, closeable } = this;
+    const classes = `alert ${status} ${fullwidth ? 'fullwidth' : ''} ${
+      backgroundOnly ? 'bg-only' : ''
+    }`;
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;
 


### PR DESCRIPTION
## Description

This is to be used in https://github.com/department-of-veterans-affairs/component-library/pull/180

Implements a fullwidth variant for `<va-alert>` as found on https://design.va.gov/components/alertboxes#full-width-alerts

![image](https://user-images.githubusercontent.com/2008881/134410594-8a2aff3a-ab14-4125-a2a0-0267579de2db.png)


## Testing done

Local storybook :eyes: 

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/134420314-c7921dd3-cdc8-470c-ad4c-fe2f8e121b83.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
