### PR TITLE
Improve glob pattern to exclude test files

### DIFF
--- a/packages/design-system-dashboard-cli/src/search-files.js
+++ b/packages/design-system-dashboard-cli/src/search-files.js
@@ -19,7 +19,9 @@ const glob = require('glob');
  * @return {Module[]}
  */
 function readAllModules(rootDir) {
-  const jsFiles = glob.sync(`${rootDir}/**/*!(.unit)*.@(js|jsx)`);
+  const jsFiles = glob.sync(
+    `${rootDir}/**/!(tests)/*!(.unit|.spec)*.@(js|jsx)`
+  );
 
   return jsFiles.map(modulePath => ({
     path: modulePath,


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Closes <ticket>

## Testing done

I made some local changes in `vets-website` to a cypress testing file as well as a file that will be included in the build:

```diff
diff --git a/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js b/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
index 735585d072..2869d3506f 100644
--- a/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
@@ -5,6 +5,7 @@ const paddingBottom = { paddingBottom: '1em' };
 export const title = <strong>Which of these best describes you?</strong>;
 export const eligibilityAccordion = (
   <>
+    <va-foo />
     <p>
       We have a limited amount of COVID-19 vaccines. We want to make sure we can
       offer vaccines to as many Veterans, caregivers, spouses, and CHAMPVA
diff --git a/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-compliance-agreements.cypress.spec.js b/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-compliance-agreements.cypress.spec.js
index 4a95c699c2..fdeae36f5d 100644
--- a/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-compliance-agreements.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-compliance-agreements.cypress.spec.js
@@ -1,3 +1,7 @@
+/**
+ * <va-foo />
+ * <va-foo />
+ */
 describe('COVID-19 SAVE LIVES Act sign up', () => {
   describe('when leaving one checkbox unchecked', () => {
     before(() => {
```


## Screenshots

### Before

![Dashboard script showing results from the testing file](https://user-images.githubusercontent.com/2008881/167013298-699914e0-ba9e-47a4-b078-2031329d5270.png)

### After

![Dashboard script excluding test files](https://user-images.githubusercontent.com/2008881/167013649-9bb71b09-67f0-4b19-82a4-a6e37c88c65f.png)


## Acceptance criteria
- [x] Glob patterns are updated to exclude test directories and .spec files
- [ ] Checked the `report` script against vets-website to make sure the correct directories are being excluded (and not others)

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
