### PR TITLE
fix: update radio option name values

### DIFF
--- a/packages/storybook/stories/va-radio.stories.jsx
+++ b/packages/storybook/stories/va-radio.stories.jsx
@@ -16,8 +16,8 @@ export default {
 const Template = args => {
   return (
     <va-radio {...args}>
-      <va-radio-option label="Option one" name="one" value="1" />
-      <va-radio-option label="Option two" name="two" value="2" />
+      <va-radio-option label="Option one" name="example" value="1" />
+      <va-radio-option label="Option two" name="example" value="2" />
     </va-radio>
   );
 };


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/33072 (including changes from https://github.com/department-of-veterans-affairs/component-library/pull/214)

This PR addresses:

> The radio inputs need to have the same name to group them together in the same radio group


https://github.com/department-of-veterans-affairs/component-library/pull/214 addressed:

> The id's for each input need to be unique. Current they're both just "input". The label for each input needs to have its' "for" attribute value updated to the unique id of its' related radio input. The radio inputs need their focus styling applied when focused

The id and label `for` attributes for each radio option were updated to use `<va-radio-option>`'s label attribute value. The ids will not conflict because of the encapsulation provided by the shadow DOM for these web components. Focus styling was also fixed.

## Testing done

Storybook

## Screenshots

<img width="1028" alt="Screen Shot 2021-11-22 at 15 36 33" src="https://user-images.githubusercontent.com/36863582/142931679-7c2f3cb5-701b-4aef-821e-cf6065d2376b.png">

<img width="1053" alt="Screen Shot 2021-11-22 at 15 51 39" src="https://user-images.githubusercontent.com/36863582/142933594-0ebe90f9-c413-44a9-afab-7f4d95c8aece.png">



## Acceptance criteria
- [ ] `va-radio-option` elements have been updated to use the same value for their name attribute

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
