### PR TITLE
791 Storybook Dismissable Background

### DIFF
--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -206,6 +206,23 @@ Dismissable.args = {
   onCloseEvent: () => console.log('Close event triggered'),
 };
 
+export const DismissableBackgroundOnly = Template.bind({});
+DismissableBackgroundOnly.args = {
+  ...defaultArgs,
+  'background-only': true,
+  closeable: true,
+  onCloseEvent: () => console.log('Close event triggered'),
+};
+
+export const DismissableBackgroundOnlyIcon = Template.bind({});
+DismissableBackgroundOnlyIcon.args = {
+  ...defaultArgs,
+  'background-only': true,
+  'show-icon': true,
+  closeable: true,
+  onCloseEvent: () => console.log('Close event triggered'),
+};
+
 export const Fullwidth = Template.bind({});
 Fullwidth.args = {
   ...defaultArgs,


### PR DESCRIPTION
## Chromatic
<!-- This `791-storybook-dismissable-background` is a placeholder for a CI job - it will be updated automatically -->
https://791-storybook-dismissable-background--60f9b557105290003b387cd5.chromatic.com

## Related PR
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/889

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/791

## Testing done - Screenshots
<img width="761" alt="Screen Shot 2022-05-18 at 11 36 46 AM" src="https://user-images.githubusercontent.com/11822533/169089972-5e079ac5-c403-4a14-a0ba-24a72a2997b4.png">

## Acceptance criteria
- [X]  Only one example in Storybook should show background color as changeable should have additional ones for Background Only and Background Only Icon

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
