### PR TITLE
Translate select

### DIFF
--- a/packages/core/src/i18n/translations/en.js
+++ b/packages/core/src/i18n/translations/en.js
@@ -3,4 +3,5 @@ export default {
   'collapse-all': 'Collapse all',
   'expand-all-aria-label': 'Expand all accordions',
   'collapse-all-aria-label': 'Collapse all accordions',
+  required: 'Required',
 };

--- a/packages/core/src/i18n/translations/en.js
+++ b/packages/core/src/i18n/translations/en.js
@@ -1,1 +1,6 @@
-export default {};
+export default {
+  'expand-all': 'Expand all',
+  'collapse-all': 'Collapse all',
+  'expand-all-aria-label': 'Expand all accordions',
+  'collapse-all-aria-label': 'Collapse all accordions',
+};

--- a/packages/core/src/i18n/translations/es.js
+++ b/packages/core/src/i18n/translations/es.js
@@ -3,4 +3,5 @@ export default {
   'collapse-all': '[Spanish "Collapse all"]',
   'expand-all-aria-label': '[Spanish "Expand all accordions"]',
   'collapse-all-aria-label': '[Spanish "Collapse all accordions"]',
+  required: '[Spanish Required]',
 };

--- a/packages/core/src/i18n/translations/es.js
+++ b/packages/core/src/i18n/translations/es.js
@@ -1,1 +1,6 @@
-export default {};
+export default {
+  'expand-all': '[Spanish "Expand all"]',
+  'collapse-all': '[Spanish "Collapse all"]',
+  'expand-all-aria-label': '[Spanish "Expand all accordions"]',
+  'collapse-all-aria-label': '[Spanish "Collapse all accordions"]',
+};

--- a/packages/react-components/src/components/Select/Select.jsx
+++ b/packages/react-components/src/components/Select/Select.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { uniqueId, isString } from '../../helpers/utilities';
 import { makeField } from '../../helpers/fields';
+import i18next from 'i18next';
 
 import dispatchAnalyticsEvent from '../../helpers/analytics';
 
@@ -15,6 +16,9 @@ class Select extends React.Component {
   constructor() {
     super();
     this.handleChange = this.handleChange.bind(this);
+    i18next.on('languageChanged', () => {
+      this.forceUpdate(this.el);
+    });
   }
 
   UNSAFE_componentWillMount() {
@@ -61,7 +65,11 @@ class Select extends React.Component {
     // Calculate required.
     let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="form-required-span">(*Required)</span>;
+      requiredSpan = (
+        <span className="form-required-span">
+          {`(*${i18next.t('required')})`}
+        </span>
+      );
     }
 
     const ariaDescribedby =

--- a/packages/react-components/src/components/Select/Select.unit.spec.jsx
+++ b/packages/react-components/src/components/Select/Select.unit.spec.jsx
@@ -200,7 +200,8 @@ describe('<Select>', () => {
         onValueChange={() => {}}
       />,
     );
-    expect(tree.find('label').text()).to.equal('my label(*Required)');
+    expect(tree.find('label').text()).to.include('my label(*');
+    expect(tree.find('.form-required-span')).to.exist;
     tree.unmount();
   });
 

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -24,11 +24,11 @@ module.exports = {
       include: path.resolve(__dirname, '../'),
     });
 
-    // This is so the docs page for each component can populate the args table.
-    // The propTypes are stripped out in the built version, so we need to use
-    // the source files
-    config.resolve.alias['@department-of-veterans-affairs/component-library$'] =
-      path.resolve(__dirname, '../../react-components/src');
+    // // This is so the docs page for each component can populate the args table.
+    // // The propTypes are stripped out in the built version, so we need to use
+    // // the source files
+    // config.resolve.alias['@department-of-veterans-affairs/component-library$'] =
+    //   path.resolve(__dirname, '../../react-components/src');
 
     // Return the altered config
     return config;

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -6,7 +6,7 @@ import '@department-of-veterans-affairs/component-library/dist/main.css';
 import {
   applyPolyfills,
   defineCustomElements,
-} from '@department-of-veterans-affairs/web-components/loader';
+} from '@department-of-veterans-affairs/component-library';
 
 applyPolyfills().then(() => {
   defineCustomElements();

--- a/packages/storybook/stories/Select.stories.jsx
+++ b/packages/storybook/stories/Select.stories.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState, useEffect } from 'react';
 
 import {Select} from '@department-of-veterans-affairs/component-library';
 
@@ -24,6 +24,27 @@ const defaultArgs = {
     dirty: false,
   },
   options: ['Army', 'Navy', 'Air Force', 'Marines', 'Coast Guard'],
+};
+
+const I18nTemplate = args => {
+  const [lang, setLang] = useState('en');
+  const [value, setValue] = useState(args.value);
+  const onValueChange = newValue => {
+    setValue(newValue);
+  };
+
+  useEffect(() => {
+    const main = document.querySelector('main');
+    main.setAttribute('lang', lang);
+  }, [lang]);
+
+  return (
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <Select {...args} value={value} onValueChange={onValueChange} />
+    </div>
+  );
 };
 
 export const Default = Template.bind({});
