### PR TITLE
Add subtitle and action link for Modal in Storybook

### DIFF
--- a/packages/storybook/stories/va-modal.stories.jsx
+++ b/packages/storybook/stories/va-modal.stories.jsx
@@ -125,3 +125,93 @@ WithoutButtons.args = {
 
 export const WithoutTitle = Template.bind({});
 WithoutTitle.args = { ...defaultArgs, 'modal-title': undefined };
+
+const CrisisTemplate = ({
+  'click-to-close': clickToClose,
+  'disable-analytics': disableAnalytics,
+  'modal-title': modalTitle,
+  'initial-focus-selector': initialFocusSelector,
+  primaryButtonClick,
+  'primary-button-text': primaryButtonText,
+  secondaryButtonClick,
+  'secondary-button-text': secondaryButtonText,
+  status,
+  visible,
+}) => {
+  const [isVisible, setIsVisible] = useState(visible);
+  const onCloseEvent = () => setIsVisible(!isVisible);
+  const openModal = () => setIsVisible(true);
+  return (
+    <div>
+      <div
+        className="va-crisis-line"
+        style={{ position: 'static', height: '600px', maxWidth: 'none' }}
+      >
+        <div className="va-flex">
+          <button
+            data-show="#modal-crisisline"
+            className="va-crisis-line-button va-overlay-trigger"
+            onClick={openModal}
+          >
+            <span className="va-flex">
+              <span className="vcl"></span>
+              Get help from Veterans Crisis Line
+            </span>
+          </button>
+        </div>
+      </div>
+      <VaModal
+        clickToClose={clickToClose}
+        disableAnalytics={disableAnalytics}
+        modalTitle={modalTitle}
+        initialFocusSelector={initialFocusSelector}
+        onCloseEvent={onCloseEvent}
+        onPrimaryButtonClick={primaryButtonClick}
+        primaryButtonText={primaryButtonText}
+        onSecondaryButtonClick={secondaryButtonClick}
+        secondaryButtonText={secondaryButtonText}
+        status={status}
+        visible={isVisible}
+      >
+        <div className="va-crisis-panel" style={{ transform: 'none' }}>
+          <div className="va-overlay-body va-crisis-panel-body">
+            <ul>
+              <li>
+                <a href="tel:18002738255">
+                  Call <strong>1-800-273-8255 (Press 1)</strong>
+                </a>
+              </li>
+              <li>
+                <a href="sms:838255">
+                  Text to <b>838255</b>
+                </a>
+              </li>
+              <li>
+                <a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat">
+                  Chat <b>confidentially now</b>
+                </a>
+              </li>
+            </ul>
+            <p>
+              If you are in crisis or having thoughts of suicide, visit{' '}
+              <a href="https://www.veteranscrisisline.net/">
+                VeteransCrisisLine.net
+              </a>{' '}
+              for more resources.
+            </p>
+          </div>
+        </div>
+      </VaModal>
+    </div>
+  );
+};
+
+export const CrisisLineModal = CrisisTemplate.bind({});
+CrisisLineModal.args = {
+  ...defaultArgs,
+  'primaryButtonClick': undefined,
+  'primary-button-text': undefined,
+  'secondaryButtonClick': undefined,
+  'secondary-button-text': undefined,
+  'modal-title': 'Get help from Veterans Crisis Line',
+};

--- a/packages/storybook/stories/va-modal.stories.jsx
+++ b/packages/storybook/stories/va-modal.stories.jsx
@@ -12,9 +12,13 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: generateEventsDescription(modalDocs),
+        component:
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/modal">View guidance for the Modal component in the Design System</a>` +
+          '\n' +
+          generateEventsDescription(modalDocs),
       },
     },
+    componentSubtitle: `Modal web component`,
   },
   argTypes: {
     status: {


### PR DESCRIPTION
## Chromatic
<!-- This `39968-modal` is a placeholder for a CI job - it will be updated automatically -->
https://39968-modal--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/39968

## Testing done


## Screenshots
<img width="1027" alt="Screen Shot 2022-04-15 at 11 28 27" src="https://user-images.githubusercontent.com/36863582/163589674-c3f6ac0a-f558-4714-99e0-512757df7874.png">


## Acceptance criteria
- [x] Add subtitle `Modal web component` for `va-modal` in Storybook
- [x] Add action link to `https://design.va.gov/components/modal` with text `View guidance for the Modal component in the Design System`

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
