### PR TITLE
Translate text input

### DIFF
--- a/packages/react-components/src/components/TextInput/TextInput.jsx
+++ b/packages/react-components/src/components/TextInput/TextInput.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { uniqueId } from '../../helpers/utilities';
 import { makeField } from '../../helpers/fields';
+import i18next from 'i18next';
 
 import dispatchAnalyticsEvent from '../../helpers/analytics';
 
@@ -46,6 +47,16 @@ class TextInput extends React.Component {
     this.props.onValueChange(makeField(this.props.field.value, true));
   }
 
+  componentDidMount() {
+    i18next.on('languageChanged', () => {
+      this.forceUpdate();
+    });
+  }
+
+  componentWillUnmount() {
+    i18next.off('languageChanged');
+  }
+  
   render() {
     let ariaDescribedBy = this.props.ariaDescribedBy;
     // Calculate error state.
@@ -57,7 +68,7 @@ class TextInput extends React.Component {
       const errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
         <span className="usa-input-error-message" role="alert" id={errorSpanId}>
-          <span className="sr-only">Error</span> {this.props.errorMessage}
+          <span className="sr-only">{i18next.t('Error')}</span> {this.props.errorMessage}
         </span>
       );
       inputErrorClass = 'usa-input-error';
@@ -70,14 +81,14 @@ class TextInput extends React.Component {
     // Calculate max characters and display '(Max. XX characters)' when max is hit.
     if (this.props.field.value) {
       if (this.props.charMax === this.props.field.value.length) {
-        maxCharacters = <small>(Max. {this.props.charMax} characters)</small>;
+        maxCharacters = <small>{i18next.t('max-chars', { length: this.maxlength })}</small>;
       }
     }
 
     // Calculate required.
     let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="form-required-span">(*Required)</span>;
+      requiredSpan = <span className="form-required-span">{i18next.t('required')}</span>;
     }
 
     // preventDefault on the div stops the form from submitting after a user

--- a/packages/react-components/src/components/TextInput/TextInput.jsx
+++ b/packages/react-components/src/components/TextInput/TextInput.jsx
@@ -81,7 +81,7 @@ class TextInput extends React.Component {
     // Calculate max characters and display '(Max. XX characters)' when max is hit.
     if (this.props.field.value) {
       if (this.props.charMax === this.props.field.value.length) {
-        maxCharacters = <small>{i18next.t('max-chars', { length: this.maxlength })}</small>;
+        maxCharacters = <small>({i18next.t('max-chars', { length: this.maxlength })})</small>;
       }
     }
 

--- a/packages/react-components/src/components/TextInput/TextInput.jsx
+++ b/packages/react-components/src/components/TextInput/TextInput.jsx
@@ -88,7 +88,7 @@ class TextInput extends React.Component {
     // Calculate required.
     let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="form-required-span">{i18next.t('required')}</span>;
+      requiredSpan = <span className="form-required-span">(*{i18next.t('required')})</span>;
     }
 
     // preventDefault on the div stops the form from submitting after a user

--- a/packages/react-components/src/components/TextInput/TextInput.unit.spec.jsx
+++ b/packages/react-components/src/components/TextInput/TextInput.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('<TextInput>', () => {
       resources: {
         en: {
           translation: {
-            required: 'Required',
+            required: '(*Required)',
           },
         },
       },

--- a/packages/react-components/src/components/TextInput/TextInput.unit.spec.jsx
+++ b/packages/react-components/src/components/TextInput/TextInput.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('<TextInput>', () => {
       resources: {
         en: {
           translation: {
-            required: '(*Required)',
+            required: 'Required',
           },
         },
       },

--- a/packages/react-components/src/components/TextInput/TextInput.unit.spec.jsx
+++ b/packages/react-components/src/components/TextInput/TextInput.unit.spec.jsx
@@ -2,12 +2,25 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { axeCheck } from '../../helpers/test-helpers';
 import { expect } from 'chai';
+import i18next from 'i18next';
 import TextInput from './TextInput.jsx';
 import { makeField } from '../../helpers/fields.js';
 import sinon from 'sinon';
 import { testAnalytics } from '../../helpers/test-helpers';
 
 describe('<TextInput>', () => {
+  before(() => {
+    i18next.init({
+      fallbackLng: 'en',
+      resources: {
+        en: {
+          translation: {
+            required: 'Required',
+          },
+        },
+      },
+    });
+  });
   it('calls onValueChange with input value and dirty state', () => {
     let valueChanged;
     // shallowly render component with callback that alters valueChanged with passed argument

--- a/packages/storybook/stories/TextInput.stories.jsx
+++ b/packages/storybook/stories/TextInput.stories.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import TextInput from '../../react-components/src/components/TextInput/TextInput';
 
@@ -16,6 +16,26 @@ const Template = args => {
   return <TextInput {...args} field={field} onValueChange={onValueChange} />;
 };
 
+const I18nTemplate = args => {
+  const [lang, setLang] = useState('en');
+  const [field, setField] = useState(args.field);
+  const onValueChange = newField => {
+    setField(newField);
+  };
+
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, [lang]);
+
+  return (
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <TextInput {...args} field={field} onValueChange={onValueChange} />
+    </div>
+  );
+};
+
 const defaultArgs = {
   label: 'First name',
   name: 'first_name',
@@ -28,6 +48,12 @@ const defaultArgs = {
 export const Default = Template.bind({});
 Default.args = {
   ...defaultArgs,
+};
+
+export const Internationalization = I18nTemplate.bind({});
+Internationalization.args = {
+  ...defaultArgs,
+  required: true,
 };
 
 export const ErrorMessage = Template.bind({});

--- a/packages/storybook/stories/TextInput.stories.jsx
+++ b/packages/storybook/stories/TextInput.stories.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import TextInput from '../../react-components/src/components/TextInput/TextInput';
+import { TextInput } from '@department-of-veterans-affairs/component-library';
 
 export default {
   title: 'Components/TextInput (deprecated)',

--- a/packages/storybook/stories/TextInput.stories.jsx
+++ b/packages/storybook/stories/TextInput.stories.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { TextInput } from '@department-of-veterans-affairs/component-library';
+import TextInput from '../../react-components/src/components/TextInput/TextInput';
 
 export default {
   title: 'Components/TextInput (deprecated)',

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -139,11 +139,6 @@ const I18nTemplate = ({
   );
 };
 
-export const Internationalization = I18nTemplate.bind({});
-Internationalization.args = {
-  ...defaultArgs,
-};
-
 export const Default = Template.bind({});
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(textInputDocs);
@@ -156,6 +151,13 @@ Success.args = { ...defaultArgs, success: true };
 
 export const Required = Template.bind({});
 Required.args = { ...defaultArgs, required: true };
+
+export const Internationalization = I18nTemplate.bind({});
+Internationalization.args = {
+  ...defaultArgs,
+  required: true,
+  maxlength: '16',
+};
 
 export const MaxLength = Template.bind({});
 MaxLength.args = {

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React from 'react';
+import React, { useState } from 'react';
 import { generateEventsDescription } from './events';
 import { getWebComponentDocs, propStructure } from './wc-helpers';
 
@@ -95,6 +95,53 @@ const Template = ({
       onInput={e => console.log('input event value', e.target.value)}
     />
   );
+};
+
+const I18nTemplate = ({
+  name,
+  label,
+  autocomplete,
+  'enable-analytics': enableAnalytics,
+  required,
+  error,
+  maxlength,
+  value,
+  inputmode,
+  type,
+  'aria-describedby': ariaDescribedby,
+}) => {
+  const [lang, setLang] = useState('en');
+  return (
+    <>
+      <button
+        onClick={() => {
+          const newLang = lang === 'en' ? 'es' : 'en';
+          setLang(newLang);
+          document.querySelector('main').setAttribute('lang', newLang);
+        }}
+      >
+        Switch language
+      </button>
+      <va-text-input
+        name={name}
+        label={label}
+        autocomplete={autocomplete}
+        enable-analytics={enableAnalytics}
+        required={required}
+        error={error}
+        maxlength={maxlength}
+        value={value}
+        inputmode={inputmode}
+        type={type}
+        aria-describedby={ariaDescribedby}
+      />
+    </>
+  );
+};
+
+export const Internationalization = I18nTemplate.bind({});
+Internationalization.args = {
+  ...defaultArgs,
 };
 
 export const Default = Template.bind({});

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -88,7 +88,7 @@ describe('va-text-input', () => {
       <va-text-input class="hydrated" label="This is a field" required="">
         <mock:shadow-root>
           <label for="inputField" part="label">
-            This is a field <span class="required">required</span>
+            This is a field <span class="required">(*required)</span>
           </label>
           <slot></slot>
           <input id="inputField" type="text" part="input" />

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -88,7 +88,7 @@ describe('va-text-input', () => {
       <va-text-input class="hydrated" label="This is a field" required="">
         <mock:shadow-root>
           <label for="inputField" part="label">
-            This is a field <span class="required">(*Required)</span>
+            This is a field <span class="required">required</span>
           </label>
           <slot></slot>
           <input id="inputField" type="text" part="input" />
@@ -196,7 +196,7 @@ describe('va-text-input', () => {
     await inputEl.press('2');
     expect(await inputEl.getProperty('value')).toBe('222');
     expect((await page.find('va-text-input >>> small')).innerText).toContain(
-      '(Max. 3 characters)',
+      'max-chars',
     );
 
     // Click three times to select all text in input

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -199,7 +199,7 @@ export class VaTextInput {
         />
         {this.maxlength && this.value?.length >= this.maxlength && (
           <small aria-live="polite" part="validation">
-            {i18next.t('max-chars', { length: this.maxlength })}
+            ({i18next.t('max-chars', { length: this.maxlength })})
           </small>
         )}
         {this.minlength && this.value?.length < this.minlength && (

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -162,6 +162,10 @@ export class VaTextInput {
     });
   };
 
+  disconnectedCallback() {
+    i18next.off('languageChanged');
+  };
+
   render() {
     const describedBy =
       `${this.ariaDescribedby} ${this.error ? 'error-message' : ''}`.trim() ||

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -178,7 +178,7 @@ export class VaTextInput {
         {this.label && (
           <label htmlFor="inputField" part="label">
             {this.label}{' '}
-            {this.required && <span class="required">{i18next.t('required')}</span>}
+            {this.required && <span class="required">(*{i18next.t('required')})</span>}
           </label>
         )}
         <slot></slot>

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -6,8 +6,16 @@ import {
   h,
   Event,
   EventEmitter,
+  forceUpdate,
 } from '@stencil/core';
+import i18next from 'i18next';
+import { Build } from '@stencil/core';
 import { consoleDevError } from '../../utils/utils';
+
+if (Build.isTesting) {
+  // Make i18next.t() return the key instead of the value
+  i18next.init({ lng: 'cimode' });
+}
 
 @Component({
   tag: 'va-text-input',
@@ -148,6 +156,12 @@ export class VaTextInput {
     }
   };
 
+  connectedCallback() {
+    i18next.on('languageChanged', () => {
+      forceUpdate(this.el);
+    });
+  };
+
   render() {
     const describedBy =
       `${this.ariaDescribedby} ${this.error ? 'error-message' : ''}`.trim() ||
@@ -160,7 +174,7 @@ export class VaTextInput {
         {this.label && (
           <label htmlFor="inputField" part="label">
             {this.label}{' '}
-            {this.required && <span class="required">(*Required)</span>}
+            {this.required && <span class="required">{i18next.t('required')}</span>}
           </label>
         )}
         <slot></slot>
@@ -181,7 +195,7 @@ export class VaTextInput {
         />
         {this.maxlength && this.value?.length >= this.maxlength && (
           <small aria-live="polite" part="validation">
-            (Max. {this.maxlength} characters)
+            {i18next.t('max-chars', { length: this.maxlength })}
           </small>
         )}
         {this.minlength && this.value?.length < this.minlength && (


### PR DESCRIPTION
## Chromatic
<!-- This `translate-text-input` is a placeholder for a CI job - it will be updated automatically -->
https://translate-text-input--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [va.gov-team/39885](https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/department-of-veterans-affairs/va.gov-team/39885)

## Testing done
Updated existing text input tests.

## Screenshots
![chrome-capture-2022-3-28](https://user-images.githubusercontent.com/13967174/165868177-e94d65fc-9ae0-42d0-972e-05f8f09375a7.gif)

![Screen Shot 2022-04-28 at 4 27 38 PM](https://user-images.githubusercontent.com/13967174/165863660-660528ad-ee51-42bd-ac63-edd58f64bb39.png)
![Screen Shot 2022-04-28 at 5 11 14 PM](https://user-images.githubusercontent.com/13967174/165867003-66f379db-6e3e-4951-80cc-7b0ca8fabf4e.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
