### PR TITLE
Replace vaBlur with native blur event for va-checkbox

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "8.8.0",
+  "version": "9.0.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -45,6 +45,7 @@ const Template = ({
     error={error}
     label={label}
     required={required}
+    onBlur={e => console.log(e)}
   />
 );
 
@@ -62,7 +63,7 @@ WithDescriptionString.args = {
 };
 
 export const WithDescriptionJSX = props => (
-  <va-checkbox {...props}>
+  <va-checkbox {...props} onBlur={e => console.log(e)}>
     <p slot="description">
       I'm a paragraph tag with <code>slot="description"</code>
     </p>

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "2.14.0",
+  "version": "3.0.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -939,10 +939,6 @@ declare namespace LocalJSX {
          */
         "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
         /**
-          * The event emitted when the input is blurred.
-         */
-        "onVaBlur"?: (event: CustomEvent<any>) => void;
-        /**
           * The event emitted when the input value changes.
          */
         "onVaChange"?: (event: CustomEvent<any>) => void;

--- a/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
@@ -166,17 +166,17 @@ describe('va-checkbox', () => {
     expect(changeSpy).toHaveReceivedEventDetail({ checked: true });
   });
 
-  it('emits the vaBlur event', async () => {
+  it('emits blur event', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-checkbox label="Just another checkbox here" required description="Description content"/>',
     );
-    const analyticsSpy = await page.spyOnEvent('vaBlur');
+    const blurSpy = await page.spyOnEvent('blur');
     const inputEl = await page.find('va-checkbox >>> input');
     await inputEl.click(); // Focus on the element
     await inputEl.press('Tab'); // Blur the element
 
-    expect(analyticsSpy).toHaveReceivedEvent();
+    expect(blurSpy).toHaveReceivedEvent();
   });
 
   it('updates the checked prop', async () => {

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -62,11 +62,6 @@ export class VaCheckbox {
   @Event() vaChange: EventEmitter;
 
   /**
-   * The event emitted when the input is blurred.
-   */
-  @Event() vaBlur: EventEmitter;
-
-  /**
    * The event used to track usage of the component. This is emitted when the
    * input value changes and enableAnalytics is true.
    */
@@ -83,9 +78,11 @@ export class VaCheckbox {
       this.description ||
       [
         // This won't work in IE
-        ...(this.el.shadowRoot.querySelector(
-          'slot[name="description"]',
-        ) as HTMLSlotElement)?.assignedNodes(),
+        ...(
+          this.el.shadowRoot.querySelector(
+            'slot[name="description"]',
+          ) as HTMLSlotElement
+        )?.assignedNodes(),
         // For IE
         ...Array.from(
           this.el.shadowRoot.querySelectorAll('[slot="description"]'),
@@ -101,7 +98,7 @@ export class VaCheckbox {
         label: this.label,
         description,
         required: this.required,
-        checked: this.checked
+        checked: this.checked,
       },
     });
   };
@@ -110,10 +107,6 @@ export class VaCheckbox {
     this.checked = (e.target as HTMLInputElement).checked;
     this.vaChange.emit({ checked: this.checked });
     if (this.enableAnalytics) this.fireAnalyticsEvent();
-  };
-
-  private handleBlur = () => {
-    this.vaBlur.emit();
   };
 
   render() {
@@ -137,7 +130,6 @@ export class VaCheckbox {
           checked={this.checked}
           aria-describedby={describedBy}
           onChange={this.handleChange}
-          onBlur={this.handleBlur}
         />
         <label htmlFor="checkbox-element">
           {this.label}


### PR DESCRIPTION
## Chromatic
<!-- This `39739-checkbox-blur` is a placeholder for a CI job - it will be updated automatically -->
https://39739-checkbox-blur--60f9b557105290003b387cd5.chromatic.com/

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/39739

## Testing done
E2E, Storybook

## Screenshots
![Screen Shot 2022-04-29 at 11 14 37](https://user-images.githubusercontent.com/36863582/165973677-49edf4dc-3678-4cca-977f-802bde1e34f8.png)


## Acceptance criteria
- [x] Replace `vaBlur` event with native `blur` event

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
