### PR TITLE
32763 storybook height issues gitignore update

### DIFF
--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -5,3 +5,4 @@ tmp/
 dist/*
 /*.js
 !*.config.js
+package.tgz

--- a/packages/react-components/.gitignore
+++ b/packages/react-components/.gitignore
@@ -4,3 +4,4 @@ node_modules
 !.eslintrc.js
 .idea
 .DS_Store
+package.tgz

--- a/packages/storybook/.storybook/style.scss
+++ b/packages/storybook/.storybook/style.scss
@@ -4,3 +4,15 @@ $formation-asset-path: '~@department-of-veterans-affairs/formation/assets';
 @import '@department-of-veterans-affairs/formation/sass/base/_b-variables.scss';
 @import '@department-of-veterans-affairs/formation/sass/base/_b-breakpoints.scss';
 @import '@department-of-veterans-affairs/formation/sass/site/_m-crisis-line.scss';
+
+// Remove Negative Margin via Default Storybook CSS
+// This is causing the show code button to overlap with components
+// Height Auto fixes Firefox Bug with height being set to a fixed 70px value
+.docs-story {
+    & > div {
+        margin: 0;
+        & > div {
+            height: auto;
+        }
+    }
+}

--- a/packages/web-components/.gitignore
+++ b/packages/web-components/.gitignore
@@ -25,3 +25,6 @@ UserInterfaceState.xcuserstate
 .env
 
 react-bindings/
+component-docs.d.ts
+component-docs.json
+package.tgz


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/32763

## Testing done
<img width="365" alt="Screen Shot 2021-11-30 at 11 57 03 AM" src="https://user-images.githubusercontent.com/11822533/144092299-27d2786b-8b42-43cd-939a-6ecabdf3f80b.png">

## Screenshots
Fix:
<img width="1162" alt="Screen Shot 2021-11-30 at 10 27 03 AM" src="https://user-images.githubusercontent.com/11822533/144092337-16a48524-a959-4d81-b588-ee92a685daab.png">
Issue:
<img width="1160" alt="Screen Shot 2021-11-30 at 10 27 29 AM" src="https://user-images.githubusercontent.com/11822533/144092382-d9454a11-4780-4086-8c43-0386f2cba819.png">

## Acceptance criteria
- [X] Stories for all components on the Storybook auto-adjust for the height of the component

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
