### PR TITLE
Limit the body width to 1000px on full-width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-components",
-  "version": "0.10.0",
+  "version": "0.11.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components/va-alert/test/va-alert.e2e.ts
+++ b/src/components/va-alert/test/va-alert.e2e.ts
@@ -11,13 +11,11 @@ describe('va-alert', () => {
     expect(element).toEqualHtml(`
       <va-alert class="hydrated">
         <mock:shadow-root>
-          <div>
-            <div class="alert info">
-              <i aria-hidden="true" role="img"></i>
-              <div class="body">
-                <slot name="headline"></slot>
-                <slot></slot>
-              </div>
+          <div class="alert info">
+            <i aria-hidden="true" role="img"></i>
+            <div class="body">
+              <slot name="headline"></slot>
+              <slot></slot>
             </div>
           </div>
         </mock:shadow-root>

--- a/src/components/va-alert/test/va-alert.e2e.ts
+++ b/src/components/va-alert/test/va-alert.e2e.ts
@@ -11,11 +11,13 @@ describe('va-alert', () => {
     expect(element).toEqualHtml(`
       <va-alert class="hydrated">
         <mock:shadow-root>
-          <div class="alert info">
-            <i aria-hidden="true" role="img"></i>
-            <div class="body">
-              <slot name="headline"></slot>
-              <slot></slot>
+          <div>
+            <div class="alert info">
+              <i aria-hidden="true" role="img"></i>
+              <div class="body">
+                <slot name="headline"></slot>
+                <slot></slot>
+              </div>
             </div>
           </div>
         </mock:shadow-root>

--- a/src/components/va-alert/test/va-alert.e2e.ts
+++ b/src/components/va-alert/test/va-alert.e2e.ts
@@ -25,6 +25,15 @@ describe('va-alert', () => {
     `);
   });
 
+  it('renders the right markup for the full-width variant', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-alert full-width></va-alert>');
+
+    const wrapper = await page.find('va-alert >>> div');
+
+    expect(wrapper).toHaveClass('full-width');
+  });
+
   it('renders an empty div with a "polite" aria-live tag when not visible', async () => {
     const page = await newE2EPage();
 

--- a/src/components/va-alert/test/va-alert.e2e.ts
+++ b/src/components/va-alert/test/va-alert.e2e.ts
@@ -23,15 +23,6 @@ describe('va-alert', () => {
     `);
   });
 
-  it('renders the right markup for the full-width variant', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-alert full-width></va-alert>');
-
-    const wrapper = await page.find('va-alert >>> div');
-
-    expect(wrapper).toHaveClass('full-width');
-  });
-
   it('renders an empty div with a "polite" aria-live tag when not visible', async () => {
     const page = await newE2EPage();
 

--- a/src/components/va-alert/va-alert.css
+++ b/src/components/va-alert/va-alert.css
@@ -30,7 +30,6 @@ div:not(.full-width) div.alert:not(.bg-only) {
   border-left-style: solid;
   border-left-width: 10px;
 }
-div.full-width,
 div.full-width {
   border-top-style: solid;
   border-top-width: 10px;

--- a/src/components/va-alert/va-alert.css
+++ b/src/components/va-alert/va-alert.css
@@ -11,6 +11,33 @@
   background-color: unset;
 }
 
+:host([full-width='true']),
+:host([full-width='']) {
+  border-top-style: solid;
+  border-top-width: 10px;
+}
+
+:host([status='warning']) {
+  border-color: var(--color-gold);
+}
+:host([status='info']) {
+  border-color: var(--color-primary-alt-dark);
+}
+:host([status='error']) {
+  border-color: var(--color-secondary-dark);
+}
+:host([status='continue']),
+:host([status='success']) {
+  border-color: var(--color-green);
+}
+
+:host([full-width='']) div.alert,
+:host([full-width='true']) div.alert {
+  border-left: none;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
 ::slotted([slot='headline']) {
   font-size: 2rem !important;
   line-height: 26px !important;
@@ -26,18 +53,10 @@ div.alert {
   box-sizing: border-box;
 }
 
-div:not(.full-width) div.alert:not(.bg-only) {
+div.alert:not(.bg-only) {
+  border-color: inherit;
   border-left-style: solid;
   border-left-width: 10px;
-}
-div.full-width {
-  border-top-style: solid;
-  border-top-width: 10px;
-}
-
-div.full-width div.alert {
-  max-width: 1000px;
-  margin: 0 auto;
 }
 
 div.alert > i::before {
@@ -91,39 +110,18 @@ div.bg-only {
   border: none;
 }
 
-:host([status='info']) div.full-width,
-.info {
-  border-color: var(--color-primary-alt-dark);
-}
 .info.bg-only {
   background-color: var(--color-primary-alt-lightest);
 }
-
-.continue,
-.success {
-  border-color: var(--color-green);
-}
-
 .continue.bg-only {
   background-color: var(--color-gray-lightest);
 }
 .success.bg-only {
   background-color: var(--color-green-lightest);
 }
-
-:host([status='warning']) div.full-width,
-.warning {
-  border-color: var(--color-gold);
-}
-
 .warning.bg-only {
   background-color: var(--color-gold-lightest);
 }
-
-.error {
-  border-color: var(--color-secondary-dark);
-}
-
 .error.bg-only {
   background-color: var(--color-secondary-lightest);
 }

--- a/src/components/va-alert/va-alert.css
+++ b/src/components/va-alert/va-alert.css
@@ -26,14 +26,19 @@ div.alert {
   box-sizing: border-box;
 }
 
-div.alert:not(.full-width):not(.bg-only) {
+div:not(.full-width) div.alert:not(.bg-only) {
   border-left-style: solid;
   border-left-width: 10px;
 }
-div.alert.full-width.info,
-div.alert.full-width.warning {
+div.full-width,
+div.full-width {
   border-top-style: solid;
   border-top-width: 10px;
+}
+
+div.full-width div.alert {
+  max-width: 1000px;
+  margin: 0 auto;
 }
 
 div.alert > i::before {
@@ -87,6 +92,7 @@ div.bg-only {
   border: none;
 }
 
+div.full-width,
 .info {
   border-color: var(--color-primary-alt-dark);
 }
@@ -106,6 +112,7 @@ div.bg-only {
   background-color: var(--color-green-lightest);
 }
 
+div.full-width,
 .warning {
   border-color: var(--color-gold);
 }

--- a/src/components/va-alert/va-alert.css
+++ b/src/components/va-alert/va-alert.css
@@ -91,7 +91,7 @@ div.bg-only {
   border: none;
 }
 
-div.full-width,
+:host([status='info']) div.full-width,
 .info {
   border-color: var(--color-primary-alt-dark);
 }
@@ -111,7 +111,7 @@ div.full-width,
   background-color: var(--color-green-lightest);
 }
 
-div.full-width,
+:host([status='warning']) div.full-width,
 .warning {
   border-color: var(--color-gold);
 }

--- a/src/components/va-alert/va-alert.tsx
+++ b/src/components/va-alert/va-alert.tsx
@@ -128,9 +128,7 @@ export class VaAlert {
 
   render() {
     const { backgroundOnly, status, fullWidth, visible, closeable } = this;
-    const classes = `alert ${status} ${fullWidth ? 'full-width' : ''} ${
-      backgroundOnly ? 'bg-only' : ''
-    }`;
+    const classes = `alert ${status} ${backgroundOnly ? 'bg-only' : ''}`;
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;
 
@@ -138,23 +136,29 @@ export class VaAlert {
 
     return (
       <Host>
-        <div role={role} aria-live={ariaLive} class={classes}>
-          <i aria-hidden="true" role="img"></i>
-          <div class="body" onClick={this.handleAlertBodyClick.bind(this)}>
-            {!backgroundOnly && <slot name="headline"></slot>}
-            <slot></slot>
+        <div class={fullWidth ? 'full-width' : ''}>
+          <div role={role} aria-live={ariaLive} class={classes}>
+            <i aria-hidden="true" role="img"></i>
+            <div class="body" onClick={this.handleAlertBodyClick.bind(this)}>
+              {!backgroundOnly && <slot name="headline"></slot>}
+              <slot></slot>
+            </div>
           </div>
-        </div>
 
-        {closeable && (
-          <button
-            class="va-alert-close"
-            aria-label={this.closeBtnAriaLabel}
-            onClick={this.closeHandler.bind(this)}
-          >
-            <i aria-hidden="true" class="fa-times-circle" role="presentation" />
-          </button>
-        )}
+          {closeable && (
+            <button
+              class="va-alert-close"
+              aria-label={this.closeBtnAriaLabel}
+              onClick={this.closeHandler.bind(this)}
+            >
+              <i
+                aria-hidden="true"
+                class="fa-times-circle"
+                role="presentation"
+              />
+            </button>
+          )}
+        </div>
       </Host>
     );
   }

--- a/src/components/va-alert/va-alert.tsx
+++ b/src/components/va-alert/va-alert.tsx
@@ -127,7 +127,7 @@ export class VaAlert {
   }
 
   render() {
-    const { backgroundOnly, status, fullWidth, visible, closeable } = this;
+    const { backgroundOnly, status, visible, closeable } = this;
     const classes = `alert ${status} ${backgroundOnly ? 'bg-only' : ''}`;
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;
@@ -136,29 +136,23 @@ export class VaAlert {
 
     return (
       <Host>
-        <div class={fullWidth ? 'full-width' : ''}>
-          <div role={role} aria-live={ariaLive} class={classes}>
-            <i aria-hidden="true" role="img"></i>
-            <div class="body" onClick={this.handleAlertBodyClick.bind(this)}>
-              {!backgroundOnly && <slot name="headline"></slot>}
-              <slot></slot>
-            </div>
+        <div role={role} aria-live={ariaLive} class={classes}>
+          <i aria-hidden="true" role="img"></i>
+          <div class="body" onClick={this.handleAlertBodyClick.bind(this)}>
+            {!backgroundOnly && <slot name="headline"></slot>}
+            <slot></slot>
           </div>
-
-          {closeable && (
-            <button
-              class="va-alert-close"
-              aria-label={this.closeBtnAriaLabel}
-              onClick={this.closeHandler.bind(this)}
-            >
-              <i
-                aria-hidden="true"
-                class="fa-times-circle"
-                role="presentation"
-              />
-            </button>
-          )}
         </div>
+
+        {closeable && (
+          <button
+            class="va-alert-close"
+            aria-label={this.closeBtnAriaLabel}
+            onClick={this.closeHandler.bind(this)}
+          >
+            <i aria-hidden="true" class="fa-times-circle" role="presentation" />
+          </button>
+        )}
       </Host>
     );
   }


### PR DESCRIPTION
## Description

It was noticed that some recent changes (#180, #181) resulted in the homepage banner being too wide in `vets-website`. This PR should fix that by limiting the body content to a maximum width of 1000px, while allowing the alert itself to extend across the entire page.

[Slack thread with additional context](https://dsva.slack.com/archives/C52CL1PKQ/p1632926162017600)

## Testing done

Looking at storybook and comparing it to va.gov

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/135352654-8d0828c1-aee9-4d2d-add1-779bc5834f71.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
