### PR TITLE
Replace breadcrumb item break with font awesome icons

### DIFF
--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs-slot.css
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs-slot.css
@@ -7,9 +7,12 @@ va-breadcrumbs .va-breadcrumbs-li {
 }
 
 va-breadcrumbs .va-breadcrumbs-li::after {
-  content: ' › ';
+  content: '\f054';
   display: inline-block;
+  font: 900 .75rem 'Font Awesome 5 Free';
+  line-height: 1;
   padding: 0 0.56rem;
+  vertical-align: middle;
 }
 
 va-breadcrumbs .va-breadcrumbs-li:last-child::after {


### PR DESCRIPTION
## Description
This PR address an inconsistency in breadcrumb break rendering. Occasionally when refreshing page or switch to new page, the breadcrumb renders a random set of characters instead of the chevron icon assigned in the stylesheet. This PR replaces that text chevron with a Font Awesome 5 chevron to provide consistent rendering.

## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34502

## Screenshots
<img width="1066" alt="Screen Shot 2022-02-11 at 10 12 39 AM" src="https://user-images.githubusercontent.com/6738544/157070977-da012dc7-ecac-46d4-a519-da1581e53fe1.png">

<img width="1026" alt="Screen Shot 2022-03-07 at 10 57 59 AM" src="https://user-images.githubusercontent.com/6738544/157071001-b2cbb157-1c59-40c1-82c9-5e2d160ac325.png">

## Acceptance criteria
- [x] Breadcrumbs render consistently on every page load

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
