### PR TITLE
Change modal header to h1

### DIFF
--- a/packages/react-components/src/components/Modal/Modal.jsx
+++ b/packages/react-components/src/components/Modal/Modal.jsx
@@ -172,9 +172,9 @@ class Modal extends React.Component {
             <div className={bodyClass}>
               <div role="document">
                 {title && (
-                  <h3 id={titleId} className={titleClass} tabIndex="-1">
+                  <h1 id={titleId} className={titleClass} tabIndex="-1">
                     {title}
-                  </h3>
+                  </h1>
                 )}
                 {content && <div className={contentClass}>{content}</div>}
               </div>

--- a/packages/react-components/src/components/Modal/Modal.jsx
+++ b/packages/react-components/src/components/Modal/Modal.jsx
@@ -133,7 +133,10 @@ class Modal extends React.Component {
     });
 
     const bodyClass = status ? 'usa-alert-body' : 'va-modal-body';
-    const titleClass = status ? 'usa-alert-heading' : 'va-modal-title';
+    const titleClass = classNames(
+      status ? 'usa-alert-heading' : 'va-modal-title',
+      'vads-u-font-size--h3',
+    );
     const contentClass = classNames({ 'usa-alert-text': status });
     const ariaRole = status => {
       if (status === 'warning' || status === 'error') {

--- a/packages/react-components/src/components/Modal/Modal.unit.spec.jsx
+++ b/packages/react-components/src/components/Modal/Modal.unit.spec.jsx
@@ -17,6 +17,17 @@ describe('<Modal/>', () => {
     tree.unmount();
   });
 
+  it('should have an <h1> as the heading', () => {
+    const tree = mount(
+      <Modal title="Modal title" visible onClose={() => {}}>
+        Some content
+      </Modal>,
+    );
+
+    expect(tree.find('h1').text()).to.equal('Modal title');
+    tree.unmount();
+  });
+
   describe('event listeners', () => {
     const checkForListener = (callsArray, listenerName) => {
       return callsArray.filter(call => {

--- a/packages/storybook/stories/Modal.stories.jsx
+++ b/packages/storybook/stories/Modal.stories.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import {Modal} from '@department-of-veterans-affairs/component-library';
+import { Modal } from '@department-of-veterans-affairs/component-library';
 
 export default {
   title: 'Components/Modal',
@@ -12,6 +12,7 @@ const Template = args => {
   const openModal = () => setVisible(true);
   return (
     <div style={{ height: '500px' }}>
+      <h1>Testing h1 heading</h1>
       <button onClick={openModal}>Click here to open modal</button>
       <Modal {...args} visible={visible} onClose={onClose}>
         {args.children}


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/29215

This is an a11y fix to the `<Modal>` React component. It replaces the `<h3>` with an `<h1>` in order to improve the semantics for assistive tech.

## Testing done

- Unit testing

I also did an axe test on a modified story that had an `<h1>` already on the page in addition to the `<h1>` that would be in the modal.

<details>
<summary>H1 on page and in modal</summary>

![image](https://user-images.githubusercontent.com/2008881/148138700-4969c681-c6ff-4ad6-9d4e-d58dc398ad1e.png)

</details>

As [this axe rule page notes](https://dequeuniversity.com/rules/axe/4.3/page-has-heading-one):

> Generally, it is a best practice to ensure that the beginning of a page's main content starts with a h1 element, **and also to ensure that the page contains only one h1 element.**

However, that page also says:

> This rule finds all elements which match the following selector and verifies that there is **at least one**: h1:not([role]), [role="heading"][aria-level="1"]

So, we don't have an automated test that will let us know if an `<h1>` in a modal conflicts with the `<h1>` already on the page. We will rely on manual testing from an a11y expert.

## Screenshots

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/2008881/148138076-87230d6c-e2de-4666-8c5b-13fb3df4aa0f.png)

</details>

### After

![image](https://user-images.githubusercontent.com/2008881/148989412-ab695ad4-19df-48af-8c50-4a2a1e5a8b84.png)



## Acceptance criteria
- [x] Change modal h3 to an h1 & adjust header size
- [x] Add unit/a11y tests

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