@@ -66,4 +87,10 @@ export const WithAnalytics = Template.bind({});
 WithAnalytics.args = {
   ...defaultArgs,
   enableAnalytics: true,
+};
+
+export const Internationalization = I18nTemplate.bind({});
+Internationalization.args = {
+  ...defaultArgs,
+  required: true,
 };

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { generateEventsDescription } from './events';
 import {
   getWebComponentDocs,
@@ -73,6 +73,41 @@ const TemplateSubheader = args => {
   );
 };
 
+const I18nTemplate = args => {
+  const { headline, level, ...rest } = args;
+  const [lang, setLang] = useState('en');
+
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, lang);
+
+  return (
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <va-accordion {...rest}>
+        <va-accordion-item id="first">
+          {headline}
+          Congress shall make no law respecting an establishment of religion, or
+          prohibiting the free exercise thereof; or abridging the freedom of
+          speech, or of the press; or the right of the people peaceably to
+          assemble, and to petition the Government for a redress of grievances.
+        </va-accordion-item>
+        <va-accordion-item id="second" level={level} header="Second Amendment">
+          A well regulated Militia, being necessary to the security of a free
+          State, the right of the people to keep and bear Arms, shall not be
+          infringed.
+        </va-accordion-item>
+        <va-accordion-item id="third" level={level} header="Third Amendment">
+          No Soldier shall, in time of peace be quartered in any house, without
+          the consent of the Owner, nor in time of war, but in a manner to be
+          prescribed by law.
+        </va-accordion-item>
+      </va-accordion>
+    </div>
+  );
+};
+
 const defaultArgs = {
   'bordered': false,
   'headline': <h6 slot="headline">First Amendment Headline</h6>,
@@ -105,5 +140,10 @@ ChangeHeaderLevel.args = {
 
 export const Subheader = TemplateSubheader.bind({});
 Subheader.args = {
+  ...defaultArgs,
+};
+
+export const Internationalization = I18nTemplate.bind({});
+Internationalization.args = {
   ...defaultArgs,
 };

--- a/packages/storybook/stories/va-select.stories.jsx
+++ b/packages/storybook/stories/va-select.stories.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { generateEventsDescription } from './events';
 import { getWebComponentDocs, propStructure } from './wc-helpers';
 
@@ -86,6 +86,24 @@ const Template = ({
   );
 };
 
+const I18nTemplate = args => {
+  const { options, ...rest } = args;
+  const [lang, setLang] = useState('en');
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, [lang]);
+
+  return (
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <va-select {...rest}>
+        {options}
+      </va-select>
+    </div>
+  );
+};
+
 export const Default = Template.bind({});
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(selectDocs);
@@ -98,3 +116,6 @@ ErrorMessage.args = { ...defaultArgs, error: 'There was a problem' };
 
 export const DynamicOptions = Template.bind({});
 DynamicOptions.args = { ...defaultArgs, 'use-add-button': true };
+
+export const Internationalization = I18nTemplate.bind({});
+Internationalization.args = { ...defaultArgs, required: true };

--- a/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
@@ -9,11 +9,12 @@ describe('va-accordion', () => {
     await page.setContent('<va-accordion></va-accordion>');
     const element = await page.find('va-accordion');
 
+    // The i18next translation keys are being rendered
     expect(element).toEqualHtml(`
       <va-accordion class="hydrated">
         <mock:shadow-root>
-          <button aria-label="Expand all accordions">
-            Expand all +
+          <button aria-label="expand-all-aria-label">
+            expand-all +
           </button>
           <slot></slot>
         </mock:shadow-root>
@@ -149,11 +150,13 @@ describe('va-accordion', () => {
     // Click to expand single accordion item manually
     await accordionItemsButtons[0].click();
     // Check if all accordions opened conditions are met
-    expect(expandButton).toEqualText('Expand all +');
+    // This is a translation key for i18next
+    expect(expandButton).toEqualText('expand-all +');
     // Click to expand single accordion item manually
     await accordionItemsButtons[1].click();
     // Check if all accordions opened conditions are met
-    expect(expandButton).toEqualText('Collapse all -');
+    // This is a translation key for i18next
+    expect(expandButton).toEqualText('collapse-all -');
   });
 
   it('fires an analytics event when expanded', async () => {

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -8,8 +8,10 @@ import {
   Prop,
   State,
   h,
+  forceUpdate
 } from '@stencil/core';
 import { getSlottedNodes } from '../../utils/utils';
+import i18next from 'i18next'
 
 /**
  * Accordions are a list of headers that can be clicked to hide or reveal additional content.
@@ -160,6 +162,12 @@ export class VaAccordion {
    */
   @Prop() sectionHeading: string = null;
 
+  connectedCallback() {
+    i18next.on('languageChanged', () => {
+      forceUpdate(this.el);
+    });
+  }
+
   render() {
     return (
       <Host>
@@ -169,11 +177,11 @@ export class VaAccordion {
             onClick={() => this.expandCollapseAll(!this.expanded)}
             aria-label={
               this.expanded
-                ? 'Collapse all accordions'
-                : 'Expand all accordions'
+                ? i18next.t('collapse-all-aria-label')
+                : i18next.t('expand-all-aria-label')
             }
           >
-            {this.expanded ? 'Collapse all -' : 'Expand all +'}
+            {this.expanded ? `${i18next.t('collapse-all')} -` : `${i18next.t('expand-all')} +`}
           </button>
         )}
         <slot />

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -12,6 +12,12 @@ import {
 } from '@stencil/core';
 import { getSlottedNodes } from '../../utils/utils';
 import i18next from 'i18next'
+import { Build } from '@stencil/core';
+
+if (Build.isTesting) {
+  // Make i18next.t() return the key instead of the value
+  i18next.init({ lng: 'cimode' });
+}
 
 /**
  * Accordions are a list of headers that can be clicked to hide or reveal additional content.

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -7,8 +7,10 @@ import {
   Prop,
   State,
   h,
+  forceUpdate,
 } from '@stencil/core';
 import { getSlottedNodes } from '../../utils/utils';
+import i18next from 'i18next';
 
 @Component({
   tag: 'va-select',
@@ -113,6 +115,12 @@ export class VaSelect {
     );
   }
 
+  connectedCallback() {
+    i18next.on('languageChanged', () => {
+      forceUpdate(this.el);
+    });
+  }
+
   render() {
     const { error, label, required, name } = this;
     const errorSpanId = error ? 'error' : undefined;
@@ -121,7 +129,7 @@ export class VaSelect {
       <Host>
         <label htmlFor="select">
           {label}
-          {required && <span>(*Required)</span>}
+          {required ? <span>{`(*${i18next.t('required')})`}</span> : null}
         </label>
 
         {error && (


### PR DESCRIPTION
## Chromatic
<!-- This `translate-select` is a placeholder for a CI job - it will be updated automatically -->
https://translate-select--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/component-library/issues/358

We're still waiting on translations, but this gets everything else in place.

**Note** This work is depended on the [`translate-accordion` branch](https://github.com/department-of-veterans-affairs/component-library/pull/367) and should be merged after that PR, with any conflicts resolved prior to merging this PR.

## Testing done

Updated `Select` unit tests & `va-select` e2e tests

## Screenshots
<details><summary><code>Select</code> storybook</summary>

<!-- leave a blank line above -->
![select react component i18n toggle](https://user-images.githubusercontent.com/136959/163848994-123cbdc3-d336-414b-90c1-2d42d187f58d.gif)</details>

<details><summary><code>va-select</code> storybook</summary>

<!-- leave a blank line above -->
![va-select web component i18n toggle](https://user-images.githubusercontent.com/136959/163848996-a8c3a843-908a-44f7-846d-5e852f50683b.gif)</details>

## Acceptance criteria
- [x] `Select` and `va-select` required tags update dynamically based on the `<main>` language setting
- [x] All tests passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
