### PR TITLE
ProgressButton a11y updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/src/components/ProgressButton/ProgressButton.jsx
+++ b/src/components/ProgressButton/ProgressButton.jsx
@@ -13,25 +13,35 @@ class ProgressButton extends React.Component {
 
   render() {
     const beforeText = this.props.beforeText ? (
-      <span className="button-icon">{this.props.beforeText} </span>
+      <span className="button-icon" aria-hidden="true">
+        {this.props.beforeText}
+        &nbsp;
+      </span>
     ) : (
       ''
     );
     const afterText = this.props.afterText ? (
-      <span className="button-icon"> {this.props.afterText}</span>
+      <span className="button-icon" aria-hidden="true">
+        &nbsp;
+        {this.props.afterText}
+      </span>
     ) : (
       ''
     );
+
+    const className =
+      [this.props.buttonClass, this.props.disabled ? 'usa-button-disabled' : '']
+        .filter(Boolean)
+        .join(' ') || null;
 
     return (
       <button
         type={this.props.submitButton ? 'submit' : 'button'}
         disabled={this.props.disabled}
-        className={`${this.props.buttonClass} ${
-          this.props.disabled ? 'usa-button-disabled' : null
-        }`}
+        className={className}
         id={`${this.id}-continueButton`}
         onClick={this.props.onButtonClick}
+        aria-label={this.props.ariaLabel || null}
       >
         {beforeText}
         {this.props.buttonText}
@@ -71,6 +81,10 @@ ProgressButton.propTypes = {
    * Whether the button is disabled
    */
   disabled: PropTypes.bool,
+
+  // aria-label attribute; needed for the review & submit page "Update page"
+  // button
+  ariaLabel: PropTypes.string,
 
   /**
    * Whether the button is a submit button

--- a/src/components/ProgressButton/ProgressButton.jsx
+++ b/src/components/ProgressButton/ProgressButton.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { uniqueId } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * A component for the continue button to navigate through panels of questions.
@@ -12,6 +13,7 @@ class ProgressButton extends React.Component {
   }
 
   render() {
+    const { ariaLabel = null, ariaDescribedby = null, disabled } = this.props;
     const beforeText = this.props.beforeText ? (
       <span className="button-icon" aria-hidden="true">
         {this.props.beforeText}
@@ -29,20 +31,17 @@ class ProgressButton extends React.Component {
       ''
     );
 
-    const className =
-      [this.props.buttonClass, this.props.disabled ? 'usa-button-disabled' : '']
-        .filter(Boolean)
-        .join(' ') || null;
-
     return (
       <button
         type={this.props.submitButton ? 'submit' : 'button'}
-        disabled={this.props.disabled}
-        className={className}
+        disabled={disabled}
+        className={classNames(this.props.buttonClass, {
+          'usa-button-disabled': disabled,
+        })}
         id={`${this.id}-continueButton`}
         onClick={this.props.onButtonClick}
-        aria-label={this.props.ariaLabel || null}
-        aria-describedby={this.props.ariaDescribedby || null}
+        aria-label={ariaLabel}
+        aria-describedby={ariaDescribedby}
       >
         {beforeText}
         {this.props.buttonText}

--- a/src/components/ProgressButton/ProgressButton.jsx
+++ b/src/components/ProgressButton/ProgressButton.jsx
@@ -42,6 +42,7 @@ class ProgressButton extends React.Component {
         id={`${this.id}-continueButton`}
         onClick={this.props.onButtonClick}
         aria-label={this.props.ariaLabel || null}
+        aria-describedby={this.props.ariaDescribedby || null}
       >
         {beforeText}
         {this.props.buttonText}
@@ -82,9 +83,15 @@ ProgressButton.propTypes = {
    */
   disabled: PropTypes.bool,
 
-  // aria-label attribute; needed for the review & submit page "Update page"
-  // button
+  /**
+   * Text read by a screenreader instead of content within the button
+   */
   ariaLabel: PropTypes.string,
+
+  /*
+   * Element ID containing additional content read by a screenreader
+   */
+  ariaDescribedby: PropTypes.string,
 
   /**
    * Whether the button is a submit button

--- a/src/components/ProgressButton/ProgressButton.mdx
+++ b/src/components/ProgressButton/ProgressButton.mdx
@@ -18,7 +18,10 @@ import ProgressButton from '@department-of-veterans-affairs/component-library/Pr
   afterText='»'
   disabled={false}
   submitButton={true}
+  ariaLabel="Click to start"
+  ariaDescribedby="additional-content"
 />
+<span id="additional-content">Additional content</span>
 ```
 
 ### Rendered Component
@@ -31,5 +34,8 @@ import ProgressButton from '@department-of-veterans-affairs/component-library/Pr
     afterText='»'
     disabled={false}
     submitButton={true}
+    ariaLabel='Click to start'
+    ariaDescribedby='additional-content'
   />
+  <span id="additional-content">Additional content</span>
 </div>

--- a/src/components/ProgressButton/ProgressButton.stories.jsx
+++ b/src/components/ProgressButton/ProgressButton.stories.jsx
@@ -27,3 +27,6 @@ Disabled.args = { ...defaultArgs, disabled: true };
 
 export const SubmitButton = Template.bind({});
 SubmitButton.args = { ...defaultArgs, submitButton: true };
+
+export const AriaLabel = Template.bind({});
+AriaLabel.args = { ...defaultArgs, ariaLabel: 'click to submit' };

--- a/src/components/ProgressButton/ProgressButton.stories.jsx
+++ b/src/components/ProgressButton/ProgressButton.stories.jsx
@@ -30,3 +30,6 @@ SubmitButton.args = { ...defaultArgs, submitButton: true };
 
 export const AriaLabel = Template.bind({});
 AriaLabel.args = { ...defaultArgs, ariaLabel: 'click to submit' };
+
+export const AriaDescribedby = Template.bind({});
+AriaDescribedby.args = { ...defaultArgs, ariaDescribedby: 'some-existing-id' };

--- a/src/components/ProgressButton/ProgressButton.unit.spec.jsx
+++ b/src/components/ProgressButton/ProgressButton.unit.spec.jsx
@@ -17,11 +17,13 @@ describe('<ProgressButton>', () => {
         buttonClass="usa-button-primary"
         disabled={false}
         ariaLabel="testing"
+        ariaDescribedby="some-id"
       />,
     );
     expect(tree.text()).to.equal('Button text');
     expect(tree).to.have.length.of(1);
     expect(tree.props()['aria-label']).to.eq('testing');
+    expect(tree.props()['aria-describedby']).to.eq('some-id');
     tree.unmount();
   });
 

--- a/src/components/ProgressButton/ProgressButton.unit.spec.jsx
+++ b/src/components/ProgressButton/ProgressButton.unit.spec.jsx
@@ -16,17 +16,19 @@ describe('<ProgressButton>', () => {
         buttonText="Button text"
         buttonClass="usa-button-primary"
         disabled={false}
+        ariaLabel="testing"
       />,
     );
     expect(tree.text()).to.equal('Button text');
     expect(tree).to.have.length.of(1);
+    expect(tree.props()['aria-label']).to.eq('testing');
     tree.unmount();
   });
 
   it('calls handle() on click', () => {
     let progressButton;
 
-    const updatePromise = new Promise((resolve, _reject) => {
+    const updatePromise = new Promise(resolve => {
       progressButton = ReactTestUtils.renderIntoDocument(
         <ProgressButton
           buttonText="Button text"
@@ -46,6 +48,24 @@ describe('<ProgressButton>', () => {
     ReactTestUtils.Simulate.click(button);
 
     return expect(updatePromise).to.eventually.eql(true);
+  });
+
+  it('should add aria-hidden button icons', () => {
+    const tree = shallow(
+      <ProgressButton
+        buttonText="Button text"
+        buttonClass="usa-button-primary"
+        disabled={false}
+        beforeText={'«'}
+        afterText={'»'}
+      />,
+    );
+    expect(tree.text()).to.equal('«\u00a0Button text\u00a0»');
+    const spans = tree.find('span[aria-hidden="true"]');
+    expect(spans).to.have.length.of(2);
+    expect(spans.first().text()).to.equal('«\u00a0');
+    expect(spans.last().text()).to.equal('\u00a0»');
+    tree.unmount();
   });
 
   it('should pass aXe check when enabled', () =>


### PR DESCRIPTION
## Description

Update `ProgressButton` component to match the component in `vets-website` `platform/forms-system/src/js/components/ProgressButton.jsx`.

I just merged in work to hide `button-icon` elements from a screenreader, but realized, that the majority of apps use the component-library ProgressButton component.

Additions:

- `aria-hidden="true"` to `button-icon` element (recent PR)
- `aria-label` prop & test (already in the platform ProgressButton from https://github.com/department-of-veterans-affairs/vets-website/pull/16114)
- `aria-describedby` prop & test - new addition. Needed for work on https://github.com/department-of-veterans-affairs/va.gov-team/issues/16182

- Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/30724
- Related to https://github.com/department-of-veterans-affairs/vets-website/pull/18931

## Testing done

Added unit tests

## Screenshots

<details><summary>Before: rendered progress buttons</summary>

<!-- leave a blank line above -->
![Rendered back and continue buttons in the upper half with developer window in the bottom half showing HTML spans with only a button-icon class](https://user-images.githubusercontent.com/136959/135339124-bac4ccbb-db6e-4f2d-a42c-4550af7c2e58.png)</details>

<details><summary>After: buttons with hidden icons</summary>

<!-- leave a blank line above -->
![Rendered back and continue buttons in the upper half with developer window in the bottom half showing HTML spans with an aria-hidden attribute](https://user-images.githubusercontent.com/136959/135343953-e38600f4-fd85-43be-9fa9-fdda82dfb16f.png)</details>

## Acceptance criteria
- [x] Progress button icons have an `aria-hidden` attribute
- [x] `aria-label` copied over from platform `ProgressButton`
- [x] `aria-describedby` property added so screenreaders include additional content for the button 
- [x] Unit tests added & all passing

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
