### PR TITLE
Only export applyPolyfills from the loader

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/src/main.js
+++ b/packages/core/src/main.js
@@ -2,4 +2,4 @@ import '@department-of-veterans-affairs/web-components/dist/component-library/co
 
 export * from '@department-of-veterans-affairs/react-components';
 export * from '@department-of-veterans-affairs/web-components';
-export * from '@department-of-veterans-affairs/web-components/loader';
+export { applyPolyfills } from '@department-of-veterans-affairs/web-components/loader';

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -26,7 +26,7 @@
     "serve": "stencil build --dev --watch --serve"
   },
   "dependencies": {
-    "@stencil/core": "^2.8.1",
+    "@stencil/core": "^2.10.0",
     "@stencil/postcss": "^2.0.0",
     "classnames": "^2.3.1",
     "intersection-observer": "^0.12.0",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,7 +1789,7 @@ __metadata:
     "@axe-core/puppeteer": ^4.1.1
     "@babel/core": ^7.12.13
     "@department-of-veterans-affairs/formation": ^6.14.0
-    "@stencil/core": ^2.8.1
+    "@stencil/core": ^2.10.0
     "@stencil/postcss": ^2.0.0
     "@stencil/react-output-target": ^0.0.9
     "@types/jest": ^26.0.20
@@ -2445,12 +2445,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/core@npm:^2.8.1":
-  version: 2.9.0
-  resolution: "@stencil/core@npm:2.9.0"
+"@stencil/core@npm:^2.10.0":
+  version: 2.10.0
+  resolution: "@stencil/core@npm:2.10.0"
   bin:
     stencil: bin/stencil
-  checksum: aa513b0242ea4677fad5156186216bf398902ff7217634e451a29fb86d190cc152b414ef9308cc05d13fa3f1deb516cd4cc3eabd1e78a3d72b0d212b9aed1142
+  checksum: 035f74e71c2428a69f15df2a3e234845e3105f3481a352a7aed65f64714fc8b4b3b135a6bb90dfd90aca559d7f80b488cf7b5b2247e96e94fccb5e1bee676634
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Related to a [support request](https://dsva.slack.com/archives/C01DBGX4P45/p1636569081014100).

A duplicate named export is causing errors in webpack 5, so this PR removes one of the duplicates. The reason we have both is because the `loader` export provides `applyPolyfills`, which we use for IE11 support. Once `vets-website` and the Design System no longer support IE11, we can remove the `loader` export entirely.

## Testing done

Checked that web components were working in storybook after the export was changed.

## Screenshots

The `defineCustomElements` function exists in `web-components/loader` as well as `web-components/dist`:

![image](https://user-images.githubusercontent.com/2008881/141348152-d9812db7-5708-4f90-a7a1-14a07f6d1f05.png)

![image](https://user-images.githubusercontent.com/2008881/141348285-4d1f6f98-ca4b-4e47-920c-c965adc50f87.png)


Build warning removed in `packages/core`:

### Before

![image](https://user-images.githubusercontent.com/2008881/141348900-22b17ceb-49a7-4105-9f97-afc1cdccf6c0.png)


### After

![image](https://user-images.githubusercontent.com/2008881/141348737-d2f79a40-5c86-4e08-ae07-dc399bd7c0bf.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
