### PR TITLE
27940 va-text-input WC Max Char Aria Accessibility

### DIFF
--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -172,7 +172,7 @@ export class VaTextInput {
           maxlength={this.maxlength}
         />
         {this.maxlength && this.value.length >= this.maxlength && (
-          <small>(Max. {this.maxlength} characters)</small>
+          <small aria-live="polite">(Max. {this.maxlength} characters)</small>
         )}
       </Host>
     );


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/27940

## Testing done / Screenshots
MacOs Voiceover Recording
https://user-images.githubusercontent.com/11822533/151055354-7d24d0ba-32d8-40bd-8418-3466593ac486.mov

## Acceptance criteria
- [x] Make max length text more accessible
- [x] Accessibility specialist review

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
