### PR TITLE
Add missing props and not visible story for va-alert in Storybook

### DIFF
--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -9,32 +9,41 @@ export default {
 };
 
 const defaultArgs = {
-  'headline': <h3 slot="headline">Alert headline</h3>,
   'status': 'info',
   'background-only': false,
+  'show-icon': false,
+  'disable-analytics': false,
+  'visible': true,
+  'close-btn-aria-label': 'Close notification',
   'closeable': false,
   'full-width': false,
-  'onclose': () => {},
-  'show-icon': false,
+  'headline': <h3 slot="headline">Alert headline</h3>,
+  'onclose': () => console.log('Closed'),
 };
 
 const Template = ({
-  headline,
-  'full-width': fullWidth,
   status,
   'background-only': backgroundOnly,
-  closeable,
-  onclose,
   'show-icon': showIcon,
+  'disable-analytics': disableAnalytics,
+  visible,
+  'close-btn-aria-label': closeBtnAriaLabel,
+  closeable,
+  'full-width': fullWidth,
+  headline,
+  onclose,
 }) => {
   return (
     <va-alert
       status={status}
       background-only={backgroundOnly}
+      show-icon={showIcon}
+      disable-analytics={disableAnalytics}
+      visible={visible}
+      close-btn-aria-label={closeBtnAriaLabel}
       closeable={closeable}
       full-width={fullWidth}
       onclose={onclose}
-      show-icon={showIcon}
     >
       {headline}
       <div>This is an alert</div>
@@ -75,7 +84,6 @@ export const Fullwidth = Template.bind({});
 Fullwidth.args = {
   ...defaultArgs,
   'full-width': true,
-  'closeable': true,
   'onclose': () => console.log('Close event triggered'),
   'status': 'warning',
 };
@@ -91,4 +99,10 @@ BackgroundOnlyWithIcon.args = {
   ...defaultArgs,
   'background-only': true,
   'show-icon': true,
+};
+
+export const NotVisible = Template.bind({});
+NotVisible.args = {
+  ...defaultArgs,
+  visible: false,
 };


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/23792

## Testing done
N/A

## Screenshots
<img width="1025" alt="Screen Shot 2021-12-28 at 12 38 29" src="https://user-images.githubusercontent.com/36863582/147592456-c4dbe3ef-bbec-48b9-ba45-dbf84abfaa21.png">

<img width="1791" alt="Screen Shot 2021-12-28 at 12 35 56" src="https://user-images.githubusercontent.com/36863582/147592298-07a046f6-3a4e-461e-9670-b2387112548c.png">
<img width="1024" alt="Screen Shot 2021-12-28 at 12 37 18" src="https://user-images.githubusercontent.com/36863582/147592357-3491bb50-6b5a-4032-afd0-25224c59224f.png">


## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
