### PR TITLE
Add process list web component

### DIFF
--- a/packages/storybook/stories/va-process-list.stories.jsx
+++ b/packages/storybook/stories/va-process-list.stories.jsx
@@ -1,0 +1,60 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { getWebComponentDocs, propStructure } from './wc-helpers';
+
+const processListDocs = getWebComponentDocs('va-process-list');
+
+export default {
+  title: 'Components/va-process-list',
+};
+
+const defaultArgs = {};
+
+const Template = ({}) => {
+  return (
+    <va-process-list>
+      <li>
+        <h3>Check to be sure you can request a Board Appeal</h3>
+        <p>
+          You can request a Board Appeal up to 1 year from the date on your
+          decision notice. (Exception: if you have a contested claim, you have
+          only 60 days from the date on your decision notice to request a Board
+          Appeal.)
+        </p>
+        <p>You can request a Board Appeal for these claim decisions:</p>
+        <ul>
+          <li>An initial claim</li>
+          <li>A Supplemental Claim</li>
+          <li>A Higher-Level Review</li>
+        </ul>
+        <p>
+          <strong>Note: </strong>
+          You can’t request a Board Appeal if you’ve already requested one for
+          this same claim.
+        </p>
+      </li>
+      <li>
+        <h3>Gather your information</h3>
+        <p>Here’s what you’ll need to apply:</p>
+        <ul>
+          <li>Your mailing address</li>
+          <li>
+            The VA decision date for each issue you’d like us to review (this is
+            the date on the decision notice you got in the mail)
+          </li>
+        </ul>
+      </li>
+      <li>
+        <h3>Start your request</h3>
+        <p>
+          We’ll take you through each step of the process. It should take about
+          30 minutes.
+        </p>
+      </li>
+    </va-process-list>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = { ...defaultArgs };
+Default.argTypes = propStructure(processListDocs);

--- a/packages/storybook/stories/va-process-list.stories.jsx
+++ b/packages/storybook/stories/va-process-list.stories.jsx
@@ -55,6 +55,36 @@ const Template = ({}) => {
   );
 };
 
+const UtilityStyling = ({}) => {
+  return (
+    <va-process-list>
+      <li>
+        <h3>First step</h3>
+        <p>Look at me in mobile view</p>
+        <va-additional-info
+          trigger="Show more"
+          class="medium-screen:vads-u-display--none"
+        >
+          <img src="https://via.placeholder.com/350" />
+        </va-additional-info>
+      </li>
+      <li>
+        <h3>Next step</h3>
+        <p>Look at me in desktop view</p>
+        <p className="vads-u-display--none medium-screen:vads-u-display--block vads-u-background-color--gray-cool-light">
+          I'm only visible on desktop.
+          <br />
+          <span className="vads-u-font-style--italic">
+            And any global utility style will work.
+          </span>
+        </p>
+      </li>
+    </va-process-list>
+  );
+};
+
 export const Default = Template.bind({});
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(processListDocs);
+
+export const AdditionalStyling = UtilityStyling.bind({});

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -140,6 +140,8 @@ export namespace Components {
     }
     interface VaOnThisPage {
     }
+    interface VaProcessList {
+    }
     interface VaProgressBar {
         /**
           * Whether or not an analytics event will be fired.
@@ -359,6 +361,12 @@ declare global {
         prototype: HTMLVaOnThisPageElement;
         new (): HTMLVaOnThisPageElement;
     };
+    interface HTMLVaProcessListElement extends Components.VaProcessList, HTMLStencilElement {
+    }
+    var HTMLVaProcessListElement: {
+        prototype: HTMLVaProcessListElement;
+        new (): HTMLVaProcessListElement;
+    };
     interface HTMLVaProgressBarElement extends Components.VaProgressBar, HTMLStencilElement {
     }
     var HTMLVaProgressBarElement: {
@@ -411,6 +419,7 @@ declare global {
         "va-featured-content": HTMLVaFeaturedContentElement;
         "va-loading-indicator": HTMLVaLoadingIndicatorElement;
         "va-on-this-page": HTMLVaOnThisPageElement;
+        "va-process-list": HTMLVaProcessListElement;
         "va-progress-bar": HTMLVaProgressBarElement;
         "va-radio": HTMLVaRadioElement;
         "va-radio-option": HTMLVaRadioOptionElement;
@@ -582,6 +591,8 @@ declare namespace LocalJSX {
         "setFocus"?: boolean;
     }
     interface VaOnThisPage {
+    }
+    interface VaProcessList {
     }
     interface VaProgressBar {
         /**
@@ -777,6 +788,7 @@ declare namespace LocalJSX {
         "va-featured-content": VaFeaturedContent;
         "va-loading-indicator": VaLoadingIndicator;
         "va-on-this-page": VaOnThisPage;
+        "va-process-list": VaProcessList;
         "va-progress-bar": VaProgressBar;
         "va-radio": VaRadio;
         "va-radio-option": VaRadioOption;
@@ -799,6 +811,7 @@ declare module "@stencil/core" {
             "va-featured-content": LocalJSX.VaFeaturedContent & JSXBase.HTMLAttributes<HTMLVaFeaturedContentElement>;
             "va-loading-indicator": LocalJSX.VaLoadingIndicator & JSXBase.HTMLAttributes<HTMLVaLoadingIndicatorElement>;
             "va-on-this-page": LocalJSX.VaOnThisPage & JSXBase.HTMLAttributes<HTMLVaOnThisPageElement>;
+            "va-process-list": LocalJSX.VaProcessList & JSXBase.HTMLAttributes<HTMLVaProcessListElement>;
             "va-progress-bar": LocalJSX.VaProgressBar & JSXBase.HTMLAttributes<HTMLVaProgressBarElement>;
             "va-radio": LocalJSX.VaRadio & JSXBase.HTMLAttributes<HTMLVaRadioElement>;
             "va-radio-option": LocalJSX.VaRadioOption & JSXBase.HTMLAttributes<HTMLVaRadioOptionElement>;

--- a/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('va-process-list', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-process-list></va-process-list>');
+
+    const element = await page.find('va-process-list');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { axeCheck } from '../../../testing/test-helpers';
 
 describe('va-process-list', () => {
   it('renders', async () => {
@@ -7,5 +8,18 @@ describe('va-process-list', () => {
 
     const element = await page.find('va-process-list');
     expect(element).toHaveClass('hydrated');
+  });
+
+  it('passes an axe check', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+        <va-process-list>
+          <li>One</li>
+          <li>Two</li>
+          <li>Three</li>
+        </va-process-list>
+      `);
+
+    await axeCheck(page);
   });
 });

--- a/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
@@ -2,12 +2,47 @@ import { newE2EPage } from '@stencil/core/testing';
 import { axeCheck } from '../../../testing/test-helpers';
 
 describe('va-process-list', () => {
-  it('renders', async () => {
+  it('renders slotted nodes into an ordered list', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-process-list></va-process-list>');
+    await page.setContent(`
+      <va-process-list>
+        <li>
+          <h2>Step one</h2>
+          <p>Some content</p>
+        </li>
+        <li>
+          <h2>Step two</h2>
+          <p>Additional content</p>
+          <ul>
+            <li>Item one</li>
+            <li>Item two</li>
+          </ul>
+        </li>
+      </va-process-list>
+    `);
 
     const element = await page.find('va-process-list');
-    expect(element).toHaveClass('hydrated');
+    expect(element).toEqualHtml(`
+      <va-process-list class="hydrated">
+        <mock:shadow-root>
+          <ol role="list">
+            <slot></slot>
+          </ol>
+        </mock:shadow-root>
+        <li>
+          <h2>Step one</h2>
+          <p>Some content</p>
+        </li>
+        <li>
+          <h2>Step two</h2>
+          <p>Additional content</p>
+          <ul>
+            <li>Item one</li>
+            <li>Item two</li>
+          </ul>
+        </li>
+      </va-process-list>
+    `);
   });
 
   it('passes an axe check', async () => {

--- a/packages/web-components/src/components/va-process-list/va-process-list.css
+++ b/packages/web-components/src/components/va-process-list/va-process-list.css
@@ -48,3 +48,13 @@ ol > li:last-child {
   border-left: 0;
   padding-left: calc(2em + 8px);
 }
+
+ul {
+  margin: 0 0 1em 1.25em;
+  padding: 0;
+}
+ul li {
+  list-style: square;
+  margin: 0;
+  padding: 0.1em 0;
+}

--- a/packages/web-components/src/components/va-process-list/va-process-list.css
+++ b/packages/web-components/src/components/va-process-list/va-process-list.css
@@ -5,21 +5,11 @@
   position: relative;
 }
 
-:host > ol > li > :is(h2, h3, h4, h5) {
-  margin-top: 0;
-  clear: none;
-  padding-top: 0.3em;
-}
-
-::slotted(li) {
-  display: none;
-}
-
-ol {
+::slotted(li:first-child) {
   counter-reset: listCounter;
 }
 
-ol > li {
+::slotted(li) {
   counter-increment: listCounter;
   border-left: 8px solid var(--color-gray-light);
   padding: 0 0 2em 2em;
@@ -27,7 +17,7 @@ ol > li {
   margin: 0 !important;
 }
 
-ol > li:before {
+::slotted(li):before {
   color: var(--color-white);
   content: counter(listCounter);
   float: left;
@@ -44,17 +34,7 @@ ol > li:before {
   position: relative;
 }
 
-ol > li:last-child {
+::slotted(li:last-child) {
   border-left: 0;
   padding-left: calc(2em + 8px);
-}
-
-ul {
-  margin: 0 0 1em 1.25em;
-  padding: 0;
-}
-ul li {
-  list-style: square;
-  margin: 0;
-  padding: 0.1em 0;
 }

--- a/packages/web-components/src/components/va-process-list/va-process-list.css
+++ b/packages/web-components/src/components/va-process-list/va-process-list.css
@@ -1,0 +1,44 @@
+:host {
+  display: block;
+  list-style: none;
+  padding: 1em 0;
+  position: relative;
+}
+
+::slotted(li) {
+  display: none;
+}
+
+ol {
+  counter-reset: listCounter;
+}
+
+li {
+  counter-increment: listCounter;
+  border-left: 8px solid var(--color-gray-light);
+  padding: 0 0 2em 2em;
+  list-style: none;
+  margin: 0 !important;
+}
+
+li:before {
+  color: var(--color-white);
+  content: counter(listCounter);
+  float: left;
+  font-size: 1.3em;
+  font-weight: 700;
+  text-align: center;
+  width: 2em;
+  top: -0.2em;
+  margin-left: -2.7em;
+  display: block;
+  border: 4px solid var(--color-white);
+  background: var(--color-gray);
+  border-radius: 4em;
+  position: relative;
+}
+
+li:last-child {
+  border-left: 0;
+  padding-left: calc(2em + 8px);
+}

--- a/packages/web-components/src/components/va-process-list/va-process-list.css
+++ b/packages/web-components/src/components/va-process-list/va-process-list.css
@@ -5,6 +5,12 @@
   position: relative;
 }
 
+:host > ol > li > :is(h2, h3, h4, h5) {
+  margin-top: 0;
+  clear: none;
+  padding-top: 0.3em;
+}
+
 ::slotted(li) {
   display: none;
 }

--- a/packages/web-components/src/components/va-process-list/va-process-list.css
+++ b/packages/web-components/src/components/va-process-list/va-process-list.css
@@ -13,7 +13,7 @@ ol {
   counter-reset: listCounter;
 }
 
-li {
+ol > li {
   counter-increment: listCounter;
   border-left: 8px solid var(--color-gray-light);
   padding: 0 0 2em 2em;
@@ -21,7 +21,7 @@ li {
   margin: 0 !important;
 }
 
-li:before {
+ol > li:before {
   color: var(--color-white);
   content: counter(listCounter);
   float: left;
@@ -38,7 +38,7 @@ li:before {
   position: relative;
 }
 
-li:last-child {
+ol > li:last-child {
   border-left: 0;
   padding-left: calc(2em + 8px);
 }

--- a/packages/web-components/src/components/va-process-list/va-process-list.tsx
+++ b/packages/web-components/src/components/va-process-list/va-process-list.tsx
@@ -17,8 +17,7 @@ export class VaProcessList {
    */
   private populateItems() {
     this.items = getSlottedNodes(this.el, 'li').map((node: HTMLLIElement) => {
-      console.log(node);
-      return <li>Testing</li>;
+      return <li innerHTML={node.innerHTML} />;
     });
   }
 

--- a/packages/web-components/src/components/va-process-list/va-process-list.tsx
+++ b/packages/web-components/src/components/va-process-list/va-process-list.tsx
@@ -1,0 +1,33 @@
+import { Component, Host, Element, State, h } from '@stencil/core';
+import { getSlottedNodes } from '../../utils/utils';
+
+@Component({
+  tag: 'va-process-list',
+  styleUrl: 'va-process-list.css',
+  shadow: true,
+})
+export class VaProcessList {
+  @Element() el: any;
+
+  @State() items: Array<Node>;
+  /**
+   * This function is for taking the slotted content and rendering
+   * it inside the `<ol>` element. Putting the `<slot>` directly
+   * inside the `<ol>` prevents `<li>` from being the only child type
+   */
+  private populateItems() {
+    this.items = getSlottedNodes(this.el, 'li').map((node: HTMLLIElement) => {
+      console.log(node);
+      return <li>Testing</li>;
+    });
+  }
+
+  render() {
+    return (
+      <Host>
+        <slot onSlotchange={() => this.populateItems()}></slot>
+        <ol role="list">{this.items}</ol>
+      </Host>
+    );
+  }
+}

--- a/packages/web-components/src/components/va-process-list/va-process-list.tsx
+++ b/packages/web-components/src/components/va-process-list/va-process-list.tsx
@@ -1,5 +1,4 @@
-import { Component, Host, Element, State, h } from '@stencil/core';
-import { getSlottedNodes } from '../../utils/utils';
+import { Component, Host, h } from '@stencil/core';
 
 @Component({
   tag: 'va-process-list',
@@ -7,25 +6,12 @@ import { getSlottedNodes } from '../../utils/utils';
   shadow: true,
 })
 export class VaProcessList {
-  @Element() el: any;
-
-  @State() items: Array<Node>;
-  /**
-   * This function is for taking the slotted content and rendering
-   * it inside the `<ol>` element. Putting the `<slot>` directly
-   * inside the `<ol>` prevents `<li>` from being the only child type
-   */
-  private populateItems() {
-    this.items = getSlottedNodes(this.el, 'li').map((node: HTMLLIElement) => {
-      return <li innerHTML={node.innerHTML} />;
-    });
-  }
-
   render() {
     return (
       <Host>
-        <slot onSlotchange={() => this.populateItems()}></slot>
-        <ol role="list">{this.items}</ol>
+        <ol role="list">
+          <slot></slot>
+        </ol>
       </Host>
     );
   }

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -30,3 +30,9 @@
     sans-serif;
   --font-serif: 'Bitter';
 }
+
+va-process-list > li > :is(h2, h3, h4, h5) {
+  margin-top: 0;
+  clear: none;
+  padding-top: 0.3em;
+}


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/35073

This adds the `<va-process-list>` Web Component. The styling implementation at the moment relies on styles being applied to `va-process-list` child elements _outside_ of the shadow DOM in order to style the heading appropriately. The `::slotted()` pseudo-element doesn't allow us to style nested elements in the slot, and there are use cases for applying utility classes to the child contents which wouldn't be available if we copied the children into the shadow DOM.

## Testing done
- E2e tests
- Storybook :eyes: 

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/149849031-03d1bfb5-0906-4aaf-8a4a-7f55b597c847.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
