### PR TITLE
Update formation version for table styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@babel/plugin-proposal-throw-expressions": "^7.12.1",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/preset-env": "^7.12.10",
-    "@department-of-veterans-affairs/formation": "6.16.1",
+    "@department-of-veterans-affairs/formation": "^6.17.3",
     "@storybook/addon-a11y": "6.1.21",
     "@storybook/addon-actions": "6.1.21",
     "@storybook/addon-essentials": "6.1.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,10 +1246,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@department-of-veterans-affairs/formation@6.16.1":
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.16.1.tgz#b25b0d1a64638a220c42b36f9671de58b54d48fe"
-  integrity sha512-tsivIl/nbsUFScCdduaDYxqgplPuDw8Xoo7pbq56fou7QBT83BS+5NW307YbtwO8ucsFW6RIOmyQYYB1AE2uyg==
+"@department-of-veterans-affairs/formation@^6.17.3":
+  version "6.17.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.17.3.tgz#204a1e86d041eec30c6ed8a16c8f74f94498dc21"
+  integrity sha512-JS103tNPG4oHYAL3PZoeEWpUdkZVNqAqkegM82Sv5L4hkf5hpPZdrmulIi7xFXE3tmfWc1rHLXL2uMf8auOKYg==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description

Updates the formation version so the sorting icon looks right in `<Table>` stories.

Related to https://github.com/department-of-veterans-affairs/component-library/pull/160 and https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/697

## Testing done

Storybook :eyes: 


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/136624069-2cf7d263-5352-4f7d-b6cc-7f784c91a3e5.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
