### PR TITLE
Add prop for res burden feature name

### DIFF
--- a/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
@@ -114,7 +114,7 @@ OMBInfo.propTypes = {
   resBurden: PropTypes.number,
 
   /**
-   * The name of the respondent burden feature. This is displayed inside the Privacy Act Statement
+   * The name of the respondent burden feature. This is displayed in the Privacy Act Statement
    * Respondent Burden section.
    */
   resBurdenName: PropTypes.string,

--- a/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
@@ -51,7 +51,7 @@ class OMBInfo extends React.Component {
         58VA21/22/28, Compensation, Pension, Education, and Vocational
         Rehabilitation and Employment Records - VA, and published in the Federal
         Register. Your obligation to respond is required to obtain or retain
-        education benefits. Giving us your SSN account information is voluntary.
+        {benefitType}. Giving us your SSN account information is voluntary.
         Refusal to provide your SSN by itself will not result in the denial of
         benefits. The VA will not deny an individual benefits for refusing to
         provide his or her SSN unless the disclosure of the SSN is required by a

--- a/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
@@ -18,24 +18,23 @@ class OMBInfo extends React.Component {
     this.setState({ modalOpen: false });
   };
 
-  modalContents = minutes => (
+  modalContents = (minutes, resBurdenName = 'education benefits') => (
     <div>
       <h3 id={`${this.id}-title`}>Privacy Act Statement</h3>
       {minutes && (
         <p>
           <strong>Respondent Burden:</strong> We need this information to
-          determine your eligibility for education benefits (38 U.S.C. 3471).
-          Title 38, United States Code, allows us to ask for this information.
-          We estimate that you will need an average of {minutes} minutes to
-          review the instructions, find the information, and complete this form.
-          The VA cannot conduct or sponsor a collection of information unless a
-          valid OMB (Office of Management and Budget) control number is
-          displayed. You are not required to respond to a collection of
-          information if this number is not displayed. Valid OMB control numbers
-          can be located on the OMB Internet Page at
-          www.reginfo.gov/public/do/PRAMain. If desired, you can call{' '}
-          <a href="+18008271000">1-800-827-1000</a> to get information on where
-          to send comments or suggestions about this form.
+          determine your eligibility for {resBurdenName} (38 U.S.C. 3471). Title
+          38, United States Code, allows us to ask for this information. We
+          estimate that you will need an average of {minutes} minutes to review
+          the instructions, find the information, and complete this form. The VA
+          cannot conduct or sponsor a collection of information unless a valid
+          OMB (Office of Management and Budget) control number is displayed. You
+          are not required to respond to a collection of information if this
+          number is not displayed. Valid OMB control numbers can be located on
+          the OMB Internet Page at www.reginfo.gov/public/do/PRAMain. If
+          desired, you can call <a href="+18008271000">1-800-827-1000</a> to get
+          information on where to send comments or suggestions about this form.
         </p>
       )}
       <p>
@@ -70,7 +69,7 @@ class OMBInfo extends React.Component {
   );
 
   render() {
-    const { resBurden, ombNumber, expDate } = this.props;
+    const { resBurden, resBurdenName, ombNumber, expDate } = this.props;
 
     return (
       <div className="omb-info">
@@ -97,7 +96,7 @@ class OMBInfo extends React.Component {
           contents={
             this.props.children
               ? this.props.children
-              : this.modalContents(resBurden)
+              : this.modalContents(resBurden, resBurdenName)
           }
           id={this.id}
           visible={this.state.modalOpen}

--- a/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
@@ -114,6 +114,12 @@ OMBInfo.propTypes = {
   resBurden: PropTypes.number,
 
   /**
+   * The name of the respondent burden feature. This is displayed inside the Privacy Act Statement
+   * Respondent Burden section.
+   */
+  resBurdenName: PropTypes.string,
+
+  /**
    * OMB control number / form number
    */
   ombNumber: PropTypes.string,

--- a/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
@@ -136,7 +136,7 @@ OMBInfo.propTypes = {
 };
 
 OMBInfo.defaultProps = {
-  benefitType: 'education benefits',
+  benefitType: 'benefits',
 };
 
 export default OMBInfo;

--- a/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.jsx
@@ -18,13 +18,13 @@ class OMBInfo extends React.Component {
     this.setState({ modalOpen: false });
   };
 
-  modalContents = (minutes, resBurdenName = 'education benefits') => (
+  modalContents = (minutes, benefitType) => (
     <div>
       <h3 id={`${this.id}-title`}>Privacy Act Statement</h3>
       {minutes && (
         <p>
           <strong>Respondent Burden:</strong> We need this information to
-          determine your eligibility for {resBurdenName} (38 U.S.C. 3471). Title
+          determine your eligibility for {benefitType} (38 U.S.C. 3471). Title
           38, United States Code, allows us to ask for this information. We
           estimate that you will need an average of {minutes} minutes to review
           the instructions, find the information, and complete this form. The VA
@@ -69,7 +69,7 @@ class OMBInfo extends React.Component {
   );
 
   render() {
-    const { resBurden, resBurdenName, ombNumber, expDate } = this.props;
+    const { resBurden, benefitType, ombNumber, expDate } = this.props;
 
     return (
       <div className="omb-info">
@@ -96,7 +96,7 @@ class OMBInfo extends React.Component {
           contents={
             this.props.children
               ? this.props.children
-              : this.modalContents(resBurden, resBurdenName)
+              : this.modalContents(resBurden, benefitType)
           }
           id={this.id}
           visible={this.state.modalOpen}
@@ -114,10 +114,10 @@ OMBInfo.propTypes = {
   resBurden: PropTypes.number,
 
   /**
-   * The name of the respondent burden feature. This is displayed in the Privacy Act Statement
-   * Respondent Burden section.
+   * The name of the benefit displayed in the Respondent Burden section
+   * of the Privacy Act Statement.
    */
-  resBurdenName: PropTypes.string,
+  benefitType: PropTypes.string,
 
   /**
    * OMB control number / form number
@@ -133,6 +133,10 @@ OMBInfo.propTypes = {
    * Child elements (content) of modal when displayed
    */
   children: PropTypes.node,
+};
+
+OMBInfo.defaultProps = {
+  benefitType: 'education benefits',
 };
 
 export default OMBInfo;

--- a/packages/react-components/src/components/OMBInfo/OMBInfo.unit.spec.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.unit.spec.jsx
@@ -98,7 +98,7 @@ describe('<OMBInfo/>', () => {
     const modelContent = shallow(
       instance.modalContents(
         instance.props.resBurden,
-        instance.props.resBurdenName,
+        instance.props.benefitType,
       ),
     );
     expect(modelContent.text()).to.contain(
@@ -108,12 +108,12 @@ describe('<OMBInfo/>', () => {
     tree.unmount();
   });
   it('modal should have response burden feature name when given', () => {
-    const tree = shallow(<OMBInfo resBurden="10" resBurdenName="TEST" />);
+    const tree = shallow(<OMBInfo resBurden="10" benefitType="TEST" />);
     const instance = tree.instance();
     const modelContent = shallow(
       instance.modalContents(
         instance.props.resBurden,
-        instance.props.resBurdenName,
+        instance.props.benefitType,
       ),
     );
     expect(modelContent.text()).to.contain('TEST (38 U.S.C. 3471)');

--- a/packages/react-components/src/components/OMBInfo/OMBInfo.unit.spec.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.unit.spec.jsx
@@ -101,9 +101,7 @@ describe('<OMBInfo/>', () => {
         instance.props.benefitType,
       ),
     );
-    expect(modelContent.text()).to.contain(
-      'education benefits (38 U.S.C. 3471)',
-    );
+    expect(modelContent.text()).to.contain('benefits (38 U.S.C. 3471)');
     modelContent.unmount();
     tree.unmount();
   });

--- a/packages/react-components/src/components/OMBInfo/OMBInfo.unit.spec.jsx
+++ b/packages/react-components/src/components/OMBInfo/OMBInfo.unit.spec.jsx
@@ -92,4 +92,32 @@ describe('<OMBInfo/>', () => {
     modelContent.unmount();
     tree.unmount();
   });
+  it('modal should have default response burden feature name when omitted', () => {
+    const tree = shallow(<OMBInfo resBurden="10" />);
+    const instance = tree.instance();
+    const modelContent = shallow(
+      instance.modalContents(
+        instance.props.resBurden,
+        instance.props.resBurdenName,
+      ),
+    );
+    expect(modelContent.text()).to.contain(
+      'education benefits (38 U.S.C. 3471)',
+    );
+    modelContent.unmount();
+    tree.unmount();
+  });
+  it('modal should have response burden feature name when given', () => {
+    const tree = shallow(<OMBInfo resBurden="10" resBurdenName="TEST" />);
+    const instance = tree.instance();
+    const modelContent = shallow(
+      instance.modalContents(
+        instance.props.resBurden,
+        instance.props.resBurdenName,
+      ),
+    );
+    expect(modelContent.text()).to.contain('TEST (38 U.S.C. 3471)');
+    modelContent.unmount();
+    tree.unmount();
+  });
 });

--- a/packages/storybook/stories/OMBInfo.stories.jsx
+++ b/packages/storybook/stories/OMBInfo.stories.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
-import {OMBInfo} from '@department-of-veterans-affairs/component-library';
+import { OMBInfo } from '@department-of-veterans-affairs/component-library';
 
 export default {
   title: 'Components/OMBInfo',
   component: OMBInfo,
 };
 
-const Template = (args) => <OMBInfo {...args} />;
+const Template = args => <OMBInfo {...args} />;
 
 const defaultArgs = {
   resBurden: 120,
   ombNumber: '12-3456',
   expDate: '12/31/2077',
+  resBurdenName: undefined,
 };
 
 export const Default = Template.bind({});
@@ -22,3 +23,10 @@ WithoutOMBNumber.args = { ...defaultArgs, ombNumber: '' };
 
 export const WithoutResponseBurden = Template.bind({});
 WithoutResponseBurden.args = { ...defaultArgs, resBurden: undefined };
+
+export const WithCustomRespondentBurdenName = Template.bind({});
+WithCustomRespondentBurdenName.args = {
+  ...defaultArgs,
+  resBurden: 90,
+  resBurdenName: 'EXAMPLE',
+};

--- a/packages/storybook/stories/OMBInfo.stories.jsx
+++ b/packages/storybook/stories/OMBInfo.stories.jsx
@@ -12,7 +12,6 @@ const defaultArgs = {
   resBurden: 120,
   ombNumber: '12-3456',
   expDate: '12/31/2077',
-  resBurdenName: undefined,
 };
 
 export const Default = Template.bind({});
@@ -24,9 +23,9 @@ WithoutOMBNumber.args = { ...defaultArgs, ombNumber: '' };
 export const WithoutResponseBurden = Template.bind({});
 WithoutResponseBurden.args = { ...defaultArgs, resBurden: undefined };
 
-export const WithCustomRespondentBurdenName = Template.bind({});
-WithCustomRespondentBurdenName.args = {
+export const WithCustomRespondentBurdenBenefitType = Template.bind({});
+WithCustomRespondentBurdenBenefitType.args = {
   ...defaultArgs,
   resBurden: 90,
-  resBurdenName: 'EXAMPLE',
+  benefitType: 'EXAMPLE BENEFITS',
 };


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/34523

## Testing done
<img width="728" alt="Screen Shot 2022-01-10 at 10 40 09" src="https://user-images.githubusercontent.com/36863582/148793942-906005be-0a37-470f-ab20-d65e465963f3.png">


## Screenshots

<img width="1048" alt="Screen Shot 2022-01-10 at 10 36 25" src="https://user-images.githubusercontent.com/36863582/148793284-fb12f2c8-34a8-4551-89c1-576a3bea7112.png">
<img width="1031" alt="Screen Shot 2022-01-10 at 10 34 26" src="https://user-images.githubusercontent.com/36863582/148793466-1b072fa9-0b0a-4721-9e66-84fdf999e456.png">
<img width="773" alt="Screen Shot 2022-01-10 at 10 34 17" src="https://user-images.githubusercontent.com/36863582/148793497-305f3dbf-3c6e-481a-97e1-02ae54f73b06.png">


## Acceptance criteria
- [x] Add ability to use custom respondent burden name in the Privacy Act Statement Respondent Burden section
- [x] Add Storybook story
- [x] Add tests

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
