### PR TITLE
Move CONTACTS table to telephone web component story

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/react-components/index.js
+++ b/packages/react-components/index.js
@@ -78,7 +78,7 @@ export {
   Table,
   Telephone,
   CONTACTS,
-  phoneContactsMap,
+  contactsMap,
   PHONE_PATTERNS,
   PHONE_PATTERNS_MAP,
   TextArea,

--- a/packages/react-components/index.js
+++ b/packages/react-components/index.js
@@ -32,8 +32,8 @@ import Select from './Select';
 import SystemDownView from './SystemDownView';
 import Table from './Table';
 import Telephone, {
-  CONTACTS as PHONE_CONTACTS,
-  contactsMap as PHONE_CONTACTS_MAP,
+  CONTACTS,
+  contactsMap,
   PATTERNS as PHONE_PATTERNS,
   patternsMap as PHONE_PATTERNS_MAP,
 } from './Telephone';
@@ -77,8 +77,8 @@ export {
   SystemDownView,
   Table,
   Telephone,
-  PHONE_CONTACTS,
-  PHONE_CONTACTS_MAP,
+  CONTACTS,
+  phoneContactsMap,
   PHONE_PATTERNS,
   PHONE_PATTERNS_MAP,
   TextArea,

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/packages/react-components/src/index.js
+++ b/packages/react-components/src/index.js
@@ -80,7 +80,7 @@ export {
   Table,
   Telephone,
   CONTACTS,
-  CONTACTS_MAP,
+  contactsMap,
   PHONE_PATTERNS,
   PHONE_PATTERNS_MAP,
   TextArea,

--- a/packages/react-components/src/index.js
+++ b/packages/react-components/src/index.js
@@ -34,8 +34,8 @@ import Select from './components/Select/Select';
 import SystemDownView from './components/SystemDownView/SystemDownView';
 import Table from './components/Table/Table';
 import Telephone, {
-  CONTACTS as PHONE_CONTACTS,
-  contactsMap as PHONE_CONTACTS_MAP,
+  CONTACTS,
+  contactsMap,
   PATTERNS as PHONE_PATTERNS,
   patternsMap as PHONE_PATTERNS_MAP,
 } from './components/Telephone/Telephone';
@@ -79,8 +79,8 @@ export {
   SystemDownView,
   Table,
   Telephone,
-  PHONE_CONTACTS,
-  PHONE_CONTACTS_MAP,
+  CONTACTS,
+  CONTACTS_MAP,
   PHONE_PATTERNS,
   PHONE_PATTERNS_MAP,
   TextArea,

--- a/packages/storybook/stories/Telephone.stories.jsx
+++ b/packages/storybook/stories/Telephone.stories.jsx
@@ -12,7 +12,7 @@ import {
 import {
   Telephone,
   CONTACTS,
-  CONTACTS_MAP,
+  contactsMap,
   PHONE_PATTERNS,
   PHONE_PATTERNS_MAP,
   Table,
@@ -28,7 +28,7 @@ const fields = [
 const Contacts = () => (
   <Table
     fields={fields}
-    data={Object.entries(PHONE_CONTACTS_MAP).map(c => ({
+    data={Object.entries(contactsMap).map(c => ({
       key: c[0],
       value: <Telephone contact={c[1].phoneNumber} />,
       description: <div style={{ maxWidth: '30em' }}>{c[1].description}</div>,
@@ -60,7 +60,7 @@ const Page = () => (
     <Subtitle />
     <Description />
     <Primary />
-    <ArgsTable story={PRIMARY_STORY}/>
+    <ArgsTable story={PRIMARY_STORY} />
     <Contacts />
     <br />
     <Patterns />
@@ -83,7 +83,7 @@ export default {
 const Template = args => <Telephone {...args} />;
 
 const defaultArgs = {
-  contact: PHONE_CONTACTS.GI_BILL,
+  contact: CONTACTS.GI_BILL,
 };
 
 export const Default = Template.bind({});
@@ -100,6 +100,6 @@ Extension.args = { ...defaultArgs, extension: '123' };
 
 export const CustomContent = Template.bind({});
 CustomContent.args = {
-  contact: PHONE_CONTACTS['222_VETS'],
+  contact: CONTACTS['222_VETS'],
   children: '877-222-VETS (8387)',
 };

--- a/packages/storybook/stories/Telephone.stories.jsx
+++ b/packages/storybook/stories/Telephone.stories.jsx
@@ -9,7 +9,14 @@ import {
   PRIMARY_STORY,
 } from '@storybook/addon-docs/blocks';
 
-import {Telephone, PHONE_CONTACTS, PHONE_CONTACTS_MAP, PHONE_PATTERNS, PHONE_PATTERNS_MAP, Table} from '@department-of-veterans-affairs/component-library';
+import {
+  Telephone,
+  CONTACTS,
+  CONTACTS_MAP,
+  PHONE_PATTERNS,
+  PHONE_PATTERNS_MAP,
+  Table,
+} from '@department-of-veterans-affairs/component-library';
 
 // This builds the available "CONTACTS" list table
 // Descriptions are available in the contacts.js file

--- a/packages/storybook/stories/Telephone.stories.jsx
+++ b/packages/storybook/stories/Telephone.stories.jsx
@@ -5,7 +5,7 @@ import {
 } from '@department-of-veterans-affairs/component-library';
 
 export default {
-  title: 'Components/Telephone',
+  title: 'Components/Telephone (deprecated)',
   component: Telephone,
 };
 

--- a/packages/storybook/stories/Telephone.stories.jsx
+++ b/packages/storybook/stories/Telephone.stories.jsx
@@ -1,83 +1,12 @@
 import React from 'react';
 import {
-  Title,
-  Subtitle,
-  Description,
-  Primary,
-  ArgsTable,
-  Stories,
-  PRIMARY_STORY,
-} from '@storybook/addon-docs/blocks';
-
-import {
   Telephone,
   CONTACTS,
-  contactsMap,
-  PHONE_PATTERNS,
-  PHONE_PATTERNS_MAP,
-  Table,
 } from '@department-of-veterans-affairs/component-library';
-
-// This builds the available "CONTACTS" list table
-// Descriptions are available in the contacts.js file
-const fields = [
-  { label: 'Property name (CONTACTS.x)', value: 'key' },
-  { label: 'Phone number', value: 'value' },
-  { label: 'Description', value: 'description' },
-];
-const Contacts = () => (
-  <Table
-    fields={fields}
-    data={Object.entries(contactsMap).map(c => ({
-      key: c[0],
-      value: <Telephone contact={c[1].phoneNumber} />,
-      description: <div style={{ maxWidth: '30em' }}>{c[1].description}</div>,
-    }))}
-  />
-);
-
-// This builds the available "PATTERNS" list table
-// Descriptions are included in the patterns.js file
-const patternFields = [
-  { label: 'Pattern name (PATTERN.x)', value: 'key' },
-  { label: 'Pattern', value: 'value' },
-  { label: 'Description', value: 'description' },
-];
-const Patterns = () => (
-  <Table
-    fields={patternFields}
-    data={Object.entries(PHONE_PATTERNS_MAP).map(p => ({
-      key: p[1].pattern,
-      value: PHONE_PATTERNS[p[1].pattern],
-      description: <div style={{ maxWidth: '30em' }}>{p[1].description}</div>,
-    }))}
-  />
-);
-
-const Page = () => (
-  <>
-    <Title />
-    <Subtitle />
-    <Description />
-    <Primary />
-    <ArgsTable story={PRIMARY_STORY} />
-    <Contacts />
-    <br />
-    <Patterns />
-    <br />
-    <Stories />
-  </>
-);
 
 export default {
   title: 'Components/Telephone',
   component: Telephone,
-  parameters: {
-    docs: {
-      // Add the contacts & pattern table to the docs page
-      page: Page,
-    },
-  },
 };
 
 const Template = args => <Telephone {...args} />;

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -1,13 +1,63 @@
 import React from 'react';
+import {
+  Title,
+  Subtitle,
+  Description,
+  Primary,
+  ArgsTable,
+  Stories,
+  PRIMARY_STORY,
+} from '@storybook/addon-docs/blocks';
+
+import {
+  CONTACTS,
+  contactsMap,
+  Table,
+} from '@department-of-veterans-affairs/component-library';
+
 import { getWebComponentDocs, propStructure } from './wc-helpers';
 
 const telephoneDocs = getWebComponentDocs('va-telephone');
+//
+// This builds the available "CONTACTS" list table
+// Descriptions are available in the contacts.js file
+const fields = [
+  { label: 'Property name (CONTACTS.x)', value: 'key' },
+  { label: 'Phone number', value: 'value' },
+  { label: 'Description', value: 'description' },
+];
+const Contacts = () => (
+  <Table
+    fields={fields}
+    data={Object.entries(contactsMap).map(c => ({
+      key: c[0],
+      value: <va-telephone contact={c[1].phoneNumber} />,
+      description: <div style={{ maxWidth: '30em' }}>{c[1].description}</div>,
+    }))}
+  />
+);
+
+const Page = () => (
+  <>
+    <Title />
+    <Subtitle />
+    <Description />
+    <Primary />
+    <ArgsTable story={PRIMARY_STORY} />
+    <Contacts />
+    <br />
+    <Stories />
+  </>
+);
 
 export default {
   title: 'Components/va-telephone',
   parameters: {
     actions: {
       handles: ['component-library-analytics'],
+    },
+    docs: {
+      page: Page,
     },
   },
 };


### PR DESCRIPTION
## Description
Related to https://github.com/department-of-veterans-affairs/vets-website/pull/20262

From a slack convo with @Mottie and @k80bowman :

> [Brooks Johnson]: Do you think the `PHONE_CONTACTS` export is fine or should it be renamed to `CONTACTS`? I think I did that since it wouldn't be imported from `/Telephone` anymore, but I still wanted to indicate that it was for the telephone component to avoid confusion that it might be for email contacts or something like that.
>
> [Robin Garrison]: I think if it's documented `CONTACTS` should be fine... it's what the devs are already familiar with

I'm undoing the aliasing for `CONTACTS` and `contactsMap` since they're related. `contactsMap` should only be used in documentation anyway. I'm leaving the `PATTERNS` aliasing as it is because hopefully we shouldn't be making any new imports of that going forward and will be able to eventually remove it.

## Testing done

- Build passed
- Verified that contacts table is still showing up in storybook

## Screenshots

![CONTACTS table moved to docs for `<va-telephone>`](https://user-images.githubusercontent.com/2008881/154555404-e5b80ef4-e5e8-48c7-a381-bf0e1693a234.png)




## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
