### PR TITLE
Update va-accordion-item paragraphs to wrap

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.css
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.css
@@ -73,6 +73,7 @@ p {
   font-weight: 400;
   line-height: 26px;
   margin: 0;
+  width: 100%;
 }
 
 /* Hiding since element would be duplicated via the Shadow DOM */


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/35553

## Testing done


## Screenshots
<img width="712" alt="Screen Shot 2022-01-19 at 10 55 29" src="https://user-images.githubusercontent.com/36863582/150167314-78a368f9-e8b6-41e4-bbf9-9e25e1176343.png">
<img width="854" alt="Screen Shot 2022-01-19 at 10 56 02" src="https://user-images.githubusercontent.com/36863582/150167330-8b393159-3e5c-44bc-828a-020b48d78187.png">


## Acceptance criteria
- [x] Paragraphs must wrap inside accordion items

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
