### PR TITLE
fix: updating tabindex to -1 to stop keyboard nav

### DIFF
--- a/packages/web-components/src/components/va-segmented-progress-bar/test/va-segmented-progress-bar.e2e.ts
+++ b/packages/web-components/src/components/va-segmented-progress-bar/test/va-segmented-progress-bar.e2e.ts
@@ -17,7 +17,6 @@ describe('va-segmented-progress-bar', () => {
             aria-valuemin="0"
             aria-valuemax="6"
             aria-valuetext="Step 3 of 6"
-            tabindex="-1"
             aria-label="Step 3 of 6"
           >
             <div class="progress-segment progress-segment-complete"></div>

--- a/packages/web-components/src/components/va-segmented-progress-bar/test/va-segmented-progress-bar.e2e.ts
+++ b/packages/web-components/src/components/va-segmented-progress-bar/test/va-segmented-progress-bar.e2e.ts
@@ -17,7 +17,7 @@ describe('va-segmented-progress-bar', () => {
             aria-valuemin="0"
             aria-valuemax="6"
             aria-valuetext="Step 3 of 6"
-            tabindex="0"
+            tabindex="-1"
             aria-label="Step 3 of 6"
           >
             <div class="progress-segment progress-segment-complete"></div>

--- a/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
+++ b/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
@@ -63,7 +63,6 @@ export class VaSegmentedProgressBar {
           aria-valuemin="0"
           aria-valuemax={total}
           aria-valuetext={label}
-          tabindex="-1"
         >
           {range.map(step => (
             <div

--- a/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
+++ b/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
@@ -63,7 +63,7 @@ export class VaSegmentedProgressBar {
           aria-valuemin="0"
           aria-valuemax={total}
           aria-valuetext={label}
-          tabindex="0"
+          tabindex="-1"
         >
           {range.map(step => (
             <div


### PR DESCRIPTION
## Chromatic
<!-- This `fix&#x2F;249-tabindex-progress-bar` is a placeholder for a CI job - it will be updated automatically -->
https://fix&#x2F;249-tabindex-progress-bar--60f9b557105290003b387cd5.chromatic.com

## Description
This a simple change to update the tabIndex to -1 on the va-segmented-progress-bar component to remove the ability to navigate using the keyboard. 

Closes [VAFSC Ticket with original ticket link](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/249)

## Testing done
- [x] Yarn test ran and completed successfully

## Acceptance criteria
- [ ] Progress bar is not navigable using the keyboard

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
