### PR TITLE
Remove link buttons from design system

### DIFF
--- a/packages/storybook/stories/buttons.stories.mdx
+++ b/packages/storybook/stories/buttons.stories.mdx
@@ -7,13 +7,15 @@ import { Meta, Canvas } from '@storybook/addon-docs/blocks';
 <Canvas>
   <Story name="Default">
     <div>
-      <button type="button" className="usa-button">Button</button>
-      <button type="button" className="usa-button usa-button-active">Active</button>
-      <button type="button" className="usa-button usa-button-hover">Hover</button>
-      <br/>
-      <a href="#" className="usa-button">Link button</a>
-      <a href="#" className="usa-button usa-button-active">Link button active</a>
-      <a href="#" className="usa-button usa-button-hover">Link button hover</a>
+      <button type="button" className="usa-button">
+        Button
+      </button>
+      <button type="button" className="usa-button usa-button-active">
+        Active
+      </button>
+      <button type="button" className="usa-button usa-button-hover">
+        Hover
+      </button>
     </div>
   </Story>
 </Canvas>
@@ -23,9 +25,9 @@ import { Meta, Canvas } from '@storybook/addon-docs/blocks';
 <Canvas>
   <Story name="Primary">
     <div>
-      <button type="button" class="usa-button-primary va-button-primary">Button</button>
-      <br/>
-      <a class="usa-button-primary va-button-primary" href="#">Link button</a>
+      <button type="button" class="usa-button-primary va-button-primary">
+        Button
+      </button>
     </div>
   </Story>
 </Canvas>
@@ -38,10 +40,6 @@ import { Meta, Canvas } from '@storybook/addon-docs/blocks';
       <button class="usa-button-secondary">Button</button>
       <button class="usa-button-secondary usa-button-active">Active</button>
       <button class="usa-button-secondary usa-button-hover">Hover</button>
-      <br/>
-      <a href="#" class="usa-button usa-button-secondary">Link button</a>
-      <a href="#" class="usa-button usa-button-secondary usa-button-active">Link button active</a>
-      <a href="#" class="usa-button usa-button-secondary usa-button-hover">Link button hover</a>
     </div>
   </Story>
 </Canvas>
@@ -51,13 +49,18 @@ import { Meta, Canvas } from '@storybook/addon-docs/blocks';
 <Canvas>
   <Story name="Big">
     <div>
-      <button type="button" class="usa-button usa-button-big">Default button</button>
-      <button type="button" class="usa-button-primary va-button-primary usa-button-big">Button</button>
-      <button class="usa-button-secondary usa-button-big">Secondary button</button>
-      <br/>
-      <a href="#" class="usa-button usa-button-big">Default link button</a>
-      <a href="#" class="usa-button-primary va-button-primary usa-button-big">Primary link</a>
-      <a href="#" class="usa-button usa-button-secondary usa-button-big">Secondary link</a>
+      <button type="button" class="usa-button usa-button-big">
+        Default button
+      </button>
+      <button
+        type="button"
+        class="usa-button-primary va-button-primary usa-button-big"
+      >
+        Button
+      </button>
+      <button class="usa-button-secondary usa-button-big">
+        Secondary button
+      </button>
     </div>
   </Story>
 </Canvas>
@@ -67,8 +70,9 @@ import { Meta, Canvas } from '@storybook/addon-docs/blocks';
 <Canvas>
   <Story name="Disabled">
     <div>
-      <button type="button" class="usa-button" disabled>Disabled button</button>
-      <a href="#" class="usa-button usa-button-disabled">Disabled link</a>
+      <button type="button" class="usa-button" disabled>
+        Disabled button
+      </button>
     </div>
   </Story>
 </Canvas>


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/584

## Testing done
Storybook

## Screenshots
<img width="1792" alt="Screen Shot 2021-12-29 at 11 08 01" src="https://user-images.githubusercontent.com/36863582/147681570-bd6707a5-75d1-4405-98ff-d0938be54663.png">
<img width="1792" alt="Screen Shot 2021-12-29 at 11 08 08" src="https://user-images.githubusercontent.com/36863582/147681572-260e38a9-a772-4eba-88e2-a32346a32068.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
