### PR TITLE
Bump version publishing translation changes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Chromatic
<!-- This `translation-version-bump` is a placeholder for a CI job - it will be updated automatically -->
https://translation-version-bump--60f9b557105290003b387cd5.chromatic.com

## Description
We've got a handful of translation-related changes in master ready to be published. This just bumps the version.

## Testing done
N/A

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
