### PR TITLE
Va alert/no headline spacing issue

### DIFF
--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -104,6 +104,7 @@ const BackgroundOnlyTemplate = ({
 }) => {
   return (
     <>
+     
       <va-alert
         status="info"
         background-only={backgroundOnly}
@@ -247,4 +248,18 @@ export const NotVisible = Template.bind({});
 NotVisible.args = {
   ...defaultArgs,
   visible: false,
+};
+
+
+export const noHeaderMessage = ({ }) => {
+  return (
+    <>
+      <va-alert
+        status="warning"
+      >
+        <div>Lorem ipsum dolor sit amet consectetur adipisicing elit. Id quod corrupti reiciendis nesciunt unde rem! Amet quos porro repellat, debitis explicabo temporibus commodi consequatur expedita, tempora corrupti, vel perferendis soluta.</div>
+       
+      </va-alert>
+    </>
+  );
 };

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -11,6 +11,25 @@ describe('va-alert', () => {
     expect(element).toEqualHtml(`
       <va-alert class="hydrated" status="info">
         <mock:shadow-root>
+          <div class="alert info no-headline">
+            <i aria-hidden="true" role="img"></i>
+            <div class="body" role="presentation">
+              <slot></slot>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </va-alert>
+    `);
+  });
+
+  it('renders a headline when present', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<va-alert><h1 slot="headline">Test headline</h1></va-alert>');
+    const element = await page.find('va-alert');
+    expect(element).toEqualHtml(`
+      <va-alert class="hydrated" status="info">
+        <mock:shadow-root>
           <div class="alert info">
             <i aria-hidden="true" role="img"></i>
             <div class="body" role="presentation">
@@ -19,9 +38,12 @@ describe('va-alert', () => {
             </div>
           </div>
         </mock:shadow-root>
-      </va-alert>
-    `);
+        <h1 slot="headline">
+          Test headline
+        </h1>
+    </va-alert>`);
   });
+
 
   it('renders an empty div with a "polite" aria-live tag when not visible', async () => {
     const page = await newE2EPage();

--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -80,6 +80,11 @@ div.body {
   vertical-align: middle;
   width: 100%;
 }
+
+.no-headline ::slotted(:not([slot]):first-child) {
+  margin-top: 0rem;
+}
+
 ::slotted(:not([slot])) {
   margin-top: 2rem;
 }

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -103,9 +103,13 @@ export class VaAlert {
 
     // This is the happy path, meaning the user isn't using IE11
     try {
-      const children = this.el.shadowRoot.querySelector('slot').assignedNodes();
+      // const children = this.el.shadowRoot.querySelector('slot').assignedNodes();
       // An empty array means that there isn't a node with `slot="headline"`
-      headlineText = children.length > 0 ? children[0].textContent : null;
+      // headlineText = children.length > 0 ? children[0].textContent : null;
+      const hasHeadline = !!this.el.querySelector('[slot="headline"]');
+      if (hasHeadline) {
+        headlineText = this.el.querySelector('[slot="headline"]').textContent;
+      }
     } catch (e) {
       // This is where we handle the edge case of the user being on IE11
       const children = this.el.shadowRoot.childNodes;
@@ -144,13 +148,14 @@ export class VaAlert {
 
   render() {
     const { backgroundOnly, status, visible, closeable, showIcon } = this;
+    const hasHeadline = !!this.el.querySelector('[slot="headline"]');
     const classes = classnames('alert', status, {
       'bg-only': backgroundOnly,
       'hide-icon': backgroundOnly && !showIcon,
+      'no-headline': !hasHeadline,
     });
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;
-
     if (!visible) return <div aria-live="polite" />;
 
     return (
@@ -162,8 +167,8 @@ export class VaAlert {
             onClick={this.handleAlertBodyClick.bind(this)}
             role="presentation"
           >
-            {!backgroundOnly && <slot name="headline"></slot>}
-            <slot></slot>
+            {!backgroundOnly && hasHeadline && <slot name="headline"></slot>}
+              <slot></slot>
           </div>
         </div>
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -103,9 +103,6 @@ export class VaAlert {
 
     // This is the happy path, meaning the user isn't using IE11
     try {
-      // const children = this.el.shadowRoot.querySelector('slot').assignedNodes();
-      // An empty array means that there isn't a node with `slot="headline"`
-      // headlineText = children.length > 0 ? children[0].textContent : null;
       const hasHeadline = !!this.el.querySelector('[slot="headline"]');
       if (hasHeadline) {
         headlineText = this.el.querySelector('[slot="headline"]').textContent;


### PR DESCRIPTION
## Chromatic
<!-- This `va-alert&#x2F;no-header` is a placeholder for a CI job - it will be updated automatically -->
https://va-alert&#x2F;no-header--60f9b557105290003b387cd5.chromatic.com

## Description
Our Design has created a new alert format with no headline. Currently, if there is no header/headline, the component renders out extra space at the top of the component (see before screenshot). This PR conditionally hides the headline slot and updates the styling to not have the extra padding if the headline does not exist. 

[Mocks from Designer](https://www.sketch.com/s/1a920e73-1dcb-47c4-aae8-08656756c131/a/zxWvzOy#Inspector)

## Testing done
- Added unit tests
- Visual 

## Screenshots
Before: 
![Screen Shot 2022-05-19 at 11 20 39 AM](https://user-images.githubusercontent.com/1793923/169333878-1fe8db14-d2a7-4a0a-b2a9-d01da55ab08f.png)
After:
![Screen Shot 2022-05-19 at 11 20 56 AM](https://user-images.githubusercontent.com/1793923/169333987-e8a9870e-64fc-4535-8d50-8ef8faea801b.png)
