### PR TITLE
35157 Promo Banner Padding Class on Body for Footer Spacing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-promo-banner/va-promo-banner.css
+++ b/packages/web-components/src/components/va-promo-banner/va-promo-banner.css
@@ -52,7 +52,7 @@
 
 .va-banner-content-link {
   padding: 0.8rem;
-  line-height: 2;
+  line-height: 2.2rem;
   text-decoration: none;
   color: var(--color-link-default);
   flex-grow: 2;

--- a/packages/web-components/src/components/va-promo-banner/va-promo-banner.tsx
+++ b/packages/web-components/src/components/va-promo-banner/va-promo-banner.tsx
@@ -98,6 +98,8 @@ export class VaPromoBanner {
     this.dismissedBanners = dismissedBannersString
       ? JSON.parse(dismissedBannersString)
       : [];
+    // Add additional padding on component load to prevent position fixed text overlap in footer
+    document.body.classList.add('va-pad-promo-banner');
   }
 
   render() {
@@ -106,6 +108,8 @@ export class VaPromoBanner {
 
     // Do not render if the promo banner is dismissed.
     if (isBannerDismissed) {
+      // Remove additional padding set on the body during component load
+      document.body.classList.remove('va-pad-promo-banner');
       return null;
     }
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/35157

We need this body class toggled whenever the promo banner is present. Without it we have a padding issue in the footer with the banner covering content and the only way to view is to dismiss the banner. This would revert https://github.com/department-of-veterans-affairs/vets-website/pull/20435 with this removed.

## Screenshots
https://user-images.githubusercontent.com/11822533/157355906-8f748157-dd05-4975-a1e6-51b094029fcf.mov

## Acceptance criteria
- [X] va-pad-promo-banner class is added to the body when `va-promo-banner` component is used and removed when the component is dismissed

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
