### PR TITLE
Fix va-alert close event dispatch

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/react-components/src/components/Banner/Banner.jsx
+++ b/packages/react-components/src/components/Banner/Banner.jsx
@@ -137,7 +137,7 @@ export class Banner extends Component {
           visible
           full-width
           closeable={showClose}
-          onClose={onCloseAlert}
+          onVaClose={onCloseAlert}
           status={type}
         >
           <h3 slot="headline">{title}</h3>

--- a/packages/react-components/src/components/Banner/Banner.jsx
+++ b/packages/react-components/src/components/Banner/Banner.jsx
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 // Relative imports.
-
 import { VaAlert } from '@department-of-veterans-affairs/web-components/react-bindings';
 
 const DISMISSED_BANNERS_KEY = 'DISMISSED_BANNERS';
@@ -98,7 +97,7 @@ export class Banner extends Component {
     // Track the dismiss event.
     if (recordEvent) {
       recordEvent({
-        event: 'int-alert-box-close',
+        'event': 'int-alert-box-close',
         'alert-box-headline': title,
       });
     }
@@ -137,7 +136,7 @@ export class Banner extends Component {
           visible
           full-width
           closeable={showClose}
-          onVaClose={onCloseAlert}
+          onCloseEvent={onCloseAlert}
           status={type}
         >
           <h3 slot="headline">{title}</h3>

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
+import { VaAlert } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { getWebComponentDocs, propStructure } from './wc-helpers';
 
 const alertDocs = getWebComponentDocs('va-alert');
@@ -16,7 +17,7 @@ export default {
         disable: true,
       },
     },
-    onclose: {
+    vaClose: {
       description:
         'If closeable is true, this event is triggered when an alert is closed.',
       table: {
@@ -47,7 +48,7 @@ const defaultArgs = {
   'closeable': false,
   'full-width': false,
   'headline': <h3 slot="headline">Alert headline</h3>,
-  'onclose': undefined,
+  'vaClose': undefined,
 };
 
 const Template = ({
@@ -60,8 +61,26 @@ const Template = ({
   closeable,
   'full-width': fullWidth,
   headline,
-  onclose,
+  vaClose,
+  storybookOnlyClose,
 }) => {
+  if (storybookOnlyClose)
+    return (
+      <VaAlert
+        status={status}
+        background-only={backgroundOnly}
+        show-icon={showIcon}
+        disable-analytics={disableAnalytics}
+        visible={visible}
+        close-btn-aria-label={closeBtnAriaLabel}
+        closeable={closeable}
+        full-width={fullWidth}
+        onVaClose={vaClose}
+      >
+        {headline}
+        <div>This is an alert</div>
+      </VaAlert>
+    );
   return (
     <va-alert
       status={status}
@@ -72,7 +91,7 @@ const Template = ({
       close-btn-aria-label={closeBtnAriaLabel}
       closeable={closeable}
       full-width={fullWidth}
-      onclose={onclose}
+      onVaClose={vaClose}
     >
       {headline}
       <div>This is an alert</div>
@@ -106,14 +125,14 @@ export const Closeable = Template.bind({});
 Closeable.args = {
   ...defaultArgs,
   closeable: true,
-  onclose: () => console.log('Close event triggered'),
+  vaClose: () => console.log('Close event triggered'),
+  storybookOnlyClose: true,
 };
 
 export const Fullwidth = Template.bind({});
 Fullwidth.args = {
   ...defaultArgs,
   'full-width': true,
-  'onclose': () => console.log('Close event triggered'),
   'status': 'warning',
 };
 

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -38,6 +38,9 @@ export default {
   },
 };
 
+// Fix for displaying component name when using bindings in 'Show code'
+VaAlert.displayName = 'VaAlert';
+
 const defaultArgs = {
   'status': 'info',
   'background-only': false,

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -51,7 +51,6 @@ const defaultArgs = {
   'closeable': false,
   'full-width': false,
   'headline': <h3 slot="headline">Alert headline</h3>,
-  'vaClose': undefined,
 };
 
 const Template = ({
@@ -65,9 +64,8 @@ const Template = ({
   'full-width': fullWidth,
   headline,
   onVaClose,
-  storybookOnlyClose,
 }) => {
-  if (storybookOnlyClose)
+  if (onVaClose)
     return (
       <VaAlert
         status={status}
@@ -84,6 +82,7 @@ const Template = ({
         <div>This is an alert</div>
       </VaAlert>
     );
+
   return (
     <va-alert
       status={status}
@@ -128,7 +127,6 @@ Closeable.args = {
   ...defaultArgs,
   closeable: true,
   onVaClose: () => console.log('Close event triggered'),
-  storybookOnlyClose: true,
 };
 
 export const Fullwidth = Template.bind({});

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -64,7 +64,7 @@ const Template = ({
   closeable,
   'full-width': fullWidth,
   headline,
-  vaClose,
+  onVaClose,
   storybookOnlyClose,
 }) => {
   if (storybookOnlyClose)
@@ -78,7 +78,7 @@ const Template = ({
         close-btn-aria-label={closeBtnAriaLabel}
         closeable={closeable}
         full-width={fullWidth}
-        onVaClose={vaClose}
+        onVaClose={onVaClose}
       >
         {headline}
         <div>This is an alert</div>
@@ -94,7 +94,6 @@ const Template = ({
       close-btn-aria-label={closeBtnAriaLabel}
       closeable={closeable}
       full-width={fullWidth}
-      onVaClose={vaClose}
     >
       {headline}
       <div>This is an alert</div>
@@ -128,7 +127,7 @@ export const Closeable = Template.bind({});
 Closeable.args = {
   ...defaultArgs,
   closeable: true,
-  vaClose: () => console.log('Close event triggered'),
+  onVaClose: () => console.log('Close event triggered'),
   storybookOnlyClose: true,
 };
 

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -17,7 +17,7 @@ export default {
         disable: true,
       },
     },
-    vaClose: {
+    closeEvent: {
       description:
         'If closeable is true, this event is triggered when an alert is closed.',
       table: {
@@ -63,20 +63,20 @@ const Template = ({
   closeable,
   'full-width': fullWidth,
   headline,
-  onVaClose,
+  onCloseEvent,
 }) => {
-  if (onVaClose)
+  if (onCloseEvent)
     return (
       <VaAlert
         status={status}
-        background-only={backgroundOnly}
-        show-icon={showIcon}
-        disable-analytics={disableAnalytics}
+        backgroundOnly={backgroundOnly}
+        showIcon={showIcon}
+        disableAnalytics={disableAnalytics}
         visible={visible}
-        close-btn-aria-label={closeBtnAriaLabel}
+        closeBtnAriaLabel={closeBtnAriaLabel}
         closeable={closeable}
-        full-width={fullWidth}
-        onVaClose={onVaClose}
+        fullWidth={fullWidth}
+        onCloseEvent={onCloseEvent}
       >
         {headline}
         <div>This is an alert</div>
@@ -126,7 +126,7 @@ export const Closeable = Template.bind({});
 Closeable.args = {
   ...defaultArgs,
   closeable: true,
-  onVaClose: () => console.log('Close event triggered'),
+  onCloseEvent: () => console.log('Close event triggered'),
 };
 
 export const Fullwidth = Template.bind({});

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.23.0",
+  "version": "1.0.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "1.0.0",
+  "version": "0.23.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "0.22.0",
+  "version": "1.0.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -536,12 +536,15 @@ declare namespace LocalJSX {
           * If true, the alert will be full width. Should be for emergency communication only.
          */
         "fullWidth"?: boolean;
-        "onClose"?: (event: CustomEvent<any>) => void;
         "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
         /**
           * Fires when the component has successfully finished rendering for the first time.
          */
         "onVa-component-did-load"?: (event: CustomEvent<any>) => void;
+        /**
+          * Fires when the component is closed by clicking on the close icon. This fires only when closeable is true.
+         */
+        "onVaClose"?: (event: CustomEvent<any>) => void;
         /**
           * This option only takes effect when background-only is true. If true, the background-only alert will include an icon.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -536,15 +536,15 @@ declare namespace LocalJSX {
           * If true, the alert will be full width. Should be for emergency communication only.
          */
         "fullWidth"?: boolean;
+        /**
+          * Fires when the component is closed by clicking on the close icon. This fires only when closeable is true.
+         */
+        "onCloseEvent"?: (event: CustomEvent<any>) => void;
         "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
         /**
           * Fires when the component has successfully finished rendering for the first time.
          */
         "onVa-component-did-load"?: (event: CustomEvent<any>) => void;
-        /**
-          * Fires when the component is closed by clicking on the close icon. This fires only when closeable is true.
-         */
-        "onVaClose"?: (event: CustomEvent<any>) => void;
         /**
           * This option only takes effect when background-only is true. If true, the background-only alert will include an icon.
          */

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -69,7 +69,7 @@ describe('va-alert', () => {
       '<va-alert closeable="true">Content inside</va-alert>',
     );
 
-    const closeSpy = await page.spyOnEvent('close');
+    const closeSpy = await page.spyOnEvent('vaClose');
 
     const button = await page.find('va-alert >>> button');
     await button.click();

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -69,7 +69,7 @@ describe('va-alert', () => {
       '<va-alert closeable="true">Content inside</va-alert>',
     );
 
-    const closeSpy = await page.spyOnEvent('vaClose');
+    const closeSpy = await page.spyOnEvent('closeEvent');
 
     const button = await page.find('va-alert >>> button');
     await button.click();

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -72,11 +72,15 @@ export class VaAlert {
   })
   vaComponentDidLoad: EventEmitter;
 
+  /**
+   * Fires when the component is closed by clicking on the close icon. This fires only
+   * when closeable is true.
+   */
   @Event({
     composed: true,
     bubbles: true,
   })
-  close: EventEmitter;
+  vaClose: EventEmitter;
 
   @Event({
     eventName: 'component-library-analytics',
@@ -86,7 +90,7 @@ export class VaAlert {
   componentLibraryAnalytics: EventEmitter;
 
   private closeHandler(e: MouseEvent): void {
-    this.close.emit(e);
+    this.vaClose.emit(e);
   }
 
   private handleAlertBodyClick(e: MouseEvent): void {

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -80,7 +80,7 @@ export class VaAlert {
     composed: true,
     bubbles: true,
   })
-  vaClose: EventEmitter;
+  closeEvent: EventEmitter;
 
   @Event({
     eventName: 'component-library-analytics',
@@ -90,7 +90,7 @@ export class VaAlert {
   componentLibraryAnalytics: EventEmitter;
 
   private closeHandler(e: MouseEvent): void {
-    this.vaClose.emit(e);
+    this.closeEvent.emit(e);
   }
 
   private handleAlertBodyClick(e: MouseEvent): void {


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/35822

## Testing done
Edge 13, Safari 10, Chrome 45, Firefox 52

Note: Storybook doesn't finish loading in Safari 9 and Chrome 44.

## Screenshots
<img width="1784" alt="Screen Shot 2022-01-24 at 15 53 21" src="https://user-images.githubusercontent.com/36863582/150862997-2cc18ca6-9a91-409b-a59e-300c2f79cf37.png">


## Acceptance criteria
- [x] The va-alert component accepts a function that gets called when the alert is closed
- [x] We are able to see this function work in Storybook
- [x] The user is able to close the Banner component and the Banner onCloseAlert function works.
- [x] This functionality has been tested in all supported browsers (See Testing done)

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
