### PR TITLE
Bump react-components version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",


### PR DESCRIPTION
## Chromatic
<!-- This `react-component-translation-bump` is a placeholder for a CI job - it will be updated automatically -->
https://react-component-translation-bump--60f9b557105290003b387cd5.chromatic.com

## Description
In #421 I forgot to include a bump for the `react-components` version :upside_down_face: . This means we didn't get the `<Date>` react component changes published. [GitHub action log](https://github.com/department-of-veterans-affairs/component-library/runs/6396508654?check_suite_focus=true#step:12:130).

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
