### PR TITLE
39872 Alert Documentation SB

### DIFF
--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import { generateEventsDescription } from './events';
 import { VaAlert } from '@department-of-veterans-affairs/web-components/react-bindings';
@@ -23,11 +22,14 @@ export default {
     docs: {
       description: {
         component:
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/alert">View guidance for the Alert component in the Design System</a>` +
+          `\n` +
           `Use a heading element with an attribute named slot and a value of "headline" to control what is displayed for the alert's headline. 
-        Any children passed into this component without a parent slot "headline" will render in the alert's body.` +
+          Any children passed into this component without a parent slot "headline" will render in the alert's body.` +
           generateEventsDescription(alertDocs),
       },
     },
+    componentSubtitle: `Alert web component`,
   },
 };
 

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -95,6 +95,88 @@ const Template = ({
   );
 };
 
+const BackgroundOnlyTemplate = ({
+  'background-only': backgroundOnly,
+  'show-icon': showIcon,
+  'close-btn-aria-label': closeBtnAriaLabel,
+  closeable,
+  headline,
+}) => {
+  return (
+    <>
+      <va-alert
+        status="info"
+        background-only={backgroundOnly}
+        show-icon={showIcon}
+        disable-analytics="false"
+        visible="true"
+        close-btn-aria-label={closeBtnAriaLabel}
+        closeable={closeable}
+        full-width="false"
+        class="vads-u-margin-bottom--1"
+      >
+        {headline}
+        <div>Info alert</div>
+      </va-alert>
+      <va-alert
+        status="error"
+        background-only={backgroundOnly}
+        show-icon={showIcon}
+        disable-analytics="false"
+        visible="true"
+        close-btn-aria-label={closeBtnAriaLabel}
+        closeable={closeable}
+        full-width="false"
+        class="vads-u-margin-bottom--1"
+      >
+        {headline}
+        <div>Error alert</div>
+      </va-alert>
+      <va-alert
+        status="success"
+        background-only={backgroundOnly}
+        show-icon={showIcon}
+        disable-analytics="false"
+        visible="true"
+        close-btn-aria-label={closeBtnAriaLabel}
+        closeable={closeable}
+        full-width="false"
+        class="vads-u-margin-bottom--1"
+      >
+        {headline}
+        <div>Success alert</div>
+      </va-alert>
+      <va-alert
+        status="warning"
+        background-only={backgroundOnly}
+        show-icon={showIcon}
+        disable-analytics="false"
+        visible="true"
+        close-btn-aria-label={closeBtnAriaLabel}
+        closeable={closeable}
+        full-width="false"
+        class="vads-u-margin-bottom--1"
+      >
+        {headline}
+        <div>Warning alert</div>
+      </va-alert>
+      <va-alert
+        status="continue"
+        background-only={backgroundOnly}
+        show-icon={showIcon}
+        disable-analytics="false"
+        visible="true"
+        close-btn-aria-label={closeBtnAriaLabel}
+        closeable={closeable}
+        full-width="false"
+      >
+        {headline}
+        <div>Continue alert</div>
+      </va-alert>
+    </>
+  );
+};
+
 export const Default = Template.bind({});
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(alertDocs);
@@ -131,13 +213,13 @@ Fullwidth.args = {
   'status': 'warning',
 };
 
-export const BackgroundOnly = Template.bind({});
+export const BackgroundOnly = BackgroundOnlyTemplate.bind({});
 BackgroundOnly.args = {
   ...defaultArgs,
   'background-only': true,
 };
 
-export const BackgroundOnlyWithIcon = Template.bind({});
+export const BackgroundOnlyWithIcon = BackgroundOnlyTemplate.bind({});
 BackgroundOnlyWithIcon.args = {
   ...defaultArgs,
   'background-only': true,

--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -140,7 +140,7 @@ div.bg-only {
   margin: 1.6rem;
   padding: 0;
   width: auto;
-  color: var(--color-primary);
+  color: var(--color-gray-dark);
   font-size: 2.25rem;
   appearance: none;
   border: 0;
@@ -152,7 +152,7 @@ div.bg-only {
   top: 0;
 }
 .va-alert-close:hover {
-  color: var(--color-primary-darker);
+  color: var(--color-base);
 }
 
 i {


### PR DESCRIPTION
## Chromatic
<!-- This `39872-alert-documentation` is a placeholder for a CI job - it will be updated automatically -->
https://39872-alert-documentation--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/39872

## Related PR
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/704

## Testing done
<img width="857" alt="Screen Shot 2022-04-15 at 12 15 51 PM" src="https://user-images.githubusercontent.com/11822533/163594816-6fbdb69f-0e3e-43ef-8cd5-9288c9c8fff8.png">

<img width="704" alt="Screen Shot 2022-04-15 at 3 51 12 PM" src="https://user-images.githubusercontent.com/11822533/163625769-4f4a8619-efaa-436c-b3a2-955a48436a3a.png">

<img width="735" alt="Screen Shot 2022-04-15 at 3 51 00 PM" src="https://user-images.githubusercontent.com/11822533/163625786-64ae5afd-4389-4f7b-95e0-c8f2f47f0907.png">

## Acceptance criteria
- [X] va-alert in Storybook includes (Alert web component)
- [X] Storybook has link to Alert on design.va.gov https://design.va.gov/components/alert
- [X] The "close-btn-aria-label" has been removed if it is deemed unnecessary (Decision was to leave close button)
- [X] Alert boxes background only story has stacked components of all colors matching USWDS

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
