### PR TITLE
Updates va-additional-info to use primary alt darkest to pass WCAG 

### DIFF
--- a/packages/web-components/src/components/va-additional-info/va-additional-info.css
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.css
@@ -8,7 +8,7 @@
 :host([disable-border='false']) a[aria-expanded='true'] ~ #info {
   padding-left: calc(2rem - 7px);
   border-left: 7px solid transparent;
-  border-left-color: var(--color-primary-alt-dark);
+  border-left-color: var(--color-primary-alt-darkest);
 }
 
 #info {
@@ -25,7 +25,7 @@ a {
 
 .additional-info-title {
   border-bottom-right-radius: 1px;
-  border-bottom: 2px dotted var(--color-primary-alt-dark);
+  border-bottom: 2px dotted var(--color-primary-alt-darkest);
   color: var(--color-gray-dark);
   cursor: pointer;
 }
@@ -53,7 +53,7 @@ i {
 
 i.fa-angle-down {
   display: inline-block;
-  color: var(--color-primary-alt-dark);
+  color: var(--color-primary-alt-darkest);
   font-size: 1.6rem;
   margin: 0.5rem;
   transform: rotate(0deg);

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -23,6 +23,7 @@
   --color-primary: #0071bb;
   --color-primary-darker: #003e73;
   --color-primary-alt-dark: #00a6d2;
+  --color-primary-alt-darkest: #046b99;
   --color-primary-alt-light: #9bdaf1;
   --color-primary-alt-lightest: #e1f3f8;
   --color-secondary-dark: #cd2026;


### PR DESCRIPTION
success criteria for contrast. Issue #650 in vets-design-system-documentation.

## Chromatic
<!-- This `va-additional-info-color-650` is a placeholder for a CI job - it will be updated automatically -->
https://va-additional-info-color-650--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/650

## Testing done
Verified in Storybook via Inspect.

## Screenshots
![Screen Shot 2022-04-28 at 10 30 22 AM](https://user-images.githubusercontent.com/52176351/165776004-371cc558-05ed-43da-851a-ec1c877fcbfc.png)


## Acceptance criteria
- [ ] When closed, the component bottom-border and caret icon use primary-alt-darkest which should be #046b99 and pass contrast at WCAG AA level for UI components

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
