### PR TITLE
Add input datalist to `va-text-input`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -64,13 +64,11 @@ const Template = ({
   inputmode,
   type,
   'aria-describedby': ariaDescribedby,
-  list,
 }) => {
   return (
     <va-text-input
       name={name}
       label={label}
-      list={list}
       autocomplete={autocomplete}
       enable-analytics={enableAnalytics}
       required={required}

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -64,11 +64,13 @@ const Template = ({
   inputmode,
   type,
   'aria-describedby': ariaDescribedby,
+  list,
 }) => {
   return (
     <va-text-input
       name={name}
       label={label}
+      list={list}
       autocomplete={autocomplete}
       enable-analytics={enableAnalytics}
       required={required}
@@ -126,4 +128,21 @@ export const WithHintText = WithHintTextTemplate.bind({});
 WithHintText.args = {
   ...defaultArgs,
   label: 'Veteran’s Social Security number',
+};
+
+const WithListTemplate = ({ name, label }) => (
+  <va-text-input name={name} label={label}>
+    <option value="Chocolate" />
+    <option value="Coconut" />
+    <option value="Mint" />
+    <option value="Strawberry" />
+    <option value="Vanilla" />
+  </va-text-input>
+);
+
+export const WithDatalistOptions = WithListTemplate.bind({});
+WithDatalistOptions.args = {
+  ...defaultArgs,
+  name: 'flavors',
+  label: 'Ice cream flavors',
 };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -235,4 +235,78 @@ describe('va-text-input', () => {
       expect(inputEl.getAttribute('inputmode')).toBe(inputMode);
     }
   });
+
+  it('renders datalist', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-text-input label="A label" value="bar">
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </va-text-input>
+    `);
+    const element = await page.find('va-text-input');
+
+    expect(element).toEqualHtml(`
+      <va-text-input label="A label" value="bar" class="hydrated">
+        <mock:shadow-root>
+          <label for="inputField">
+            A label
+          </label>
+          <slot></slot>
+          <datalist id="inputList">
+            <option value="foo"></option>
+            <option value="bar"></option>
+          </datalist>
+          <input id="inputField" type="text" list="inputList" />
+        </mock:shadow-root>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </va-text-input>
+    `);
+  });
+
+  it('passes an axe check with datalist', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-text-input label="A label" value="bar">
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </va-text-input>
+    `);
+
+    await axeCheck(page);
+  });
+
+  it('renders datalist with only options', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-text-input label="A label" value="bar">
+        <div>Extra content</div>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </va-text-input>
+    `);
+    const element = await page.find('va-text-input');
+
+    expect(element).toEqualHtml(`
+      <va-text-input label="A label" value="bar" class="hydrated">
+        <mock:shadow-root>
+          <label for="inputField">
+            A label
+          </label>
+          <slot></slot>
+          <datalist id="inputList">
+            <option value="foo"></option>
+            <option value="bar"></option>
+          </datalist>
+          <input id="inputField" type="text" list="inputList" />
+        </mock:shadow-root>
+        <div>
+          Extra content
+        </div>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </va-text-input>
+    `);
+  });
 });

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -34,6 +34,10 @@ input:not([disabled]):focus {
     outline-offset: 2px;
 }
 
+::slotted(option) {
+  display: none;
+}
+
 #error-message {
     color: var(--color-secondary-dark);
     display: block;


### PR DESCRIPTION
## Chromatic
<!-- This `39873-input-datalist` is a placeholder for a CI job - it will be updated automatically -->
https://39873-input-datalist--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/39873

## Testing done

E2E and storybook

## Screenshots

<img width="850" alt="Storybook 'with datalist options' example with expanded code block" src="https://user-images.githubusercontent.com/136959/162996567-bf0ab365-d89a-45df-a8f3-686005e25b40.png">

## Acceptance criteria
- [x] `va-text-input` accepts datalist options
- [x] All tests passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
