### PR TITLE
Fix react build public path

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "10.2.1-0",
+  "version": "10.2.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"
@@ -34,6 +34,5 @@
     "@department-of-veterans-affairs/formation": "*",
     "react": "^17",
     "react-dom": "*"
-  },
-  "stableVersion": "10.2.0"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "10.2.0",
+  "version": "10.2.1-0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"
@@ -34,5 +34,6 @@
     "@department-of-veterans-affairs/formation": "*",
     "react": "^17",
     "react-dom": "*"
-  }
+  },
+  "stableVersion": "10.2.0"
 }

--- a/packages/core/src/i18n/translations/es.js
+++ b/packages/core/src/i18n/translations/es.js
@@ -6,7 +6,7 @@ export default {
   'month': 'Mes',
   'day': 'Día',
   'year': 'Año',
-  'year-range': 'Ingrese un año entre {{start}} y {{end}}"',
+  'year-range': 'Ingrese un año entre {{start}} y {{end}}',
   'expand-all': 'Expandir todo',
   'collapse-all': 'Contraer todo',
   'expand-all-aria-label': 'Expandir todos los acordeones',

--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
   entry: ['./src/main.js'],
   target: ['web', 'es5'],
   output: {
+    publicPath: '',
     path: __dirname + '/dist',
     filename: 'app.bundle.js',
   },

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "6.1.0",
+  "version": "6.1.1-0",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",
@@ -99,5 +99,6 @@
     "i18next-browser-languagedetector": "*",
     "react": "^17",
     "react-dom": "*"
-  }
+  },
+  "stableVersion": "6.1.0"
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "6.1.1-0",
+  "version": "6.1.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",
@@ -99,6 +99,5 @@
     "i18next-browser-languagedetector": "*",
     "react": "^17",
     "react-dom": "*"
-  },
-  "stableVersion": "6.1.0"
+  }
 }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.1.1-0",
+  "version": "4.1.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -56,6 +56,5 @@
     "@department-of-veterans-affairs/formation": "^7.0.1",
     "i18next": "*",
     "i18next-browser-languagedetector": "*"
-  },
-  "stableVersion": "4.1.0"
+  }
 }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.1.0",
+  "version": "4.1.1-0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -56,5 +56,6 @@
     "@department-of-veterans-affairs/formation": "^7.0.1",
     "i18next": "*",
     "i18next-browser-languagedetector": "*"
-  }
+  },
+  "stableVersion": "4.1.0"
 }


### PR DESCRIPTION
## Chromatic
<!-- This `fix-react-build-publicPath` is a placeholder for a CI job - it will be updated automatically -->
https://fix-react-build-publicPath--60f9b557105290003b387cd5.chromatic.com

## Description
In order for dynamic translation in the `<Date>` react component to work, the import needs to be made in the root of the `component-library` package. Doing this causes `vets-website` tests to fail, saying:

```
Error: Automatic publicPath is not supported in this browser
```

Setting `publicPath: ''` is a workaround that I've seen mentioned in a few places:

- [SO answer](https://stackoverflow.com/a/64715069)
    - This seems to be about fonts, which isn't our use case
- [GH issue on `cypress` repo](https://github.com/cypress-io/cypress/issues/18435#issue-1022498688)
   - This is testing/JS related, so maybe it will work

## Testing done

Tested using a [pre-release](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v10.2.1-0) in https://github.com/department-of-veterans-affairs/vets-website/pull/21050

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
