### PR TITLE
Fix CSS in Stencil dev server for IE11

### DIFF
--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Stencil Component Starter</title>
 
-    <script type="module" src="/build/component-library.esm.js"></script>
-    <script nomodule src="/build/component-library.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/@department-of-veterans-affairs/formation@6.16.2/dist/formation.min.css">
     <link rel="stylesheet" href="build/component-library.css">
+    <script type="module" src="/build/component-library.esm.js"></script>
+    <script nomodule src="/build/component-library.js"></script>
     <style type="text/css" media="screen">
       body {
           /* For a little breathing room around the components */


### PR DESCRIPTION
## Description
While using Stencil's dev server to test and view web components in IE11, I noticed that our web components were missing styles. Loading the CSS files before the components fixes this issue in IE11.

Note: This issue exists only in IE11. This did not occur for Chrome, Firefox, Edge and Safari.

## Testing done
N/A

## Screenshots
Before (IE11)
<img width="1483" alt="Screen Shot 2022-02-10 at 11 08 53" src="https://user-images.githubusercontent.com/36863582/153448474-2eb6e190-4d69-42be-9628-bf39b9eeab52.png">
After (IE11)
<img width="1493" alt="Screen Shot 2022-02-10 at 11 09 15" src="https://user-images.githubusercontent.com/36863582/153448502-9c164d7e-b666-4584-9e1e-223d21b160a3.png">


## Acceptance criteria
- [x] Stencil dev server should correctly display DS web components in IE11

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
