### PR TITLE
Provide property to optimize va-text-input fields for numeric input

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -188,7 +188,7 @@ export namespace Components {
     }
     interface VaTextInput {
         /**
-          * The aria-describedby attribute for the <intput> in the shadow DOM.
+          * The aria-describedby attribute for the <input> in the shadow DOM.
          */
         "ariaDescribedby"?: string;
         /**
@@ -204,6 +204,10 @@ export namespace Components {
          */
         "error"?: string | HTMLElement;
         /**
+          * The inputmode attribute.
+         */
+        "inputmode"?: string;
+        /**
           * The label for the text input.
          */
         "label": string | HTMLElement;
@@ -215,6 +219,14 @@ export namespace Components {
           * The name to pass to the input element.
          */
         "name"?: string;
+        /**
+          * Optimize the field for numeric input.
+         */
+        "numericInput"?: boolean;
+        /**
+          * The pattern attribute.
+         */
+        "pattern"?: string;
         /**
           * Placeholder text to show in the input field.
          */
@@ -519,7 +531,7 @@ declare namespace LocalJSX {
     }
     interface VaTextInput {
         /**
-          * The aria-describedby attribute for the <intput> in the shadow DOM.
+          * The aria-describedby attribute for the <input> in the shadow DOM.
          */
         "ariaDescribedby"?: string;
         /**
@@ -535,6 +547,10 @@ declare namespace LocalJSX {
          */
         "error"?: string | HTMLElement;
         /**
+          * The inputmode attribute.
+         */
+        "inputmode"?: string;
+        /**
           * The label for the text input.
          */
         "label"?: string | HTMLElement;
@@ -547,6 +563,10 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         /**
+          * Optimize the field for numeric input.
+         */
+        "numericInput"?: boolean;
+        /**
           * The event used to track usage of the component. This is emitted when the input is blurred and enableAnalytics is true.
          */
         "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
@@ -558,6 +578,10 @@ declare namespace LocalJSX {
           * The event emitted when the input value changes
          */
         "onVaChange"?: (event: CustomEvent<any>) => void;
+        /**
+          * The pattern attribute.
+         */
+        "pattern"?: string;
         /**
           * Placeholder text to show in the input field.
          */

--- a/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -11,7 +11,7 @@ describe('va-text-input', () => {
     expect(element).toEqualHtml(`
       <va-text-input class="hydrated">
         <mock:shadow-root>
-          <input id="inputField" type="text" />
+          <input id="inputField" inputmode="" pattern="" type="text">
         </mock:shadow-root>
       </va-text-input>
     `);
@@ -64,7 +64,7 @@ describe('va-text-input', () => {
       <va-text-input class="hydrated" label="This is a field" required="">
         <mock:shadow-root>
           <label for="inputField">This is a field <span class="required">(*Required)</span></label>
-          <input id="inputField" type="text" />
+          <input id="inputField" inputmode="" pattern="" type="text">
         </mock:shadow-root>
       </va-text-input>
     `);
@@ -160,7 +160,7 @@ describe('va-text-input', () => {
     );
   });
 
-  it('adds adds a character limit with descriptive text', async () => {
+  it('adds a character limit with descriptive text', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-text-input maxlength="3" value="22"/>');
 
@@ -175,5 +175,48 @@ describe('va-text-input', () => {
     expect((await page.find('va-text-input >>> small')).innerText).toContain(
       '(Max. 3 characters)',
     );
+  });
+
+  it('adds a field optimized for numeric input', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input numeric-input />');
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(inputEl.getAttribute('inputmode')).toBe('numeric');
+    expect(inputEl.getAttribute('pattern')).toBe('[0-9]*');
+
+    // Test the functionality
+    await inputEl.press('2');
+    expect(await inputEl.getProperty('value')).toBe('2');
+  });
+
+  it('allows manually setting the inputmode attribute', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input inputmode="decimal" />');
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(inputEl.getAttribute('inputmode')).toBe('decimal');
+
+    // Test the functionality
+    await inputEl.press('2');
+    await inputEl.press('.');
+    await inputEl.press('0');
+    expect(await inputEl.getProperty('value')).toBe('2.0');
+  });
+
+  it('allows manually setting the pattern attribute', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input pattern="[a-z]*" />');
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(inputEl.getAttribute('pattern')).toBe('[a-z]*');
+
+    // Test the functionality
+    await inputEl.press('v');
+    await inputEl.press('a');
+    expect(await inputEl.getProperty('value')).toBe('va');
   });
 });

--- a/src/components/va-text-input/va-text-input.tsx
+++ b/src/components/va-text-input/va-text-input.tsx
@@ -27,6 +27,11 @@ export class VaTextInput {
   @Prop() error?: string | HTMLElement;
 
   /**
+   * Optimize the field for numeric input.
+   */
+  @Prop() numericInput?: boolean;
+
+  /**
    * Set the input to required and render the (Required) text.
    */
   @Prop() required?: boolean;
@@ -35,6 +40,16 @@ export class VaTextInput {
    * Placeholder text to show in the input field.
    */
   @Prop() placeholder?: string;
+
+  /**
+   * The inputmode attribute.
+   */
+  @Prop() inputmode?: string = '';
+
+  /**
+   * The pattern attribute.
+   */
+  @Prop() pattern?: string = '';
 
   /**
    * The maximum number of characters allowed in the input.
@@ -57,7 +72,7 @@ export class VaTextInput {
   @Prop() name?: string;
 
   /**
-   * The aria-describedby attribute for the <intput> in the shadow DOM.
+   * The aria-describedby attribute for the <input> in the shadow DOM.
    */
   @Prop() ariaDescribedby?: string = '';
 
@@ -136,6 +151,8 @@ export class VaTextInput {
           onInput={this.handleChange}
           onBlur={this.handleBlur}
           aria-describedby={describedBy}
+          inputmode={this.numericInput ? "numeric" : this.inputmode}
+          pattern={this.numericInput ? "[0-9]*" : this.pattern}
           placeholder={this.placeholder}
           maxlength={this.maxlength}
         />


### PR DESCRIPTION
## Description

This PR is in support of [va.gov-team#30129 ](department-of-veterans-affairs/va.gov-team#30129). With this PR, you may specify that input should be numeric, causing the number keypad to be shown on mobile:

`<va-text-input numeric-input />`

When this attribute is set, `inputmode` is set to `numeric` and the `pattern` attribute is set to `[0-9]*`. This is the approach suggested in this excellent post: [Why the GOV.UK Design System team changed the input type for numbers](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/) 

Additionally, it aligns with the [accessibility guidance we've received](https://dsva.slack.com/archives/C022AC2STBM/p1632408155062000?thread_ts=1632337879.046900&cid=C022AC2STBM).

This is my first PR to `component-library` so I much appreciate any guidance/help!

## Testing done

Tested locally with stencil using this html:

```html
<va-text-input
  label="Last 4 digits of your Social Security number"
  maxlength=4
  name="last-4-ssn"
  numeric-input
  required
/>
```

## Screenshots

<img src="https://user-images.githubusercontent.com/101649/135352816-aa725697-6a66-4851-b6cd-567c7806f673.jpeg" width=250 />

## Acceptance criteria

- [ ] a VA-sanctioned approach for displaying the number keypad on text input fields is available

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
