### PR TITLE
36385 Checkbox Group axe check test in error state

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
@@ -42,6 +42,20 @@ describe('va-checkbox-group', () => {
     `);
   });
 
+  it('passes an axe check in error state', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `
+      <va-checkbox-group error="There has been an error" label="This is a label">
+        <va-checkbox label="Option one" name="example" value="1"/>
+        <va-checkbox label="Option two" name="example" value="2"/>
+      </va-checkbox-group>
+    `,
+    );
+
+    await axeCheck(page);
+  });
+
   it('renders a required span based on prop', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-checkbox-group required></va-checkbox-group>');


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/36385

## Testing done / Screenshots
<img width="657" alt="Screen Shot 2022-03-08 at 2 15 08 PM" src="https://user-images.githubusercontent.com/11822533/157309112-863388ed-62b7-4ed7-a960-84ee97c1f9ba.png">


## Acceptance criteria
- [X] Consider adding an E2E test that runs an aXe check on the component when there is an error message.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
