### PR TITLE
Add subtitle and link to DS for va-back-to-top

### DIFF
--- a/packages/storybook/stories/va-back-to-top.stories.jsx
+++ b/packages/storybook/stories/va-back-to-top.stories.jsx
@@ -5,6 +5,14 @@ const bttDocs = getWebComponentDocs('va-back-to-top');
 
 export default {
   title: 'Components/va-back-to-top',
+  parameters: {
+    docs: {
+      description: {
+        component: `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/back-to-top">View guidance for the Back to top component in the Design System</a>`,
+      },
+    },
+    componentSubtitle: `Back to top web component`,
+  },
 };
 
 const Template = () => {


### PR DESCRIPTION
## Chromatic
<!-- This `40110-btp` is a placeholder for a CI job - it will be updated automatically -->
https://40110-btp--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/40110

## Testing done
N/A

## Screenshots
![Screen Shot 2022-04-29 at 13 03 33](https://user-images.githubusercontent.com/36863582/165990520-42d6721f-8be7-4f90-9d74-810873a77adc.png)


## Acceptance criteria
- [x] Add subtitle `Back to top web component`
- [x] Add `View guidance for the Back to top component in the Design System` with url `https://design.va.gov/components/back-to-top`

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
