### PR TITLE
Add aria-labelledby to on-this-page web component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/packages/web-components/src/components/va-on-this-page/test/va-on-this-page.e2e.ts
+++ b/packages/web-components/src/components/va-on-this-page/test/va-on-this-page.e2e.ts
@@ -11,7 +11,7 @@ describe('va-on-this-page', () => {
     expect(element).toEqualHtml(`
       <va-on-this-page class="hydrated">
         <mock:shadow-root>
-          <nav aria-label="table of contents">
+          <nav aria-labelledby="on-this-page">
             <dl>
               <dt id="on-this-page">On this page</dt>
               <dd role="definition"></dd>
@@ -58,7 +58,7 @@ describe('va-on-this-page', () => {
     expect(element).toEqualHtml(`
       <va-on-this-page class="hydrated">
         <mock:shadow-root>
-          <nav aria-label="table of contents">
+          <nav aria-labelledby="on-this-page">
             <dl>
               <dt id="on-this-page">On this page</dt>
               <dd role="definition">
@@ -97,7 +97,7 @@ describe('va-on-this-page', () => {
     expect(element).toEqualHtml(`
     <va-on-this-page class="hydrated">
     <mock:shadow-root>
-      <nav aria-label="table of contents">
+      <nav aria-labelledby="on-this-page">
         <dl>
           <dt id="on-this-page">On this page</dt>
           <dd role="definition">

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
@@ -11,12 +11,12 @@ import { Component, h } from '@stencil/core';
 })
 export class VaOnThisPage {
   render() {
-    const h2s = Array.from(document.querySelectorAll('article h2')) as Array<
-      HTMLElement
-    >;
+    const h2s = Array.from(
+      document.querySelectorAll('article h2'),
+    ) as Array<HTMLElement>;
 
     return (
-      <nav aria-label="table of contents">
+      <nav aria-labelledby="on-this-page">
         <dl>
           <dt id="on-this-page">On this page</dt>
           <dd role="definition">


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/33214

## Testing done

Storybook & E2E

## Screenshots
<img width="356" alt="Screen Shot 2021-12-01 at 16 21 54" src="https://user-images.githubusercontent.com/36863582/144316064-f368753e-7df4-4cb5-8cd4-d0278bc02070.png">


## Acceptance criteria
- [ ] Add aria-labelledby to on-this-page web component

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
