### PR TITLE
split text prop in promo banner and add icon to last word in nowrap s…

### DIFF
--- a/packages/react-components/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/react-components/src/components/PromoBanner/PromoBanner.jsx
@@ -46,6 +46,11 @@ function PromoBanner({
     }
   };
 
+  let splitText = text.split(' ');
+  const lastWord = splitText.pop();
+  const formattedText = splitText.join(' ');
+
+
   return (
     <div className="vads-c-promo-banner">
       <div className="vads-c-promo-banner__body">
@@ -70,12 +75,12 @@ function PromoBanner({
               target={target}
               onClick={handleLinkClick}
             >
-              {text}{' '}
-              <i
+              {formattedText}
+              <span style={{whiteSpace: 'nowrap'}}> {lastWord} <i
                 aria-hidden="true"
                 className="fas fa-angle-right"
                 role="presentation"
-              />
+              /></span>
             </a>
           )}
         </div>


### PR DESCRIPTION
split text prop in promo banner and add icon to last word in nowrap span element

## Description
Closes 32078

## Testing done
tested locally, no issues

## Screenshots


<img width="324" alt="Screen Shot 2021-11-05 at 3 10 42 PM" src="https://user-images.githubusercontent.com/17556493/140573997-df32c92c-723f-4bed-a9b6-09755dae0c4b.png">

