### PR TITLE
add space to featured content text

### DIFF
--- a/packages/storybook/stories/va-featured-content.stories.jsx
+++ b/packages/storybook/stories/va-featured-content.stories.jsx
@@ -25,8 +25,8 @@ const Template = () => (
         Didn't receive a dishonorable discharge, <strong>and</strong>
       </li>
       <li>
-        Have a service-connected disability rating of at least 10% from VA, 
-        <strong>and</strong>
+        Have a service-connected disability rating of at least 10% from VA,
+        <strong> and</strong>
       </li>
       <li>
         <a href="#">Apply for VR&amp;E services</a>

--- a/packages/storybook/stories/va-featured-content.stories.jsx
+++ b/packages/storybook/stories/va-featured-content.stories.jsx
@@ -25,7 +25,7 @@ const Template = () => (
         Didn't receive a dishonorable discharge, <strong>and</strong>
       </li>
       <li>
-        Have a service-connected disability rating of at least 10% from VA,
+        Have a service-connected disability rating of at least 10% from VA, 
         <strong>and</strong>
       </li>
       <li>


### PR DESCRIPTION
## Description
Adds space between words in the va-featured-content storybook example

## Testing done
Visual testing

## Screenshots
<img width="218" alt="image" src="https://user-images.githubusercontent.com/12739849/141361781-028393b7-dd29-48ac-9807-3c53f01788ad.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
