### PR TITLE
773 Fix Form Control links from Storybook to design.va

### DIFF
--- a/packages/storybook/stories/va-checkbox-group.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-group.stories.jsx
@@ -20,7 +20,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form-controls#checkboxes">View guidance for the Checkbox Group component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/checkbox">View guidance for the Checkbox Group component in the Design System</a>` +
           '\n' +
           generateEventsDescription(checkBoxGroupDocs),
       },

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -13,7 +13,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form-controls#checkboxes">View guidance for the Checkbox component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/checkbox">View guidance for the Checkbox component in the Design System</a>` +
           '\n' +
           generateEventsDescription(checkboxDocs),
       },

--- a/packages/storybook/stories/va-date.stories.jsx
+++ b/packages/storybook/stories/va-date.stories.jsx
@@ -10,9 +10,13 @@ const dateDocs = getWebComponentDocs('va-date');
 export default {
   title: 'Components/va-date',
   parameters: {
+    componentSubtitle: `Date web component`,
     docs: {
       description: {
-        component: generateEventsDescription(dateDocs),
+        component:
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/date-input">View guidance for the Date component in the Design System</a>` +
+          '\n' +
+          generateEventsDescription(dateDocs),
       },
     },
   },

--- a/packages/storybook/stories/va-radio.stories.jsx
+++ b/packages/storybook/stories/va-radio.stories.jsx
@@ -17,7 +17,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form-controls#radio-buttons">View guidance for the Radio buttons component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/radio-button">View guidance for the Radio buttons component in the Design System</a>` +
           '\n' +
           generateEventsDescription(radioDocs),
       },

--- a/packages/storybook/stories/va-select.stories.jsx
+++ b/packages/storybook/stories/va-select.stories.jsx
@@ -11,7 +11,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form-controls#select-box">View guidance for the Select Box component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/select">View guidance for the Select Box component in the Design System</a>` +
           '\n' +
           generateEventsDescription(selectDocs),
       },

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form-controls#text-inputs">View guidance for the Text Input component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/text-inputs">View guidance for the Text Input component in the Design System</a>` +
           '\n' +
           generateEventsDescription(textInputDocs),
       },


### PR DESCRIPTION
## Chromatic
<!-- This `773-text-input-storybook-link` is a placeholder for a CI job - it will be updated automatically -->
https://773-text-input-storybook-link--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/773

## Testing done - Screenshots
<img width="712" alt="Screen Shot 2022-05-09 at 1 05 37 PM" src="https://user-images.githubusercontent.com/11822533/167461346-0f9f2323-d9d2-4b64-9123-2979abc18662.png">

## Acceptance criteria
- [X] Fix paths for form control links in design.va.gov

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
