### PR TITLE
Add subtitle, link and success state example for va-text-input

### DIFF
--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -8,9 +8,13 @@ const textInputDocs = getWebComponentDocs('va-text-input');
 export default {
   title: 'Components/va-text-input',
   parameters: {
+    componentSubtitle: `Text Input web component`,
     docs: {
       description: {
-        component: generateEventsDescription(textInputDocs),
+        component:
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form-controls#text-inputs">View guidance for the Text Input component in the Design System</a>` +
+          '\n' +
+          generateEventsDescription(textInputDocs),
       },
     },
   },
@@ -64,6 +68,7 @@ const Template = ({
   inputmode,
   type,
   'aria-describedby': ariaDescribedby,
+  status,
 }) => {
   return (
     <va-text-input
@@ -78,6 +83,7 @@ const Template = ({
       inputmode={inputmode}
       type={type}
       aria-describedby={ariaDescribedby}
+      status={status}
     />
   );
 };
@@ -88,6 +94,9 @@ Default.argTypes = propStructure(textInputDocs);
 
 export const Error = Template.bind({});
 Error.args = { ...defaultArgs, error: 'This is an error message' };
+
+export const Success = Template.bind({});
+Success.args = { ...defaultArgs, status: 'success' };
 
 export const Required = Template.bind({});
 Required.args = { ...defaultArgs, required: true };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -469,6 +469,10 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
+          * Adds styling based on status value
+         */
+        "status": 'success';
+        /**
           * The type attribute.
          */
         "type"?: 'email' | 'number' | 'search' | 'tel' | 'text' | 'url';
@@ -1291,6 +1295,10 @@ declare namespace LocalJSX {
           * Set the input to required and render the (Required) text.
          */
         "required"?: boolean;
+        /**
+          * Adds styling based on status value
+         */
+        "status"?: 'success';
         /**
           * The type attribute.
          */

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -1,58 +1,63 @@
 :host {
-    display: block;
-    font-family: var(--font-source-sans);
-    margin-top: 3rem;
+  display: block;
+  font-family: var(--font-source-sans);
+  margin-top: 3rem;
 }
 
 label {
-    display: block;
-    max-width: 46rem;
+  display: block;
+  max-width: 46rem;
 }
 
 span.required {
-    color: var(--color-secondary-dark);
+  color: var(--color-secondary-dark);
 }
 
 input {
-    appearance: none;
-    border: .1rem solid var(--color-gray);
-    border-radius: 0;
-    box-sizing: border-box;
-    color: var(--color-base);
-    display: block;
-    font-size: 1.6rem;
-    height: 4.2rem;
-    line-height: 1.3;
-    margin: 0.2em 0;
-    max-width: 46rem;
-    padding: 1rem 0.7em;
-    width: 100%;
+  appearance: none;
+  border: 0.1rem solid var(--color-gray);
+  border-radius: 0;
+  box-sizing: border-box;
+  color: var(--color-base);
+  display: block;
+  font-size: 1.6rem;
+  height: 4.2rem;
+  line-height: 1.3;
+  margin: 0.2em 0;
+  max-width: 46rem;
+  padding: 1rem 0.7em;
+  width: 100%;
 }
 
 input:not([disabled]):focus {
-    outline: 2px solid var(--color-gold-light);
-    outline-offset: 2px;
+  outline: 2px solid var(--color-gold-light);
+  outline-offset: 2px;
 }
 
 #error-message {
-    color: var(--color-secondary-dark);
-    display: block;
+  color: var(--color-secondary-dark);
+  display: block;
 }
 
 :host([error]) {
-    border-left: 4px solid var(--color-secondary-dark);
-    margin-top: 3rem;
-    padding-bottom: .8rem;
-    padding-left: 1.5rem;
-    padding-top: .8rem;
-    position: relative;
-    right: 1.9rem;
+  border-left: 4px solid var(--color-secondary-dark);
+  margin-top: 3rem;
+  padding-bottom: 0.8rem;
+  padding-left: 1.5rem;
+  padding-top: 0.8rem;
+  position: relative;
+  right: 1.9rem;
 }
 
-:host([error]) label, :host([error]) span {
-    font-weight: 700;
+:host([error]) label,
+:host([error]) span {
+  font-weight: 700;
 }
 
 :host([error]) input {
-    border: 3px solid var(--color-secondary-dark);
+  border: 3px solid var(--color-secondary-dark);
+}
+
+:host([status='success']) input {
+  border: 3px solid var(--color-green);
 }

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -55,9 +55,9 @@ input:not([disabled]):focus {
 }
 
 :host([error]) input {
-  border: 3px solid var(--color-secondary-dark);
+  border: 2px solid var(--color-secondary-dark);
 }
 
 :host([status='success']) input {
-  border: 3px solid var(--color-green);
+  border: 2px solid var(--color-green);
 }

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -94,6 +94,11 @@ export class VaTextInput {
   // $('va-text-input').getAttribute('value') will be incorrect
 
   /**
+   * Adds styling based on status value
+   */
+  @Prop() status: 'success';
+
+  /**
    * The event emitted when the input is blurred.
    */
   @Event() vaBlur: EventEmitter;


### PR DESCRIPTION
## Chromatic
<!-- This `39929-text-input` is a placeholder for a CI job - it will be updated automatically -->
https://39929-text-input--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/39929

## Testing done
N/A

## Screenshots
<img width="1032" alt="Screen Shot 2022-04-20 at 16 22 21" src="https://user-images.githubusercontent.com/36863582/164316292-5c9e8253-ba9f-46ab-8960-84795756cced.png">
<img width="1045" alt="Screen Shot 2022-04-20 at 16 23 32" src="https://user-images.githubusercontent.com/36863582/164316453-c171d70b-76b1-4f5d-a816-061aac5dd690.png">


## Acceptance criteria
- [x] Add subtitle `Text Input web component` for `va-text-input`
- [x] Add `View guidance for the Text Input component in the Design System` link with an url value of `https://design.va.gov/components/form-controls#text-inputs`
- [x] Add success state example in `va-text-input` story

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
