### PR TITLE
39738 Number Input Docs Link Fix and Input El fix

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -11,7 +11,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form-controls#text-inputs">View guidance for the Number Input component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/number-input">View guidance for the Number Input component in the Design System</a>` +
           '\n' +
           generateEventsDescription(numberInputDocs),
       },

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -245,11 +245,11 @@ export namespace Components {
          */
         "label"?: string;
         /**
-          * Maximum number value The max attribute specifies the maximum value for an `<input>` element.
+          * Maximum number value The max attribute specifies the maximum value for an input element.
          */
         "max": number | string;
         /**
-          * Minimum number value The min attribute specifies the minimum value for an `<input>` element.
+          * Minimum number value The min attribute specifies the minimum value for an input element.
          */
         "min": number | string;
         /**
@@ -1021,11 +1021,11 @@ declare namespace LocalJSX {
          */
         "label"?: string;
         /**
-          * Maximum number value The max attribute specifies the maximum value for an `<input>` element.
+          * Maximum number value The max attribute specifies the maximum value for an input element.
          */
         "max"?: number | string;
         /**
-          * Minimum number value The min attribute specifies the minimum value for an `<input>` element.
+          * Minimum number value The min attribute specifies the minimum value for an input element.
          */
         "min"?: number | string;
         /**

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -48,13 +48,13 @@ export class VaNumberInput {
 
   /**
    * Minimum number value
-   * The min attribute specifies the minimum value for an `<input>` element.
+   * The min attribute specifies the minimum value for an input element.
    */
   @Prop() min: number | string;
 
   /**
    * Maximum number value
-   * The max attribute specifies the maximum value for an `<input>` element.
+   * The max attribute specifies the maximum value for an input element.
    */
   @Prop() max: number | string;
 


### PR DESCRIPTION
## Chromatic
<!-- This `39738-number-input-docs` is a placeholder for a CI job - it will be updated automatically -->
https://39738-number-input-docs--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/39738

## Fixes
<img width="1036" alt="Screen Shot 2022-04-26 at 1 05 50 PM" src="https://user-images.githubusercontent.com/11822533/165354984-7e203e1a-62f9-4bb0-91bc-7730d6d720d8.png">

## Testing done 
<img width="537" alt="Screen Shot 2022-04-26 at 1 06 56 PM" src="https://user-images.githubusercontent.com/11822533/165354941-feaa506d-c204-4175-a32f-00d68ba742b7.png">

## Related PR
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/742

## Acceptance criteria
- [X] Fix link to Number Input in documentation
- [X] Fix input in JSDocs on Number Input

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
