### PR TITLE
Show the total in the search results

### DIFF
--- a/packages/design-system-dashboard-cli/src/display-search-data.js
+++ b/packages/design-system-dashboard-cli/src/display-search-data.js
@@ -15,7 +15,9 @@ const chalk = require('chalk');
  */
 function displaySearchData(data) {
   const stringified = {};
+  let total = 0;
   Object.keys(data).forEach(componentName => {
+    total += data[componentName].total;
     stringified[componentName] = Object.keys(data[componentName])
       // We're displaying the total by the app name, so don't display it twice
       .filter(cn => cn !== 'total')
@@ -37,6 +39,12 @@ function displaySearchData(data) {
     );
     console.log(stringified[componentName] + '\n');
   });
+
+  // Only show the final "Total" if we have more than one component
+  // in the data
+  if (Object.keys(stringified).length > 1) {
+    console.log(chalk.bold('Total:'), total);
+  }
 }
 
 module.exports = displaySearchData;


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Closes <ticket>

This is just a small quality of life improvement that shows us the total when our search query includes more than once component.

## Testing done

- Local testing

## Screenshots

Output with one component:

![Console output without "Total"](https://user-images.githubusercontent.com/2008881/162092360-4416260e-b43d-4696-acbe-8ef5d9cca884.png)

Output with multiple components:

![Console output with "Total" highlighted](https://user-images.githubusercontent.com/2008881/162092514-0591e9db-cf03-4755-9b23-af6cb1cddf29.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
