### PR TITLE
Fix NumberInput styling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/packages/react-components/src/components/NumberInput/NumberInput.jsx
+++ b/packages/react-components/src/components/NumberInput/NumberInput.jsx
@@ -56,9 +56,7 @@ class NumberInput extends React.Component {
       <div className={this.props.errorMessage ? 'usa-input-error' : undefined}>
         <label
           className={
-            this.props.errorMessage !== undefined
-              ? 'usa-input-error-label'
-              : undefined
+            this.props.errorMessage ? 'usa-input-error-label' : undefined
           }
           htmlFor={this.inputId}
         >

--- a/packages/react-components/src/components/NumberInput/NumberInput.unit.spec.jsx
+++ b/packages/react-components/src/components/NumberInput/NumberInput.unit.spec.jsx
@@ -89,6 +89,33 @@ describe('<NumberInput>', () => {
     tree.unmount();
   });
 
+  it('no error styles when errorMessage is an empty string', () => {
+    const tree = shallow(
+      <NumberInput
+        field={testValue}
+        label="my label"
+        errorMessage=""
+        onValueChange={() => {}}
+      />,
+    );
+
+    // No error classes.
+    expect(tree.find('.usa-input-error')).to.have.lengthOf(0);
+    expect(tree.find('.usa-input-error-label')).to.have.lengthOf(0);
+    expect(tree.find('.usa-input-error-message')).to.have.lengthOf(0);
+
+    // Ensure no unnecessary class names on label w/o error..
+    const labels = tree.find('label');
+    expect(labels).to.have.lengthOf(1);
+    expect(labels.hasClass('foo')).to.be.false;
+
+    // No error means no aria-describedby to not confuse screen readers.
+    const inputs = tree.find('input');
+    expect(inputs).to.have.lengthOf(1);
+    expect(inputs.prop('aria-describedby')).to.be.undefined;
+    tree.unmount();
+  });
+
   it('has error styles when errorMessage is set', () => {
     const tree = shallow(
       <NumberInput


### PR DESCRIPTION
## Description

Our app is using the `SimpleDate` React component, which sets the `errorMessage` to an empty string. The `NumberInput` will bold the label (add `usa-input-error-label`) if the `errorMessage` is not undefined. So this PR fixes the `NumberInput` to use a falsy value instead of only `undefined`

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/34827

## Testing done

Added unit test

## Screenshots

![Screen Shot 2022-01-06 at 2 30 06 PM](https://user-images.githubusercontent.com/136959/148448933-c1509924-a0f8-4ffa-9567-d8f6d0d90c56.png)

## Acceptance criteria
- [x] The `NumberInput` component no longer bolds the label if the `errorMessage` is an empty string
- [x] All tests passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
