### PR TITLE
Fix for JSDoc usage of <input> in docs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "8.6.2",
+  "version": "8.6.3",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -130,7 +130,7 @@ export namespace Components {
     }
     interface VaCheckbox {
         /**
-          * The aria-describedby attribute for the `<input>` in the shadow DOM.
+          * The aria-describedby attribute for the input element in the shadow DOM.
          */
         "ariaDescribedby": string;
         /**
@@ -465,7 +465,7 @@ export namespace Components {
     }
     interface VaTextInput {
         /**
-          * The aria-describedby attribute for the `<input>` in the shadow DOM.
+          * The aria-describedby attribute for the input element in the shadow DOM.
          */
         "ariaDescribedby"?: string;
         /**
@@ -870,7 +870,7 @@ declare namespace LocalJSX {
     }
     interface VaCheckbox {
         /**
-          * The aria-describedby attribute for the `<input>` in the shadow DOM.
+          * The aria-describedby attribute for the input element in the shadow DOM.
          */
         "ariaDescribedby"?: string;
         /**
@@ -1329,7 +1329,7 @@ declare namespace LocalJSX {
     }
     interface VaTextInput {
         /**
-          * The aria-describedby attribute for the `<input>` in the shadow DOM.
+          * The aria-describedby attribute for the input element in the shadow DOM.
          */
         "ariaDescribedby"?: string;
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -746,7 +746,7 @@ declare namespace LocalJSX {
          */
         "level"?: number;
         /**
-          * This event is fired so that `<va-accordion>` can manage which items are opened or closed
+          * This event is fired so that va-accordion element can manage which items are opened or closed
          */
         "onAccordionItemToggled"?: (event: CustomEvent<any>) => void;
         /**

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.css
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.css
@@ -43,14 +43,14 @@ button {
   background-size: 1.5rem;
   display: block;
   /* This color assignment is for IE11 compatibility - the one in */
-  /* the `<va-accordion>`'s CSS with `:host` doesn't work well */
+  /* the va-accordion's CSS with `:host` doesn't work well */
   color: var(--color-gray-dark);
 }
 
 button:hover {
   background-color: var(--color-gray-lighter);
   /* This color assignment is for IE11 compatibility - the one in */
-  /* the `<va-accordion>`'s CSS with `:host` doesn't work well */
+  /* the va-accordion's CSS with `:host` doesn't work well */
   color: var(--color-gray-dark);
 }
 

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -12,7 +12,7 @@ export class VaAccordionItem {
   @Element() el: HTMLElement;
 
   /**
-   * This event is fired so that `<va-accordion>` can manage which items are opened or closed
+   * This event is fired so that va-accordion element can manage which items are opened or closed
    */
   @Event({
     composed: true,

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -52,7 +52,7 @@ export class VaCheckbox {
   @Prop({ mutable: true }) checked: boolean = false;
 
   /**
-   * The aria-describedby attribute for the `<input>` in the shadow DOM.
+   * The aria-describedby attribute for the input element in the shadow DOM.
    */
   @Prop() ariaDescribedby: string = '';
 

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -76,7 +76,7 @@ export class VaTextInput {
   @Prop() name?: string;
 
   /**
-   * The aria-describedby attribute for the `<input>` in the shadow DOM.
+   * The aria-describedby attribute for the input element in the shadow DOM.
    */
   @Prop() ariaDescribedby?: string = '';
 


### PR DESCRIPTION
## Chromatic
<!-- This `jsdoc-input-element-fix` is a placeholder for a CI job - it will be updated automatically -->
https://jsdoc-input-element-fix--60f9b557105290003b387cd5.chromatic.com

## Description
When using `<input>` in JSDoc it converts from a code block to a HTML Element. Changing our comments for the docs to type out input element instead of putting the comment in as a `<input>`.

## Fixes
<img width="1025" alt="Screen Shot 2022-04-27 at 9 39 45 AM" src="https://user-images.githubusercontent.com/11822533/165532147-206b9cd4-9676-425a-952d-e770e073d60a.png">

## Acceptance criteria
- [X] Fix all places where we use `<input>` in our JSDoc comments


