### PR TITLE
Add dependency caching to `publish-storybook` CI workflow

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -12,6 +12,11 @@ jobs:
         bucket: [dev-design.va.gov, staging-design.va.gov, design.va.gov]
     steps:
       - uses: actions/checkout@master
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+        cache: 'yarn'
       - run: yarn install
       - name: Install dependencies in react-components
         run: yarn install


### PR DESCRIPTION
## Description
PR to speed up the `publish-storybook` CI workflow by caching dependencies.

## Acceptance criteria
- [ ] CI passes on master after this PR is merged.