### PR TITLE
Added translation to alert aria-label on close button.

### DIFF
--- a/packages/core/src/i18n/translations/en.js
+++ b/packages/core/src/i18n/translations/en.js
@@ -11,4 +11,5 @@ export default {
   'collapse-all': 'English "Expand all"',
   'expand-all-aria-label': 'English "Expand all accordions"',
   'collapse-all-aria-label': 'English "Collapse all accordions"',
+  'close-notification': 'Close Notification'
 };

--- a/packages/core/src/i18n/translations/es.js
+++ b/packages/core/src/i18n/translations/es.js
@@ -11,4 +11,5 @@ export default {
   'collapse-all': 'Spanish "Expand all"',
   'expand-all-aria-label': 'Spanish "Expand all accordions"',
   'collapse-all-aria-label': 'Spanish "Collapse all accordions"',
+  'close-notification': 'Spanish "Close Notification"'
 };

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import { generateEventsDescription } from './events';
 import { VaAlert } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { getWebComponentDocs, propStructure } from './wc-helpers';
@@ -177,6 +177,47 @@ const BackgroundOnlyTemplate = ({
   );
 };
 
+const I18nTemplate = ({
+  status,
+  'background-only': backgroundOnly,
+  'show-icon': showIcon,
+  'disable-analytics': disableAnalytics,
+  visible,
+  'full-width': fullWidth,
+  closeable,
+  headline,
+}) => {
+  const thisTemplate = useRef(null);
+  const [lang, setLang] = useState('en');
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          const newLang = lang === 'en' ? 'es' : 'en';
+          setLang(newLang);
+          thisTemplate.current.closest('main').setAttribute('lang', newLang);
+        }}
+      >
+        Switch language
+      </button>
+      
+      <va-alert
+        status={status}
+        background-only={backgroundOnly}
+        show-icon={showIcon}
+        disable-analytics={disableAnalytics}
+        visible={visible}
+        closeable={closeable}
+        full-width={fullWidth}
+      >
+        {headline}
+        <div ref={thisTemplate}>This is an alert</div>
+      </va-alert>
+    </>
+  );
+};
+
 export const Default = Template.bind({});
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(alertDocs);
@@ -192,6 +233,9 @@ Warning.args = { ...defaultArgs, status: 'warning' };
 
 export const Error = Template.bind({});
 Error.args = { ...defaultArgs, status: 'error' };
+
+export const Internationalization = I18nTemplate.bind({});
+Internationalization.args = { ...defaultArgs, closeable: true };
 
 export const HeadingLevel = Template.bind({});
 HeadingLevel.args = {

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -3,11 +3,19 @@ import {
   Element,
   Event,
   EventEmitter,
+  forceUpdate,
   Host,
   Prop,
   h,
 } from '@stencil/core';
+import i18next from 'i18next';
+import { Build } from '@stencil/core';
 import classnames from 'classnames';
+
+if (Build.isTesting) {
+  // Make i18next.t() return the key instead of the value
+  i18next.init({ lng: 'cimode' });
+}
 
 @Component({
   tag: 'va-alert',
@@ -49,7 +57,7 @@ export class VaAlert {
   /**
    * Aria-label text for the close button.
    */
-  @Prop() closeBtnAriaLabel: string = 'Close notification';
+  @Prop() closeBtnAriaLabel: string = i18next.t('close-notification');
 
   /**
    * If true, a close button will be displayed.
@@ -93,6 +101,16 @@ export class VaAlert {
     bubbles: true,
   })
   componentLibraryAnalytics: EventEmitter;
+
+  connectedCallback() {
+    i18next.on('languageChanged', () => {
+      forceUpdate(this.el);
+    });
+  }
+
+  disconnectedCallback() {
+    i18next.off('languageChanged');
+  }
 
   private closeHandler(e: MouseEvent): void {
     this.closeEvent.emit(e);


### PR DESCRIPTION
## Chromatic
<!-- This `translate-alert` is a placeholder for a CI job - it will be updated automatically -->
https://translate-alert--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [va.gov-team/39886](https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/department-of-veterans-affairs/va.gov-team/39886)

Is there a DS ticket related to this?

## Testing done
No testes needing updates
## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
