### PR TITLE
Add placeholder translations for a few components

### DIFF
--- a/packages/core/src/i18n/translations/en.js
+++ b/packages/core/src/i18n/translations/en.js
@@ -1,1 +1,14 @@
-export default {};
+export default {
+  'error': 'English "Error"',
+  'required': 'English "Required"',
+  'max-chars': 'English "Max. {{length}} characters"',
+  'date-of-birth': 'English "Date of birth"',
+  'month': 'English "Month"',
+  'day': 'English "Day"',
+  'year': 'English "Year"',
+  'year-range': 'English "Please enter a year between {{start}} and {{end}}"',
+  'expand-all': 'English "Expand all"',
+  'collapse-all': 'English "Expand all"',
+  'expand-all-aria-label': 'English "Expand all accordions"',
+  'collapse-all-aria-label': 'English "Collapse all accordions"',
+};

--- a/packages/core/src/i18n/translations/es.js
+++ b/packages/core/src/i18n/translations/es.js
@@ -1,1 +1,14 @@
-export default {};
+export default {
+  'error': 'Spanish "Error"',
+  'required': 'Spanish "Required"',
+  'max-chars': 'Spanish "Max. {{length}} characters"',
+  'date-of-birth': 'Spanish "Date of birth"',
+  'month': 'Spanish "Month"',
+  'day': 'Spanish "Day"',
+  'year': 'Spanish "Year"',
+  'year-range': 'Spanish "Please enter a year between {{start}} and {{end}}"',
+  'expand-all': 'Spanish "Expand all"',
+  'collapse-all': 'Spanish "Expand all"',
+  'expand-all-aria-label': 'Spanish "Expand all accordions"',
+  'collapse-all-aria-label': 'Spanish "Collapse all accordions"',
+};


### PR DESCRIPTION
## Chromatic
<!-- This `add-placeholder-translations` is a placeholder for a CI job - it will be updated automatically -->
https://add-placeholder-translations--60f9b557105290003b387cd5.chromatic.com

## Description

This is to initialize the translation files with all the keys we need so that PRs for each component have something to work with. No code in `master` is making use of the `i18next` dependency at the moment so this will go unused for now.

Tests should be able to use the `cimode` language if they need to test for specific values.

## Testing done

N/A

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
