### PR TITLE
Auto-expand va-accordion-item with matching hash

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -17,19 +17,19 @@ const Template = args => {
   const { headline, level, ...rest } = args;
   return (
     <va-accordion {...rest}>
-      <va-accordion-item>
+      <va-accordion-item id="first">
         {headline}
         Congress shall make no law respecting an establishment of religion, or
         prohibiting the free exercise thereof; or abridging the freedom of
         speech, or of the press; or the right of the people peaceably to
         assemble, and to petition the Government for a redress of grievances.
       </va-accordion-item>
-      <va-accordion-item level={level} header="Second Amendment">
+      <va-accordion-item id="second" level={level} header="Second Amendment">
         A well regulated Militia, being necessary to the security of a free
         State, the right of the people to keep and bear Arms, shall not be
         infringed.
       </va-accordion-item>
-      <va-accordion-item level={level} header="Third Amendment">
+      <va-accordion-item id="third" level={level} header="Third Amendment">
         No Soldier shall, in time of peace be quartered in any house, without
         the consent of the Owner, nor in time of war, but in a manner to be
         prescribed by law.

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from '@stencil/core/testing';
 import { axeCheck } from '../../testing/test-helpers';
 
-// **NOTE** Duplicate tests written to handle scenario of both Props and Slot Usage of Component 
+// **NOTE** Duplicate tests written to handle scenario of both Props and Slot Usage of Component
 
 describe('va-accordion-item', () => {
   it('renders', async () => {
@@ -138,7 +138,7 @@ describe('va-accordion-item', () => {
     await page.setContent(
       '<va-accordion-item header="The header" subheader="The subheader">Content inside</va-accordion-item>',
     );
-    
+
     const element = await page.find('va-accordion-item');
     let subheader = element.shadowRoot.querySelector('p');
 
@@ -150,10 +150,24 @@ describe('va-accordion-item', () => {
     await page.setContent(
       '<va-accordion-item subheader="The subheader"><h3 slot="headline">The header</h3>Content inside</va-accordion-item>',
     );
-    
+
     const element = await page.find('va-accordion-item');
     let subheader = element.shadowRoot.querySelector('p');
 
     expect(subheader).toEqualText('The subheader');
+  });
+
+  it.skip('fires a custom event when the location hash matches the accordion id', async () => {
+    const page = await newE2EPage();
+
+    // await page.evaluate(() => { window.location.hash = '#testing'; });
+    await page.goto(`/${page.url()}#testing`);
+
+    const accordionItemToggled = await page.spyOnEvent('accordionItemToggled');
+    await page.setContent(
+      '<va-accordion-item id="testing" header="The header">Content inside</va-accordion-item>',
+    );
+
+    expect(accordionItemToggled).toHaveReceivedEventTimes(1);
   });
 });

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -157,17 +157,15 @@ describe('va-accordion-item', () => {
     expect(subheader).toEqualText('The subheader');
   });
 
-  it.skip('fires a custom event when the location hash matches the accordion id', async () => {
-    const page = await newE2EPage();
+  it('fires a custom event when the location hash matches the accordion id', async () => {
+    const page = await newE2EPage({ url: '/#testing' });
 
-    // await page.evaluate(() => { window.location.hash = '#testing'; });
-    await page.goto(`/${page.url()}#testing`);
-
-    const accordionItemToggled = await page.spyOnEvent('accordionItemToggled');
     await page.setContent(
       '<va-accordion-item id="testing" header="The header">Content inside</va-accordion-item>',
     );
+    const accordionItemToggled = await page.spyOnEvent('accordionItemToggled');
+    await page.waitForChanges();
 
-    expect(accordionItemToggled).toHaveReceivedEventTimes(1);
+    expect(accordionItemToggled).toHaveReceivedEvent();
   });
 });

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -55,7 +55,7 @@ export class VaAccordionItem {
   /**
    * Toggle button reference
    */
-  private expandButton: HTMLElement = null;
+  private expandButton: HTMLButtonElement = null;
 
   private toggleOpen(e: MouseEvent): void {
     this.accordionItemToggled.emit(e);
@@ -76,7 +76,7 @@ export class VaAccordionItem {
   componentDidLoad() {
     // auto-expand accordion if the window hash matches the ID
     if (this.el.id && this.el.id === window.location.hash.slice(1)) {
-      const currentTarget: HTMLElement = this.expandButton;
+      const currentTarget = this.expandButton;
       if (currentTarget) {
         currentTarget.click();
       }

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -52,6 +52,11 @@ export class VaAccordionItem {
    */
   @State() slotTag: string = null;
 
+  /**
+   * Toggle button reference
+   */
+  private expandButton: HTMLElement = null;
+
   private toggleOpen(e: MouseEvent): void {
     this.accordionItemToggled.emit(e);
   }
@@ -68,12 +73,23 @@ export class VaAccordionItem {
       })
   }
 
+  componentDidLoad() {
+    // auto-expand accordion if the window hash matches the ID
+    if (this.el.id === window.location.hash.slice(1)) {
+      const currentTarget: HTMLElement = this.expandButton;
+      if (currentTarget) {
+        currentTarget.click();
+      }
+    }
+  }
+
   render() {
     const Header = () =>
       h(
         this.slotTag || `h${this.level}`,
         null,
         <button
+          ref={el => { this.expandButton = el }}
           onClick={this.toggleOpen.bind(this)}
           aria-expanded={this.open ? 'true' : 'false'}
           aria-controls="content"

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -75,7 +75,7 @@ export class VaAccordionItem {
 
   componentDidLoad() {
     // auto-expand accordion if the window hash matches the ID
-    if (this.el.id === window.location.hash.slice(1)) {
+    if (this.el.id && this.el.id === window.location.hash.slice(1)) {
       const currentTarget: HTMLElement = this.expandButton;
       if (currentTarget) {
         currentTarget.click();

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -52,7 +52,7 @@ export class VaAccordion {
       event.detail.currentTarget.parentNode.parentNode.host || // if we are on IE, `.host` won't be there
       event.detail.currentTarget.parentNode.parentNode;
     // Close the other items if this accordion isn't multi-selectable
-    
+
     // Usage for slot to provide context to analytics for header and level
     let headerText
     let headerLevel


### PR DESCRIPTION
## Description

When linking to a specific accordion, the ID of the accordion and the window location hash must exactly match for it to scroll that anchor into view. This PR makes the targeted accordion auto-expand.

- See https://github.com/department-of-veterans-affairs/content-build/pull/764 - this adds the content ID to the accordion
- Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/32966

## Testing done

Pending... I added one, but I can't get the `window.location.hash` to change in puppeteer.

## Screenshots

<img width="1020" alt="Location hash & expanded accordion shown" src="https://user-images.githubusercontent.com/136959/143313915-5a5640b5-609c-4fb5-8d03-32946c2ef5bd.png">

## Acceptance criteria
- [x] Accordion expands when the ID matches the anchor
- [x] All tests passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
