### PR TITLE
Fix children overflowing parent container in va-accordion-item

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion-item.css
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.css
@@ -61,6 +61,8 @@ button:hover {
   border-left: var(--item-border);
   border-right: var(--item-border);
   border-bottom: var(--item-border);
+  display: flex;
+  flex-wrap: wrap;
 }
 
 button[aria-expanded='false'] {


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/602

## Testing done
Storybook

## Screenshots
<img width="979" alt="Screen Shot 2021-12-28 at 16 34 07" src="https://user-images.githubusercontent.com/36863582/147609184-358bfde9-830f-40c8-95b7-32c10fab4b56.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
