### PR TITLE
Isolate host styling in "Back to top"

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-back-to-top.stories.jsx
+++ b/packages/storybook/stories/va-back-to-top.stories.jsx
@@ -9,24 +9,28 @@ export default {
 
 const Template = () => {
   return (
-    <main className="vads-l-col--12 medium-screen:vads-l-col--8">
-      <h1>The top</h1>
-      {[...Array(10)].map(i => (
-        <div
-          key={i}
-          style={{
-            height: '300px',
-            background: 'whitesmoke',
-            margin: '2em 0',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          Scroll down
+    <>
+      <div className="usa-grid usa-grid-full">
+        <div className="usa-width-three-fourths">
+          <h1>The top</h1>
+          {[...Array(10)].map(i => (
+            <div
+              key={i}
+              style={{
+                height: '300px',
+                background: 'whitesmoke',
+                margin: '2em 0',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              Scroll down
+            </div>
+          ))}
+          <va-back-to-top />
         </div>
-      ))}
-      <va-back-to-top />
+      </div>
       <footer
         style={{
           height: '500px',
@@ -38,7 +42,7 @@ const Template = () => {
       >
         The footer
       </footer>
-    </main>
+    </>
   );
 };
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/packages/web-components/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/packages/web-components/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -41,7 +41,7 @@ describe('va-back-to-top', () => {
 
   it('reveals when the viewport is below the reveal pixel', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
+    const wrapper = await page.find('va-back-to-top >>> div');
     const notQuitePastRevealPoint = 199;
 
     // Button shouldn't be revealed initially
@@ -65,7 +65,7 @@ describe('va-back-to-top', () => {
 
   it('docks when the "dock" is scrolled into view', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
+    const wrapper = await page.find('va-back-to-top >>> div');
     const pastPlaceholder = 1000;
 
     expect(wrapper).not.toHaveClass('docked');
@@ -82,7 +82,7 @@ describe('va-back-to-top', () => {
 
   it('stays docked even with really long footers', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
+    const wrapper = await page.find('va-back-to-top >>> div');
     const pastPlaceholder = 1000;
     // Placeholder section is 1000px tall. Accounting for the header,
     // 2000px should put us well past the dock
@@ -127,7 +127,7 @@ describe('va-back-to-top', () => {
 
   it('passes an axe check when revealed', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
+    const wrapper = await page.find('va-back-to-top >>> div');
     const pastRevealPoint = 300;
 
     await page.mouse.wheel({ deltaY: pastRevealPoint });
@@ -140,7 +140,7 @@ describe('va-back-to-top', () => {
 
   it('passes an axe check when docked', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
+    const wrapper = await page.find('va-back-to-top >>> div');
     const pastPlaceholder = 1000;
 
     await page.mouse.wheel({ deltaY: pastPlaceholder });

--- a/packages/web-components/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/packages/web-components/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -26,6 +26,7 @@ const pageSetup = async () => {
     `);
 
   await page.addStyleTag({ content: pageStyles });
+  await page.waitForChanges();
 
   return page;
 };

--- a/packages/web-components/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/packages/web-components/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -41,7 +41,7 @@ describe('va-back-to-top', () => {
 
   it('reveals when the viewport is below the reveal pixel', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> div');
+    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
     const notQuitePastRevealPoint = 199;
 
     // Button shouldn't be revealed initially
@@ -65,7 +65,7 @@ describe('va-back-to-top', () => {
 
   it('docks when the "dock" is scrolled into view', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> div');
+    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
     const pastPlaceholder = 1000;
 
     expect(wrapper).not.toHaveClass('docked');
@@ -82,7 +82,7 @@ describe('va-back-to-top', () => {
 
   it('stays docked even with really long footers', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> div');
+    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
     const pastPlaceholder = 1000;
     // Placeholder section is 1000px tall. Accounting for the header,
     // 2000px should put us well past the dock
@@ -127,7 +127,7 @@ describe('va-back-to-top', () => {
 
   it('passes an axe check when revealed', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> div');
+    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
     const pastRevealPoint = 300;
 
     await page.mouse.wheel({ deltaY: pastRevealPoint });
@@ -140,7 +140,7 @@ describe('va-back-to-top', () => {
 
   it('passes an axe check when docked', async () => {
     const page = await pageSetup();
-    const wrapper = await page.find('va-back-to-top >>> div');
+    const wrapper = await page.find('va-back-to-top >>> #marginWrapper div');
     const pastPlaceholder = 1000;
 
     await page.mouse.wheel({ deltaY: pastPlaceholder });

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
@@ -1,7 +1,8 @@
 @import '../../../../../node_modules/animate.css/source/sliding_entrances/slideInUp.css';
 @import '../../../../../node_modules/animate.css/source/sliding_exits/slideOutDown.css';
 @import '../../mixins/buttons.css';
-:host {
+
+#marginWrapper {
   display: block;
   width: 100%;
   height: 44px;
@@ -9,7 +10,7 @@
   margin-bottom: 2rem;
 }
 
-div {
+#marginWrapper div {
   position: fixed;
   bottom: 0;
   width: 100%;
@@ -43,12 +44,12 @@ button {
 button:hover {
   background-color: var(--color-black);
 }
-div.reveal button {
+#marginWrapper div.reveal button {
   pointer-events: auto;
   opacity: 1;
   animation: slideInUp 0.25s;
 }
-div:not(.reveal) button {
+#marginWrapper div:not(.reveal) button {
   animation: slideOutDown 0.25s;
 }
 
@@ -56,10 +57,10 @@ div:not(.reveal) button {
   button {
     transition: none;
   }
-  div.reveal button {
+  #marginWRapper div.reveal button {
     animation: none;
   }
-  div:not(.reveal) button {
+  #marginWrapper div:not(.reveal) button {
     animation: none;
   }
 }
@@ -68,19 +69,19 @@ button span {
   display: none;
 }
 
-div.docked {
+#marginWrapper div.docked {
   position: relative;
   display: flex;
   flex-direction: row-reverse;
 }
-div:not(.docked) {
+#marginWrapper div:not(.docked) {
   max-width: var(--undocked-width);
 }
-div:not(.docked):not(.reveal) {
+#marginWrapper div:not(.docked):not(.reveal) {
   position: relative;
 }
 
-div.docked button {
+#marginWrapper div.docked button {
   position: relative;
 }
 

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
@@ -10,7 +10,7 @@
   margin-bottom: 2rem;
 }
 
-#marginWrapper div {
+div {
   position: fixed;
   bottom: 0;
   width: 100%;
@@ -44,12 +44,12 @@ button {
 button:hover {
   background-color: var(--color-black);
 }
-#marginWrapper div.reveal button {
+div.reveal button {
   pointer-events: auto;
   opacity: 1;
   animation: slideInUp 0.25s;
 }
-#marginWrapper div:not(.reveal) button {
+div:not(.reveal) button {
   animation: slideOutDown 0.25s;
 }
 
@@ -57,10 +57,10 @@ button:hover {
   button {
     transition: none;
   }
-  #marginWRapper div.reveal button {
+  div.reveal button {
     animation: none;
   }
-  #marginWrapper div:not(.reveal) button {
+  div:not(.reveal) button {
     animation: none;
   }
 }
@@ -69,19 +69,19 @@ button span {
   display: none;
 }
 
-#marginWrapper div.docked {
+div.docked {
   position: relative;
   display: flex;
   flex-direction: row-reverse;
 }
-#marginWrapper div:not(.docked) {
+div:not(.docked) {
   max-width: var(--undocked-width);
 }
-#marginWrapper div:not(.docked):not(.reveal) {
+div:not(.docked):not(.reveal) {
   position: relative;
 }
 
-#marginWrapper div.docked button {
+div.docked button {
   position: relative;
 }
 

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
@@ -70,7 +70,7 @@ export class VaBackToTop {
 
     return (
       <Host>
-        <div id="marginWrapper">
+        <span id="marginWrapper">
           <span
             class="reveal-point"
             ref={el => (this.revealPixel = el as HTMLSpanElement)}
@@ -84,7 +84,7 @@ export class VaBackToTop {
               <span>Back to top</span>
             </button>
           </div>
-        </div>
+        </span>
       </Host>
     );
   }

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
@@ -70,18 +70,20 @@ export class VaBackToTop {
 
     return (
       <Host>
-        <span
-          class="reveal-point"
-          ref={el => (this.revealPixel = el as HTMLSpanElement)}
-        ></span>
+        <div id="marginWrapper">
+          <span
+            class="reveal-point"
+            ref={el => (this.revealPixel = el as HTMLSpanElement)}
+          ></span>
 
-        <div
-          class={classnames({ docked: this.isDocked, reveal: this.revealed })}
-        >
-          <button type="button" onClick={this.navigateToTop.bind(this)}>
-            <i aria-hidden="true" role="img"></i>
-            <span>Back to top</span>
-          </button>
+          <div
+            class={classnames({ docked: this.isDocked, reveal: this.revealed })}
+          >
+            <button type="button" onClick={this.navigateToTop.bind(this)}>
+              <i aria-hidden="true" role="img"></i>
+              <span>Back to top</span>
+            </button>
+          </div>
         </div>
       </Host>
     );


### PR DESCRIPTION
## Description
Related to https://github.com/department-of-veterans-affairs/va.gov-team/issues/31200

`<va-back-to-top>` is designed to be the last element in the main content area. Sometimes the main content area is styled with `usa-width-three-fourths` - a `uswds` class, and part of that styling is to [remove the margin from the last child](https://github.com/uswds/uswds/blob/c4c9410d54b537c6112037a36ed289d8b7e8940a/src/stylesheets/elements/_typography.scss#L227-L231). This PR adds "insulation" to `<va-back-top>` by adding an internal element that we can style as if it were the host. The `uswds` styles aren't able to have an effect this way with `:last-child` or `:first-child`.

This will unblock https://github.com/department-of-veterans-affairs/content-build/pull/759

## Testing done

Storybook :eyes: 


## Screenshots

### No margin from `:host`, `uswds` styles are _technically_ applying

![image](https://user-images.githubusercontent.com/2008881/142293942-9b896fca-42de-49d6-9fde-50496f8f8a65.png)

### The actual margin for the component is applied to the internal `#marginWrapper`

![image](https://user-images.githubusercontent.com/2008881/142294077-3931bce3-7218-4e07-8edb-49cb566c41de.png)


## Acceptance criteria
- [x] `<va-back-to-top>` doesn't have its margin removed by `uswds` styles

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
