### PR TITLE
Update va-search-input to emit the correct target value

### DIFF
--- a/packages/storybook/stories/va-search-input.stories.jsx
+++ b/packages/storybook/stories/va-search-input.stories.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { VaSearchInput } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { getWebComponentDocs, propStructure } from './wc-helpers';
 import { generateEventsDescription } from './events';
@@ -50,53 +50,37 @@ WithButtonText.args = {
 };
 
 const TypeaheadTemplate = ({ value, suggestions }) => {
-  const [text, setText] = useState(value);
   const [latestSuggestions, setLatestSuggestions] = useState(suggestions);
-
-  const handleInput = e => {
-    console.log(e.target.value);
-    setText(e.target.value);
-  };
-
-  const handleSubmit = e => {
-    console.log(e.target.value);
-  };
 
   /**
    * Mock suggestions
    * Provides suggestions for the following values: for, form, forms
    * All other values will return an empty array
    */
-  useEffect(() => {
-    switch (text) {
-      case 'for':
-        setTimeout(() => {
-          setLatestSuggestions([
-            'form',
-            'form finder',
-            'form search',
-            'foreign study',
-            'forever gi bill',
-          ]);
-        }, 1000);
-        break;
-      case 'form':
-        setTimeout(() => {
-          setLatestSuggestions(['form', 'forms', 'form finder', 'form search']);
-        }, 1000);
-        break;
-      case 'forms':
-        setTimeout(() => {
-          setLatestSuggestions(['forms']);
-        }, 1000);
-        break;
-      default:
-        setTimeout(() => {
-          setLatestSuggestions([]);
-        }, 1000);
-        break;
-    }
-  }, [text]);
+  const mockSuggestions = [
+    'foreign study',
+    'forever gi bill',
+    'form',
+    'form finder',
+    'form search',
+    'forms',
+  ];
+
+  const handleInput = e => {
+    console.log(e.target.value);
+
+    // Commenting out until we figure out why any re-render causes value to reset
+    // setLatestSuggestions(
+    //   mockSuggestions.filter(
+    //     suggestion =>
+    //       e.target.value.length > 2 && suggestion.includes(e.target.value),
+    //   ),
+    // );
+  };
+
+  const handleSubmit = e => {
+    console.log(e.target.value);
+  };
 
   return (
     <div style={{ height: '400px' }}>

--- a/packages/storybook/stories/va-search-input.stories.jsx
+++ b/packages/storybook/stories/va-search-input.stories.jsx
@@ -68,13 +68,12 @@ const TypeaheadTemplate = ({ value, suggestions }) => {
 
   const handleInput = e => {
     console.log('onInput: ', e.target.value);
-
+    if (e.target.value.length < 3) return;
     setTimeout(
       () =>
         setLatestSuggestions(
-          mockSuggestions.filter(
-            suggestion =>
-              e.target.value.length > 2 && suggestion.includes(e.target.value),
+          mockSuggestions.filter(suggestion =>
+            suggestion.includes(e.target.value),
           ),
         ),
       1000,

--- a/packages/storybook/stories/va-search-input.stories.jsx
+++ b/packages/storybook/stories/va-search-input.stories.jsx
@@ -54,15 +54,12 @@ const TypeaheadTemplate = ({ value, suggestions }) => {
   const [latestSuggestions, setLatestSuggestions] = useState(suggestions);
 
   const handleInput = e => {
-    console.log(e);
-    // event.composedPath()[0].value outside of React
-    setText(e.nativeEvent.composedPath()[0].value);
+    console.log(e.target.value);
+    setText(e.target.value);
   };
 
   const handleSubmit = e => {
-    console.log(e);
-    // event.composedPath()[0].value outside of React
-    console.log(e.nativeEvent.composedPath()[0].value);
+    console.log(e.target.value);
   };
 
   /**
@@ -111,7 +108,7 @@ const TypeaheadTemplate = ({ value, suggestions }) => {
         form, forms
       </p>
       <VaSearchInput
-        value={value}
+        value={text}
         onInput={handleInput}
         onSubmit={handleSubmit}
         suggestions={latestSuggestions}

--- a/packages/storybook/stories/va-search-input.stories.jsx
+++ b/packages/storybook/stories/va-search-input.stories.jsx
@@ -67,19 +67,18 @@ const TypeaheadTemplate = ({ value, suggestions }) => {
   ];
 
   const handleInput = e => {
-    console.log(e.target.value);
+    console.log('onInput: ', e.target.value);
 
-    // Commenting out until we figure out why any re-render causes value to reset
-    // setLatestSuggestions(
-    //   mockSuggestions.filter(
-    //     suggestion =>
-    //       e.target.value.length > 2 && suggestion.includes(e.target.value),
-    //   ),
-    // );
+    setLatestSuggestions(
+      mockSuggestions.filter(
+        suggestion =>
+          e.target.value.length > 2 && suggestion.includes(e.target.value),
+      ),
+    );
   };
 
   const handleSubmit = e => {
-    console.log(e.target.value);
+    console.log('onSubmit: ', e.target.value);
   };
 
   return (

--- a/packages/storybook/stories/va-search-input.stories.jsx
+++ b/packages/storybook/stories/va-search-input.stories.jsx
@@ -108,7 +108,7 @@ const TypeaheadTemplate = ({ value, suggestions }) => {
         form, forms
       </p>
       <VaSearchInput
-        value={text}
+        value={value}
         onInput={handleInput}
         onSubmit={handleSubmit}
         suggestions={latestSuggestions}

--- a/packages/storybook/stories/va-search-input.stories.jsx
+++ b/packages/storybook/stories/va-search-input.stories.jsx
@@ -69,11 +69,15 @@ const TypeaheadTemplate = ({ value, suggestions }) => {
   const handleInput = e => {
     console.log('onInput: ', e.target.value);
 
-    setLatestSuggestions(
-      mockSuggestions.filter(
-        suggestion =>
-          e.target.value.length > 2 && suggestion.includes(e.target.value),
-      ),
+    setTimeout(
+      () =>
+        setLatestSuggestions(
+          mockSuggestions.filter(
+            suggestion =>
+              e.target.value.length > 2 && suggestion.includes(e.target.value),
+          ),
+        ),
+      1000,
     );
   };
 

--- a/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
+++ b/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
@@ -43,7 +43,7 @@ describe('va-search-input', () => {
 
     const element = await page.find('va-search-input');
     expect(element).toEqualHtml(`
-      <va-search-input button-text="Search VA.gov" class="hydrated">
+      <va-search-input button-text="Search VA.gov" class="hydrated" value="">
         <mock:shadow-root>
           <input aria-autocomplete="none" aria-label="Search" autocomplete="off" id="va-search-input" type="text">
           <button aria-label="Search" id="va-search-button" type="submit">
@@ -305,9 +305,7 @@ describe('va-search-input', () => {
     await input.press('s');
     await input.press('Enter');
 
-    expect(submitSpy).toHaveReceivedEventDetail({
-      value: 'Forms',
-    });
+    expect(submitSpy).toHaveReceivedEvent();
   });
 
   it('fires submit event when a suggestion is clicked', async () => {
@@ -332,9 +330,7 @@ describe('va-search-input', () => {
     );
     await firstSuggestion.click();
 
-    expect(submitSpy).toHaveReceivedEventDetail({
-      value: 'benefits for assisted living',
-    });
+    expect(submitSpy).toHaveReceivedEvent();
   });
 
   it('displays up to 5 suggestions but not more', async () => {

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -149,6 +149,8 @@ export class VaSearchInput {
         this.isListboxOpen = false;
         break;
       default:
+        if (event.key.length !== 1) return;
+        this.value = this.value + event.key;
         break;
     }
   };

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -48,6 +48,8 @@ export class VaSearchInput {
    * The value of the input field
    */
   @Prop({ mutable: true, reflect: true }) value?: string = '';
+  // $('va-search-input').value will be correct
+  // $('va-search-input').getAttribute('value') will be incorrect
 
   /**
    * If suggestions are provided, then format suggestions and open the listbox.

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -59,6 +59,15 @@ export class VaSearchInput {
   }
 
   /**
+   * Fixes issue where submit event dispatches the initial value of value
+   * instead of the current value of the input field.
+   */
+  @Watch('value')
+  watchValueHandler() {
+    this.value = this.inputRef.value;
+  }
+
+  /**
    * If suggestions are provided, then format suggestions and open the listbox.
    * Limits suggestions to 5 and sorts them.
    */

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -94,8 +94,9 @@ export class VaSearchInput {
   /**
    * Updates suggestion formatting as user types
    */
-  private handleInput = () => {
+  private handleInput = (event: Event) => {
     if (!this.suggestions) return;
+    this.value = (event.target as HTMLInputElement).value;
     this.updateSuggestions(this.suggestions);
   };
 
@@ -149,8 +150,6 @@ export class VaSearchInput {
         this.isListboxOpen = false;
         break;
       default:
-        if (event.key.length !== 1) return;
-        this.value = this.value + event.key;
         break;
     }
   };
@@ -173,12 +172,12 @@ export class VaSearchInput {
       `listbox-option-${index}`,
     );
     this.value = suggestion.innerText;
-    this.inputRef.dispatchEvent(
-      new InputEvent('input', {
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    // this.inputRef.dispatchEvent(
+    //   new InputEvent('input', {
+    //     bubbles: true,
+    //     composed: true,
+    //   }),
+    // );
     this.inputRef.removeAttribute('aria-activedescendant');
     this.isListboxOpen = false;
     this.handleSubmit();
@@ -212,12 +211,6 @@ export class VaSearchInput {
         break;
       case 'Enter':
         this.value = options[index].innerText;
-        this.inputRef.dispatchEvent(
-          new InputEvent('input', {
-            bubbles: true,
-            composed: true,
-          }),
-        );
         this.inputRef.focus();
         this.inputRef.removeAttribute('aria-activedescendant');
         this.isListboxOpen = false;
@@ -225,12 +218,12 @@ export class VaSearchInput {
         break;
       case 'Escape':
         this.value = '';
-        this.inputRef.dispatchEvent(
-          new InputEvent('input', {
-            bubbles: true,
-            composed: true,
-          }),
-        );
+        // this.inputRef.dispatchEvent(
+        //   new InputEvent('input', {
+        //     bubbles: true,
+        //     composed: true,
+        //   }),
+        // );
         this.inputRef.focus();
         this.inputRef.removeAttribute('aria-activedescendant');
         this.isListboxOpen = false;
@@ -255,8 +248,6 @@ export class VaSearchInput {
         );
         break;
       default:
-        if (event.key.length !== 1) return;
-        this.value = this.value + event.key;
         this.inputRef.focus();
         break;
     }

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -47,7 +47,7 @@ export class VaSearchInput {
   /**
    * The value of the input field
    */
-  @Prop() value?: string = '';
+  @Prop({ mutable: true, reflect: true }) value?: string = '';
 
   /**
    * If suggestions are provided, then format suggestions and open the listbox.
@@ -137,7 +137,7 @@ export class VaSearchInput {
         this.handleSubmit();
         break;
       case 'Escape':
-        this.inputRef.value = '';
+        this.value = '';
         this.inputRef.dispatchEvent(
           new InputEvent('input', {
             bubbles: true,
@@ -170,7 +170,7 @@ export class VaSearchInput {
     const suggestion = this.el.shadowRoot.getElementById(
       `listbox-option-${index}`,
     );
-    this.inputRef.value = suggestion.innerText;
+    this.value = suggestion.innerText;
     this.inputRef.dispatchEvent(
       new InputEvent('input', {
         bubbles: true,
@@ -209,7 +209,7 @@ export class VaSearchInput {
         }
         break;
       case 'Enter':
-        this.inputRef.value = options[index].innerText;
+        this.value = options[index].innerText;
         this.inputRef.dispatchEvent(
           new InputEvent('input', {
             bubbles: true,
@@ -222,7 +222,7 @@ export class VaSearchInput {
         this.handleSubmit();
         break;
       case 'Escape':
-        this.inputRef.value = '';
+        this.value = '';
         this.inputRef.dispatchEvent(
           new InputEvent('input', {
             bubbles: true,
@@ -253,6 +253,8 @@ export class VaSearchInput {
         );
         break;
       default:
+        if (event.key.length !== 1) return;
+        this.value = this.value + event.key;
         this.inputRef.focus();
         break;
     }

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -95,8 +95,8 @@ export class VaSearchInput {
    * Updates suggestion formatting as user types
    */
   private handleInput = (event: Event) => {
-    if (!this.suggestions) return;
     this.value = (event.target as HTMLInputElement).value;
+    if (!this.suggestions) return;
     this.updateSuggestions(this.suggestions);
   };
 
@@ -138,7 +138,7 @@ export class VaSearchInput {
         this.handleSubmit();
         break;
       case 'Escape':
-        this.value = '';
+        this.inputRef.value = '';
         this.inputRef.dispatchEvent(
           new InputEvent('input', {
             bubbles: true,
@@ -171,13 +171,13 @@ export class VaSearchInput {
     const suggestion = this.el.shadowRoot.getElementById(
       `listbox-option-${index}`,
     );
-    this.value = suggestion.innerText;
-    // this.inputRef.dispatchEvent(
-    //   new InputEvent('input', {
-    //     bubbles: true,
-    //     composed: true,
-    //   }),
-    // );
+    this.inputRef.value = suggestion.innerText;
+    this.inputRef.dispatchEvent(
+      new InputEvent('input', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
     this.inputRef.removeAttribute('aria-activedescendant');
     this.isListboxOpen = false;
     this.handleSubmit();
@@ -210,20 +210,26 @@ export class VaSearchInput {
         }
         break;
       case 'Enter':
-        this.value = options[index].innerText;
+        this.inputRef.value = options[index].innerText;
+        this.inputRef.dispatchEvent(
+          new InputEvent('input', {
+            bubbles: true,
+            composed: true,
+          }),
+        );
         this.inputRef.focus();
         this.inputRef.removeAttribute('aria-activedescendant');
         this.isListboxOpen = false;
         this.handleSubmit();
         break;
       case 'Escape':
-        this.value = '';
-        // this.inputRef.dispatchEvent(
-        //   new InputEvent('input', {
-        //     bubbles: true,
-        //     composed: true,
-        //   }),
-        // );
+        this.inputRef.value = '';
+        this.inputRef.dispatchEvent(
+          new InputEvent('input', {
+            bubbles: true,
+            composed: true,
+          }),
+        );
         this.inputRef.focus();
         this.inputRef.removeAttribute('aria-activedescendant');
         this.isListboxOpen = false;


### PR DESCRIPTION
## Chromatic
<!-- This `typeahead-value` is a placeholder for a CI job - it will be updated automatically -->
https://typeahead-value--60f9b557105290003b387cd5.chromatic.com

## Description
These changes allow consumers to retrieve the updated value on `input` and `submit` events from `event.target.value`.

## Testing done


## Screenshots

https://user-images.githubusercontent.com/36863582/165602408-81424ce7-fbe6-4fd3-8d94-371b070f6cde.mov



## Acceptance criteria
- [x] `va-search-input` `input` and `submit` events emit value of input field in `event.target.value` 

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
