### PR TITLE
Update story breadcrumb segments to sentence casing

### DIFF
--- a/packages/storybook/stories/va-breadcrumbs.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs.stories.jsx
@@ -10,8 +10,8 @@ export default {
 const Template = ({ label, 'disable-analytics': disableAnalytics }) => (
   <va-breadcrumbs label={label} disable-analytics={disableAnalytics}>
     <a href="#home">Home</a>
-    <a href="#one">Level One</a>
-    <a href="#two">Level Two</a>
+    <a href="#one">Level one</a>
+    <a href="#two">Level two</a>
   </va-breadcrumbs>
 );
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/35508

## Testing done
N/A

## Screenshots
<img width="1034" alt="Screen Shot 2022-01-18 at 21 41 40" src="https://user-images.githubusercontent.com/36863582/150053653-b78fe51f-56c3-46b3-990b-9b1d5e38203a.png">


## Acceptance criteria
- [x] Update story breadcrumb segments to sentence casing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
