### PR TITLE
34126 Update Accordion Story Default Args

### DIFF
--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -67,7 +67,8 @@ const TemplateSubheader = args => {
 
 const defaultArgs = {
   bordered: false,
-  headline: <h6 slot="headline">First Amendment Headline</h6>
+  headline: <h6 slot="headline">First Amendment Headline</h6>,
+  'open-single': undefined
 };
 
 export const Default = Template.bind({});

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -77,8 +77,8 @@ Default.args = {
 };
 Default.argTypes = propStructure(accordionDocs);
 
-export const OnlyOpenOne = Template.bind({});
-OnlyOpenOne.args = {
+export const SingleSelect = Template.bind({});
+SingleSelect.args = {
   ...defaultArgs,
   'open-single': true,
 };


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/34126

## Testing done
<img width="350" alt="Screen Shot 2021-12-30 at 9 57 58 AM" src="https://user-images.githubusercontent.com/11822533/147762827-98680f49-e70c-49b1-a4b3-8699c2188347.png">

## Screenshots
<img width="679" alt="Screen Shot 2021-12-30 at 9 56 38 AM" src="https://user-images.githubusercontent.com/11822533/147762761-9e2747e7-f1b1-4972-872f-2fefe4a085b6.png">

## Acceptance criteria
- [X] fix default accordion Storybook story to show multi-selectable accordion

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
