### PR TITLE
Fix Storybook stories render

### DIFF
--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -118,5 +118,5 @@ export function StoryDocs({ data }) {
   );
 }
 StoryDocs.propTypes = {
-  data: PropTypes.Object.isRequired,
+  data: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/36546

This was affecting `va-accordion` because it is the first web component story. If you remove the `va-accordion` story, the same problem appears for the next story that follows it: `va-additional-info`.

## Testing done
Storybook

## Screenshots
<img width="1786" alt="Screen Shot 2022-02-08 at 11 25 52" src="https://user-images.githubusercontent.com/36863582/153030724-cf9bfde2-7a02-430c-a594-53ede354e4c2.png">


## Acceptance criteria
- [x] Fix va-accordion in Storybook 

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
