### PR TITLE
35769 Fix Analytics Component Name

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
@@ -98,7 +98,7 @@ describe('va-accordion', () => {
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'expand',
-      componentName: 'Accordion',
+      componentName: 'va-accordion',
       details: {
         header: "First item",
         subheader: "First subheader",
@@ -143,7 +143,7 @@ describe('va-accordion', () => {
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'expand',
-      componentName: 'Accordion',
+      componentName: 'va-accordion',
       details: {
         header: "First item",
         subheader: "First subheader",
@@ -172,7 +172,7 @@ describe('va-accordion', () => {
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'expand',
-      componentName: 'Accordion',
+      componentName: 'va-accordion',
       details: {
         header: "First header",
         subheader: "First subheader",
@@ -200,7 +200,7 @@ describe('va-accordion', () => {
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'expand',
-      componentName: 'Accordion',
+      componentName: 'va-accordion',
       details: {
         level: 2,
         sectionHeading: null,

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -79,7 +79,7 @@ export class VaAccordion {
 
     if (!this.disableAnalytics) {
       const detail = {
-        componentName: 'Accordion',
+        componentName: 'va-accordion',
         action: prevAttr ? 'collapse' : 'expand',
         details: {
           header: headerText || clickedItem.header,

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -90,7 +90,7 @@ describe('va-alert', () => {
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'linkClick',
-      componentName: 'AlertBox',
+      componentName: 'va-alert',
       details: {
         headline: 'This is an alert',
         backgroundOnly: false,
@@ -114,7 +114,7 @@ describe('va-alert', () => {
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'linkClick',
-      componentName: 'AlertBox',
+      componentName: 'va-alert',
       details: {
         headline: null,
         backgroundOnly: false,

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -122,7 +122,7 @@ export class VaAlert {
       // If it's a link being clicked, dispatch an analytics event
       if (target?.tagName === 'A') {
         const detail = {
-          componentName: 'AlertBox',
+          componentName: 'va-alert',
           action: 'linkClick',
           details: {
             clickLabel: target.innerText,


### PR DESCRIPTION
## Description
Closes part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/35769

## Testing done
<img width="661" alt="Screen Shot 2022-02-24 at 9 52 53 AM" src="https://user-images.githubusercontent.com/11822533/155547957-875ddefd-ad54-4703-a9b2-c841f0e1769b.png">

## Acceptance criteria
- [X] Fix analytics event componentNames for web components. Name should match the web component name

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
