### PR TITLE
Require label on PRs

### DIFF
--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          labels: "patch, minor, major, ignore-for-release"


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/35707

Use [this GitHub action](https://github.com/marketplace/actions/require-labels) to configure required labels on our PRs. For now this is to help ensure consistent release notes, but later the labels may be used to trigger other things.

I've also updated the `master` branch protection rule to make this status check be required to pass before merging a PR.

## Testing done

This PR - adding labels, :eyes: on status checks


## Screenshots

Failing on no labels:

<details>

![image](https://user-images.githubusercontent.com/2008881/151269261-7f6d9151-7c96-498d-97a6-1911c5ece506.png)

</details>

Passing when an expected label is applied:

<details>

![image](https://user-images.githubusercontent.com/2008881/151269438-354b74ae-78a4-4b0c-afbf-c170b3f759a8.png)

</details>

Adding additional labels that aren't in the exclusive list doesn't cause problems:

<details>

![image](https://user-images.githubusercontent.com/2008881/151270108-34622c40-ed46-4241-882f-3faaeca3a607.png)

</details>

Failing when the right label isn't applied:

<details>

![image](https://user-images.githubusercontent.com/2008881/151270468-76ac510e-66be-4bdf-99e1-923f34a7b077.png)

</details>

Failing when two mutually exclusive labels are applied:

<details>

![image](https://user-images.githubusercontent.com/2008881/151271078-945e35a7-8279-4ddc-8660-43b5e03fcc28.png)

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
