### PR TITLE
40575/va date year input

### DIFF
--- a/packages/storybook/stories/va-date.stories.jsx
+++ b/packages/storybook/stories/va-date.stories.jsx
@@ -19,24 +19,14 @@ export default {
 };
 
 const defaultArgs = {
-  'label': 'Label should be specific',
-  'name': 'test',
-  'required': false,
-  'error': undefined,
-  'value': undefined,
-  'min-year': undefined,
-  'max-year': undefined,
+  label: 'Label should be specific',
+  name: 'test',
+  required: false,
+  error: undefined,
+  value: undefined,
 };
 
-const Template = ({
-  label,
-  name,
-  required,
-  error,
-  value,
-  'min-year': minYear,
-  'max-year': maxYear,
-}) => {
+const Template = ({ label, name, required, error, value }) => {
   return (
     <VaDate
       label={label}
@@ -44,28 +34,18 @@ const Template = ({
       required={required}
       error={error}
       value={value}
-      min-year={minYear}
-      max-year={maxYear}
       onDateBlur={e => console.log(e, 'DATE BLUR FIRED')}
       onDateChange={e => console.log(e, 'DATE CHANGE FIRED')}
     />
   );
 };
 
-const CustomValidationTemplate = ({
-  label,
-  name,
-  required,
-  error,
-  value,
-  'min-year': minYear,
-  'max-year': maxYear,
-}) => {
+const CustomValidationTemplate = ({ label, name, required, error, value }) => {
   const [dateVal, setDateVal] = useState(value);
   const [currentYear, currentMonth, currentDay] = (dateVal || '').split('-');
 
-  if (currentYear < minYear || currentYear > maxYear) {
-    error = `Please enter a year between ${minYear} and ${maxYear}`;
+  if (currentYear < 1900 || currentYear > 2122) {
+    error = 'Please enter a year between 1900 and 2122';
   }
   const today = new Date();
   // new Date as YYYY-MM-DD is giving the day prior to the day select
@@ -82,8 +62,6 @@ const CustomValidationTemplate = ({
         required={required}
         error={error}
         value={dateVal}
-        min-year={minYear}
-        max-year={maxYear}
         onDateBlur={e => console.log(e, 'DATE BLUR')}
         onDateChange={e => setDateVal(e.target.value)}
       />
@@ -109,13 +87,8 @@ const CustomValidationTemplate = ({
         <pre>const dateInput = new Date(dateVal.split('-').join(' '));</pre>
         <h5>Sample Custom Validation Conditional Statements</h5>
         <strong>Year Check</strong>
-        <pre>
-          if (currentYear &lt; minYear || currentYear &gt; maxYear) &#123;
-        </pre>
-        <pre>
-          error = `Please enter a year between $&#123;minYear&#125; and
-          $&#123;maxYear&#125;`;
-        </pre>
+        <pre>if (currentYear &lt; 1900 || currentYear &gt; 2122) &#123;</pre>
+        <pre>error = 'Please enter a year between 1900 and 2122';</pre>
         <pre>&#125;</pre>
         <strong>Date in Future Check</strong>
         <pre>if (dateInput &lt;= today)&#123;</pre>
@@ -136,8 +109,6 @@ Error.args = { ...defaultArgs, error: 'Error Message Example' };
 export const CustomValidation = CustomValidationTemplate.bind({});
 CustomValidation.args = {
   ...defaultArgs,
-  'min-year': '1900',
-  'max-year': '2122',
-  'required': true,
-  'value': '2022-04-19',
+  required: true,
+  value: '2022-04-19',
 };

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -50,10 +50,11 @@ const defaultArgs = {
   'required': false,
   'error': undefined,
   'maxlength': undefined,
+  'minlength': undefined,
   'value': undefined,
   'inputmode': undefined,
   'type': undefined,
-  'aria-describedby': undefined,
+  'pattern': undefined,
 };
 
 const Template = ({
@@ -64,11 +65,12 @@ const Template = ({
   required,
   error,
   maxlength,
+  minlength,
   value,
   inputmode,
   type,
-  'aria-describedby': ariaDescribedby,
   status,
+  pattern,
 }) => {
   return (
     <va-text-input
@@ -79,11 +81,14 @@ const Template = ({
       required={required}
       error={error}
       maxlength={maxlength}
+      minlength={minlength}
       value={value}
       inputmode={inputmode}
       type={type}
-      aria-describedby={ariaDescribedby}
       status={status}
+      pattern={pattern}
+      onBlur={e => console.log('blur event', e)}
+      onInput={e => console.log('input event value', e.target.value)}
     />
   );
 };
@@ -105,6 +110,21 @@ export const MaxLength = Template.bind({});
 MaxLength.args = {
   ...defaultArgs,
   maxlength: '16',
+};
+
+export const Range = Template.bind({});
+Range.args = {
+  ...defaultArgs,
+  label: 'Acceptable range 3 - 6 characters',
+  minlength: '3',
+  maxlength: '6',
+};
+
+export const Pattern = Template.bind({});
+Pattern.args = {
+  ...defaultArgs,
+  label: 'Must be 4 digits',
+  pattern: '[0-9]{4}',
 };
 
 export const Autocomplete = Template.bind({});

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -190,14 +190,6 @@ export namespace Components {
          */
         "label": string;
         /**
-          * Set the `max` value on the year input.
-         */
-        "maxYear": number;
-        /**
-          * Set the `min` value on the year input.
-         */
-        "minYear": number;
-        /**
           * Used to create unique name attributes for each input.
          */
         "name": string;
@@ -990,14 +982,6 @@ declare namespace LocalJSX {
           * Label for the field.
          */
         "label": string;
-        /**
-          * Set the `max` value on the year input.
-         */
-        "maxYear"?: number;
-        /**
-          * Set the `min` value on the year input.
-         */
-        "minYear"?: number;
         /**
           * Used to create unique name attributes for each input.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -499,10 +499,6 @@ export namespace Components {
     }
     interface VaTextInput {
         /**
-          * The aria-describedby attribute for the input element in the shadow DOM.
-         */
-        "ariaDescribedby"?: string;
-        /**
           * What to tell the browser to auto-complete the field with.
          */
         "autocomplete"?: string;
@@ -533,9 +529,17 @@ export namespace Components {
          */
         "maxlength"?: number;
         /**
+          * The minimum number of characters allowed in the input.
+         */
+        "minlength"?: number;
+        /**
           * The name to pass to the input element.
          */
         "name"?: string;
+        /**
+          * The regular expression that the input element's value is checked against on submission
+         */
+        "pattern"?: string;
         /**
           * Set the input to required and render the (Required) text.
          */
@@ -1416,10 +1420,6 @@ declare namespace LocalJSX {
     }
     interface VaTextInput {
         /**
-          * The aria-describedby attribute for the input element in the shadow DOM.
-         */
-        "ariaDescribedby"?: string;
-        /**
           * What to tell the browser to auto-complete the field with.
          */
         "autocomplete"?: string;
@@ -1450,6 +1450,10 @@ declare namespace LocalJSX {
          */
         "maxlength"?: number;
         /**
+          * The minimum number of characters allowed in the input.
+         */
+        "minlength"?: number;
+        /**
           * The name to pass to the input element.
          */
         "name"?: string;
@@ -1465,6 +1469,10 @@ declare namespace LocalJSX {
           * The event emitted when the input value changes
          */
         "onVaChange"?: (event: CustomEvent<any>) => void;
+        /**
+          * The regular expression that the input element's value is checked against on submission
+         */
+        "pattern"?: string;
         /**
           * Set the input to required and render the (Required) text.
          */

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -108,20 +108,20 @@ describe('va-date', () => {
     expect(elementDay.getAttribute('value')).toBe('');
   });
 
-  it('provides a max and min year to input field', async () => {
+  it('year input only allows for 4 characters to be used', async () => {
     const page = await newE2EPage();
-    await page.setContent(
-      '<va-date name="test" min-year="2000" max-year="2022" />',
-    );
+    await page.setContent('<va-date name="test" />');
 
-    const inputYear = await page.$('pierce/[name="testYear"]');
+    const elementYear = await page.find('va-date >>> .input-year');
+    const handleYear = await page.$('pierce/[name="testYear"]');
+    await handleYear.press('2');
+    await handleYear.press('0');
+    await handleYear.press('2');
+    await handleYear.press('2');
+    await handleYear.press('3');
 
-    expect(await inputYear.evaluate(node => node.getAttribute('min'))).toBe(
-      '2000',
-    );
-    expect(await inputYear.evaluate(node => node.getAttribute('max'))).toBe(
-      '2022',
-    );
+    await page.waitForChanges();
+    expect(elementYear.getAttribute('value')).toBe('2022');
   });
 
   it('fires an invalid message if date is invalid and component is required', async () => {
@@ -174,6 +174,8 @@ describe('va-date', () => {
 
     expect(spy).toHaveReceivedEventTimes(2);
 
+    // Click three times to select all text in input
+    await handleYear.click({ clickCount: 3 });
     await handleYear.press('2');
     await handleYear.press('0');
     await handleYear.press('2');

--- a/packages/web-components/src/components/va-date/va-date.css
+++ b/packages/web-components/src/components/va-date/va-date.css
@@ -73,3 +73,7 @@ va-select::part(label),
 va-text-input::part(label) {
   margin-top: 0;
 }
+
+va-text-input::part(validation){
+  display: none;
+}

--- a/packages/web-components/src/components/va-date/va-date.css
+++ b/packages/web-components/src/components/va-date/va-date.css
@@ -40,10 +40,10 @@ span.required {
 }
 
 :host([error]:not([error=''])) va-select::part(select),
-:host([error]:not([error=''])) va-number-input::part(input),
+:host([error]:not([error=''])) va-text-input::part(input),
 :host([invalid]) va-select::part(select),
-:host([invalid]) va-number-input::part(input) {
-  border: 3px solid var(--color-secondary-dark);
+:host([invalid]) va-text-input::part(input) {
+  border: 2px solid var(--color-secondary-dark);
 }
 
 .error-message {
@@ -70,6 +70,6 @@ span.required {
 }
 
 va-select::part(label),
-va-number-input::part(label) {
+va-text-input::part(label) {
   margin-top: 0;
 }

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -29,16 +29,6 @@ export class VaDate {
   @Prop() error: string;
 
   /**
-   * Set the `min` value on the year input.
-   */
-  @Prop() minYear: number;
-
-  /**
-   * Set the `max` value on the year input.
-   */
-  @Prop() maxYear: number;
-
-  /**
    * Set the default date value must be in YYYY-MM-DD format.
    */
   @Prop({ mutable: true }) value: string;
@@ -114,8 +104,6 @@ export class VaDate {
       label,
       name,
       error,
-      maxYear,
-      minYear,
       handleDateBlur,
       handleDateChange,
       value,
@@ -141,12 +129,7 @@ export class VaDate {
       <Host value={value} invalid={dateInvalid}>
         <fieldset aria-label="Select Month and two digit day XX and four digit year format XXXX">
           <legend>
-            {label}{' '}
-            {required && (
-              <span class="required">
-                (*Required)
-              </span>
-            )}
+            {label} {required && <span class="required">(*Required)</span>}
           </legend>
           {(error || dateInvalid) && (
             <span class="error-message" role="alert">
@@ -186,17 +169,20 @@ export class VaDate {
                   <option value={day}>{day}</option>
                 ))}
             </va-select>
-            <va-number-input
+            <va-text-input
               label="Year"
               name={`${name}Year`}
-              max={maxYear}
-              min={minYear}
+              maxlength={4}
+              minlength={4}
+              pattern="[0-9]{4}"
               // Value must be a string
-              value={year?.toString()}
+              // Checking is NaN if so provide empty string
+              value={year ? year.toString() : ''}
               onInput={handleDateChange}
               onBlur={handleDateBlur}
               class="input-year"
               inputmode="numeric"
+              type="text"
             />
           </div>
         </fieldset>

--- a/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
+++ b/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
@@ -11,10 +11,10 @@ describe('va-number-input', () => {
     expect(element).toEqualHtml(`
       <va-number-input class="hydrated" label="Hello, world">
         <mock:shadow-root>
-          <label for="inputField" part="label">
+          <label for="inputField">
             Hello, world
           </label>
-          <input id="inputField" part="input" type="number" />
+          <input id="inputField" type="number" />
         </mock:shadow-root>
       </va-number-input>
     `);
@@ -40,10 +40,10 @@ describe('va-number-input', () => {
     expect(el).toEqualHtml(`
       <va-number-input class="hydrated" label="This is a field" required="">
         <mock:shadow-root>
-          <label for="inputField" part="label">
+          <label for="inputField">
             This is a field <span class="required">(*Required)</span>
           </label>
-          <input id="inputField" part="input" type="number" />
+          <input id="inputField" type="number" />
         </mock:shadow-root>
       </va-number-input>
     `);

--- a/packages/web-components/src/components/va-number-input/va-number-input.css
+++ b/packages/web-components/src/components/va-number-input/va-number-input.css
@@ -1,9 +1,5 @@
 @import '../va-text-input/va-text-input.css';
 
-input:invalid {
-  border: 3px solid var(--color-secondary-dark);
-}
-
 input[type='number'] {
   -moz-appearance: textfield;
 }

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -96,7 +96,7 @@ export class VaNumberInput {
     return (
       <Host>
         {this.label && (
-          <label htmlFor="inputField" part="label">
+          <label htmlFor="inputField">
             {this.label}{' '}
             {this.required && (
               <span class="required">
@@ -116,7 +116,6 @@ export class VaNumberInput {
           value={this.value}
           onInput={this.handleInput}
           onBlur={this.handleBlur}
-          part="input"
         />
       </Host>
     );

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -57,27 +57,6 @@ describe('va-text-input', () => {
     expect(error.innerText).toContain('This is a mistake');
   });
 
-  it('adds new aria-describedby for error message', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-text-input error="This is a mistake" />');
-
-    // Render the error message text
-    const inputEl = await page.find('va-text-input >>> input');
-    expect(inputEl.getAttribute('aria-describedby')).toContain('error-message');
-  });
-
-  it('appends to an existing aria-describedby for error message', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-text-input error="This is a mistake" aria-describedby="random-thing" />',
-    );
-
-    // Render the error message text
-    const error = await page.find('va-text-input >>> input');
-    expect(error.getAttribute('aria-describedby')).toContain('random-thing');
-    expect(error.getAttribute('aria-describedby')).toContain('error-message');
-  });
-
   it('renders a required span', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-text-input label="This is a field" required />');
@@ -136,29 +115,36 @@ describe('va-text-input', () => {
     });
   });
 
-  it('emits vaBlur event', async () => {
+  it('emits blur event', async () => {
     const page = await newE2EPage();
 
     await page.setContent('<va-text-input label="Input Field"/>');
 
     const inputEl = await page.find('va-text-input >>> input');
-    const blurSpy = await page.spyOnEvent('vaBlur');
+    const blurSpy = await page.spyOnEvent('blur');
     await inputEl.press('Tab');
 
     expect(blurSpy).toHaveReceivedEvent();
   });
 
-  it('emits vaChange event', async () => {
+  it('emits input event with value updated', async () => {
     const page = await newE2EPage();
 
     await page.setContent('<va-text-input label="Input Field"/>');
 
     const inputEl = await page.find('va-text-input >>> input');
-    const changeSpy = await page.spyOnEvent('vaChange');
-    await inputEl.press('a');
-    await inputEl.press('s');
+    const inputSpy = await page.spyOnEvent('input');
 
-    expect(changeSpy).toHaveReceivedEventDetail({ value: 'as' });
+    // Act
+    await inputEl.press('a');
+    const firstValue = await page.$eval("va-text-input", (comp : HTMLInputElement) => comp.value)
+    await inputEl.press('s');
+    const secondValue = await page.$eval("va-text-input", (comp : HTMLInputElement) => comp.value)
+
+    // Assert
+    expect(inputSpy).toHaveReceivedEventTimes(2);
+    expect(firstValue).toEqual('a');
+    expect(secondValue).toEqual('as');
   });
 
   it("doesn't fire analytics events", async () => {
@@ -176,7 +162,9 @@ describe('va-text-input', () => {
 
   it('adds a character limit with descriptive text', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-text-input maxlength="3" value="22"/>');
+    await page.setContent(
+      '<va-text-input minlength="2" maxlength="3" value="22"/>',
+    );
 
     // Level-setting expectations
     const inputEl = await page.find('va-text-input >>> input');
@@ -188,6 +176,13 @@ describe('va-text-input', () => {
     expect(await inputEl.getProperty('value')).toBe('222');
     expect((await page.find('va-text-input >>> small')).innerText).toContain(
       '(Max. 3 characters)',
+    );
+
+    await inputEl.click({ clickCount: 3 });
+    await inputEl.press('2');
+    expect(await inputEl.getProperty('value')).toBe('2');
+    expect((await page.find('va-text-input >>> small')).innerText).toContain(
+      '(Min. 2 characters)',
     );
   });
 

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -11,11 +11,11 @@ describe('va-text-input', () => {
     expect(element).toEqualHtml(`
       <va-text-input class="hydrated" label="Hello, world">
         <mock:shadow-root>
-          <label for="inputField">
+          <label for="inputField" part="label">
             Hello, world
           </label>
           <slot></slot>
-          <input id="inputField" type="text" />
+          <input id="inputField" type="text" part="input" />
         </mock:shadow-root>
       </va-text-input>
     `);
@@ -34,11 +34,11 @@ describe('va-text-input', () => {
     expect(element).toEqualHtml(`
       <va-text-input class="hydrated" label="Name of issue">
         <mock:shadow-root>
-          <label for="inputField">
+          <label for="inputField" part="label">
             Name of issue
           </label>
           <slot></slot>
-          <input id="inputField" type="text" />
+          <input id="inputField" type="text" part="input" />
         </mock:shadow-root>
         <p className="vads-u-font-weight--normal label-description">
           You can only add an issue that you've already received a VA decision
@@ -66,11 +66,11 @@ describe('va-text-input', () => {
     expect(el).toEqualHtml(`
       <va-text-input class="hydrated" label="This is a field" required="">
         <mock:shadow-root>
-          <label for="inputField">
+          <label for="inputField" part="label">
             This is a field <span class="required">(*Required)</span>
           </label>
           <slot></slot>
-          <input id="inputField" type="text" />
+          <input id="inputField" type="text" part="input" />
         </mock:shadow-root>
       </va-text-input>
     `);

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -1,12 +1,12 @@
 :host {
-    display: block;
-    font-family: var(--font-source-sans);
+  display: block;
+  font-family: var(--font-source-sans);
 }
 
 label {
-    display: block;
-    max-width: 46rem;
-    margin-top: 3rem;
+  display: block;
+  max-width: 46rem;
+  margin-top: 3rem;
 }
 
 span.required {
@@ -54,7 +54,8 @@ input:not([disabled]):focus {
   font-weight: 700;
 }
 
-:host([error]:not([error=''])) input {
+:host([error]:not([error=''])) input,
+input:invalid {
   border: 2px solid var(--color-secondary-dark);
 }
 

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -61,6 +61,11 @@ export class VaTextInput {
   @Prop() maxlength?: number;
 
   /**
+   * The minimum number of characters allowed in the input.
+   */
+  @Prop() minlength?: number;
+
+  /**
    * What to tell the browser to auto-complete the field with.
    */
   @Prop() autocomplete?: string;
@@ -76,9 +81,9 @@ export class VaTextInput {
   @Prop() name?: string;
 
   /**
-   * The aria-describedby attribute for the input element in the shadow DOM.
+   * The regular expression that the input element's value is checked against on submission
    */
-  @Prop() ariaDescribedby?: string = '';
+  @Prop() pattern?: string;
 
   /**
    * The value for the input.
@@ -130,7 +135,7 @@ export class VaTextInput {
     return this.type;
   }
 
-  private handleChange = (e: Event) => {
+  private handleInput = (e: Event) => {
     const target = e.target as HTMLInputElement;
     this.value = target.value;
     this.vaChange.emit({ value: this.value });
@@ -152,9 +157,6 @@ export class VaTextInput {
   };
 
   render() {
-    const describedBy =
-      `${this.ariaDescribedby} ${this.error ? 'error-message' : ''}`.trim() ||
-      null; // Null so we don't add the attribute if we have an empty string
     const inputMode = this.inputmode ? this.inputmode : null; // Null so we don't add the attribute if we have an empty string
     const type = this.getInputType();
 
@@ -172,15 +174,19 @@ export class VaTextInput {
           id="inputField"
           type={type}
           value={this.value}
-          onInput={this.handleChange}
+          onInput={this.handleInput}
           onBlur={this.handleBlur}
-          aria-describedby={describedBy}
           inputmode={inputMode}
           maxlength={this.maxlength}
+          minlength={this.minlength}
+          pattern={this.pattern}
           name={this.name}
         />
         {this.maxlength && this.value?.length >= this.maxlength && (
           <small aria-live="polite">(Max. {this.maxlength} characters)</small>
+        )}
+        {this.minlength && this.value?.length < this.minlength && (
+          <small aria-live="polite">(Min. {this.minlength} characters)</small>
         )}
       </Host>
     );

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -88,7 +88,7 @@ export class VaTextInput {
   /**
    * The value for the input.
    */
-  @Prop({ mutable: true }) value?: string;
+  @Prop({ mutable: true, reflect: true }) value?: string;
   // TODO: Make the value prop reflective. Currently, it isn't because it screws
   // up the input behavior. For now, the only "bug" is that the changed value
   // isn't reflected in the DOM on the web component. That seems to be how the
@@ -163,7 +163,7 @@ export class VaTextInput {
     return (
       <Host>
         {this.label && (
-          <label htmlFor="inputField">
+          <label htmlFor="inputField" part="label">
             {this.label}{' '}
             {this.required && <span class="required">(*Required)</span>}
           </label>
@@ -181,6 +181,7 @@ export class VaTextInput {
           minlength={this.minlength}
           pattern={this.pattern}
           name={this.name}
+          part="input"
         />
         {this.maxlength && this.value?.length >= this.maxlength && (
           <small aria-live="polite">(Max. {this.maxlength} characters)</small>

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -184,10 +184,10 @@ export class VaTextInput {
           part="input"
         />
         {this.maxlength && this.value?.length >= this.maxlength && (
-          <small aria-live="polite">(Max. {this.maxlength} characters)</small>
+          <small aria-live="polite" part="validation">(Max. {this.maxlength} characters)</small>
         )}
         {this.minlength && this.value?.length < this.minlength && (
-          <small aria-live="polite">(Min. {this.minlength} characters)</small>
+          <small aria-live="polite" part="validation">(Min. {this.minlength} characters)</small>
         )}
       </Host>
     );


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/40575

## Testing done
<img width="372" alt="Screen Shot 2022-05-02 at 12 55 44 PM" src="https://user-images.githubusercontent.com/11822533/166290926-6d212caa-d73a-4906-8f48-15adb17d922e.png">

## Screenshots
<img width="700" alt="Screen Shot 2022-05-02 at 12 55 12 PM" src="https://user-images.githubusercontent.com/11822533/166290951-c53dd5e0-a5c8-4f32-8c48-2caa423b1680.png">

## Acceptance criteria
- [X] Use this ticket to make updates and switch from `va-number-input` over to `va-text-input` for `va-date`
- [X] Add 2 additional props for `va-text-input` - `minlength` and `pattern` so that we can replicate what is being done by [uswds](https://designsystem.digital.gov/components/memorable-date/)
- [X] Add tests and storybook examples for `va-text-input` to accommodate the new props
- [X] For `va-text-input` switch `handleChange` to `handleInput` and use `onBlur` and `onInput` per [PR](https://github.com/department-of-veterans-affairs/component-library/pull/363/files) 
- [X] Once updates are made for both `va-text-input` and `va-date` a new patch version should be created

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
