### PR TITLE
Update Modal aria-label close button

### DIFF
--- a/packages/react-components/src/components/Modal/Modal.jsx
+++ b/packages/react-components/src/components/Modal/Modal.jsx
@@ -120,7 +120,7 @@ class Modal extends React.Component {
   render() {
     if (!this.props.visible) return null;
 
-    const { id, status, title } = this.props;
+    const { id, status, title = 'this' } = this.props;
     const titleId = `${id || 'va-modal'}-title`;
     const content = this.props.contents || this.props.children;
 
@@ -146,7 +146,7 @@ class Modal extends React.Component {
       <button
         className="va-modal-close"
         type="button"
-        aria-label="close"
+        aria-label={`close ${title} modal`}
         onClick={this.handleClose}
       >
         <i className="fas fa-times-circle" aria-hidden="true" />

--- a/packages/react-components/src/components/Modal/Modal.jsx
+++ b/packages/react-components/src/components/Modal/Modal.jsx
@@ -120,7 +120,7 @@ class Modal extends React.Component {
   render() {
     if (!this.props.visible) return null;
 
-    const { id, status, title = 'this' } = this.props;
+    const { id, status, title } = this.props;
     const titleId = `${id || 'va-modal'}-title`;
     const content = this.props.contents || this.props.children;
 
@@ -142,11 +142,13 @@ class Modal extends React.Component {
       return 'dialog';
     };
 
+    const btnAriaLabel = title ? `close ${title} modal` : 'close modal'
+
     const closeButton = !this.props.hideCloseButton && (
       <button
         className="va-modal-close"
         type="button"
-        aria-label={`close ${title} modal`}
+        aria-label={btnAriaLabel}
         onClick={this.handleClose}
       >
         <i className="fas fa-times-circle" aria-hidden="true" />

--- a/packages/react-components/src/components/Modal/Modal.unit.spec.jsx
+++ b/packages/react-components/src/components/Modal/Modal.unit.spec.jsx
@@ -137,6 +137,36 @@ describe('<Modal/>', () => {
       expect(global.document.activeElement.id).to.equal('second-button');
       tree.unmount();
     });
+
+    it('should include the title in the close button aria label if given', () => {
+      const tree = mount(
+        <Modal id="modal" title="Programmatic focus" visible onClose={() => {}}>
+          <button id="first-button">First button</button>
+          <button id="second-button">Second button</button>
+        </Modal>,
+        { attachTo: root },
+      );
+
+      expect(global.document.activeElement.ariaLabel).to.equal(
+        'close Programmatic focus modal',
+      );
+      tree.unmount();
+    });
+
+    it('should not include the title in the close button aria label when not given', () => {
+      const tree = mount(
+        <Modal id="modal" visible onClose={() => {}}>
+          <button id="first-button">First button</button>
+          <button id="second-button">Second button</button>
+        </Modal>,
+        { attachTo: root },
+      );
+
+      expect(global.document.activeElement.ariaLabel).to.equal(
+        'close modal',
+      );
+      tree.unmount();
+    });
   });
 
   describe('analytics event', function () {


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/5871

## Testing done
<img width="724" alt="Screen Shot 2022-01-07 at 18 49 09" src="https://user-images.githubusercontent.com/36863582/148621217-c08d94f0-f8ae-4eae-aa4b-86f8086ac430.png">


## Screenshots
<img width="661" alt="Screen Shot 2022-01-07 at 18 51 00" src="https://user-images.githubusercontent.com/36863582/148621331-3f560df1-4652-40c6-a022-779c6f4fb156.png">


## Acceptance criteria
- [x] Add title to close button aria label for Modal
- [x] Add tests

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
