### PR TITLE
Add initial release notes config file

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: New Features & Components 🎉
+      labels:
+        - enhancement
+    - title: Fixes
+      labels:
+        - fix
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/32736

At the moment when we auto generate release notes, all PRs go into the same category:

![image](https://user-images.githubusercontent.com/2008881/142239238-9fa3227b-d790-4e64-a3d0-a9d1409cf052.png)

We want to specifically call out which PRs belong to which semver category, and which PRs don't fit into those categories, like pure CI work or storybook updates.

### Examples

For this template to generate the kinds of release notes we want, we need to make sure that the @department-of-veterans-affairs/vsp-design-system-fe is applying appropriate labels to PRs.

#### If we're tagging a release with a `patch` version increase, we should:
- Not see anything for the "Breaking Changes" category
- Not see anything for the "New Features & Components" category
- See at least one change in the "Fixes" category
- Maybe see changes in the "Other" category

#### If we're tagging a release with a `minor` version increase, we should:
- Not see anything for the "Breaking Changes" category
- See at least one change in the "New Features & Components" category
- Maybe see changes in the "Fixes" category
- Maybe see changes in the "Other" category

#### If we're tagging a release with a `major` version increase, we should:
- See at least one change in the "Breaking Changes" category
- Maybe see changes in the "New Features & Components" category
- Maybe see changes in the "Fixes" category
- Maybe see changes in the "Other" category


## Testing done

I haven't tested this, but GitHub's docs have an [example config](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configuration) which this was based on. 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
