### PR TITLE
33479 va accordion item test

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -166,6 +166,6 @@ describe('va-accordion-item', () => {
     const accordionItemToggled = await page.spyOnEvent('accordionItemToggled');
     await page.waitForChanges();
 
-    expect(await accordionItemToggled).toHaveReceivedEventTimes(1);
+    await expect(accordionItemToggled).toHaveReceivedEventTimes(1);
   });
 });

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -166,6 +166,6 @@ describe('va-accordion-item', () => {
     const accordionItemToggled = await page.spyOnEvent('accordionItemToggled');
     await page.waitForChanges();
 
-    expect(accordionItemToggled).toHaveReceivedEvent();
+    expect(await accordionItemToggled).toHaveReceivedEventTimes(1);
   });
 });


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/33479

## Testing done
<img width="691" alt="Screen Shot 2021-12-08 at 1 48 38 PM" src="https://user-images.githubusercontent.com/11822533/145266327-34825b08-f1ad-419b-9416-a5fe524b4cf3.png">
<img width="726" alt="Screen Shot 2021-12-08 at 1 49 01 PM" src="https://user-images.githubusercontent.com/11822533/145266328-d98111d2-bd8f-4a85-93d1-ac13d628c567.png">

Included failing test to show that it's working properly when set to: `await expect(accordionItemToggled).toHaveReceivedEventTimes(1);`

## Screenshots
See above

## Acceptance criteria
- [X] All e2e tests in the accordion-item suite should pass consistently and be actionable

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

## Notation on Issue
- Upon page load if a hash is present with the accordion the componentDidLoad Lifecycle event will fire a custom click event on the accordion item with the matching ID to the hash
- Issue was that we needed to await for the event to be present in the expect before firing and the event should only fire once since only one ID would match the hash
- componentDidLoad will fire immediately so we sometimes get inconsistent results due to the asynchronous timing of the testing suite
