### PR TITLE
Prevent text overflowing container in va-accordion-item

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.css
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.css
@@ -61,8 +61,7 @@ button:hover {
   border-left: var(--item-border);
   border-right: var(--item-border);
   border-bottom: var(--item-border);
-  display: flex;
-  flex-wrap: wrap;
+  overflow-wrap: break-word;
 }
 
 button[aria-expanded='false'] {
@@ -73,7 +72,6 @@ p {
   font-weight: 400;
   line-height: 26px;
   margin: 0;
-  width: 100%;
 }
 
 /* Hiding since element would be duplicated via the Shadow DOM */


### PR DESCRIPTION
## Description
The previous CSS changes made to va-accordion-item in #252 and #267 have introduced defects and are reverted in this PR.  The fix for the original issue is included.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/602

## Testing done


## Screenshots
<img width="597" alt="Screen Shot 2022-01-19 at 20 38 14" src="https://user-images.githubusercontent.com/36863582/150246957-cfa77eaa-eb3a-4f33-889d-585e0eb58a20.png">

Here you can see a child container with width 100% that contains children containers of different widths (400px, 100%). Each container has a string long enough to require a horizontal scrollbar to view unless wrapped. There is no horizontal bar.
<img width="1011" alt="Screen Shot 2022-01-19 at 20 47 44" src="https://user-images.githubusercontent.com/36863582/150247577-d9a6cfad-7020-4a26-a6b9-b37eedd2052d.png">


## Acceptance criteria
- [x] va-accordion-item should wrap content inside (preventing a horizontal scrollbar)

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
