### PR TITLE
Fix padding for background-only alert web component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -115,6 +115,7 @@ div.alert.bg-only > i::before {
 
 div.bg-only {
   border: none;
+  padding: 2rem;
 }
 
 .info.bg-only {


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/32091

## Testing done

Visual (Storybook)

## Screenshots
### Before
<img width="1026" alt="before" src="https://user-images.githubusercontent.com/36863582/140311265-3bcaab6d-7d1c-4140-ad96-fee891dd9bec.png">

### After
<img width="1028" alt="after" src="https://user-images.githubusercontent.com/36863582/140311274-6c6b4f9d-1b0d-466c-8c82-4ce804c7dc7c.png">


## Acceptance criteria
- [ ] `<va-alert>` background-only variant has reduced padding

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
