### PR TITLE
Bring the icon in closer to the body

### DIFF
--- a/src/components/va-alert/va-alert.css
+++ b/src/components/va-alert/va-alert.css
@@ -15,6 +15,14 @@
 :host([full-width='']) {
   border-top-style: solid;
   border-top-width: 10px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+:host([full-width='true']) .va-alert-close,
+:host([full-width='']) .va-alert-close {
+  position: relative;
 }
 
 :host([status='warning']) {
@@ -35,7 +43,6 @@
 :host([full-width='true']) div.alert {
   border-left: none;
   max-width: 1000px;
-  margin: 0 auto;
 }
 
 ::slotted([slot='headline']) {

--- a/src/components/va-alert/va-alert.stories.tsx
+++ b/src/components/va-alert/va-alert.stories.tsx
@@ -73,6 +73,7 @@ export const Fullwidth = Template.bind({});
 Fullwidth.args = {
   ...defaultArgs,
   fullWidth: true,
+  closeable: true,
 };
 
 export const BackgroundOnly = Template.bind({});


### PR DESCRIPTION
## Description

When I merged a previous PR to fix a styling issue in prod, the fix didn't include the styling change to the close icon. [Slack thread](https://dsva.slack.com/archives/C52CL1PKQ/p1633015634043600?thread_ts=1632926162.017600&cid=C52CL1PKQ).

Related PRs:

- #180
- #181
- #186 


## Testing done

Storybook :eyes: 


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/135500620-59fe6fd0-79ee-4d80-ae9d-252ef7eccf1a.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
