### PR TITLE
40187 Storybook Banners Documentation

### DIFF
--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -7,9 +7,12 @@ const bannerDocs = getWebComponentDocs('va-banner');
 export default {
   title: 'Components/va-banner',
   parameters: {
+    componentSubtitle: `Banner web component`,
     docs: {
       description: {
         component:
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/banner">View guidance for the Banner component in the Design System</a>` +
+          `\n` +
           `Reset the banners in storage by opening Developer Tools in the browser and then clicking on the Application Tab. ` +
           `Under Storage you will see both Local and Session Storage check each Storage to see if a DISMISSED_BANNERS Key exists. ` +
           `If it does right click and delete it and refresh your page to see the banners again.` +


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/40187

## Related PR

## Testing done - Screenshots
<img width="705" alt="Screen Shot 2022-05-18 at 10 10 56 AM" src="https://user-images.githubusercontent.com/11822533/169061992-8fa4fa5a-2e0e-457e-87ce-b430e092e619.png">

## Acceptance criteria
- [x] Storybook has link “View guidance for Banner component in the Design System”
- [x] Storybook has a link to the component page on design.va.gov

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
