### PR TITLE
Added a prop for the required label to the the va-text-input...

### DIFF
--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -22,6 +22,7 @@ const defaultArgs = {
   'autocomplete': false,
   'enable-analytics': false,
   'required': false,
+  'requiredLabel': null,
   'error': null,
   'maxlength': null,
   'value': null,
@@ -33,6 +34,7 @@ const Template = ({
   autocomplete,
   'enable-analytics': enableAnalytics,
   required,
+  'required-label': requiredLabel,
   error,
   maxlength,
   value,
@@ -44,6 +46,7 @@ const Template = ({
       autocomplete={autocomplete}
       enable-analytics={enableAnalytics}
       required={required}
+      required-label={requiredLabel}
       error={error}
       maxlength={maxlength}
       value={value}

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -437,6 +437,10 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
+          * The label for the (Required) text.
+         */
+        "requiredLabel"?: string;
+        /**
           * The type attribute.
          */
         "type"?: string;
@@ -1185,6 +1189,10 @@ declare namespace LocalJSX {
           * Set the input to required and render the (Required) text.
          */
         "required"?: boolean;
+        /**
+          * The label for the (Required) text.
+         */
+        "requiredLabel"?: string;
         /**
           * The type attribute.
          */

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -80,7 +80,7 @@ describe('va-text-input', () => {
 
     // Render the required label text
     const error = await page.find('va-text-input >>> span.required');
-    expect(error.innerText).toContain('(*Required)');
+    expect(error.innerText).toBe('(*Required)');
   });
 
   it('renders a passed in required label', async () => {
@@ -89,7 +89,7 @@ describe('va-text-input', () => {
 
     // Render the required label text
     const error = await page.find('va-text-input >>> span.required');
-    expect(error.innerText).toContain('(*Required + extra text)');
+    expect(error.innerText).toBe('(*Required + extra text)');
   });
 
   it('passes an aXe check', async () => {

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -74,6 +74,24 @@ describe('va-text-input', () => {
     expect(requiredSpan).not.toBeNull();
   });
 
+  it('renders a default required label', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input label="This is a field" required />');
+
+    // Render the required label text
+    const error = await page.find('va-text-input >>> span.required');
+    expect(error.innerText).toContain('(*Required)');
+  });
+
+  it('renders a passed in required label', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input label="This is a field" required required-label="(*Required + extra text)" />');
+
+    // Render the required label text
+    const error = await page.find('va-text-input >>> span.required');
+    expect(error.innerText).toContain('(*Required + extra text)');
+  });
+
   it('passes an aXe check', async () => {
     const page = await newE2EPage();
 

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -38,6 +38,11 @@ export class VaTextInput {
   @Prop() required?: boolean;
 
   /**
+   * The label for the (Required) text.
+   */
+  @Prop() requiredLabel?: string = '(*Required)';
+
+  /**
    * The inputmode attribute.
    */
   @Prop() inputmode?: string = '';
@@ -151,7 +156,7 @@ export class VaTextInput {
         {this.label && (
           <label htmlFor="inputField">
             {this.label}{' '}
-            {this.required && <span class="required">(*Required)</span>}
+            {this.required && <span class="required">{this.requiredLabel}</span>}
           </label>
         )}
         {this.error && <span id="error-message">{this.error}</span>}


### PR DESCRIPTION
…component moving the hard coded label to the default along with tests for default and passed prop.

## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
This is a PR to add a new optional prop for the (*Required) label text. Our use case for needing this change is so that we can fully implement Spanish translation in the Check In Experience app. This would be a nice to have pattern for all form field components, but this PR only covers text input. The current `(*Required)` text is set to the default when no value is present.

I made the entire previously hardcoded string overridable from the opening parenthesis to the closing parenthesis as well as the `*`, I figured that this would be better than just the text portion incase a future need to override the whole string comes along. I could see this happening with a custom icon or something similar that another application may need.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/39012
Zen hub: https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/department-of-veterans-affairs/va.gov-team/39012

## Testing done
Updated va-text-input.e2e test to include default required label and passed in prop label.

## Screenshots
![Screen Shot 2022-03-29 at 2 00 53 PM](https://user-images.githubusercontent.com/13967174/160706366-a2b5dc06-222b-45b2-989d-3af6063ab2a0.png)


## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
