### PR TITLE
Fix links to design system docs

### DIFF
--- a/packages/storybook/stories/events.js
+++ b/packages/storybook/stories/events.js
@@ -6,5 +6,5 @@ export const generateEventsDescription = componentDocs => {
 
   return ` This component has ${events.length} ${
     events.length > 1 ? 'events' : 'event'
-  }: ${eventNames}. Please see our documentation on how to use web component events at https://design.va.gov/documentation/developers#using-web-components.`;
+  }: ${eventNames}. Please see our documentation on how to use web component events at https://design.va.gov/about/developers#using-web-components.`;
 };

--- a/packages/storybook/stories/va-loading-indicator.stories.jsx
+++ b/packages/storybook/stories/va-loading-indicator.stories.jsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/loading-indicator">View guidance for the Loading Indicator component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/loading-indicators">View guidance for the Loading Indicator component in the Design System</a>` +
           '\n' +
           generateEventsDescription(loadingIndicatorDocs),
       },

--- a/packages/storybook/stories/va-loading-indicator.stories.jsx
+++ b/packages/storybook/stories/va-loading-indicator.stories.jsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/loading-indicators">View guidance for the Loading Indicator component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/loading-indicator">View guidance for the Loading Indicator component in the Design System</a>` +
           '\n' +
           generateEventsDescription(loadingIndicatorDocs),
       },


### PR DESCRIPTION
## Description
A couple of links give 403/404 when followed.
Update `event.js` to link to https://design.va.gov/about/developers#using-web-components


## Acceptance criteria
- [X] Links created by `event.js` link to the new IA location for design.va.gov 
