### PR TITLE
Fix monthyear months

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "10.2.1",
+  "version": "10.2.2-0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"
@@ -34,5 +34,6 @@
     "@department-of-veterans-affairs/formation": "*",
     "react": "^17",
     "react-dom": "*"
-  }
+  },
+  "stableVersion": "10.2.1"
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "6.1.1",
+  "version": "6.1.2-0",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",
@@ -99,5 +99,6 @@
     "i18next-browser-languagedetector": "*",
     "react": "^17",
     "react-dom": "*"
-  }
+  },
+  "stableVersion": "6.1.1"
 }

--- a/packages/react-components/src/components/MonthYear/MonthYear.jsx
+++ b/packages/react-components/src/components/MonthYear/MonthYear.jsx
@@ -96,7 +96,7 @@ class MonthYear extends React.Component {
                 errorMessage={isValid ? undefined : ''}
                 label="Month"
                 name={`${this.props.name}Month`}
-                options={months}
+                options={months()}
                 value={month}
                 onValueChange={update => {
                   this.handleChange('month', update);

--- a/packages/storybook/stories/MonthYear.stories.jsx
+++ b/packages/storybook/stories/MonthYear.stories.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import MonthYear from '../../react-components/src/components/MonthYear/MonthYear';
+import { MonthYear } from '@department-of-veterans-affairs/component-library';
 
 export default {
   title: 'Components/MonthYear',


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
In https://github.com/department-of-veterans-affairs/component-library/pull/394 I turned the `months` helper into a function so that the values could be dynamic. `<MonthYear>` was still trying to use it as an array, so it wasn't displaying values correctly. This fixes that.

## Testing done

Storybook

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
