### PR TITLE
Fix i18next observer setup in Storybook

### DIFF
--- a/packages/core/src/i18n/i18n-setup.js
+++ b/packages/core/src/i18n/i18n-setup.js
@@ -20,7 +20,7 @@ i18next.use(languageDetector).init({
 
 export { i18next };
 
-window.addEventListener('DOMContentLoaded', event => {
+window.addEventListener('load', event => {
   console.log('DOM fully loaded and parsed');
 
   const element = document.querySelector('main');


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
This change defers setting up the mutation observer used by i18next until main element exists in the DOM.

## Testing done
Storybook

## Screenshots
https://user-images.githubusercontent.com/36863582/164569308-494dcf37-c0e8-43a7-a1ce-15f8ce021cac.mov
