### PR TITLE
Fix va-alert heading to not announce as clickable when using NVDA

### DIFF
--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -96,8 +96,3 @@ export const parameters = {
 };
 
 export const decorators = [withHTML];
-
-// Test
-document.body.onload = function () {
-  document.querySelector('#root').setAttribute('role', 'presentation');
-};

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -96,3 +96,10 @@ export const parameters = {
 };
 
 export const decorators = [withHTML];
+
+// Fix for React 17/NVDA bug where React root is read as "clickable"
+// https://github.com/nvaccess/nvda/issues/13262
+// https://github.com/facebook/react/issues/20895
+document.body.onload = function () {
+  document.querySelector('#root').setAttribute('role', 'presentation');
+};

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -96,3 +96,8 @@ export const parameters = {
 };
 
 export const decorators = [withHTML];
+
+// Test
+document.body.onload = function () {
+  document.querySelector('#root').setAttribute('role', 'presentation');
+};

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -9,7 +9,7 @@ describe('va-alert', () => {
     const element = await page.find('va-alert');
 
     expect(element).toEqualHtml(`
-      <va-alert class="hydrated" role="presentation">
+      <va-alert class="hydrated">
         <mock:shadow-root>
           <div class="alert info">
             <i aria-hidden="true" role="img"></i>

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -15,11 +15,7 @@ describe('va-alert', () => {
             <i aria-hidden="true" role="img"></i>
             <div class="body">
               <slot name="headline"></slot>
-              <div id="body-click" role="presentation">
-                <div>
-                  <slot></slot>
-                </div>
-              </div>
+              <slot></slot>
             </div>
           </div>
         </mock:shadow-root>

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -15,7 +15,7 @@ describe('va-alert', () => {
             <i aria-hidden="true" role="img"></i>
             <div class="body">
               <slot name="headline"></slot>
-              <div role="presentation">
+              <div id="body-click" role="presentation">
                 <div>
                   <slot></slot>
                 </div>

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -9,7 +9,7 @@ describe('va-alert', () => {
     const element = await page.find('va-alert');
 
     expect(element).toEqualHtml(`
-      <va-alert class="hydrated">
+      <va-alert class="hydrated" role="presentation">
         <mock:shadow-root>
           <div class="alert info">
             <i aria-hidden="true" role="img"></i>

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -13,11 +13,9 @@ describe('va-alert', () => {
         <mock:shadow-root>
           <div class="alert info">
             <i aria-hidden="true" role="img"></i>
-            <div class="body">
+            <div class="body" role="presentation">
               <slot name="headline"></slot>
-              <div role="presentation">
-                <slot></slot>
-              </div>
+              <slot></slot>
             </div>
           </div>
         </mock:shadow-root>

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -15,7 +15,9 @@ describe('va-alert', () => {
             <i aria-hidden="true" role="img"></i>
             <div class="body">
               <slot name="headline"></slot>
-              <slot></slot>
+              <div role="presentation">
+                <slot></slot>
+              </div>
             </div>
           </div>
         </mock:shadow-root>

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -15,7 +15,11 @@ describe('va-alert', () => {
             <i aria-hidden="true" role="img"></i>
             <div class="body">
               <slot name="headline"></slot>
-              <slot></slot>
+              <div role="presentation">
+                <div>
+                  <slot></slot>
+                </div>
+              </div>
             </div>
           </div>
         </mock:shadow-root>

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -158,7 +158,7 @@ export class VaAlert {
     if (!visible) return <div aria-live="polite" />;
 
     return (
-      <Host>
+      <Host role="presentation">
         <div role={role} aria-live={ariaLive} class={classes}>
           <i aria-hidden="true" role="img"></i>
           <div class="body">

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -160,13 +160,9 @@ export class VaAlert {
       <Host>
         <div role={role} aria-live={ariaLive} class={classes}>
           <i aria-hidden="true" role="img"></i>
-          <div class="body">
+          <div class="body" onClick={this.handleAlertBodyClick.bind(this)}>
             {!backgroundOnly && <slot name="headline"></slot>}
-            <div id="body-click" role="presentation">
-              <div>
-                <slot></slot>
-              </div>
-            </div>
+            <slot></slot>
           </div>
         </div>
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -157,7 +157,7 @@ export class VaAlert {
     if (!visible) return <div aria-live="polite" />;
 
     return (
-      <Host role="presentation">
+      <Host>
         <div role={role} aria-live={ariaLive} class={classes}>
           <i aria-hidden="true" role="img"></i>
           <div class="body">

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -138,10 +138,6 @@ export class VaAlert {
   }
 
   componentDidLoad() {
-    // NVDA workaround to prevent "clickable" announcement
-    this.el?.shadowRoot
-      .querySelector('#body-click')
-      .addEventListener('click', e => this.handleAlertBodyClick(e));
     this.vaComponentDidLoad.emit();
   }
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -156,14 +156,13 @@ export class VaAlert {
       <Host>
         <div role={role} aria-live={ariaLive} class={classes}>
           <i aria-hidden="true" role="img"></i>
-          <div class="body">
+          <div
+            class="body"
+            onClick={this.handleAlertBodyClick.bind(this)}
+            role="presentation"
+          >
             {!backgroundOnly && <slot name="headline"></slot>}
-            <div
-              onClick={this.handleAlertBodyClick.bind(this)}
-              role="presentation"
-            >
-              <slot></slot>
-            </div>
+            <slot></slot>
           </div>
         </div>
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -16,6 +16,7 @@ import classnames from 'classnames';
 })
 export class VaAlert {
   @Element() el!: any;
+  bodyClickEl: HTMLDivElement;
 
   /**
    * Determines the icon and border/background color.
@@ -138,8 +139,11 @@ export class VaAlert {
   }
 
   componentDidLoad() {
+    // NVDA workaround to prevent "clickable" announcement
+    this.bodyClickEl?.addEventListener('click', e =>
+      this.handleAlertBodyClick(e),
+    );
     this.vaComponentDidLoad.emit();
-    this.el.addEventListener('click', e => this.handleAlertBodyClick(e));
   }
 
   render() {
@@ -159,7 +163,7 @@ export class VaAlert {
           <i aria-hidden="true" role="img"></i>
           <div class="body">
             {!backgroundOnly && <slot name="headline"></slot>}
-            <div role="presentation">
+            <div ref={el => (this.bodyClickEl = el)} role="presentation">
               <div>
                 <slot></slot>
               </div>

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -156,9 +156,14 @@ export class VaAlert {
       <Host>
         <div role={role} aria-live={ariaLive} class={classes}>
           <i aria-hidden="true" role="img"></i>
-          <div class="body" onClick={this.handleAlertBodyClick.bind(this)}>
+          <div class="body">
             {!backgroundOnly && <slot name="headline"></slot>}
-            <slot></slot>
+            <div
+              onClick={this.handleAlertBodyClick.bind(this)}
+              role="presentation"
+            >
+              <slot></slot>
+            </div>
           </div>
         </div>
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -16,7 +16,6 @@ import classnames from 'classnames';
 })
 export class VaAlert {
   @Element() el!: any;
-  bodyClickEl: HTMLDivElement;
 
   /**
    * Determines the icon and border/background color.
@@ -140,9 +139,9 @@ export class VaAlert {
 
   componentDidLoad() {
     // NVDA workaround to prevent "clickable" announcement
-    this.bodyClickEl?.addEventListener('click', e =>
-      this.handleAlertBodyClick(e),
-    );
+    this.el?.shadowRoot
+      .querySelector('#body-click')
+      .addEventListener('click', e => this.handleAlertBodyClick(e));
     this.vaComponentDidLoad.emit();
   }
 
@@ -163,7 +162,7 @@ export class VaAlert {
           <i aria-hidden="true" role="img"></i>
           <div class="body">
             {!backgroundOnly && <slot name="headline"></slot>}
-            <div ref={el => (this.bodyClickEl = el)} role="presentation">
+            <div id="body-click" role="presentation">
               <div>
                 <slot></slot>
               </div>

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -139,6 +139,7 @@ export class VaAlert {
 
   componentDidLoad() {
     this.vaComponentDidLoad.emit();
+    this.el.addEventListener('click', e => this.handleAlertBodyClick(e));
   }
 
   render() {
@@ -158,10 +159,7 @@ export class VaAlert {
           <i aria-hidden="true" role="img"></i>
           <div class="body">
             {!backgroundOnly && <slot name="headline"></slot>}
-            <div
-              role="presentation"
-              onClick={this.handleAlertBodyClick.bind(this)}
-            >
+            <div role="presentation">
               <div>
                 <slot></slot>
               </div>

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -156,9 +156,16 @@ export class VaAlert {
       <Host>
         <div role={role} aria-live={ariaLive} class={classes}>
           <i aria-hidden="true" role="img"></i>
-          <div class="body" onClick={this.handleAlertBodyClick.bind(this)}>
+          <div class="body">
             {!backgroundOnly && <slot name="headline"></slot>}
-            <slot></slot>
+            <div
+              role="presentation"
+              onClick={this.handleAlertBodyClick.bind(this)}
+            >
+              <div>
+                <slot></slot>
+              </div>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/34161

## Testing done
Tested with NVDA

## Screenshots
N/A

## Acceptance criteria
- [x] va-alert heading should not read as clickable using NVDA

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
