### PR TITLE
Build bindings for autopublish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
       working-directory: packages/react-components
     - run: yarn workspace @department-of-veterans-affairs/react-components run build
     - run: yarn workspace @department-of-veterans-affairs/web-components run build
+    - run: yarn workspace @department-of-veterans-affairs/web-components run build-bindings
     - run: yarn workspace @department-of-veterans-affairs/component-library run build
     - run: yarn workspaces foreach --verbose --no-private npm publish --access public --tolerate-republish
       env:

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -23,8 +23,7 @@
     "test": "stencil test --spec --e2e",
     "test.watch": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate",
-    "serve": "stencil build --dev --watch --serve",
-    "prepare": "npm run build && npm run build-bindings"
+    "serve": "stencil build --dev --watch --serve"
   },
   "dependencies": {
     "@stencil/core": "^2.8.1",


### PR DESCRIPTION
## Description

The `prepare` script is [no longer part of `yarn`'s lifecycle scripts](https://yarnpkg.com/advanced/lifecycle-scripts), so it wasn't being run in the automation. This will ensure that the `react-bindings` directory is created and included in the published package.

## Testing done

I ran the following commands in order:

- `cd packages/react-components && yarn install`
- `cd -`
- `yarn workspace @department-of-veterans-affairs/react-components run build`
- `yarn workspace @department-of-veterans-affairs/web-components run build`
- `yarn workspace @department-of-veterans-affairs/web-components run build-bindings`
- `yarn workspace @department-of-veterans-affairs/component-library run build`

This is to mimic the setup that the CI would do. I then did a `pack` and checked to see if `react-bindings` was included in the package:

```shell
yarn workspaces foreach --verbose --no-private pack | grep "react-bindings"
```

![image](https://user-images.githubusercontent.com/2008881/140232302-414c63d3-b931-4026-8821-33f32957608b.png)

Having these files present in the package should resolve the [build issues in `vets-website` with version 3.4.0 of `component-library`](https://github.com/department-of-veterans-affairs/vets-website/runs/4093171472?check_suite_focus=true#step:4:25):

![image](https://user-images.githubusercontent.com/2008881/140233450-f7bfcb5b-94bd-458c-8769-3363eb00476b.png)


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
