### PR TITLE
Reuse error prop for internal date validation

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -182,7 +182,7 @@ export namespace Components {
          */
         "enableAnalytics": boolean;
         /**
-          * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component
+          * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component It is mutable and reflected into the DOM so that we can use it for simple internal validation
          */
         "error": string;
         /**
@@ -979,7 +979,7 @@ declare namespace LocalJSX {
          */
         "enableAnalytics"?: boolean;
         /**
-          * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component
+          * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component It is mutable and reflected into the DOM so that we can use it for simple internal validation
          */
         "error"?: string;
         /**

--- a/packages/web-components/src/components/va-date/va-date.css
+++ b/packages/web-components/src/components/va-date/va-date.css
@@ -21,8 +21,7 @@ span.required {
   color: var(--color-secondary-dark);
 }
 
-:host([error]:not([error=''])),
-:host([invalid]) {
+:host([error]:not([error=''])) {
   border-left: 4px solid var(--color-secondary-dark);
   margin-top: 3rem;
   padding-bottom: 0.8rem;
@@ -33,16 +32,12 @@ span.required {
 }
 
 :host([error]:not([error=''])) label,
-:host([error]:not([error=''])) span,
-:host([invalid]) label,
-:host([invalid]) span {
+:host([error]:not([error=''])) span {
   font-weight: 700;
 }
 
 :host([error]:not([error=''])) va-select::part(select),
-:host([error]:not([error=''])) va-number-input::part(input),
-:host([invalid]) va-select::part(select),
-:host([invalid]) va-number-input::part(input) {
+:host([error]:not([error=''])) va-number-input::part(input) {
   border: 3px solid var(--color-secondary-dark);
 }
 

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -25,8 +25,9 @@ export class VaDate {
   /**
    * The error message to render (if any)
    * This prop should be leveraged to display any custom validations needed for this component
+   * It is mutable and reflected into the DOM so that we can use it for simple internal validation
    */
-  @Prop() error: string;
+  @Prop({ mutable: true, reflect: true }) error: string;
 
   /**
    * Set the `min` value on the year input.
@@ -113,7 +114,6 @@ export class VaDate {
       required,
       label,
       name,
-      error,
       maxYear,
       minYear,
       handleDateBlur,
@@ -131,14 +131,18 @@ export class VaDate {
     // Check validity of date if invalid provide message and error state styling
     const dateInvalid =
       required && (!isFullDate(value) || day > daysForSelectedMonth.length)
-        ? 'Please provide a valid date'
-        : null;
+
+    if (dateInvalid) this.error = 'Please provide a valid date'
+
+    // This is pulled out from the earlier deconstruction since
+    // we might be assigning a value to it with internal validation
+    const { error } = this;
 
     // Setting new attribute to avoid conflicts with only using error attribute
     // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group
     return (
-      <Host value={value} invalid={dateInvalid}>
+      <Host value={value}>
         <fieldset aria-label="Select Month and two digit day XX and four digit year format XXXX">
           <legend>
             {label}{' '}
@@ -148,9 +152,9 @@ export class VaDate {
               </span>
             )}
           </legend>
-          {(error || dateInvalid) && (
+          {(error) && (
             <span class="error-message" role="alert">
-              <span class="sr-only">Error</span> {error || dateInvalid}
+              <span class="sr-only">Error</span> {error}
             </span>
           )}
           <div class="date-container">

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -138,7 +138,6 @@ export class VaDate {
     // we might be assigning a value to it with internal validation
     const { error } = this;
 
-    // Setting new attribute to avoid conflicts with only using error attribute
     // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group
     return (


### PR DESCRIPTION
## Chromatic
<!-- This `date-error-internal-validation` is a placeholder for a CI job - it will be updated automatically -->
https://date-error-internal-validation--60f9b557105290003b387cd5.chromatic.com

## Description

This is just some discovery to see if the `invalid` attribute is necessary. I was curious since `error` and `invalid` were very similar but separate.

## Testing done

Local storybook :eyes: 


## Screenshots

![Error message changing to reflect custom validation as well as internal validation](https://user-images.githubusercontent.com/2008881/166734775-1fc17ed5-6880-4eab-b9fa-9016f642839b.gif)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
