### PR TITLE
Increase minor version of core & web-components to 3.8

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.7.4",
+  "version": "3.8.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",


### PR DESCRIPTION
## Description
Preparing to publish `v3.8.0`

Here are the generated release notes if I try to draft a release right now:

![image](https://user-images.githubusercontent.com/2008881/145076081-ec4b71fb-8481-4f67-adb4-5cda3e4f7e31.png)

The last published version was `3.7.2`. Since these staged changes include an enhancement, I'm increasing the minor version.

## Testing done
N/A


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
