### PR TITLE
Add telephone Web Component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.10.1",
+  "version": "3.11.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -7,12 +7,13 @@ export default {
   title: 'Components/va-telephone',
 };
 
-const Template = ({ contact, extension, inactive }) => {
+const Template = ({ contact, extension, inactive, international }) => {
   return (
     <va-telephone
       contact={contact}
       extension={extension}
       inactive={inactive}
+      international={international}
     ></va-telephone>
   );
 };
@@ -39,4 +40,10 @@ export const Inactive = Template.bind({});
 Inactive.args = {
   ...defaultArgs,
   inactive: true,
+};
+
+export const International = Template.bind({});
+International.args = {
+  ...defaultArgs,
+  international: true,
 };

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -7,14 +7,26 @@ export default {
   title: 'Components/va-telephone',
 };
 
-const Template = ({ contact, extension, inactive, international }) => {
+const Template = ({
+  contact,
+  extension,
+  inactive,
+  international,
+  ariaDescribedby,
+}) => {
   return (
-    <va-telephone
-      contact={contact}
-      extension={extension}
-      inactive={inactive}
-      international={international}
-    ></va-telephone>
+    <div>
+      {ariaDescribedby && (
+        <span id={ariaDescribedby}>Phone number title: </span>
+      )}
+      <va-telephone
+        contact={contact}
+        extension={extension}
+        inactive={inactive}
+        international={international}
+        aria-describedby={ariaDescribedby}
+      ></va-telephone>
+    </div>
   );
 };
 
@@ -51,4 +63,10 @@ export const International = Template.bind({});
 International.args = {
   ...defaultArgs,
   international: true,
+};
+
+export const AriaDescribedBy = Template.bind({});
+AriaDescribedBy.args = {
+  ...defaultArgs,
+  ariaDescribedby: 'numberDescription',
 };

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -38,6 +38,7 @@ const Template = ({
 const defaultArgs = {
   'contact': '8773459876',
   'not-clickable': false,
+  'international': false,
 };
 
 export const Default = Template.bind({});

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { getWebComponentDocs, propStructure } from './wc-helpers';
+
+const telephoneDocs = getWebComponentDocs('va-telephone');
+
+export default {
+  title: 'Components/va-telephone',
+};
+
+const Template = ({ contact }) => {
+  return <va-telephone contact={contact}></va-telephone>;
+};
+
+const defaultArgs = {
+  contact: '8773459876',
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+Default.argTypes = propStructure(telephoneDocs);

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -21,3 +21,10 @@ Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(telephoneDocs);
+
+export const ThreeDigitNumber = Template.bind({});
+ThreeDigitNumber.args = {
+  ...defaultArgs,
+  contact: '711',
+  extension: 0,
+};

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -7,12 +7,13 @@ export default {
   title: 'Components/va-telephone',
 };
 
-const Template = ({ contact }) => {
-  return <va-telephone contact={contact}></va-telephone>;
+const Template = ({ contact, extension }) => {
+  return <va-telephone contact={contact} extension={extension}></va-telephone>;
 };
 
 const defaultArgs = {
   contact: '8773459876',
+  extension: 123,
 };
 
 export const Default = Template.bind({});

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -37,6 +37,7 @@ const Template = ({
 
 const defaultArgs = {
   'contact': '8773459876',
+  'extension': undefined,
   'not-clickable': false,
   'international': false,
 };

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -5,6 +5,11 @@ const telephoneDocs = getWebComponentDocs('va-telephone');
 
 export default {
   title: 'Components/va-telephone',
+  parameters: {
+    actions: {
+      handles: ['component-library-analytics'],
+    },
+  },
 };
 
 const Template = ({

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -7,11 +7,12 @@ export default {
   title: 'Components/va-telephone',
 };
 
-const Template = ({ contact, extension, international }) => {
+const Template = ({ contact, extension, inactive, international }) => {
   return (
     <va-telephone
       contact={contact}
       extension={extension}
+      inactive={inactive}
       international={international}
     ></va-telephone>
   );
@@ -19,7 +20,7 @@ const Template = ({ contact, extension, international }) => {
 
 const defaultArgs = {
   contact: '8773459876',
-  extension: 123,
+  inactive: false,
 };
 
 export const Default = Template.bind({});
@@ -33,6 +34,12 @@ ThreeDigitNumber.args = {
   ...defaultArgs,
   contact: '711',
   extension: 0,
+};
+
+export const Inactive = Template.bind({});
+Inactive.args = {
+  ...defaultArgs,
+  inactive: true,
 };
 
 export const International = Template.bind({});

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -7,12 +7,11 @@ export default {
   title: 'Components/va-telephone',
 };
 
-const Template = ({ contact, extension, inactive, international }) => {
+const Template = ({ contact, extension, international }) => {
   return (
     <va-telephone
       contact={contact}
       extension={extension}
-      inactive={inactive}
       international={international}
     ></va-telephone>
   );
@@ -20,7 +19,7 @@ const Template = ({ contact, extension, inactive, international }) => {
 
 const defaultArgs = {
   contact: '8773459876',
-  inactive: false,
+  extension: 123,
 };
 
 export const Default = Template.bind({});
@@ -34,12 +33,6 @@ ThreeDigitNumber.args = {
   ...defaultArgs,
   contact: '711',
   extension: 0,
-};
-
-export const Inactive = Template.bind({});
-Inactive.args = {
-  ...defaultArgs,
-  inactive: true,
 };
 
 export const International = Template.bind({});

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -7,13 +7,19 @@ export default {
   title: 'Components/va-telephone',
 };
 
-const Template = ({ contact, extension }) => {
-  return <va-telephone contact={contact} extension={extension}></va-telephone>;
+const Template = ({ contact, extension, inactive }) => {
+  return (
+    <va-telephone
+      contact={contact}
+      extension={extension}
+      inactive={inactive}
+    ></va-telephone>
+  );
 };
 
 const defaultArgs = {
   contact: '8773459876',
-  extension: 123,
+  inactive: false,
 };
 
 export const Default = Template.bind({});
@@ -27,4 +33,10 @@ ThreeDigitNumber.args = {
   ...defaultArgs,
   contact: '711',
   extension: 0,
+};
+
+export const Inactive = Template.bind({});
+Inactive.args = {
+  ...defaultArgs,
+  inactive: true,
 };

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -15,7 +15,7 @@ export default {
 const Template = ({
   contact,
   extension,
-  inactive,
+  'not-clickable': notClickable,
   international,
   ariaDescribedby,
 }) => {
@@ -27,7 +27,7 @@ const Template = ({
       <va-telephone
         contact={contact}
         extension={extension}
-        inactive={inactive}
+        not-clickable={notClickable}
         international={international}
         aria-describedby={ariaDescribedby}
       ></va-telephone>
@@ -36,8 +36,8 @@ const Template = ({
 };
 
 const defaultArgs = {
-  contact: '8773459876',
-  inactive: false,
+  'contact': '8773459876',
+  'not-clickable': false,
 };
 
 export const Default = Template.bind({});
@@ -58,10 +58,10 @@ Extension.args = {
   extension: '123',
 };
 
-export const Inactive = Template.bind({});
-Inactive.args = {
+export const NotClickable = Template.bind({});
+NotClickable.args = {
   ...defaultArgs,
-  inactive: true,
+  'not-clickable': true,
 };
 
 export const International = Template.bind({});

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -33,7 +33,12 @@ export const ThreeDigitNumber = Template.bind({});
 ThreeDigitNumber.args = {
   ...defaultArgs,
   contact: '711',
-  extension: 0,
+};
+
+export const Extension = Template.bind({});
+Extension.args = {
+  ...defaultArgs,
+  extension: '123',
 };
 
 export const Inactive = Template.bind({});

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -194,10 +194,6 @@ export namespace Components {
     }
     interface VaTelephone {
         /**
-          * Indicates if the phone number can be clicked or not
-         */
-        "clickable": boolean;
-        /**
           * 3 or 10 digit string representing the contact number
          */
         "contact": string;
@@ -209,6 +205,10 @@ export namespace Components {
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */
         "international": boolean;
+        /**
+          * Indicates if the phone number can be clicked or not
+         */
+        "notClickable": boolean;
     }
     interface VaTextInput {
         /**
@@ -575,10 +575,6 @@ declare namespace LocalJSX {
     }
     interface VaTelephone {
         /**
-          * Indicates if the phone number can be clicked or not
-         */
-        "clickable"?: boolean;
-        /**
           * 3 or 10 digit string representing the contact number
          */
         "contact": string;
@@ -590,6 +586,10 @@ declare namespace LocalJSX {
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */
         "international"?: boolean;
+        /**
+          * Indicates if the phone number can be clicked or not
+         */
+        "notClickable"?: boolean;
         "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
     }
     interface VaTextInput {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -198,6 +198,7 @@ export namespace Components {
          */
         "contact": string;
         "extension": number;
+        "inactive": boolean;
     }
     interface VaTextInput {
         /**
@@ -568,6 +569,7 @@ declare namespace LocalJSX {
          */
         "contact"?: string;
         "extension"?: number;
+        "inactive"?: boolean;
     }
     interface VaTextInput {
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -194,11 +194,14 @@ export namespace Components {
     }
     interface VaTelephone {
         /**
+          * Indicates if the phone number can be clicked or not
+         */
+        "clickable": boolean;
+        /**
           * 3 or 10 digit string representing the contact number
          */
         "contact": string;
         "extension": number;
-        "inactive": boolean;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */
@@ -569,11 +572,14 @@ declare namespace LocalJSX {
     }
     interface VaTelephone {
         /**
+          * Indicates if the phone number can be clicked or not
+         */
+        "clickable"?: boolean;
+        /**
           * 3 or 10 digit string representing the contact number
          */
         "contact": string;
         "extension"?: number;
-        "inactive"?: boolean;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -198,7 +198,6 @@ export namespace Components {
          */
         "contact": string;
         "extension": number;
-        "inactive": boolean;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */
@@ -573,7 +572,6 @@ declare namespace LocalJSX {
          */
         "contact"?: string;
         "extension"?: number;
-        "inactive"?: boolean;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -197,6 +197,7 @@ export namespace Components {
           * 3 or 10 digit string representing the contact number
          */
         "contact": string;
+        "extension": number;
     }
     interface VaTextInput {
         /**
@@ -566,6 +567,7 @@ declare namespace LocalJSX {
           * 3 or 10 digit string representing the contact number
          */
         "contact"?: string;
+        "extension"?: number;
     }
     interface VaTextInput {
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -192,6 +192,12 @@ export namespace Components {
          */
         "value": string;
     }
+    interface VaTelephone {
+        /**
+          * 3 or 10 digit string representing the contact number
+         */
+        "contact": string;
+    }
     interface VaTextInput {
         /**
           * The aria-describedby attribute for the <input> in the shadow DOM.
@@ -307,6 +313,12 @@ declare global {
         prototype: HTMLVaSelectElement;
         new (): HTMLVaSelectElement;
     };
+    interface HTMLVaTelephoneElement extends Components.VaTelephone, HTMLStencilElement {
+    }
+    var HTMLVaTelephoneElement: {
+        prototype: HTMLVaTelephoneElement;
+        new (): HTMLVaTelephoneElement;
+    };
     interface HTMLVaTextInputElement extends Components.VaTextInput, HTMLStencilElement {
     }
     var HTMLVaTextInputElement: {
@@ -325,6 +337,7 @@ declare global {
         "va-radio": HTMLVaRadioElement;
         "va-radio-option": HTMLVaRadioOptionElement;
         "va-select": HTMLVaSelectElement;
+        "va-telephone": HTMLVaTelephoneElement;
         "va-text-input": HTMLVaTextInputElement;
     }
 }
@@ -548,6 +561,12 @@ declare namespace LocalJSX {
          */
         "value"?: string;
     }
+    interface VaTelephone {
+        /**
+          * 3 or 10 digit string representing the contact number
+         */
+        "contact"?: string;
+    }
     interface VaTextInput {
         /**
           * The aria-describedby attribute for the <input> in the shadow DOM.
@@ -619,6 +638,7 @@ declare namespace LocalJSX {
         "va-radio": VaRadio;
         "va-radio-option": VaRadioOption;
         "va-select": VaSelect;
+        "va-telephone": VaTelephone;
         "va-text-input": VaTextInput;
     }
 }
@@ -637,6 +657,7 @@ declare module "@stencil/core" {
             "va-radio": LocalJSX.VaRadio & JSXBase.HTMLAttributes<HTMLVaRadioElement>;
             "va-radio-option": LocalJSX.VaRadioOption & JSXBase.HTMLAttributes<HTMLVaRadioOptionElement>;
             "va-select": LocalJSX.VaSelect & JSXBase.HTMLAttributes<HTMLVaSelectElement>;
+            "va-telephone": LocalJSX.VaTelephone & JSXBase.HTMLAttributes<HTMLVaTelephoneElement>;
             "va-text-input": LocalJSX.VaTextInput & JSXBase.HTMLAttributes<HTMLVaTextInputElement>;
         }
     }

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -201,6 +201,9 @@ export namespace Components {
           * 3 or 10 digit string representing the contact number
          */
         "contact": string;
+        /**
+          * Optional phone number extension
+         */
         "extension": number;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
@@ -579,6 +582,9 @@ declare namespace LocalJSX {
           * 3 or 10 digit string representing the contact number
          */
         "contact": string;
+        /**
+          * Optional phone number extension
+         */
         "extension"?: number;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -590,6 +590,7 @@ declare namespace LocalJSX {
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */
         "international"?: boolean;
+        "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
     }
     interface VaTextInput {
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -198,6 +198,7 @@ export namespace Components {
          */
         "contact": string;
         "extension": number;
+        "inactive": boolean;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */
@@ -572,6 +573,7 @@ declare namespace LocalJSX {
          */
         "contact"?: string;
         "extension"?: number;
+        "inactive"?: boolean;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -571,7 +571,7 @@ declare namespace LocalJSX {
         /**
           * 3 or 10 digit string representing the contact number
          */
-        "contact"?: string;
+        "contact": string;
         "extension"?: number;
         "inactive"?: boolean;
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -199,6 +199,10 @@ export namespace Components {
         "contact": string;
         "extension": number;
         "inactive": boolean;
+        /**
+          * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
+         */
+        "international": boolean;
     }
     interface VaTextInput {
         /**
@@ -570,6 +574,10 @@ declare namespace LocalJSX {
         "contact"?: string;
         "extension"?: number;
         "inactive"?: boolean;
+        /**
+          * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
+         */
+        "international"?: boolean;
     }
     interface VaTextInput {
         /**

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('va-telephone', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-telephone></va-telephone>');
+
+    const element = await page.find('va-telephone');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -19,6 +19,18 @@ describe('va-telephone', () => {
     expect(link.innerText).toEqual('877-955-1234');
   });
 
+  it('handles a 10 digit international contact prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone international contact="8779551234"></va-telephone>',
+    );
+
+    const link = await page.find('va-telephone >>> a');
+    expect(link.getAttribute('aria-label')).toEqual('1. 8 7 7. 9 5 5. 1 2 3 4');
+    expect(link.getAttribute('href')).toEqual('tel:+18779551234');
+    expect(link.innerText).toEqual('+1-877-955-1234');
+  });
+
   it('handles an inactive 10 digit contact prop', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -13,10 +13,19 @@ describe('va-telephone', () => {
     const page = await newE2EPage();
     await page.setContent('<va-telephone contact="8779551234"></va-telephone>');
 
-    // const element = await page.find('va-telephone');
     const link = await page.find('va-telephone >>> a');
     expect(link.getAttribute('aria-label')).toEqual('8 7 7. 9 5 5. 1 2 3 4');
     expect(link.getAttribute('href')).toEqual('tel:+18779551234');
     expect(link.innerText).toEqual('877-955-1234');
+  });
+
+  it('handles a 3 digit contact prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-telephone contact="711"></va-telephone>');
+
+    const link = await page.find('va-telephone >>> a');
+    expect(link.getAttribute('aria-label')).toEqual('7 1 1');
+    expect(link.getAttribute('href')).toEqual('tel:711');
+    expect(link.innerText).toEqual('711');
   });
 });

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -14,7 +14,7 @@ describe('va-telephone', () => {
     await page.setContent('<va-telephone contact="8779551234"></va-telephone>');
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual('8 7 7. 9 5 5. 1 2 3 4');
+    expect(link.getAttribute('aria-label')).toEqual('8 7 7. 9 5 5. 1 2 3 4.');
     expect(link.getAttribute('href')).toEqual('tel:+18779551234');
     expect(link.innerText).toEqual('877-955-1234');
   });
@@ -26,7 +26,9 @@ describe('va-telephone', () => {
     );
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual('1. 8 7 7. 9 5 5. 1 2 3 4');
+    expect(link.getAttribute('aria-label')).toEqual(
+      '1. 8 7 7. 9 5 5. 1 2 3 4.',
+    );
     expect(link.getAttribute('href')).toEqual('tel:+18779551234');
     expect(link.innerText).toEqual('+1-877-955-1234');
   });
@@ -45,7 +47,7 @@ describe('va-telephone', () => {
             877-955-1234
           </span>
           <span class="sr-only">
-            8 7 7. 9 5 5. 1 2 3 4
+            8 7 7. 9 5 5. 1 2 3 4.
           </span>
         </mock:shadow-root>
       </va-telephone>
@@ -66,7 +68,7 @@ describe('va-telephone', () => {
             877-955-1234, ext. 123
           </span>
           <span class="sr-only">
-            8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3
+            8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3.
           </span>
         </mock:shadow-root>
       </va-telephone>
@@ -81,7 +83,7 @@ describe('va-telephone', () => {
 
     const link = await page.find('va-telephone >>> a');
     expect(link.getAttribute('aria-label')).toEqual(
-      '8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3',
+      '8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3.',
     );
     expect(link.getAttribute('href')).toEqual('tel:+18779551234,123');
     expect(link.innerText).toEqual('877-955-1234, ext. 123');
@@ -92,7 +94,7 @@ describe('va-telephone', () => {
     await page.setContent('<va-telephone contact="711"></va-telephone>');
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual('7 1 1');
+    expect(link.getAttribute('aria-label')).toEqual('7 1 1.');
     expect(link.getAttribute('href')).toEqual('tel:711');
     expect(link.innerText).toEqual('711');
   });

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -33,15 +33,15 @@ describe('va-telephone', () => {
     expect(link.innerText).toEqual('+1-877-955-1234');
   });
 
-  it('handles an inactive 10 digit contact prop', async () => {
+  it('handles a non-clickable 10 digit contact prop', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-telephone inactive contact="8779551234"></va-telephone>',
+      '<va-telephone clickable="false" contact="8779551234"></va-telephone>',
     );
 
     const element = await page.find('va-telephone');
     expect(element).toEqualHtml(`
-      <va-telephone class="hydrated" contact="8779551234" inactive="">
+      <va-telephone class="hydrated" contact="8779551234" clickable="false">
         <mock:shadow-root>
           <span aria-hidden="true">
             877-955-1234
@@ -54,15 +54,15 @@ describe('va-telephone', () => {
     `);
   });
 
-  it('handles an inactive 10 digit contact prop with extension', async () => {
+  it('handles a non-clickable 10 digit contact prop with extension', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-telephone inactive contact="8779551234" extension="123"></va-telephone>',
+      '<va-telephone clickable="false" contact="8779551234" extension="123"></va-telephone>',
     );
 
     const element = await page.find('va-telephone');
     expect(element).toEqualHtml(`
-      <va-telephone class="hydrated" contact="8779551234" extension="123" inactive="">
+      <va-telephone class="hydrated" contact="8779551234" extension="123" clickable="false">
         <mock:shadow-root>
           <span aria-hidden="true">
             877-955-1234, ext. 123

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -19,6 +19,48 @@ describe('va-telephone', () => {
     expect(link.innerText).toEqual('877-955-1234');
   });
 
+  it('handles an inactive 10 digit contact prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone inactive contact="8779551234"></va-telephone>',
+    );
+
+    const element = await page.find('va-telephone');
+    expect(element).toEqualHtml(`
+      <va-telephone class="hydrated" contact="8779551234" inactive="">
+        <mock:shadow-root>
+          <span aria-hidden="true">
+            877-955-1234
+          </span>
+          <span class="sr-only">
+            8 7 7. 9 5 5. 1 2 3 4
+          </span>
+        </mock:shadow-root>
+      </va-telephone>
+    `);
+  });
+
+  it('handles an inactive 10 digit contact prop with extension', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone inactive contact="8779551234" extension="123"></va-telephone>',
+    );
+
+    const element = await page.find('va-telephone');
+    expect(element).toEqualHtml(`
+      <va-telephone class="hydrated" contact="8779551234" extension="123" inactive="">
+        <mock:shadow-root>
+          <span aria-hidden="true">
+            877-955-1234, ext. 123
+          </span>
+          <span class="sr-only">
+            8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3
+          </span>
+        </mock:shadow-root>
+      </va-telephone>
+    `);
+  });
+
   it('handles a 10 digit contact prop with extension', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -36,12 +36,12 @@ describe('va-telephone', () => {
   it('handles a non-clickable 10 digit contact prop', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-telephone clickable="false" contact="8779551234"></va-telephone>',
+      '<va-telephone not-clickable contact="8779551234"></va-telephone>',
     );
 
     const element = await page.find('va-telephone');
     expect(element).toEqualHtml(`
-      <va-telephone class="hydrated" contact="8779551234" clickable="false">
+      <va-telephone class="hydrated" contact="8779551234" not-clickable>
         <mock:shadow-root>
           <span aria-hidden="true">
             877-955-1234
@@ -57,12 +57,12 @@ describe('va-telephone', () => {
   it('handles a non-clickable 10 digit contact prop with extension', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-telephone clickable="false" contact="8779551234" extension="123"></va-telephone>',
+      '<va-telephone not-clickable contact="8779551234" extension="123"></va-telephone>',
     );
 
     const element = await page.find('va-telephone');
     expect(element).toEqualHtml(`
-      <va-telephone class="hydrated" contact="8779551234" extension="123" clickable="false">
+      <va-telephone class="hydrated" contact="8779551234" extension="123" not-clickable>
         <mock:shadow-root>
           <span aria-hidden="true">
             877-955-1234, ext. 123

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -31,6 +31,48 @@ describe('va-telephone', () => {
     expect(link.innerText).toEqual('+1-877-955-1234');
   });
 
+  it('handles an inactive 10 digit contact prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone inactive contact="8779551234"></va-telephone>',
+    );
+
+    const element = await page.find('va-telephone');
+    expect(element).toEqualHtml(`
+      <va-telephone class="hydrated" contact="8779551234" inactive="">
+        <mock:shadow-root>
+          <span aria-hidden="true">
+            877-955-1234
+          </span>
+          <span class="sr-only">
+            8 7 7. 9 5 5. 1 2 3 4
+          </span>
+        </mock:shadow-root>
+      </va-telephone>
+    `);
+  });
+
+  it('handles an inactive 10 digit contact prop with extension', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone inactive contact="8779551234" extension="123"></va-telephone>',
+    );
+
+    const element = await page.find('va-telephone');
+    expect(element).toEqualHtml(`
+      <va-telephone class="hydrated" contact="8779551234" extension="123" inactive="">
+        <mock:shadow-root>
+          <span aria-hidden="true">
+            877-955-1234, ext. 123
+          </span>
+          <span class="sr-only">
+            8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3
+          </span>
+        </mock:shadow-root>
+      </va-telephone>
+    `);
+  });
+
   it('handles a 10 digit contact prop with extension', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { axeCheck } from '../../../testing/test-helpers';
 
 describe('va-telephone', () => {
   it('renders', async () => {
@@ -7,6 +8,38 @@ describe('va-telephone', () => {
 
     const element = await page.find('va-telephone');
     expect(element).toHaveClass('hydrated');
+  });
+
+  it('passes an axe check', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-telephone contact="8779551234"></va-telephone>');
+
+    await axeCheck(page);
+  });
+
+  it('passes an axe check as an international number', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone international contact="8779551234"></va-telephone>',
+    );
+
+    await axeCheck(page);
+  });
+
+  it('passes an axe check with extension', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone contact="8779551234" extension="123"></va-telephone>',
+    );
+
+    await axeCheck(page);
+  });
+
+  it('passes an axe check for an N11 number', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-telephone contact="711"></va-telephone>');
+
+    await axeCheck(page);
   });
 
   it('handles a 10 digit contact prop', async () => {

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -19,6 +19,20 @@ describe('va-telephone', () => {
     expect(link.innerText).toEqual('877-955-1234');
   });
 
+  it('handles a 10 digit contact prop with extension', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone contact="8779551234" extension="123"></va-telephone>',
+    );
+
+    const link = await page.find('va-telephone >>> a');
+    expect(link.getAttribute('aria-label')).toEqual(
+      '8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3',
+    );
+    expect(link.getAttribute('href')).toEqual('tel:+18779551234,123');
+    expect(link.innerText).toEqual('877-955-1234, ext. 123');
+  });
+
   it('handles a 3 digit contact prop', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-telephone contact="711"></va-telephone>');

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -98,4 +98,25 @@ describe('va-telephone', () => {
     expect(link.getAttribute('href')).toEqual('tel:711');
     expect(link.innerText).toEqual('711');
   });
+
+  it('fires an analytics event when clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone contact="8779551234" extension="123"></va-telephone>',
+    );
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const link = await page.find('va-telephone >>> a');
+    await link.click();
+
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      action: 'click',
+      componentName: 'va-telephone',
+      details: {
+        contact: '8779551234',
+        extension: 123,
+      },
+    });
+  });
 });

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -8,4 +8,15 @@ describe('va-telephone', () => {
     const element = await page.find('va-telephone');
     expect(element).toHaveClass('hydrated');
   });
+
+  it('handles a 10 digit contact prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-telephone contact="8779551234"></va-telephone>');
+
+    // const element = await page.find('va-telephone');
+    const link = await page.find('va-telephone >>> a');
+    expect(link.getAttribute('aria-label')).toEqual('8 7 7. 9 5 5. 1 2 3 4');
+    expect(link.getAttribute('href')).toEqual('tel:+18779551234');
+    expect(link.innerText).toEqual('877-955-1234');
+  });
 });

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -31,48 +31,6 @@ describe('va-telephone', () => {
     expect(link.innerText).toEqual('+1-877-955-1234');
   });
 
-  it('handles an inactive 10 digit contact prop', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-telephone inactive contact="8779551234"></va-telephone>',
-    );
-
-    const element = await page.find('va-telephone');
-    expect(element).toEqualHtml(`
-      <va-telephone class="hydrated" contact="8779551234" inactive="">
-        <mock:shadow-root>
-          <span aria-hidden="true">
-            877-955-1234
-          </span>
-          <span class="sr-only">
-            8 7 7. 9 5 5. 1 2 3 4
-          </span>
-        </mock:shadow-root>
-      </va-telephone>
-    `);
-  });
-
-  it('handles an inactive 10 digit contact prop with extension', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-telephone inactive contact="8779551234" extension="123"></va-telephone>',
-    );
-
-    const element = await page.find('va-telephone');
-    expect(element).toEqualHtml(`
-      <va-telephone class="hydrated" contact="8779551234" extension="123" inactive="">
-        <mock:shadow-root>
-          <span aria-hidden="true">
-            877-955-1234, ext. 123
-          </span>
-          <span class="sr-only">
-            8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3
-          </span>
-        </mock:shadow-root>
-      </va-telephone>
-    `);
-  });
-
   it('handles a 10 digit contact prop with extension', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -2,6 +2,7 @@ import { VaTelephone } from '../va-telephone';
 
 describe('formatPhoneNumber', () => {
   const contact = '8885551234';
+  const N11 = '911';
   const extension = 123;
   it('formats a contact number with no extension', () => {
     expect(VaTelephone.formatPhoneNumber(contact, null)).toBe('888-555-1234');
@@ -11,6 +12,18 @@ describe('formatPhoneNumber', () => {
     expect(VaTelephone.formatPhoneNumber(contact, extension)).toBe(
       '888-555-1234, ext. 123',
     );
+  });
+
+  it('formats a 3 digit contact number', () => {
+    expect(VaTelephone.formatPhoneNumber(N11, null)).toBe('911');
+  });
+
+  it('does not use extension for 3 digit contact', () => {
+    expect(VaTelephone.formatPhoneNumber(N11, extension)).toBe('911');
+  });
+
+  it('does not use international formatting for 3 digit contact', () => {
+    expect(VaTelephone.formatPhoneNumber(N11, extension, true)).toBe('911');
   });
 });
 

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -1,0 +1,36 @@
+import { VaTelephone } from '../va-telephone';
+
+describe('formatPhoneNumber', () => {
+  const contact = '8885551234';
+  const extension = 123;
+  it('formats a contact number with no extension', () => {
+    expect(VaTelephone.formatPhoneNumber(contact, null)).toBe('888-555-1234');
+  });
+
+  it('formats a contact number with extension', () => {
+    expect(VaTelephone.formatPhoneNumber(contact, extension)).toBe(
+      '888-555-1234, ext. 123',
+    );
+  });
+});
+
+describe('formatTelLabel', () => {
+  const contact = '8885551234';
+  const extension = 123;
+  const formattedNumber = VaTelephone.formatPhoneNumber(contact, null);
+  const formattedNumberWithExt = VaTelephone.formatPhoneNumber(
+    contact,
+    extension,
+  );
+  it('formats a phone number into an assistive tech label', () => {
+    expect(VaTelephone.formatTelLabel(formattedNumber)).toBe(
+      '8 8 8. 5 5 5. 1 2 3 4',
+    );
+  });
+
+  it('formats a phone number with extension into an assistive tech label', () => {
+    expect(VaTelephone.formatTelLabel(formattedNumberWithExt)).toBe(
+      '8 8 8. 5 5 5. 1 2 3 4. extension. 1 2 3',
+    );
+  });
+});

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -34,3 +34,20 @@ describe('formatTelLabel', () => {
     );
   });
 });
+
+describe('createHref', () => {
+  const contact = '8885551234';
+  const n11 = '911';
+  const extension = 123;
+  it('creates a tel link for a phone number', () => {
+    expect(VaTelephone.createHref(contact, null)).toBe('tel:+18885551234');
+  });
+  it('creates a tel link for a phone number with extension', () => {
+    expect(VaTelephone.createHref(contact, extension)).toBe(
+      'tel:+18885551234,123',
+    );
+  });
+  it('creates a tel link for an N11 number', () => {
+    expect(VaTelephone.createHref(n11, null)).toBe('tel:911');
+  });
+});

--- a/packages/web-components/src/components/va-telephone/va-telephone.css
+++ b/packages/web-components/src/components/va-telephone/va-telephone.css
@@ -1,4 +1,5 @@
 @import '../../mixins/links.css';
+@import '../../mixins/accessibility.css';
 :host {
   display: block;
 }

--- a/packages/web-components/src/components/va-telephone/va-telephone.css
+++ b/packages/web-components/src/components/va-telephone/va-telephone.css
@@ -1,0 +1,9 @@
+@import '../../mixins/links.css';
+:host {
+  display: block;
+}
+
+a,
+a:hover {
+  text-decoration: underline;
+}

--- a/packages/web-components/src/components/va-telephone/va-telephone.css
+++ b/packages/web-components/src/components/va-telephone/va-telephone.css
@@ -1,5 +1,4 @@
 @import '../../mixins/links.css';
-@import '../../mixins/accessibility.css';
 :host {
   display: block;
 }

--- a/packages/web-components/src/components/va-telephone/va-telephone.css
+++ b/packages/web-components/src/components/va-telephone/va-telephone.css
@@ -1,8 +1,5 @@
 @import '../../mixins/links.css';
 @import '../../mixins/accessibility.css';
-:host {
-  display: block;
-}
 
 a,
 a:hover {

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -65,7 +65,7 @@ export class VaTelephone {
       extension,
       international,
     );
-    const formattedAriaLabel = this.formatTelLabel(formattedNumber);
+    const formattedAriaLabel = `${this.formatTelLabel(formattedNumber)}.`;
 
     if (inactive) {
       return (

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -14,10 +14,12 @@ export class VaTelephone {
   @Prop() extension: number;
 
   private formatPhoneNumber(num: string, extension: number): string {
-    const regex = /(?<area>\d{3})(?<local>\d{3})(?<last4>\d{4})/g;
-    const { area, local, last4 } = regex.exec(num).groups;
-
-    const formattedNum = `${area}-${local}-${last4}`;
+    let formattedNum = num;
+    if (num.length === 10) {
+      const regex = /(?<area>\d{3})(?<local>\d{3})(?<last4>\d{4})/g;
+      const { area, local, last4 } = regex.exec(num).groups;
+      formattedNum = `${area}-${local}-${last4}`;
+    }
     return extension ? `${formattedNum} ext. ${extension}` : formattedNum;
   }
   /**

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -9,7 +9,7 @@ export class VaTelephone {
   /**
    * 3 or 10 digit string representing the contact number
    */
-  @Prop() contact: string;
+  @Prop() contact!: string;
 
   @Prop() extension: number;
 

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -1,0 +1,53 @@
+import { Component, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'va-telephone',
+  styleUrl: 'va-telephone.css',
+  shadow: true,
+})
+export class VaTelephone {
+  /**
+   * 3 or 10 digit string representing the contact number
+   */
+  @Prop() contact: string;
+
+  private formatPhoneNumber(num: string): string {
+    const regex = /(?<area>\d{3})(?<local>\d{3})(?<last4>\d{4})/g;
+    const { area, local, last4 } = regex.exec(num).groups;
+    console.log(area, local, last4);
+
+    return `${area}-${local}-${last4}`;
+  }
+  /**
+   * Format telephone number for label
+   * @param {string} number - Expected a phone number with or without dashes that
+   * matches the number of "#" within the default or set pattern
+   * @return {string} - Combined phone number parts within the label separated by
+   * periods, e.g. "800-555-1212" becomes "8 0 0. 5 5 5. 1 2 1 2"
+   */
+  private formatTelLabel(number: string): string {
+    return number
+      .split(/[^\d]+/)
+      .filter(n => n)
+      .map(number => number.split('').join(' '))
+      .join('. ');
+  }
+
+  render() {
+    const { contact } = this;
+    const isN11 = this.contact.length === 3;
+    // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
+    // but it seems that using a comma to pause for 2 seconds might be a better
+    // solution - see https://dsva.slack.com/archives/C8E985R32/p1589814301103200
+    const href = `tel:${isN11 ? `+1${contact}` : contact}`;
+
+    const formattedNumber = this.formatPhoneNumber(this.contact);
+    const formattedAriaLabel = this.formatTelLabel(formattedNumber);
+
+    return (
+      <a href={href} aria-label={formattedAriaLabel}>
+        {formattedNumber}
+      </a>
+    );
+  }
+}

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -20,7 +20,7 @@ export class VaTelephone {
       const { area, local, last4 } = regex.exec(num).groups;
       formattedNum = `${area}-${local}-${last4}`;
     }
-    return extension ? `${formattedNum} ext. ${extension}` : formattedNum;
+    return extension ? `${formattedNum}, ext. ${extension}` : formattedNum;
   }
   /**
    * Format telephone number for label

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -1,4 +1,11 @@
-import { Component, Fragment, Prop, h } from '@stencil/core';
+import {
+  Component,
+  Event,
+  EventEmitter,
+  Fragment,
+  Prop,
+  h,
+} from '@stencil/core';
 
 @Component({
   tag: 'va-telephone',
@@ -26,6 +33,13 @@ export class VaTelephone {
    * Prepends a "+1" to the formatted number.
    */
   @Prop() international: boolean = false;
+
+  @Event({
+    eventName: 'component-library-analytics',
+    composed: true,
+    bubbles: true,
+  })
+  componentLibraryAnalytics: EventEmitter;
 
   /**
    * Format telephone number for display.
@@ -71,6 +85,17 @@ export class VaTelephone {
     return `${href}${extension ? `,${extension}` : ''}`;
   }
 
+  private handleClick(): void {
+    this.componentLibraryAnalytics.emit({
+      componentName: 'va-telephone',
+      action: 'click',
+      details: {
+        contact: this.contact,
+        extension: this.extension,
+      },
+    });
+  }
+
   render() {
     const { contact, extension, clickable, international } = this;
     const formattedNumber = VaTelephone.formatPhoneNumber(
@@ -86,6 +111,7 @@ export class VaTelephone {
       <a
         href={VaTelephone.createHref(contact, extension)}
         aria-label={formattedAriaLabel}
+        onClick={this.handleClick.bind(this)}
       >
         {formattedNumber}
       </a>

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -1,4 +1,4 @@
-import { Component, Fragment, Prop, h } from '@stencil/core';
+import { Component, Prop, h } from '@stencil/core';
 
 @Component({
   tag: 'va-telephone',
@@ -12,8 +12,6 @@ export class VaTelephone {
   @Prop() contact: string;
 
   @Prop() extension: number;
-
-  @Prop() inactive: boolean = false;
 
   /**
    * Indicates if this is a number meant to be called from outside the US.
@@ -51,7 +49,7 @@ export class VaTelephone {
   }
 
   render() {
-    const { contact, extension, inactive, international } = this;
+    const { contact, extension, international } = this;
     const isN11 = this.contact.length === 3;
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better
@@ -66,15 +64,6 @@ export class VaTelephone {
       international,
     );
     const formattedAriaLabel = this.formatTelLabel(formattedNumber);
-
-    if (inactive) {
-      return (
-        <Fragment>
-          <span aria-hidden="true">{formattedNumber}</span>
-          <span class="sr-only">{formattedAriaLabel}</span>
-        </Fragment>
-      );
-    }
 
     return (
       <a href={href} aria-label={formattedAriaLabel}>

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -21,7 +21,7 @@ export class VaTelephone {
    */
   @Prop() international: boolean = false;
 
-  private formatPhoneNumber(
+  static formatPhoneNumber(
     num: string,
     extension: number,
     international: boolean = false,
@@ -42,7 +42,7 @@ export class VaTelephone {
    * @return {string} - Combined phone number parts within the label separated by
    * periods, e.g. "800-555-1212" becomes "8 0 0. 5 5 5. 1 2 1 2"
    */
-  private formatTelLabel(number: string): string {
+  static formatTelLabel(number: string): string {
     return number
       .split(/[^\d\w]+/)
       .filter(n => n)
@@ -60,12 +60,14 @@ export class VaTelephone {
       extension ? `,${extension}` : ''
     }`;
 
-    const formattedNumber = this.formatPhoneNumber(
+    const formattedNumber = VaTelephone.formatPhoneNumber(
       contact,
       extension,
       international,
     );
-    const formattedAriaLabel = `${this.formatTelLabel(formattedNumber)}.`;
+    const formattedAriaLabel = `${VaTelephone.formatTelLabel(
+      formattedNumber,
+    )}.`;
 
     if (inactive) {
       return (

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -11,6 +11,9 @@ export class VaTelephone {
    */
   @Prop() contact!: string;
 
+  /**
+   * Optional phone number extension
+   */
   @Prop() extension: number;
 
   /**

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -41,7 +41,7 @@ export class VaTelephone {
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better
     // solution - see https://dsva.slack.com/archives/C8E985R32/p1589814301103200
-    const href = `tel:${isN11 ? `+1${contact}` : contact}${
+    const href = `tel:${isN11 ? contact : `+1${contact}`}${
       extension ? `,${extension}` : ''
     }`;
 

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Fragment, Prop, h } from '@stencil/core';
 
 @Component({
   tag: 'va-telephone',
@@ -12,6 +12,8 @@ export class VaTelephone {
   @Prop() contact: string;
 
   @Prop() extension: number;
+
+  @Prop() inactive: boolean = false;
 
   /**
    * Indicates if this is a number meant to be called from outside the US.
@@ -49,7 +51,7 @@ export class VaTelephone {
   }
 
   render() {
-    const { contact, extension, international } = this;
+    const { contact, extension, inactive, international } = this;
     const isN11 = this.contact.length === 3;
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better
@@ -64,6 +66,15 @@ export class VaTelephone {
       international,
     );
     const formattedAriaLabel = this.formatTelLabel(formattedNumber);
+
+    if (inactive) {
+      return (
+        <Fragment>
+          <span aria-hidden="true">{formattedNumber}</span>
+          <span class="sr-only">{formattedAriaLabel}</span>
+        </Fragment>
+      );
+    }
 
     return (
       <a href={href} aria-label={formattedAriaLabel}>

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -62,10 +62,9 @@ export class VaTelephone {
   }
 
   /**
-   * Format telephone number for label
-   * @param {string} number - Expected a phone number with or without dashes that
-   * matches the number of "#" within the default or set pattern
-   * @return {string} - Combined phone number parts within the label separated by
+   * Format telephone number for screen readers
+   * @param {string} number - Expected a formatted phone number with or without extension
+   * @return {string} - Combined phone number parts within the label seperated by
    * periods, e.g. "800-555-1212" becomes "8 0 0. 5 5 5. 1 2 1 2"
    */
   static formatTelLabel(number: string): string {

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -34,7 +34,7 @@ export class VaTelephone {
       const regex = /(?<area>\d{3})(?<local>\d{3})(?<last4>\d{4})/g;
       const { area, local, last4 } = regex.exec(num).groups;
       formattedNum = `${area}-${local}-${last4}`;
-      formattedNum = international ? `+1-${formattedNum}` : formattedNum;
+      if (international) formattedNum = `+1-${formattedNum}`;
     }
     return extension ? `${formattedNum}, ext. ${extension}` : formattedNum;
   }

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -13,7 +13,10 @@ export class VaTelephone {
 
   @Prop() extension: number;
 
-  @Prop() inactive: boolean = false;
+  /**
+   * Indicates if the phone number can be clicked or not
+   */
+  @Prop() clickable: boolean = true;
 
   /**
    * Indicates if this is a number meant to be called from outside the US.
@@ -60,7 +63,7 @@ export class VaTelephone {
   }
 
   render() {
-    const { contact, extension, inactive, international } = this;
+    const { contact, extension, clickable, international } = this;
     const formattedNumber = VaTelephone.formatPhoneNumber(
       contact,
       extension,
@@ -70,18 +73,18 @@ export class VaTelephone {
       formattedNumber,
     )}.`;
 
-    return inactive ? (
-      <Fragment>
-        <span aria-hidden="true">{formattedNumber}</span>
-        <span class="sr-only">{formattedAriaLabel}</span>
-      </Fragment>
-    ) : (
+    return clickable ? (
       <a
         href={VaTelephone.createHref(contact, extension)}
         aria-label={formattedAriaLabel}
       >
         {formattedNumber}
       </a>
+    ) : (
+      <Fragment>
+        <span aria-hidden="true">{formattedNumber}</span>
+        <span class="sr-only">{formattedAriaLabel}</span>
+      </Fragment>
     );
   }
 }

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -11,12 +11,14 @@ export class VaTelephone {
    */
   @Prop() contact: string;
 
-  private formatPhoneNumber(num: string): string {
+  @Prop() extension: number;
+
+  private formatPhoneNumber(num: string, extension: number): string {
     const regex = /(?<area>\d{3})(?<local>\d{3})(?<last4>\d{4})/g;
     const { area, local, last4 } = regex.exec(num).groups;
-    console.log(area, local, last4);
 
-    return `${area}-${local}-${last4}`;
+    const formattedNum = `${area}-${local}-${last4}`;
+    return extension ? `${formattedNum} ext. ${extension}` : formattedNum;
   }
   /**
    * Format telephone number for label
@@ -27,21 +29,23 @@ export class VaTelephone {
    */
   private formatTelLabel(number: string): string {
     return number
-      .split(/[^\d]+/)
+      .split(/[^\d\w]+/)
       .filter(n => n)
-      .map(number => number.split('').join(' '))
+      .map(chunk => (chunk === 'ext' ? 'extension' : chunk.split('').join(' ')))
       .join('. ');
   }
 
   render() {
-    const { contact } = this;
+    const { contact, extension } = this;
     const isN11 = this.contact.length === 3;
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better
     // solution - see https://dsva.slack.com/archives/C8E985R32/p1589814301103200
-    const href = `tel:${isN11 ? `+1${contact}` : contact}`;
+    const href = `tel:${isN11 ? `+1${contact}` : contact}${
+      extension ? `,${extension}` : ''
+    }`;
 
-    const formattedNumber = this.formatPhoneNumber(this.contact);
+    const formattedNumber = this.formatPhoneNumber(contact, extension);
     const formattedAriaLabel = this.formatTelLabel(formattedNumber);
 
     return (

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Fragment, Prop, h } from '@stencil/core';
 
 @Component({
   tag: 'va-telephone',
@@ -12,6 +12,8 @@ export class VaTelephone {
   @Prop() contact: string;
 
   @Prop() extension: number;
+
+  @Prop() inactive: boolean = false;
 
   private formatPhoneNumber(num: string, extension: number): string {
     let formattedNum = num;
@@ -38,7 +40,7 @@ export class VaTelephone {
   }
 
   render() {
-    const { contact, extension } = this;
+    const { contact, extension, inactive } = this;
     const isN11 = this.contact.length === 3;
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better
@@ -49,6 +51,15 @@ export class VaTelephone {
 
     const formattedNumber = this.formatPhoneNumber(contact, extension);
     const formattedAriaLabel = this.formatTelLabel(formattedNumber);
+
+    if (inactive) {
+      return (
+        <Fragment>
+          <span aria-hidden="true">{formattedNumber}</span>
+          <span class="sr-only">{formattedAriaLabel}</span>
+        </Fragment>
+      );
+    }
 
     return (
       <a href={href} aria-label={formattedAriaLabel}>

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -24,6 +24,10 @@ export class VaTelephone {
    */
   @Prop() international: boolean = false;
 
+  /**
+   * Format telephone number for display.
+   * `international` and `extension` args only work on 10 digit contacts
+   */
   static formatPhoneNumber(
     num: string,
     extension: number,
@@ -35,9 +39,11 @@ export class VaTelephone {
       const { area, local, last4 } = regex.exec(num).groups;
       formattedNum = `${area}-${local}-${last4}`;
       if (international) formattedNum = `+1-${formattedNum}`;
+      if (extension) formattedNum = `${formattedNum}, ext. ${extension}`;
     }
-    return extension ? `${formattedNum}, ext. ${extension}` : formattedNum;
+    return formattedNum;
   }
+
   /**
    * Format telephone number for label
    * @param {string} number - Expected a phone number with or without dashes that

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -26,7 +26,7 @@ export class VaTelephone {
   /**
    * Indicates if the phone number can be clicked or not
    */
-  @Prop() clickable: boolean = true;
+  @Prop() notClickable: boolean = false;
 
   /**
    * Indicates if this is a number meant to be called from outside the US.
@@ -96,7 +96,7 @@ export class VaTelephone {
   }
 
   render() {
-    const { contact, extension, clickable, international } = this;
+    const { contact, extension, notClickable, international } = this;
     const formattedNumber = VaTelephone.formatPhoneNumber(
       contact,
       extension,
@@ -106,7 +106,12 @@ export class VaTelephone {
       formattedNumber,
     )}.`;
 
-    return clickable ? (
+    return notClickable ? (
+      <Fragment>
+        <span aria-hidden="true">{formattedNumber}</span>
+        <span class="sr-only">{formattedAriaLabel}</span>
+      </Fragment>
+    ) : (
       <a
         href={VaTelephone.createHref(contact, extension)}
         aria-label={formattedAriaLabel}
@@ -114,11 +119,6 @@ export class VaTelephone {
       >
         {formattedNumber}
       </a>
-    ) : (
-      <Fragment>
-        <span aria-hidden="true">{formattedNumber}</span>
-        <span class="sr-only">{formattedAriaLabel}</span>
-      </Fragment>
     );
   }
 }

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -70,16 +70,12 @@ export class VaTelephone {
       formattedNumber,
     )}.`;
 
-    if (inactive) {
-      return (
-        <Fragment>
-          <span aria-hidden="true">{formattedNumber}</span>
-          <span class="sr-only">{formattedAriaLabel}</span>
-        </Fragment>
-      );
-    }
-
-    return (
+    return inactive ? (
+      <Fragment>
+        <span aria-hidden="true">{formattedNumber}</span>
+        <span class="sr-only">{formattedAriaLabel}</span>
+      </Fragment>
+    ) : (
       <a
         href={VaTelephone.createHref(contact, extension)}
         aria-label={formattedAriaLabel}

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -50,16 +50,17 @@ export class VaTelephone {
       .join('. ');
   }
 
-  render() {
-    const { contact, extension, inactive, international } = this;
-    const isN11 = this.contact.length === 3;
+  static createHref(contact: string, extension: number): string {
+    const isN11 = contact.length === 3;
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better
     // solution - see https://dsva.slack.com/archives/C8E985R32/p1589814301103200
-    const href = `tel:${isN11 ? contact : `+1${contact}`}${
-      extension ? `,${extension}` : ''
-    }`;
+    const href = `tel:${isN11 ? contact : `+1${contact}`}`;
+    return `${href}${extension ? `,${extension}` : ''}`;
+  }
 
+  render() {
+    const { contact, extension, inactive, international } = this;
     const formattedNumber = VaTelephone.formatPhoneNumber(
       contact,
       extension,
@@ -79,7 +80,10 @@ export class VaTelephone {
     }
 
     return (
-      <a href={href} aria-label={formattedAriaLabel}>
+      <a
+        href={VaTelephone.createHref(contact, extension)}
+        aria-label={formattedAriaLabel}
+      >
         {formattedNumber}
       </a>
     );

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -15,12 +15,23 @@ export class VaTelephone {
 
   @Prop() inactive: boolean = false;
 
-  private formatPhoneNumber(num: string, extension: number): string {
+  /**
+   * Indicates if this is a number meant to be called from outside the US.
+   * Prepends a "+1" to the formatted number.
+   */
+  @Prop() international: boolean = false;
+
+  private formatPhoneNumber(
+    num: string,
+    extension: number,
+    international: boolean = false,
+  ): string {
     let formattedNum = num;
     if (num.length === 10) {
       const regex = /(?<area>\d{3})(?<local>\d{3})(?<last4>\d{4})/g;
       const { area, local, last4 } = regex.exec(num).groups;
       formattedNum = `${area}-${local}-${last4}`;
+      formattedNum = international ? `+1-${formattedNum}` : formattedNum;
     }
     return extension ? `${formattedNum}, ext. ${extension}` : formattedNum;
   }
@@ -40,7 +51,7 @@ export class VaTelephone {
   }
 
   render() {
-    const { contact, extension, inactive } = this;
+    const { contact, extension, inactive, international } = this;
     const isN11 = this.contact.length === 3;
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better
@@ -49,7 +60,11 @@ export class VaTelephone {
       extension ? `,${extension}` : ''
     }`;
 
-    const formattedNumber = this.formatPhoneNumber(contact, extension);
+    const formattedNumber = this.formatPhoneNumber(
+      contact,
+      extension,
+      international,
+    );
     const formattedAriaLabel = this.formatTelLabel(formattedNumber);
 
     if (inactive) {


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/30137

The React `<Telephone>` implementation is a bit different than what I'm doing here, so I'll talk about what I've changed/left out.

### `pattern` prop

The React component allowed a `pattern` prop to be passed so that a developer could choose how to format the number:

1. default
2. N11-style
3. a number for international use (+1 at the beginning)
4. any other way you want

We can cover the first two cases by seeing if the length of the `contact` prop is 3 or 10, and a boolean prop can be used for the third case. I've only found one example of `pattern` being used in a custom way:

https://github.com/department-of-veterans-affairs/vets-website/blob/f3ee0b52ddbaf311f64740fa3ab1d6803845793c/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx#L15

This is a vanity number and this particular use might [go against our guidance](https://design.va.gov/content-style-guide/dates-and-numbers#phone-numbers):

> We don’t use vanity phone numbers in body copy, as it adds visual noise and is not helpful to screen readers. We use and **hyperlink only the numeric phone number** in body copy.

The exception is:

> In marketing or promotional components, use the format: 877-222-VETS (8387) **and hyperlink the complete number including the parenthetical**.

![image](https://user-images.githubusercontent.com/2008881/144331818-ced5ccfb-75e5-4c39-b68f-7b3f0f8fd365.png)

Since it seems like a help sidebar might not be considered a marketing or promotional component, I haven't added any functionality that would allow for vanity numbers/formatting.

### Children

The React component also allowed children to be passed in. Out of 140 files that import & use this component, this feature is only used 3 times:

- [`src/applications/check-in/pre-check-in/components/Footer.jsx`](https://github.com/department-of-veterans-affairs/vets-website/blob/f3ee0b52ddbaf311f64740fa3ab1d6803845793c/src/applications/check-in/pre-check-in/components/Footer.jsx#L28)
- [`src/applications/health-care-questionnaire/shared/components/footer/GetHelpFooter.jsx`](https://github.com/department-of-veterans-affairs/vets-website/blob/f3ee0b52ddbaf311f64740fa3ab1d6803845793c/src/applications/health-care-questionnaire/shared/components/footer/GetHelpFooter.jsx#L107)
- [`src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx`](https://github.com/department-of-veterans-affairs/vets-website/blob/f3ee0b52ddbaf311f64740fa3ab1d6803845793c/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx#L44)

Since it is rarely used, I'm opting to not port that functionality over for now in order to ensure that `<va-telephone>` isn't used to display arbitrary content. We may be able to address those instances and see if it truly is required at a later date.

### AriaDescribedby

Rather than having a pass-through prop for `aria-describedby` [like we have for the React component](https://github.com/department-of-veterans-affairs/component-library/blob/4a7c522fe2f21d8ba0e7b0bea795fe0d959a2a0c/packages/react-components/src/components/Telephone/Telephone.jsx#L219-L222), I'm hoping that developers can set the aria attribute on the host component and have it work as expected.

## Testing done

- E2E tests
- Unit tests for static helper functions
- Storybook :eyes: 

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/145065920-14952c10-8d63-49c7-aad6-3cf79c0161c5.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
