### PR TITLE
Remove placeholder prop from va-text-input

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -16,7 +16,6 @@ const defaultArgs = {
   'required': false,
   'error': null,
   'maxlength': null,
-  'placeholder': null,
   'value': null,
 };
 
@@ -28,7 +27,6 @@ const Template = ({
   required,
   error,
   maxlength,
-  placeholder,
   value,
 }) => {
   return (
@@ -40,7 +38,6 @@ const Template = ({
       required={required}
       error={error}
       maxlength={maxlength}
-      placeholder={placeholder}
       value={value}
     />
   );
@@ -56,14 +53,10 @@ Error.args = { ...defaultArgs, error: 'This is an error message' };
 export const Required = Template.bind({});
 Required.args = { ...defaultArgs, required: true };
 
-export const WithPlaceholder = Template.bind({});
-WithPlaceholder.args = { ...defaultArgs, placeholder: 'This is a placeholder' };
-
 export const MaxLength = Template.bind({});
 MaxLength.args = {
   ...defaultArgs,
   maxlength: '16',
-  placeholder: 'No more than 16 characters',
 };
 
 export const Autocomplete = Template.bind({});
@@ -71,7 +64,6 @@ Autocomplete.args = {
   ...defaultArgs,
   name: 'email',
   autocomplete: 'email',
-  placeholder: 'This should complete using email addresses',
 };
 
 export const WithAnalytics = Template.bind({});

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -318,10 +318,6 @@ export namespace Components {
          */
         "name"?: string;
         /**
-          * Placeholder text to show in the input field.
-         */
-        "placeholder"?: string;
-        /**
           * Set the input to required and render the (Required) text.
          */
         "required"?: boolean;
@@ -828,10 +824,6 @@ declare namespace LocalJSX {
           * The event emitted when the input value changes
          */
         "onVaChange"?: (event: CustomEvent<any>) => void;
-        /**
-          * Placeholder text to show in the input field.
-         */
-        "placeholder"?: string;
         /**
           * Set the input to required and render the (Required) text.
          */

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -147,19 +147,6 @@ describe('va-text-input', () => {
     expect(analyticsSpy).not.toHaveReceivedEvent();
   });
 
-  it('adds placeholder text', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-text-input placeholder="Enter your life story" />',
-    );
-
-    // Render the error message text
-    const inputEl = await page.find('va-text-input >>> input');
-    expect(inputEl.getAttribute('placeholder')).toContain(
-      'Enter your life story',
-    );
-  });
-
   it('adds a character limit with descriptive text', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-text-input maxlength="3" value="22"/>');

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -38,11 +38,6 @@ export class VaTextInput {
   @Prop() required?: boolean;
 
   /**
-   * Placeholder text to show in the input field.
-   */
-  @Prop() placeholder?: string;
-
-  /**
    * The inputmode attribute.
    */
   @Prop() inputmode?: string = '';
@@ -168,7 +163,6 @@ export class VaTextInput {
           onBlur={this.handleBlur}
           aria-describedby={describedBy}
           inputmode={inputMode}
-          placeholder={this.placeholder}
           maxlength={this.maxlength}
         />
         {this.maxlength && this.value.length >= this.maxlength && (


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/27936

This removes the `placeholder` prop from `<va-text-input>` in accordance with the DSC's decision.

## Testing done

- Unit tests passing
- Storybook :eyes: 


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
