### PR TITLE
Modal a11y updates

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/packages/react-components/src/components/Modal/Modal.jsx
+++ b/packages/react-components/src/components/Modal/Modal.jsx
@@ -146,7 +146,7 @@ class Modal extends React.Component {
       <button
         className="va-modal-close"
         type="button"
-        aria-label={`Close the ${status} modal`}
+        aria-label="close"
         onClick={this.handleClose}
       >
         <i className="fas fa-times-circle" aria-hidden="true" />
@@ -159,7 +159,7 @@ class Modal extends React.Component {
           className={modalClass}
           id={id}
           role={ariaRole(status)}
-          aria-label={titleId}
+          aria-labelledby={titleId}
           aria-modal
         >
           <div

--- a/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
@@ -7,6 +7,7 @@ class OMBInfo extends React.Component {
     super(props);
 
     this.state = { modalOpen: false };
+    this.id = 'omb-modal';
   }
 
   openModal = () => {
@@ -19,7 +20,7 @@ class OMBInfo extends React.Component {
 
   modalContents = minutes => (
     <div>
-      <h3>Privacy Act Statement</h3>
+      <h3 id={`${this.id}-title`}>Privacy Act Statement</h3>
       {minutes && (
         <p>
           <strong>Respondent Burden:</strong> We need this information to
@@ -98,7 +99,7 @@ class OMBInfo extends React.Component {
               ? this.props.children
               : this.modalContents(resBurden)
           }
-          id="omb-modal"
+          id={this.id}
           visible={this.state.modalOpen}
           onClose={this.closeModal}
         />


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/31444

Specifically addresses these two issues:
1. Upon opening, the id "va-modal-title" is announced and not the heading itself as aria-label is used instead of aria-labelledby
2. The close button has an aria-label "close the warning modal," which can be simplified to just "close"

I'm not sure if this should be a patch or a minor version bump so I went with minor.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)