### PR TITLE
Build our main bundle for IE11

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -4,6 +4,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   entry: ['./src/main.js'],
+  target: ['web', 'es5'],
   output: {
     path: __dirname + '/dist',
     filename: 'app.bundle.js',

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",


### PR DESCRIPTION
Following the guidance:
https://webpack.js.org/migrate/5/#need-to-support-an-older-browser-like-ie-11

## Description
Closes <ticket>

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
