### PR TITLE
Match release note labels to required labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,13 +5,13 @@ changelog:
   categories:
     - title: Breaking Changes
       labels:
-        - breaking
+        - major
     - title: New Features & Components 🎉
       labels:
-        - enhancement
+        - minor
     - title: Fixes
       labels:
-        - fix
+        - patch
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## Description

In https://github.com/department-of-veterans-affairs/component-library/pull/274 we added a GitHub action to require labels on PRs. This update matches the labels required in that PR to the appropriate release note categories.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
