### PR TITLE
Add option to show icon in background-only alert for <va-alert>

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -15,7 +15,7 @@ const defaultArgs = {
   closeable: false,
   fullWidth: false,
   onClose: () => {},
-  'show-icon-in-background-only': false
+  'show-icon': false
 };
 
 const Template = ({
@@ -25,7 +25,7 @@ const Template = ({
   backgroundOnly,
   closeable,
   onClose,
-  'show-icon-in-background-only': showIconInBackgroundOnly
+  'show-icon': showIcon
 }) => {
   return (
     <va-alert
@@ -34,7 +34,7 @@ const Template = ({
       closeable={closeable}
       full-width={fullWidth}
       onClose={onClose}
-      show-icon-in-background-only={showIconInBackgroundOnly}
+      show-icon={showIcon}
     >
       {headline}
       <div>This is an alert</div>
@@ -90,5 +90,5 @@ export const BackgroundOnlyWithIcon = Template.bind({});
 BackgroundOnlyWithIcon.args = {
   ...defaultArgs,
   backgroundOnly: true,
-  'show-icon-in-background-only': true
+  'show-icon': true
 };

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -15,6 +15,7 @@ const defaultArgs = {
   closeable: false,
   fullWidth: false,
   onClose: () => {},
+  'show-icon-in-background-only': false
 };
 
 const Template = ({
@@ -24,6 +25,7 @@ const Template = ({
   backgroundOnly,
   closeable,
   onClose,
+  'show-icon-in-background-only': showIconInBackgroundOnly
 }) => {
   return (
     <va-alert
@@ -32,6 +34,7 @@ const Template = ({
       closeable={closeable}
       full-width={fullWidth}
       onClose={onClose}
+      show-icon-in-background-only={showIconInBackgroundOnly}
     >
       {headline}
       <div>This is an alert</div>
@@ -81,4 +84,11 @@ export const BackgroundOnly = Template.bind({});
 BackgroundOnly.args = {
   ...defaultArgs,
   backgroundOnly: true,
+};
+
+export const BackgroundOnlyWithIcon = Template.bind({});
+BackgroundOnlyWithIcon.args = {
+  ...defaultArgs,
+  backgroundOnly: true,
+  'show-icon-in-background-only': true
 };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -64,6 +64,10 @@ export namespace Components {
          */
         "fullWidth": boolean;
         /**
+          * This only takes effect when background-only is true. If true, the background-only alert will include an icon.
+         */
+        "showIconInBackgroundOnly": boolean;
+        /**
           * Determines the icon and border/background color. One of `info`, `error`, `success`, `warning`, or `continue`
          */
         "status": string;
@@ -397,6 +401,10 @@ declare namespace LocalJSX {
           * Fires when the component has successfully finished rendering for the first time.
          */
         "onVa-component-did-load"?: (event: CustomEvent<any>) => void;
+        /**
+          * This only takes effect when background-only is true. If true, the background-only alert will include an icon.
+         */
+        "showIconInBackgroundOnly"?: boolean;
         /**
           * Determines the icon and border/background color. One of `info`, `error`, `success`, `warning`, or `continue`
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -64,9 +64,9 @@ export namespace Components {
          */
         "fullWidth": boolean;
         /**
-          * This only takes effect when background-only is true. If true, the background-only alert will include an icon.
+          * This option only takes effect when background-only is true. If true, the background-only alert will include an icon.
          */
-        "showIconInBackgroundOnly": boolean;
+        "showIcon": boolean;
         /**
           * Determines the icon and border/background color. One of `info`, `error`, `success`, `warning`, or `continue`
          */
@@ -402,9 +402,9 @@ declare namespace LocalJSX {
          */
         "onVa-component-did-load"?: (event: CustomEvent<any>) => void;
         /**
-          * This only takes effect when background-only is true. If true, the background-only alert will include an icon.
+          * This option only takes effect when background-only is true. If true, the background-only alert will include an icon.
          */
-        "showIconInBackgroundOnly"?: boolean;
+        "showIcon"?: boolean;
         /**
           * Determines the icon and border/background color. One of `info`, `error`, `success`, `warning`, or `continue`
          */

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -11,7 +11,7 @@ describe('va-alert', () => {
     expect(element).toEqualHtml(`
       <va-alert class="hydrated">
         <mock:shadow-root>
-          <div class="alert hide-icon info">
+          <div class="alert info">
             <i aria-hidden="true" role="img"></i>
             <div class="body">
               <slot name="headline"></slot>

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -11,7 +11,7 @@ describe('va-alert', () => {
     expect(element).toEqualHtml(`
       <va-alert class="hydrated">
         <mock:shadow-root>
-          <div class="alert info">
+          <div class="alert hide-icon info">
             <i aria-hidden="true" role="img"></i>
             <div class="body">
               <slot name="headline"></slot>

--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -109,6 +109,10 @@ div.error > i::before {
   color: var(--color-secondary-dark);
 }
 
+div.bg-only.hide-icon > i::before {
+  content: '';
+}
+
 div.bg-only {
   border: none;
   padding: 2rem;

--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -109,10 +109,6 @@ div.error > i::before {
   color: var(--color-secondary-dark);
 }
 
-div.alert.bg-only > i::before {
-  content: '';
-}
-
 div.bg-only {
   border: none;
   padding: 2rem;

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -7,6 +7,7 @@ import {
   Prop,
   h,
 } from '@stencil/core';
+import classnames from 'classnames';
 
 @Component({
   tag: 'va-alert',
@@ -134,9 +135,10 @@ export class VaAlert {
 
   render() {
     const { backgroundOnly, status, visible, closeable, showIcon } = this;
-    const classes = `alert ${status} ${backgroundOnly ? 'bg-only' : ''} ${
-      backgroundOnly ? (showIcon ? '' : 'hide-icon') : ''
-    }`;
+    const classes = classnames('alert', status, {
+      'bg-only': backgroundOnly,
+      'hide-icon': backgroundOnly && !showIcon,
+    });
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -29,6 +29,12 @@ export class VaAlert {
   @Prop() backgroundOnly: boolean = false;
 
   /**
+   * This only takes effect when background-only is true. If true, the background-only alert will
+   * include an icon.
+   */
+  @Prop() showIconInBackgroundOnly: boolean = false; 
+
+  /**
    * If true, doesn't fire the CustomEvent which can be used for analytics tracking.
    */
   @Prop() disableAnalytics: boolean = false;
@@ -127,8 +133,10 @@ export class VaAlert {
   }
 
   render() {
-    const { backgroundOnly, status, visible, closeable } = this;
-    const classes = `alert ${status} ${backgroundOnly ? 'bg-only' : ''}`;
+    const { backgroundOnly, status, visible, closeable, showIconInBackgroundOnly } = this;
+    const classes = `alert ${status} ${backgroundOnly ? 'bg-only' : ''} ${
+      showIconInBackgroundOnly ? '' : 'hide-icon'
+    }`;
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -29,10 +29,10 @@ export class VaAlert {
   @Prop() backgroundOnly: boolean = false;
 
   /**
-   * This only takes effect when background-only is true. If true, the background-only alert will
+   * This option only takes effect when background-only is true. If true, the background-only alert will
    * include an icon.
    */
-  @Prop() showIconInBackgroundOnly: boolean = false;
+  @Prop() showIcon: boolean = false;
 
   /**
    * If true, doesn't fire the CustomEvent which can be used for analytics tracking.
@@ -133,15 +133,9 @@ export class VaAlert {
   }
 
   render() {
-    const {
-      backgroundOnly,
-      status,
-      visible,
-      closeable,
-      showIconInBackgroundOnly,
-    } = this;
+    const { backgroundOnly, status, visible, closeable, showIcon } = this;
     const classes = `alert ${status} ${backgroundOnly ? 'bg-only' : ''} ${
-      backgroundOnly ? (showIconInBackgroundOnly ? '' : 'hide-icon') : ''
+      backgroundOnly ? (showIcon ? '' : 'hide-icon') : ''
     }`;
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -32,7 +32,7 @@ export class VaAlert {
    * This only takes effect when background-only is true. If true, the background-only alert will
    * include an icon.
    */
-  @Prop() showIconInBackgroundOnly: boolean = false; 
+  @Prop() showIconInBackgroundOnly: boolean = false;
 
   /**
    * If true, doesn't fire the CustomEvent which can be used for analytics tracking.
@@ -133,9 +133,15 @@ export class VaAlert {
   }
 
   render() {
-    const { backgroundOnly, status, visible, closeable, showIconInBackgroundOnly } = this;
+    const {
+      backgroundOnly,
+      status,
+      visible,
+      closeable,
+      showIconInBackgroundOnly,
+    } = this;
     const classes = `alert ${status} ${backgroundOnly ? 'bg-only' : ''} ${
-      showIconInBackgroundOnly ? '' : 'hide-icon'
+      backgroundOnly ? (showIconInBackgroundOnly ? '' : 'hide-icon') : ''
     }`;
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/586

## Testing done

Storybook

## Screenshots

<img width="1029" alt="Screen Shot 2021-12-01 at 16 56 59" src="https://user-images.githubusercontent.com/36863582/144320644-a734a835-9dd4-40da-ae3c-1b474fdb0255.png">

<img width="1029" alt="Screen Shot 2021-12-01 at 16 56 26" src="https://user-images.githubusercontent.com/36863582/144320563-ace466b8-88ed-4646-8ca9-d48998a24d94.png">


## Acceptance criteria
- [x] Add option to show icon in background-only alert for `<va-alert>`
## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
