### PR TITLE
Don't use ES6 imports for generated bindings

### DIFF
--- a/tsconfig.bindings.json
+++ b/tsconfig.bindings.json
@@ -7,7 +7,6 @@
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "lib": ["dom", "es2015"],
-    "module": "es2015",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitReturns": true,
@@ -16,7 +15,7 @@
     "removeComments": false,
     "sourceMap": true,
     "jsx": "react",
-    "target": "es2015"
+    "target": "es5"
   },
   "include": ["react-bindings/**/*.ts", "react-bindings/**/*.tsx"],
   "compileOnSave": false,


### PR DESCRIPTION
## Description

This is based off of a support request: https://dsva.slack.com/archives/CBU0KDSB1/p1632262136454800?thread_ts=1632163115.337400&cid=CBU0KDSB1

The mocha/babel setup in `vets-website` has problems importing a file from `node_modules` with ES6 imports. This should make the generated React bindings files use CommonJS so that the unit tests can run.


## Testing done

Tested putting a React binding on a page in `vets-website` on a branch that used this one for the `web-components` dependency.


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
