### PR TITLE
Add comment to prop doc about IE11 support

### DIFF
--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -25,7 +25,7 @@ export class VaTable {
   @Prop() tableTitle: string;
 
   /**
-   * The zero-based index of the column to sort by. Optional.
+   * The zero-based index of the column to sort by (Doesn't work in IE11). Optional.
    */
   @Prop() sortColumn: number;
 


### PR DESCRIPTION
## Chromatic
<!-- This `sortColumn-ie11-doc` is a placeholder for a CI job - it will be updated automatically -->
https://sortColumn-ie11-doc--60f9b557105290003b387cd5.chromatic.com

(I broke the branch naming rule and used a capital letter :see_no_evil: . Here you go: https://60f9b557105290003b387cd5-qplzanilil.chromatic.com/?path=/docs/components-va-table--default)

## Description

[Relevant slack thread](https://dsva.slack.com/archives/G01BJ3ESXL4/p1649162602102219?thread_ts=1649109622.789609&cid=G01BJ3ESXL4)

This is a storybook update to go out ahead of the `<va-table>` announcement.


## Testing done

Storybook :eyes: 


## Screenshots

![Highlighting the IE11 part of the prop comment](https://user-images.githubusercontent.com/2008881/161866881-a04d3fd1-401a-4032-ab98-51a3f4a9e458.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
