### PR TITLE
Add subtitle and link to DS for va-featured-content

### DIFF
--- a/packages/storybook/stories/va-featured-content.stories.jsx
+++ b/packages/storybook/stories/va-featured-content.stories.jsx
@@ -6,6 +6,14 @@ const featuredContentDocs = getWebComponentDocs('va-featured-content');
 
 export default {
   title: 'Components/va-featured-content',
+  parameters: {
+    docs: {
+      description: {
+        component: `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/featured-content">View guidance for the Featured content component in the Design System</a>`,
+      },
+    },
+    componentSubtitle: `Featured content web component`,
+  },
 };
 
 const Template = () => (


### PR DESCRIPTION
## Chromatic
<!-- This `40188-featured-content` is a placeholder for a CI job - it will be updated automatically -->
https://40188-featured-content--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/40188

## Screenshots
<img width="1021" alt="Screen Shot 2022-05-20 at 10 51 10" src="https://user-images.githubusercontent.com/36863582/169554457-dac98ea8-c403-4d49-bf73-9ef589318dc1.png">


## Acceptance criteria
- [x] Featured content has a subtitle
- [x] Featured content has a link to https://design.va.gov/components/featured-content

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
