### PR TITLE
Focus only radio button for va-radio 

### DIFF
--- a/packages/web-components/src/components/va-radio-option/va-radio-option.css
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.css
@@ -5,6 +5,10 @@
   margin-top: 1rem;
 }
 
+:host(:focus) {
+  outline: none !important;
+}
+
 label {
   box-sizing: border-box;
   outline: none;
@@ -31,4 +35,9 @@ label::before {
 :host([aria-checked='true']) label::before {
   background-color: var(--color-primary);
   box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-primary);
+}
+
+:host(:focus) label::before {
+  outline: 2px solid var(--color-gold-light);
+  outline-offset: 6px;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `40279-radio-option` is a placeholder for a CI job - it will be updated automatically -->
https://40279-radio-option--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/40279

## Testing done
Storybook

## Screenshots
<img width="1053" alt="Screen Shot 2022-05-17 at 10 43 32" src="https://user-images.githubusercontent.com/36863582/168839578-16dcc72f-1125-4509-947a-e616b51c5d74.png">


## Acceptance criteria
- [x] Focus halo is visible only on radio button

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
