### PR TITLE
Adjust peer dependencies to remove warnings

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,5 +27,9 @@
     "mini-css-extract-plugin": "^2.4.2",
     "webpack": "^5.56.0",
     "webpack-cli": "^4.8.0"
+  },
+  "peerDependencies": {
+    "react": "^16.3.1",
+    "react-dom": "*"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "6.2.1",
+  "version": "6.2.2-0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"
@@ -31,5 +31,6 @@
   "peerDependencies": {
     "react": "^16.3.1",
     "react-dom": "*"
-  }
+  },
+  "stableVersion": "6.2.1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "webpack-cli": "^4.8.0"
   },
   "peerDependencies": {
+    "@department-of-veterans-affairs/formation": "*",
     "react": "^16.3.1",
     "react-dom": "*"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@department-of-veterans-affairs/formation": "*",
-    "react": "^16.3.1",
+    "react": "^17",
     "react-dom": "*"
   },
   "stableVersion": "6.2.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "6.2.2-1",
+  "version": "6.2.2-2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "6.2.2-0",
+  "version": "6.2.2-1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "6.2.2-2",
+  "version": "6.2.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"
@@ -32,6 +32,5 @@
     "@department-of-veterans-affairs/formation": "*",
     "react": "^17",
     "react-dom": "*"
-  },
-  "stableVersion": "6.2.1"
+  }
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -97,7 +97,7 @@
   },
   "peerDependencies": {
     "@department-of-veterans-affairs/web-components": "*",
-    "react": "^16.13.1",
+    "react": "^17",
     "react-dom": "*"
   },
   "stableVersion": "4.0.3"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "4.0.4-0",
+  "version": "4.0.4-1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -97,6 +97,6 @@
   },
   "peerDependencies": {
     "react": "^16.13.1",
-    "web-components": "*"
+    "@department-of-veterans-affairs/web-components": "*"
   }
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "4.0.4-1",
+  "version": "4.0.3",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",
@@ -99,6 +99,5 @@
     "@department-of-veterans-affairs/web-components": "*",
     "react": "^17",
     "react-dom": "*"
-  },
-  "stableVersion": "4.0.3"
+  }
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -96,7 +96,7 @@
     "trim-newlines": "^4.0.2"
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "@department-of-veterans-affairs/web-components": "*"
+    "@department-of-veterans-affairs/web-components": "*",
+    "react": "^16.13.1"
   }
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -97,7 +97,8 @@
   },
   "peerDependencies": {
     "@department-of-veterans-affairs/web-components": "*",
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "react-dom": "*"
   },
   "stableVersion": "4.0.3"
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "4.0.3",
+  "version": "4.0.4-0",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",
@@ -98,5 +98,6 @@
   "peerDependencies": {
     "@department-of-veterans-affairs/web-components": "*",
     "react": "^16.13.1"
-  }
+  },
+  "stableVersion": "4.0.3"
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -27,16 +27,15 @@
   },
   "dependencies": {
     "@stencil/core": "^2.10.0",
-    "@stencil/postcss": "^2.0.0",
     "classnames": "^2.3.1",
-    "intersection-observer": "^0.12.0",
-    "postcss-url": "^10.1.1"
+    "intersection-observer": "^0.12.0"
   },
   "license": "MIT",
   "devDependencies": {
     "@axe-core/puppeteer": "^4.1.1",
     "@babel/core": "^7.12.13",
     "@department-of-veterans-affairs/formation": "^6.17.5",
+    "@stencil/postcss": "^2.0.0",
     "@stencil/react-output-target": "^0.0.9",
     "@types/jest": "^26.0.20",
     "@types/puppeteer": "^5.4.3",
@@ -46,6 +45,7 @@
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
     "lit-html": "^1.3.0",
+    "postcss-url": "^10.1.1",
     "puppeteer": "10.0.0",
     "react-dom": "^16.7.0",
     "typescript": "^4.3.5"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.2.1",
+  "version": "2.2.2-0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -52,5 +52,6 @@
   },
   "peerDependencies": {
     "@department-of-veterans-affairs/formation": "^6.14.0"
-  }
+  },
+  "stableVersion": "2.2.1"
 }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.2.2-0",
