### PR TITLE
Update stories to use kebab case for props

### DIFF
--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -9,23 +9,23 @@ export default {
 };
 
 const defaultArgs = {
-  headline: <h3 slot="headline">Alert headline</h3>,
-  status: 'info',
-  backgroundOnly: false,
-  closeable: false,
-  fullWidth: false,
-  onClose: () => {},
-  'show-icon': false
+  'headline': <h3 slot="headline">Alert headline</h3>,
+  'status': 'info',
+  'background-only': false,
+  'closeable': false,
+  'full-width': false,
+  'onclose': () => {},
+  'show-icon': false,
 };
 
 const Template = ({
   headline,
-  fullWidth,
+  'full-width': fullWidth,
   status,
-  backgroundOnly,
+  'background-only': backgroundOnly,
   closeable,
-  onClose,
-  'show-icon': showIcon
+  onclose,
+  'show-icon': showIcon,
 }) => {
   return (
     <va-alert
@@ -33,7 +33,7 @@ const Template = ({
       background-only={backgroundOnly}
       closeable={closeable}
       full-width={fullWidth}
-      onClose={onClose}
+      onclose={onclose}
       show-icon={showIcon}
     >
       {headline}
@@ -68,27 +68,27 @@ export const Closeable = Template.bind({});
 Closeable.args = {
   ...defaultArgs,
   closeable: true,
-  onClose: () => console.log('Close event triggered'),
+  onclose: () => console.log('Close event triggered'),
 };
 
 export const Fullwidth = Template.bind({});
 Fullwidth.args = {
   ...defaultArgs,
-  fullWidth: true,
-  closeable: true,
-  onClose: () => console.log('Close event triggered'),
-  status: 'warning',
+  'full-width': true,
+  'closeable': true,
+  'onclose': () => console.log('Close event triggered'),
+  'status': 'warning',
 };
 
 export const BackgroundOnly = Template.bind({});
 BackgroundOnly.args = {
   ...defaultArgs,
-  backgroundOnly: true,
+  'background-only': true,
 };
 
 export const BackgroundOnlyWithIcon = Template.bind({});
 BackgroundOnlyWithIcon.args = {
   ...defaultArgs,
-  backgroundOnly: true,
-  'show-icon': true
+  'background-only': true,
+  'show-icon': true,
 };

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -10,15 +10,31 @@ export default {
 };
 
 const defaultArgs = {
-  label: 'This is a cleverly-labelled checkbox',
-  checked: null,
-  error: null,
-  required: null,
-  description: null,
-  enableAnalytics: false,
+  'label': 'This is a cleverly-labelled checkbox',
+  'checked': false,
+  'error': null,
+  'required': false,
+  'description': null,
+  'enable-analytics': false,
 };
 
-const Template = props => <va-checkbox {...props} />;
+const Template = ({
+  checked,
+  description,
+  'enable-analytics': enableAnalytics,
+  error,
+  label,
+  required,
+}) => (
+  <va-checkbox
+    checked={checked}
+    description={description}
+    enable-analytics={enableAnalytics}
+    error={error}
+    label={label}
+    required={required}
+  />
+);
 
 export const Default = Template.bind({});
 Default.args = { ...defaultArgs };

--- a/packages/storybook/stories/va-loading-indicator.stories.jsx
+++ b/packages/storybook/stories/va-loading-indicator.stories.jsx
@@ -14,13 +14,18 @@ export default {
 };
 
 const defaultArgs = {
-  message: 'Loading your application...',
-  label: 'Loading',
-  setFocus: false,
-  enableAnalytics: false,
+  'message': 'Loading your application...',
+  'label': 'Loading',
+  'set-focus': false,
+  'enable-analytics': false,
 };
 
-const Template = ({ message, setFocus, enableAnalytics }) => {
+const Template = ({
+  'enable-analytics': enableAnalytics,
+  label,
+  message,
+  'set-focus': setFocus,
+}) => {
   const [isLoading, setIsLoading] = useState(true);
   return (
     <div>
@@ -34,6 +39,7 @@ const Template = ({ message, setFocus, enableAnalytics }) => {
       )}
       {isLoading && (
         <va-loading-indicator
+          label={label}
           message={message}
           set-focus={setFocus}
           enable-analytics={enableAnalytics}
@@ -48,7 +54,7 @@ Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(loadingIndicatorDocs);
 
 export const SetFocus = Template.bind({});
-SetFocus.args = { ...defaultArgs, setFocus: true };
+SetFocus.args = { ...defaultArgs, 'set-focus': true };
 
 export const EnableAnalytics = Template.bind({});
-EnableAnalytics.args = { ...defaultArgs, enableAnalytics: true };
+EnableAnalytics.args = { ...defaultArgs, 'enable-analytics': true };

--- a/packages/storybook/stories/va-select.stories.jsx
+++ b/packages/storybook/stories/va-select.stories.jsx
@@ -9,13 +9,13 @@ export default {
 };
 
 const defaultArgs = {
-  label: 'Branch of Service',
-  name: 'branch',
-  value: 'army',
-  required: false,
-  error: null,
-  ariaLiveRegionText: 'You selected',
-  options: [
+  'label': 'Branch of Service',
+  'name': 'branch',
+  'value': 'army',
+  'required': false,
+  'error': null,
+  'aria-live-region-text': 'You selected',
+  'options': [
     <option key="1" value="navy">
       Navy
     </option>,
@@ -32,7 +32,7 @@ const defaultArgs = {
       Coastguard
     </option>,
   ],
-  useAddButton: false,
+  'use-add-button': false,
 };
 
 const Template = ({
@@ -41,9 +41,9 @@ const Template = ({
   value,
   required,
   error,
-  ariaLiveRegionText,
+  'aria-live-region-text': ariaLiveRegionText,
   options,
-  useAddButton,
+  'use-add-button': useAddButton,
 }) => {
   const [modifiedOptions, setModifiedOptions] = useState(options);
 
@@ -70,6 +70,7 @@ const Template = ({
         required={required}
         error={error}
         aria-live-region-text={ariaLiveRegionText}
+        use-add-button={useAddButton}
       >
         {modifiedOptions}
       </va-select>
@@ -88,4 +89,4 @@ export const ErrorMessage = Template.bind({});
 ErrorMessage.args = { ...defaultArgs, error: 'There was a problem' };
 
 export const DynamicOptions = Template.bind({});
-DynamicOptions.args = { ...defaultArgs, useAddButton: true };
+DynamicOptions.args = { ...defaultArgs, 'use-add-button': true };

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -12,12 +12,7 @@ const defaultArgs = {
   'name': 'my-input',
   'label': 'My input',
   'autocomplete': false,
-  // Fun fact: This should really be false, but that passes
-  // enable-analytics="false" to the web component, which correctly interprets
-  // this as a truthy value. See also:
-  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute
   'enable-analytics': false,
-  // Same story here
   'required': false,
   'error': null,
   'maxlength': null,

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -9,24 +9,46 @@ export default {
 };
 
 const defaultArgs = {
-  name: 'my-input',
-  label: 'My input',
-  autocomplete: false,
+  'name': 'my-input',
+  'label': 'My input',
+  'autocomplete': false,
   // Fun fact: This should really be false, but that passes
   // enable-analytics="false" to the web component, which correctly interprets
   // this as a truthy value. See also:
   // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute
-  'enable-analytics': null,
+  'enable-analytics': false,
   // Same story here
-  required: null,
-  error: null,
-  maxlength: null,
-  placeholder: null,
-  value: null,
+  'required': false,
+  'error': null,
+  'maxlength': null,
+  'placeholder': null,
+  'value': null,
 };
 
-const Template = props => {
-  return <va-text-input {...props} />;
+const Template = ({
+  name,
+  label,
+  autocomplete,
+  'enable-analytics': enableAnalytics,
+  required,
+  error,
+  maxlength,
+  placeholder,
+  value,
+}) => {
+  return (
+    <va-text-input
+      name={name}
+      label={label}
+      autocomplete={autocomplete}
+      enable-analytics={enableAnalytics}
+      required={required}
+      error={error}
+      maxlength={maxlength}
+      placeholder={placeholder}
+      value={value}
+    />
+  );
 };
 
 export const Default = Template.bind({});


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/588

## Testing done

Storybook

## Screenshots

va-alert:
<img width="1063" alt="Screen Shot 2021-12-03 at 17 44 34" src="https://user-images.githubusercontent.com/36863582/144682614-261363d7-930d-45ae-85e4-f70f7f8ad283.png">
va-text-input:
<img width="1027" alt="Screen Shot 2021-12-03 at 17 45 27" src="https://user-images.githubusercontent.com/36863582/144682616-468531a8-faf6-4575-8783-9af40108c639.png">
va-select:
<img width="1043" alt="Screen Shot 2021-12-03 at 17 45 16" src="https://user-images.githubusercontent.com/36863582/144682618-c0f7142b-c63f-4348-957f-ba8d41636726.png">
<img width="1026" alt="Screen Shot 2021-12-03 at 17 44 57" src="https://user-images.githubusercontent.com/36863582/144682620-ba871e59-9094-41c1-ba73-7bbb587d5c61.png">
<img width="1033" alt="Screen Shot 2021-12-03 at 17 44 47" src="https://user-images.githubusercontent.com/36863582/144682621-80542d36-a608-435a-9257-f34b902cb1dc.png">


## Acceptance criteria
- [ ] Story props for `<va-alert>`, `<va-checkbox>`, `<va-loading-indicator>`, `<va-select>` and `<va-text-input>` are updated to use kebab case

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
