### PR TITLE
39967 Loading Indicator Storybook Documentation

### DIFF
--- a/packages/storybook/stories/va-loading-indicator.stories.jsx
+++ b/packages/storybook/stories/va-loading-indicator.stories.jsx
@@ -1,12 +1,22 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
 import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { generateEventsDescription } from './events';
 
 const loadingIndicatorDocs = getWebComponentDocs('va-loading-indicator');
 
 export default {
   title: 'Components/va-loading-indicator',
   parameters: {
+    componentSubtitle: `Loading Indicator web component`,
+    docs: {
+      description: {
+        component:
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/loading-indicator">View guidance for the Loading Indicator component in the Design System</a>` +
+          '\n' +
+          generateEventsDescription(loadingIndicatorDocs),
+      },
+    },
     actions: {
       handles: ['component-library-analytics'],
     },


### PR DESCRIPTION
## Chromatic
<!-- This `39967-loading-indicator` is a placeholder for a CI job - it will be updated automatically -->
https://39967-loading-indicator--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/39967

## Testing done / Screenshots
<img width="732" alt="Screen Shot 2022-04-21 at 9 11 46 AM" src="https://user-images.githubusercontent.com/11822533/164465627-47c6ac31-a1bf-406a-af97-11973777ab0d.png">

## Related PR
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/709

## Acceptance criteria
- [x]  Storybook has link “View guidance for Loading Indicator component in the Design System”
- [x] Storybook has link to Loading indicators on design.va.gov

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
