### PR TITLE
34239 Segmented Progress Bar WC Aria Label displays incorrect default text

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
+++ b/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
@@ -14,17 +14,17 @@ export class VaSegmentedProgressBar {
   /**
    * The current segment in progress
    */
-  @Prop() current: number = 0;
+  @Prop() current: number;
 
   /**
    * The total number of segments in the progress bar
    */
-  @Prop() total: number = 10;
+  @Prop() total: number;
 
   /**
    * An override for the default aria label.
    */
-  @Prop() label: string = `Step ${this.current} of ${this.total}`;
+  @Prop() label: string;
 
   @Event({
     eventName: 'component-library-analytics',
@@ -47,7 +47,7 @@ export class VaSegmentedProgressBar {
   }
 
   render() {
-    const { current, total, label } = this;
+    const { current, total, label = `Step ${current} of ${total}`} = this;
     const range = Array.from({ length: total }, (_, i) => i);
     return (
       <Host>


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/34239

## Testing done
<img width="345" alt="Screen Shot 2021-12-15 at 8 18 25 PM" src="https://user-images.githubusercontent.com/11822533/146290197-21a306b6-7e05-48d9-9911-7616ca2b14f1.png">

## Screenshots
<img width="1207" alt="Screen Shot 2021-12-15 at 8 19 58 PM" src="https://user-images.githubusercontent.com/11822533/146290439-ec7a04b8-3804-4f34-9f29-d75b5c186108.png">
<img width="1202" alt="Screen Shot 2021-12-15 at 8 20 23 PM" src="https://user-images.githubusercontent.com/11822533/146290456-fbd982ee-dfbe-4778-bc8c-51226ebe0c0a.png">

## Acceptance criteria
- [X] If the label prop is set on the component the aria-label should equal the text set in the prop.
- [X] If the label prop is not set on the component the aria-label should equal 'Step {current prop} of {total prop}'

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
