### PR TITLE
34439 Remove date-fns dependency from component library

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@department-of-veterans-affairs/react-components": "workspace:*",
     "@department-of-veterans-affairs/web-components": "workspace:*",
-    "date-fns-tz": "^1.1.1",
     "react-focus-on": "^3.5.1",
     "react-scroll": "^1.7.16",
     "react-transition-group": "^1.0.0"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -23,7 +23,6 @@
     "@whitespace/storybook-addon-html": "^2.0.1",
     "babel-loader": "^8.2.2",
     "css-loader": "^5.2.4",
-    "date-fns": "^2.17.0",
     "node-sass": "4.14.1",
     "react-dom": "^17.0.2",
     "sass-loader": "^8.0.2"

--- a/packages/storybook/stories/MaintenanceBanner.stories.jsx
+++ b/packages/storybook/stories/MaintenanceBanner.stories.jsx
@@ -14,20 +14,6 @@ export default {
   },
 };
 
-function addHoursToDate(objDate, intHours) {
-  var numberOfMlSeconds = objDate.getTime();
-  var addMlSeconds = intHours * 60 * 60 * 1000;
-  var newDateObj = new Date(numberOfMlSeconds + addMlSeconds);
-  return newDateObj;
-}
-
-function subtractTimeFromDate(objDate, intHours) {
-  var numberOfMlSeconds = objDate.getTime();
-  var addMlSeconds = intHours * 60 * 60 * 1000;
-  var newDateObj = new Date(numberOfMlSeconds - addMlSeconds);
-  return newDateObj;
-}
-
 const Template = args => {
   const startTime = args.startsAt;
   const endTime = args.expiresAt;
@@ -48,9 +34,9 @@ const defaultArgs = {
     'We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.',
   warnContent:
     'We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools.',
-  startsAt: new Date(Date.now()),
-  expiresAt: addHoursToDate(new Date(Date.now()), 2),
-  warnStartsAt: subtractTimeFromDate(new Date(Date.now()), 1),
+  startsAt: new Date(),
+  expiresAt: new Date(new Date().setHours(new Date().getHours() + 2)),
+  warnStartsAt: new Date(new Date().setHours(new Date().getHours() - 1)),
 };
 
 export const DuringMaintenance = Template.bind({});
@@ -59,7 +45,7 @@ DuringMaintenance.args = { ...defaultArgs };
 export const BeforeMaintenance = Template.bind({});
 BeforeMaintenance.args = {
   ...defaultArgs,
-  startsAt: addHoursToDate(new Date(Date.now()), 1),
-  expiresAt: addHoursToDate(new Date(Date.now()), 2),
-  warnStartsAt: new Date(Date.now()),
+  startsAt: new Date(new Date().setHours(new Date().getHours() + 1)),
+  expiresAt: new Date(new Date().setHours(new Date().getHours() + 2)),
+  warnStartsAt: new Date(),
 };

--- a/packages/storybook/stories/MaintenanceBanner.stories.jsx
+++ b/packages/storybook/stories/MaintenanceBanner.stories.jsx
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 import React from 'react';
-import { addHours, subMinutes, format } from 'date-fns';
+import { formatDate } from '../../react-components/src/helpers/format-date';
 
-import {MaintenanceBanner} from '@department-of-veterans-affairs/component-library';
+import { MaintenanceBanner } from '@department-of-veterans-affairs/component-library';
 
 export default {
   title: 'Components/Banners/MaintenanceBanner',
@@ -14,14 +14,28 @@ export default {
   },
 };
 
-const Template = (args) => {
+function addHoursToDate(objDate, intHours) {
+  var numberOfMlSeconds = objDate.getTime();
+  var addMlSeconds = intHours * 60 * 60 * 1000;
+  var newDateObj = new Date(numberOfMlSeconds + addMlSeconds);
+  return newDateObj;
+}
+
+function subtractTimeFromDate(objDate, intHours) {
+  var numberOfMlSeconds = objDate.getTime();
+  var addMlSeconds = intHours * 60 * 60 * 1000;
+  var newDateObj = new Date(numberOfMlSeconds - addMlSeconds);
+  return newDateObj;
+}
+
+const Template = args => {
   const startTime = args.startsAt;
   const endTime = args.expiresAt;
   const warnStart = args.warnStartsAt;
   console.group('Times passed to Template');
-  console.log('startTime:', format(startTime, 'MM/dd/yy p'));
-  console.log('endTime', format(endTime, 'MM/dd/yy p'));
-  console.log('warnStart', format(warnStart, 'MM/dd/yy p'));
+  console.log('startTime:', formatDate(startTime, 'timeShort'));
+  console.log('endTime', formatDate(endTime, 'timeShort'));
+  console.log('warnStart', formatDate(warnStart, 'timeShort'));
   console.groupEnd();
   return <MaintenanceBanner {...args} />;
 };
@@ -33,10 +47,10 @@ const defaultArgs = {
   content:
     'We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.',
   warnContent:
-    'We’ll be doing some work on VA.gov. The maintenance will last 1 hour. During that time, you won’t be able to sign in or use tools.',
+    'We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools.',
   startsAt: new Date(Date.now()),
-  expiresAt: addHours(Date.now(), 1),
-  warnStartsAt: subMinutes(Date.now(), 30),
+  expiresAt: addHoursToDate(new Date(Date.now()), 2),
+  warnStartsAt: subtractTimeFromDate(new Date(Date.now()), 1),
 };
 
 export const DuringMaintenance = Template.bind({});
@@ -45,7 +59,7 @@ DuringMaintenance.args = { ...defaultArgs };
 export const BeforeMaintenance = Template.bind({});
 BeforeMaintenance.args = {
   ...defaultArgs,
-  startsAt: addHours(Date.now(), 1),
-  expiresAt: addHours(Date.now(), 2),
+  startsAt: addHoursToDate(new Date(Date.now()), 1),
+  expiresAt: addHoursToDate(new Date(Date.now()), 2),
   warnStartsAt: new Date(Date.now()),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,7 +1653,6 @@ __metadata:
     babel-loader: ^8.2.2
     copy-webpack-plugin: ^9.0.1
     css-loader: ^6.4.0
-    date-fns-tz: ^1.1.1
     mini-css-extract-plugin: ^2.4.2
     react-focus-on: ^3.5.1
     react-scroll: ^1.7.16
@@ -1768,7 +1767,6 @@ __metadata:
     "@whitespace/storybook-addon-html": ^2.0.1
     babel-loader: ^8.2.2
     css-loader: ^5.2.4
-    date-fns: ^2.17.0
     node-sass: 4.14.1
     prop-types: ^15.7.2
     react: ^17.0.2
@@ -7516,22 +7514,6 @@ __metadata:
     whatwg-mimetype: ^2.3.0
     whatwg-url: ^8.0.0
   checksum: 97caf828aac25e25e04ba6869db0f99c75e6859bb5b424ada28d3e7841941ebf08ddff3c1b1bb4585986bd507a5d54c2a716853ea6cb98af877400e637393e71
-  languageName: node
-  linkType: hard
-
-"date-fns-tz@npm:^1.1.1":
-  version: 1.1.6
-  resolution: "date-fns-tz@npm:1.1.6"
-  peerDependencies:
-    date-fns: ">=2.0.0-alpha.13"
-  checksum: cfe4c799372fcb586b7f22d9c31e10df33dabc74452fbd92269ae02bbaed4024636c477b9aac06c521ec78a7391826d5526fedbcefbad2e5de25bcc00c61ad8f
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:^2.17.0":
-  version: 2.25.0
-  resolution: "date-fns@npm:2.25.0"
-  checksum: 8896dc1dde0ee5ef77616942423bfa11fa2017a5ac19457293b7aaedc8822ff94f0a14eaf93da573b09b601dc0149eb430988a046cc9f79a2eb15f8c66c9c50c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/34439

## Testing done
N/A

## Screenshots
Chrome:
<img width="1440" alt="Screen Shot 2022-01-25 at 12 53 03 PM" src="https://user-images.githubusercontent.com/11822533/151031989-1ac09b7e-8693-4780-9e78-2779580613d2.png">
<img width="1440" alt="Screen Shot 2022-01-25 at 12 53 20 PM" src="https://user-images.githubusercontent.com/11822533/151031991-06acee9f-5b7c-4e81-b02a-328147ab5e0d.png">

Safari:
<img width="1067" alt="Screen Shot 2022-01-25 at 12 55 46 PM" src="https://user-images.githubusercontent.com/11822533/151032549-d706848f-efae-4f40-948a-dd14e7df14ad.png">
<img width="1060" alt="Screen Shot 2022-01-25 at 12 55 55 PM" src="https://user-images.githubusercontent.com/11822533/151032552-336d5380-9847-4681-83c9-70b6f96587ec.png">

Firefox:
<img width="1056" alt="Screen Shot 2022-01-25 at 12 56 19 PM" src="https://user-images.githubusercontent.com/11822533/151032575-baf10eb3-b91d-4f9e-8a77-60adc9e3a14f.png">
<img width="1080" alt="Screen Shot 2022-01-25 at 12 56 31 PM" src="https://user-images.githubusercontent.com/11822533/151032576-47f45968-96cc-48de-9653-41d2d30c74bc.png">

Edge:
![Screenshot (12)](https://user-images.githubusercontent.com/11822533/151365597-365c3a34-b0d7-4909-8aab-f669a4ff90dd.png)
![Screenshot (13)](https://user-images.githubusercontent.com/11822533/151365598-8f088d17-03bb-4ce9-b0ce-a0e513d4ca02.png)

## Acceptance criteria
- [x] Remove from `MaintenanceBanner.stories.jsx` and adjust story as needed to work properly
- [x] Remove dependency from `core` and `storybook` package.json - `core` is `date-fns-tz`
- [x] Tested and confirmed working in all supported browsers: https://depo-platform-documentation.scrollhelp.site/developer-docs/Browser-Support-Policy.1847951366.html

## Acceptance Criteria Upon Component Library Merge
- [ ] Test IE 11 Support
- [ ] Add `date-fns-tz` as a dependency in `vets-website` repo `package.json`

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
