### PR TITLE
Update link for va-textarea and va-text-input

### DIFF
--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/text-inputs">View guidance for the Text Input component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/text-input">View guidance for the Text Input component in the Design System</a>` +
           '\n' +
           generateEventsDescription(textInputDocs),
       },

--- a/packages/storybook/stories/va-textarea.stories.jsx
+++ b/packages/storybook/stories/va-textarea.stories.jsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/text-inputs#text-area">View guidance for the Textarea component in the Design System</a>` +
+          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/textarea">View guidance for the Textarea component in the Design System</a>` +
           '\n' +
           generateEventsDescription(textareaDocs),
       },


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/40157

[Related PR](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/890)

## Acceptance criteria
- [x] Link to DS for va-textarea is correct (components/form/textarea)
- [x] Link to DS for va-text-input is correct (components/form/text-input)

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
