### PR TITLE
chore: increment patch version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "7.4.1",
+  "version": "7.4.3",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.6.1",
+  "version": "2.6.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Chromatic
<!-- This `hotfix-revert-increment-patch` is a placeholder for a CI job - it will be updated automatically -->
https://hotfix-revert-increment-patch--60f9b557105290003b387cd5.chromatic.com

## Description
Cleanup work that should have been part of https://github.com/department-of-veterans-affairs/component-library/pull/323

## Testing done


## Screenshots


## Acceptance criteria
- [x] Increment component-library to a new version to create a new release without the va-accordion changes

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