+  "version": "2.2.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -52,6 +52,5 @@
   },
   "peerDependencies": {
     "@department-of-veterans-affairs/formation": "^6.14.0"
-  },
-  "stableVersion": "2.2.1"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,6 +1775,7 @@ __metadata:
   peerDependencies:
     "@department-of-veterans-affairs/web-components": "*"
     react: ^16.13.1
+    react-dom: "*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,8 +1773,8 @@ __metadata:
     rimraf: ^3.0.2
     sinon: ^9.2.2
   peerDependencies:
+    "@department-of-veterans-affairs/web-components": "*"
     react: ^16.13.1
-    web-components: "*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,6 +1688,7 @@ __metadata:
     webpack: ^5.56.0
     webpack-cli: ^4.8.0
   peerDependencies:
+    "@department-of-veterans-affairs/formation": "*"
     react: ^16.3.1
     react-dom: "*"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,6 +1687,9 @@ __metadata:
     react-transition-group: ^1.0.0
     webpack: ^5.56.0
     webpack-cli: ^4.8.0
+  peerDependencies:
+    react: ^16.3.1
+    react-dom: "*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,7 +1689,7 @@ __metadata:
     webpack-cli: ^4.8.0
   peerDependencies:
     "@department-of-veterans-affairs/formation": "*"
-    react: ^16.3.1
+    react: ^17
     react-dom: "*"
   languageName: unknown
   linkType: soft
@@ -1775,7 +1775,7 @@ __metadata:
     sinon: ^9.2.2
   peerDependencies:
     "@department-of-veterans-affairs/web-components": "*"
-    react: ^16.13.1
+    react: ^17
     react-dom: "*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

This is in response to comment: https://github.com/department-of-veterans-affairs/va.gov-team/issues/33798#issuecomment-1048959308

`vets-website` is updating to yarn 3 and is receiving some warnings/errors related to peer dependencies on a `yarn install`:

```
➤ YN0002: │ @department-of-veterans-affairs/component-library@npm:6.2.1 doesn't provide @department-of-veterans-affairs/formation (pc959a), requested by @department-of-veterans-affairs/web-components
➤ YN0002: │ @department-of-veterans-affairs/component-library@npm:6.2.1 doesn't provide react (p40b9e), requested by react-focus-on
➤ YN0002: │ @department-of-veterans-affairs/component-library@npm:6.2.1 doesn't provide react (pacd1e), requested by react-scroll
➤ YN0002: │ @department-of-veterans-affairs/component-library@npm:6.2.1 doesn't provide react (pa708c), requested by react-transition-group
➤ YN0002: │ @department-of-veterans-affairs/component-library@npm:6.2.1 doesn't provide react (p2f9dc), requested by @department-of-veterans-affairs/react-components
➤ YN0002: │ @department-of-veterans-affairs/component-library@npm:6.2.1 doesn't provide react-dom (p78559), requested by react-scroll
➤ YN0002: │ @department-of-veterans-affairs/component-library@npm:6.2.1 doesn't provide react-dom (p88153), requested by react-transition-group
➤ YN0002: │ @department-of-veterans-affairs/component-library@npm:6.2.1 doesn't provide web-components (p5284a), requested by @department-of-veterans-affairs/react-components
➤ YN0002: │ @department-of-veterans-affairs/react-components@npm:4.0.3 [e4de1] doesn't provide react-dom (pbc1b2), requested by react-scroll
➤ YN0002: │ @department-of-veterans-affairs/react-components@npm:4.0.3 [e4de1] doesn't provide react-dom (p84f8d), requested by react-transition-group
➤ YN0002: │ @department-of-veterans-affairs/web-components@npm:2.2.1 [e4de1] doesn't provide postcss (p1012c), requested by postcss-url
```


## Testing done

Published prereleases for local testing

## Screenshots

No `YN0002` error codes related to `component-library` or its subpackages:

![terminal output of adding the prerelease](https://user-images.githubusercontent.com/2008881/155405454-b4db1d6f-70eb-4089-9f1d-f5a88f8ca281.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
