### PR TITLE
Mention canvas tab in docs page

### DIFF
--- a/packages/storybook/stories/events.js
+++ b/packages/storybook/stories/events.js
@@ -6,5 +6,5 @@ export const generateEventsDescription = componentDocs => {
 
   return ` This component has ${events.length} ${
     events.length > 1 ? 'events' : 'event'
-  }: ${eventNames}. Please see our documentation on how to use web component events at https://design.va.gov/about/developers#using-web-components.`;
+  }: ${eventNames}.`;
 };

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { generateEventsDescription } from './events';
 import {
   getWebComponentDocs,
   componentStructure,

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -4,6 +4,7 @@ import {
   getWebComponentDocs,
   componentStructure,
   propStructure,
+  StoryDocs,
 } from './wc-helpers';
 
 const accordionDocs = getWebComponentDocs('va-accordion');
@@ -15,12 +16,17 @@ export default {
   parameters: {
     componentSubtitle: `Accordion web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/accordion">View guidance for the Accordion component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(accordionDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...accordionDocs,
+            guidance: {
+              componentHref: 'accordion',
+              componentName: 'Accordion',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -15,17 +15,7 @@ export default {
   parameters: {
     componentSubtitle: `Accordion web component`,
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...accordionDocs,
-            guidance: {
-              componentHref: 'accordion',
-              componentName: 'Accordion',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={accordionDocs} />,
     },
   },
 };

--- a/packages/storybook/stories/va-additional-info.stories.jsx
+++ b/packages/storybook/stories/va-additional-info.stories.jsx
@@ -7,17 +7,7 @@ export default {
   parameters: {
     componentSubtitle: `Additional Info web component`,
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...additionalInfoDocs,
-            guidance: {
-              componentHref: 'additional-info',
-              componentName: 'Additional info',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={additionalInfoDocs} />,
     },
     actions: {
       handles: ['component-library-analytics'],

--- a/packages/storybook/stories/va-additional-info.stories.jsx
+++ b/packages/storybook/stories/va-additional-info.stories.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
-import { generateEventsDescription } from './events';
-
 const additionalInfoDocs = getWebComponentDocs('va-additional-info');
 
 export default {

--- a/packages/storybook/stories/va-additional-info.stories.jsx
+++ b/packages/storybook/stories/va-additional-info.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 import { generateEventsDescription } from './events';
 
 const additionalInfoDocs = getWebComponentDocs('va-additional-info');
@@ -9,12 +9,17 @@ export default {
   parameters: {
     componentSubtitle: `Additional Info web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/additional-info">View guidance for the Additional Info component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(additionalInfoDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...additionalInfoDocs,
+            guidance: {
+              componentHref: 'additional-info',
+              componentName: 'Additional info',
+            },
+          }}
+        />
+      ),
     },
     actions: {
       handles: ['component-library-analytics'],

--- a/packages/storybook/stories/va-alert-expandable.stories.jsx
+++ b/packages/storybook/stories/va-alert-expandable.stories.jsx
@@ -12,7 +12,6 @@ export default {
           data={{
             ...alertExpandableDocs,
             guidance: {
-              componentHref: 'alert-expandable',
               componentName: 'Alert Expandable',
             },
           }}

--- a/packages/storybook/stories/va-alert-expandable.stories.jsx
+++ b/packages/storybook/stories/va-alert-expandable.stories.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
-import { generateEventsDescription } from './events';
-
 const alertExpandableDocs = getWebComponentDocs('va-alert-expandable');
 
 export default {

--- a/packages/storybook/stories/va-alert-expandable.stories.jsx
+++ b/packages/storybook/stories/va-alert-expandable.stories.jsx
@@ -1,6 +1,5 @@
-
 import React from 'react';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 import { generateEventsDescription } from './events';
 
 const alertExpandableDocs = getWebComponentDocs('va-alert-expandable');
@@ -10,12 +9,17 @@ export default {
   parameters: {
     componentSubtitle: `Alert Expandable web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/alert-expandable">View guidance for the Alert Expandable component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(alertExpandableDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...alertExpandableDocs,
+            guidance: {
+              componentHref: 'alert-expandable',
+              componentName: 'Alert Expandable',
+            },
+          }}
+        />
+      ),
     },
     actions: {
       handles: ['component-library-analytics'],

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { generateEventsDescription } from './events';
 import { VaAlert } from '@department-of-veterans-affairs/web-components/react-bindings';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const alertDocs = getWebComponentDocs('va-alert');
 
@@ -25,14 +25,17 @@ export default {
   },
   parameters: {
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/alert">View guidance for the Alert component in the Design System</a>` +
-          `\n` +
-          `Use a heading element with an attribute named slot and a value of "headline" to control what is displayed for the alert's headline. 
-          Any children passed into this component without a parent slot "headline" will render in the alert's body.` +
-          generateEventsDescription(alertDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...alertDocs,
+            guidance: {
+              componentHref: 'alert',
+              componentName: 'Alert',
+            },
+          }}
+        />
+      ),
     },
     componentSubtitle: `Alert web component`,
   },

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -24,17 +24,7 @@ export default {
   },
   parameters: {
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...alertDocs,
-            guidance: {
-              componentHref: 'alert',
-              componentName: 'Alert',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={alertDocs} />,
     },
     componentSubtitle: `Alert web component`,
   },

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { generateEventsDescription } from './events';
 import { VaAlert } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 

--- a/packages/storybook/stories/va-back-to-top.stories.jsx
+++ b/packages/storybook/stories/va-back-to-top.stories.jsx
@@ -7,17 +7,7 @@ export default {
   title: 'Components/va-back-to-top',
   parameters: {
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...bttDocs,
-            guidance: {
-              componentHref: 'back-to-top',
-              componentName: 'Back to top',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={bttDocs} />,
     },
     componentSubtitle: `Back to top web component`,
   },

--- a/packages/storybook/stories/va-back-to-top.stories.jsx
+++ b/packages/storybook/stories/va-back-to-top.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const bttDocs = getWebComponentDocs('va-back-to-top');
 
@@ -7,9 +7,17 @@ export default {
   title: 'Components/va-back-to-top',
   parameters: {
     docs: {
-      description: {
-        component: `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/back-to-top">View guidance for the Back to top component in the Design System</a>`,
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...bttDocs,
+            guidance: {
+              componentHref: 'back-to-top',
+              componentName: 'Back to top',
+            },
+          }}
+        />
+      ),
     },
     componentSubtitle: `Back to top web component`,
   },

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { generateEventsDescription } from './events';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const bannerDocs = getWebComponentDocs('va-banner');

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -8,17 +8,7 @@ export default {
   parameters: {
     componentSubtitle: `Banner web component`,
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...bannerDocs,
-            guidance: {
-              componentHref: 'banner',
-              componentName: 'Banner',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={bannerDocs} />,
     },
   },
   argTypes: {

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const bannerDocs = getWebComponentDocs('va-banner');
 
@@ -9,15 +9,17 @@ export default {
   parameters: {
     componentSubtitle: `Banner web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/banner">View guidance for the Banner component in the Design System</a>` +
-          `\n` +
-          `Reset the banners in storage by opening Developer Tools in the browser and then clicking on the Application Tab. ` +
-          `Under Storage you will see both Local and Session Storage check each Storage to see if a DISMISSED_BANNERS Key exists. ` +
-          `If it does right click and delete it and refresh your page to see the banners again.` +
-          generateEventsDescription(bannerDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...bannerDocs,
+            guidance: {
+              componentHref: 'banner',
+              componentName: 'Banner',
+            },
+          }}
+        />
+      ),
     },
   },
   argTypes: {

--- a/packages/storybook/stories/va-breadcrumbs.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs.stories.jsx
@@ -7,17 +7,7 @@ export default {
   title: 'Components/va-breadcrumbs',
   parameters: {
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...breadcrumbsDocs,
-            guidance: {
-              componentHref: 'breadcrumbs',
-              componentName: 'Breadcrumbs',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={breadcrumbsDocs} />,
     },
   },
 };

--- a/packages/storybook/stories/va-breadcrumbs.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs.stories.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const breadcrumbsDocs = getWebComponentDocs('va-breadcrumbs');
 
 export default {
   title: 'Components/va-breadcrumbs',
+  parameters: {
+    docs: {
+      page: () => (
+        <StoryDocs
+          data={{
+            ...breadcrumbsDocs,
+            guidance: {
+              componentHref: 'breadcrumbs',
+              componentName: 'Breadcrumbs',
+            },
+          }}
+        />
+      ),
+    },
+  },
 };
 
 const Template = ({ label, 'disable-analytics': disableAnalytics }) => (

--- a/packages/storybook/stories/va-checkbox-group.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-group.stories.jsx
@@ -4,6 +4,7 @@ import {
   getWebComponentDocs,
   componentStructure,
   propStructure,
+  StoryDocs,
 } from './wc-helpers';
 
 const checkBoxGroupDocs = getWebComponentDocs('va-checkbox-group');
@@ -18,12 +19,17 @@ export default {
       handles: ['component-library-analytics'],
     },
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/checkbox">View guidance for the Checkbox Group component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(checkBoxGroupDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...checkBoxGroupDocs,
+            guidance: {
+              componentHref: 'checkbox',
+              componentName: 'Checkbox Group',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-checkbox-group.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-group.stories.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { generateEventsDescription } from './events';
 import {
   getWebComponentDocs,
   componentStructure,

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/no-unescaped-entities */
 import React from 'react';
 import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const checkboxDocs = getWebComponentDocs('va-checkbox');
 
@@ -11,12 +11,17 @@ export default {
   parameters: {
     componentSubtitle: `Checkbox web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/checkbox">View guidance for the Checkbox component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(checkboxDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...checkboxDocs,
+            guidance: {
+              componentHref: 'checkbox',
+              componentName: 'Checkbox',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/no-unescaped-entities */
 import React from 'react';
-import { generateEventsDescription } from './events';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const checkboxDocs = getWebComponentDocs('va-checkbox');

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -10,17 +10,7 @@ export default {
   parameters: {
     componentSubtitle: `Checkbox web component`,
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...checkboxDocs,
-            guidance: {
-              componentHref: 'checkbox',
-              componentName: 'Checkbox',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={checkboxDocs} />,
     },
   },
 };

--- a/packages/storybook/stories/va-date.stories.jsx
+++ b/packages/storybook/stories/va-date.stories.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { VaDate } from '@department-of-veterans-affairs/web-components/react-bindings';
-import { generateEventsDescription } from './events';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 VaDate.displayName = 'VaDate';

--- a/packages/storybook/stories/va-date.stories.jsx
+++ b/packages/storybook/stories/va-date.stories.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { VaDate } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 VaDate.displayName = 'VaDate';
 
@@ -12,12 +12,17 @@ export default {
   parameters: {
     componentSubtitle: `Date web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/date-input">View guidance for the Date component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(dateDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...dateDocs,
+            guidance: {
+              componentHref: 'date-input',
+              componentName: 'Date',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-date.stories.jsx
+++ b/packages/storybook/stories/va-date.stories.jsx
@@ -16,8 +16,7 @@ export default {
           data={{
             ...dateDocs,
             guidance: {
-              componentHref: 'date-input',
-              componentName: 'Date',
+              componentHref: 'form/date-input',
             },
           }}
         />

--- a/packages/storybook/stories/va-featured-content.stories.jsx
+++ b/packages/storybook/stories/va-featured-content.stories.jsx
@@ -8,17 +8,7 @@ export default {
   title: 'Components/va-featured-content',
   parameters: {
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...featuredContentDocs,
-            guidance: {
-              componentHref: 'featured-content',
-              componentName: 'Featured content',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={featuredContentDocs} />,
     },
     componentSubtitle: `Featured content web component`,
   },

--- a/packages/storybook/stories/va-featured-content.stories.jsx
+++ b/packages/storybook/stories/va-featured-content.stories.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const featuredContentDocs = getWebComponentDocs('va-featured-content');
 
@@ -8,9 +8,17 @@ export default {
   title: 'Components/va-featured-content',
   parameters: {
     docs: {
-      description: {
-        component: `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/featured-content">View guidance for the Featured content component in the Design System</a>`,
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...featuredContentDocs,
+            guidance: {
+              componentHref: 'featured-content',
+              componentName: 'Featured content',
+            },
+          }}
+        />
+      ),
     },
     componentSubtitle: `Featured content web component`,
   },

--- a/packages/storybook/stories/va-loading-indicator.stories.jsx
+++ b/packages/storybook/stories/va-loading-indicator.stories.jsx
@@ -14,7 +14,6 @@ export default {
           data={{
             ...loadingIndicatorDocs,
             guidance: {
-              componentHref: 'loading-indicator',
               componentName: 'Loading Indicator',
             },
           }}

--- a/packages/storybook/stories/va-loading-indicator.stories.jsx
+++ b/packages/storybook/stories/va-loading-indicator.stories.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
-import { generateEventsDescription } from './events';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const loadingIndicatorDocs = getWebComponentDocs('va-loading-indicator');
 
@@ -10,12 +9,17 @@ export default {
   parameters: {
     componentSubtitle: `Loading Indicator web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/loading-indicator">View guidance for the Loading Indicator component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(loadingIndicatorDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...loadingIndicatorDocs,
+            guidance: {
+              componentHref: 'loading-indicator',
+              componentName: 'Loading Indicator',
+            },
+          }}
+        />
+      ),
     },
     actions: {
       handles: ['component-library-analytics'],

--- a/packages/storybook/stories/va-modal.stories.jsx
+++ b/packages/storybook/stories/va-modal.stories.jsx
@@ -10,17 +10,7 @@ export default {
   title: 'Components/va-modal',
   parameters: {
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...modalDocs,
-            guidance: {
-              componentHref: 'modal',
-              componentName: 'Modal',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={modalDocs} />,
     },
     componentSubtitle: `Modal web component`,
   },

--- a/packages/storybook/stories/va-modal.stories.jsx
+++ b/packages/storybook/stories/va-modal.stories.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { VaModal } from '@department-of-veterans-affairs/web-components/react-bindings';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
-import { generateEventsDescription } from './events';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 VaModal.displayName = 'VaModal';
 
@@ -11,12 +10,17 @@ export default {
   title: 'Components/va-modal',
   parameters: {
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/modal">View guidance for the Modal component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(modalDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...modalDocs,
+            guidance: {
+              componentHref: 'modal',
+              componentName: 'Modal',
+            },
+          }}
+        />
+      ),
     },
     componentSubtitle: `Modal web component`,
   },

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const numberInputDocs = getWebComponentDocs('va-number-input');
 
@@ -9,12 +8,17 @@ export default {
   parameters: {
     componentSubtitle: `Number Input web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/number-input">View guidance for the Number Input component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(numberInputDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...numberInputDocs,
+            guidance: {
+              componentHref: 'number-input',
+              componentName: 'Number Input',
+            },
+          }}
+        />
+      ),
     },
   },
   argTypes: {

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -13,7 +13,7 @@ export default {
           data={{
             ...numberInputDocs,
             guidance: {
-              componentHref: 'number-input',
+              componentHref: 'form/number-input',
               componentName: 'Number Input',
             },
           }}

--- a/packages/storybook/stories/va-on-this-page.stories.jsx
+++ b/packages/storybook/stories/va-on-this-page.stories.jsx
@@ -7,7 +7,17 @@ export default {
   title: 'Components/va-on-this-page',
   parameters: {
     docs: {
-      page: () => <StoryDocs data={otpDocs} />,
+      page: () => (
+        <StoryDocs
+          data={{
+            ...otpDocs,
+            guidance: {
+              componentHref: 'on-this-page',
+              componentName: 'On this page',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-on-this-page.stories.jsx
+++ b/packages/storybook/stories/va-on-this-page.stories.jsx
@@ -7,17 +7,7 @@ export default {
   title: 'Components/va-on-this-page',
   parameters: {
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...otpDocs,
-            guidance: {
-              componentHref: 'on-this-page',
-              componentName: 'On this page',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={otpDocs} />,
     },
   },
 };

--- a/packages/storybook/stories/va-pagination.stories.jsx
+++ b/packages/storybook/stories/va-pagination.stories.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 import { VaPagination } from '@department-of-veterans-affairs/web-components/react-bindings';
-import { generateEventsDescription } from './events';
 
 VaPagination.displayName = 'VaPagination';
 const paginationDocs = getWebComponentDocs('va-pagination');
@@ -11,12 +10,17 @@ export default {
   parameters: {
     componentSubtitle: `Pagination web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/pagination">View guidance for the Pagination component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(paginationDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...paginationDocs,
+            guidance: {
+              componentHref: 'pagination',
+              componentName: 'Pagination',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-pagination.stories.jsx
+++ b/packages/storybook/stories/va-pagination.stories.jsx
@@ -10,17 +10,7 @@ export default {
   parameters: {
     componentSubtitle: `Pagination web component`,
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...paginationDocs,
-            guidance: {
-              componentHref: 'pagination',
-              componentName: 'Pagination',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={paginationDocs} />,
     },
   },
 };

--- a/packages/storybook/stories/va-process-list.stories.jsx
+++ b/packages/storybook/stories/va-process-list.stories.jsx
@@ -8,19 +8,8 @@ export default {
   title: 'Components/va-process-list',
   parameters: {
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...processListDocs,
-            guidance: {
-              componentHref: 'process-list',
-              componentName: 'Process list',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={processListDocs} />,
     },
-
     componentSubtitle: `Process list web component`,
   },
 };

--- a/packages/storybook/stories/va-progress-bar.stories.jsx
+++ b/packages/storybook/stories/va-progress-bar.stories.jsx
@@ -8,17 +8,7 @@ export default {
   parameters: {
     componentSubtitle: `Progress bar web component`,
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...progressBarDocs,
-            guidance: {
-              componentHref: 'progress-bar',
-              componentName: 'Progress bar',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={progressBarDocs} />,
     },
   },
 };

--- a/packages/storybook/stories/va-progress-bar.stories.jsx
+++ b/packages/storybook/stories/va-progress-bar.stories.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const progressBarDocs = getWebComponentDocs('va-progress-bar');
 
@@ -9,12 +8,17 @@ export default {
   parameters: {
     componentSubtitle: `Progress bar web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/progress-bar">View guidance for the Progress bar component in the Design System</a>` +
-          `\n` +
-          generateEventsDescription(progressBarDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...progressBarDocs,
+            guidance: {
+              componentHref: 'progress-bar',
+              componentName: 'Progress bar',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-promo-banner.stories.jsx
+++ b/packages/storybook/stories/va-promo-banner.stories.jsx
@@ -13,7 +13,6 @@ export default {
             ...promoBannerDocs,
             guidance: {
               componentHref: 'promo-banners',
-              componentName: 'Promo banner',
             },
           }}
         />

--- a/packages/storybook/stories/va-promo-banner.stories.jsx
+++ b/packages/storybook/stories/va-promo-banner.stories.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const promoBannerDocs = getWebComponentDocs('va-promo-banner');
 
@@ -8,14 +7,17 @@ export default {
   title: 'Components/va-promo-banner',
   parameters: {
     docs: {
-      description: {
-        component:
-          `Reset the banner in storage by opening Developer Tools in the browser and then clicking on the Application Tab. ` +
-          `Under Storage you will see Local Storage and check the Storage to see if a DISMISSED_PROMO_BANNERS Key exists. ` +
-          `If it does right click and delete it and refresh your page to see the banner again. ` +
-          `Alternatively you can change the id on the component since the new id would not match the id in storage.` +
-          generateEventsDescription(promoBannerDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...promoBannerDocs,
+            guidance: {
+              componentHref: 'promo-banners',
+              componentName: 'Promo banner',
+            },
+          }}
+        />
+      ),
     },
   },
   argTypes: {

--- a/packages/storybook/stories/va-radio.stories.jsx
+++ b/packages/storybook/stories/va-radio.stories.jsx
@@ -20,7 +20,7 @@ export default {
           data={{
             ...radioDocs,
             guidance: {
-              componentHref: 'radio-button',
+              componentHref: 'form/radio-button',
               componentName: 'Radio buttons',
             },
           }}

--- a/packages/storybook/stories/va-radio.stories.jsx
+++ b/packages/storybook/stories/va-radio.stories.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { generateEventsDescription } from './events';
 import {
   getWebComponentDocs,
   componentStructure,
   propStructure,
+  StoryDocs,
 } from './wc-helpers';
 
 const radioDocs = getWebComponentDocs('va-radio');
@@ -15,12 +15,17 @@ export default {
   parameters: {
     componentSubtitle: `Radio buttons web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/radio-button">View guidance for the Radio buttons component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(radioDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...radioDocs,
+            guidance: {
+              componentHref: 'radio-button',
+              componentName: 'Radio buttons',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-search-input.stories.jsx
+++ b/packages/storybook/stories/va-search-input.stories.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { VaSearchInput } from '@department-of-veterans-affairs/web-components/react-bindings';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
-import { generateEventsDescription } from './events';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 VaSearchInput.displayName = 'VaSearchInput';
 
@@ -12,9 +11,17 @@ export default {
   parameters: {
     componentSubtitle: 'Search Input web component',
     docs: {
-      description: {
-        component: generateEventsDescription(searchDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...searchDocs,
+            guidance: {
+              componentHref: 'search-input',
+              componentName: 'Search input',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-search-input.stories.jsx
+++ b/packages/storybook/stories/va-search-input.stories.jsx
@@ -11,17 +11,7 @@ export default {
   parameters: {
     componentSubtitle: 'Search Input web component',
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...searchDocs,
-            guidance: {
-              componentHref: 'search-input',
-              componentName: 'Search input',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={searchDocs} />,
     },
   },
 };

--- a/packages/storybook/stories/va-segmented-progress-bar.stories.jsx
+++ b/packages/storybook/stories/va-segmented-progress-bar.stories.jsx
@@ -16,7 +16,6 @@ export default {
             ...segmentedProgressBarDocs,
             guidance: {
               componentHref: 'progress-bar/segmented',
-              componentName: 'Segmented progress bar',
             },
           }}
         />

--- a/packages/storybook/stories/va-segmented-progress-bar.stories.jsx
+++ b/packages/storybook/stories/va-segmented-progress-bar.stories.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const segmentedProgressBarDocs = getWebComponentDocs(
   'va-segmented-progress-bar',
@@ -11,12 +10,17 @@ export default {
   parameters: {
     componentSubtitle: `Segmented progress bar web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/progress-bar/segmented">View guidance for the Segmented progress bar component in the Design System</a>` +
-          `\n` +
-          generateEventsDescription(segmentedProgressBarDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...segmentedProgressBarDocs,
+            guidance: {
+              componentHref: 'progress-bar/segmented',
+              componentName: 'Segmented progress bar',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-select.stories.jsx
+++ b/packages/storybook/stories/va-select.stories.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect, useState } from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const selectDocs = getWebComponentDocs('va-select');
 
@@ -10,12 +9,17 @@ export default {
   parameters: {
     componentSubtitle: 'Select Box web component',
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/select">View guidance for the Select Box component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(selectDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...selectDocs,
+            guidance: {
+              componentHref: 'form/select',
+              componentName: 'Select Box',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-table.stories.jsx
+++ b/packages/storybook/stories/va-table.stories.jsx
@@ -1,15 +1,30 @@
 import React from 'react';
-import { generateEventsDescription } from './events';
 import {
   getWebComponentDocs,
   componentStructure,
   propStructure,
+  StoryDocs,
 } from './wc-helpers';
 
-const accordionDocs = getWebComponentDocs('va-table');
+const tableDocs = getWebComponentDocs('va-table');
 
 export default {
   title: 'Components/va-table',
+  parameters: {
+    docs: {
+      page: () => (
+        <StoryDocs
+          data={{
+            ...tableDocs,
+            guidance: {
+              componentHref: 'table',
+              componentName: 'Table',
+            },
+          }}
+        />
+      ),
+    },
+  },
 };
 const data = [
   [
@@ -77,7 +92,7 @@ export const Default = Template.bind({ data });
 Default.args = {
   ...defaultArgs,
 };
-Default.argTypes = propStructure(accordionDocs);
+Default.argTypes = propStructure(tableDocs);
 
 export const Sortable = Template.bind({ data });
 Sortable.args = {

--- a/packages/storybook/stories/va-table.stories.jsx
+++ b/packages/storybook/stories/va-table.stories.jsx
@@ -12,17 +12,7 @@ export default {
   title: 'Components/va-table',
   parameters: {
     docs: {
-      page: () => (
-        <StoryDocs
-          data={{
-            ...tableDocs,
-            guidance: {
-              componentHref: 'table',
-              componentName: 'Table',
-            },
-          }}
-        />
-      ),
+      page: () => <StoryDocs data={tableDocs} />,
     },
   },
 };

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -15,7 +15,7 @@ import {
   Table,
 } from '@department-of-veterans-affairs/component-library';
 
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const telephoneDocs = getWebComponentDocs('va-telephone');
 //
@@ -37,19 +37,6 @@ const Contacts = () => (
   />
 );
 
-const Page = () => (
-  <>
-    <Title />
-    <Subtitle />
-    <Description />
-    <Primary />
-    <ArgsTable story={PRIMARY_STORY} />
-    <Contacts />
-    <br />
-    <Stories />
-  </>
-);
-
 export default {
   title: 'Components/va-telephone',
   parameters: {
@@ -57,7 +44,11 @@ export default {
       handles: ['component-library-analytics'],
     },
     docs: {
-      page: Page,
+      page: () => (
+        <StoryDocs data={telephoneDocs}>
+          <Contacts />
+        </StoryDocs>
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -1,15 +1,5 @@
 import React from 'react';
 import {
-  Title,
-  Subtitle,
-  Description,
-  Primary,
-  ArgsTable,
-  Stories,
-  PRIMARY_STORY,
-} from '@storybook/addon-docs/blocks';
-
-import {
   CONTACTS,
   contactsMap,
   Table,

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const textInputDocs = getWebComponentDocs('va-text-input');
 
@@ -10,12 +9,17 @@ export default {
   parameters: {
     componentSubtitle: `Text Input web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/text-input">View guidance for the Text Input component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(textInputDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...textInputDocs,
+            guidance: {
+              componentHref: 'form/text-input',
+              componentName: 'Text Input',
+            },
+          }}
+        />
+      ),
     },
   },
   argTypes: {

--- a/packages/storybook/stories/va-textarea.stories.jsx
+++ b/packages/storybook/stories/va-textarea.stories.jsx
@@ -15,7 +15,6 @@ export default {
             ...textareaDocs,
             guidance: {
               componentHref: 'form/textarea',
-              componentName: 'Textarea',
             },
           }}
         />

--- a/packages/storybook/stories/va-textarea.stories.jsx
+++ b/packages/storybook/stories/va-textarea.stories.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const textareaDocs = getWebComponentDocs('va-textarea');
 
@@ -10,12 +9,17 @@ export default {
   parameters: {
     componentSubtitle: `Textarea web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/textarea">View guidance for the Textarea component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(textareaDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...textareaDocs,
+            guidance: {
+              componentHref: 'form/textarea',
+              componentName: 'Textarea',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -136,7 +136,7 @@ export function StoryDocs({ data, children }) {
   // This feels a bit awkward, but I didn't want to use a magic number
   const componentName = tagName.slice('va-'.length);
   if (!guidance.componentName)
-    guidance.componentName = capitalize(componentName);
+    guidance.componentName = capitalize(componentName).replace('-', ' ');
   if (!guidance.componentHref) guidance.componentHref = componentName;
   const eventsDescription = generateEventsDescription(data);
   return (

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -138,7 +138,7 @@ export function StoryDocs({ data }) {
       {eventsDescription && (
         <p>
           {eventsDescription} Please see our{' '}
-          <a href="https://design.va.gov/developers#using-web-components">
+          <a href="https://design.va.gov/about/developers#using-web-components">
             documentation on how to use web component events
           </a>
           .

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -135,7 +135,15 @@ export function StoryDocs({ data }) {
         Information on this component's accessibility, html output, and how it
         is used within Storybook can be viewed by clicking the Canvas tab.
       </p>
-      {eventsDescription && <p>{eventsDescription}</p>}
+      {eventsDescription && (
+        <p>
+          {eventsDescription} Please see our{' '}
+          <a href="https://design.va.gov/developers#using-web-components">
+            documentation on how to use web component events
+          </a>
+          .
+        </p>
+      )}
       <Description markdown={data.docs} />
       <Primary />
       {args && <ArgsTable story={PRIMARY_STORY} />}

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -136,7 +136,7 @@ export function StoryDocs({ data, children }) {
   // This feels a bit awkward, but I didn't want to use a magic number
   const componentName = tagName.slice('va-'.length);
   if (!guidance.componentName)
-    guidance.componentName = capitalize(componentName).replace('-', ' ');
+    guidance.componentName = capitalize(componentName).replaceAll('-', ' ');
   if (!guidance.componentHref) guidance.componentHref = componentName;
   const eventsDescription = generateEventsDescription(data);
   return (

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -105,8 +105,7 @@ export const propStructure = comp => {
 /**
  * Renders an Action link to the Design System
  */
-function Guidance({ data }) {
-  const { componentName, componentHref } = data;
+function Guidance({ componentHref, componentName }) {
   if (!componentName || !componentHref) return null;
   return (
     <a
@@ -130,7 +129,7 @@ export function StoryDocs({ data, children }) {
     <>
       <Title />
       <Subtitle />
-      {guidance && <Guidance data={guidance} />}
+      <Guidance {...guidance} />
       <p>
         Information on this component's accessibility, html output, and how it
         is used within Storybook can be viewed by clicking the Canvas tab.

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -122,7 +122,7 @@ function Guidance({ data }) {
  * Return a component with Storybook docs blocks in a standard order.
  * Accepts a JSON object as a prop representing component information
  */
-export function StoryDocs({ data }) {
+export function StoryDocs({ data, children }) {
   const args = data?.props?.length > 0;
   const guidance = data?.guidance;
   const eventsDescription = generateEventsDescription(data);
@@ -147,6 +147,7 @@ export function StoryDocs({ data }) {
       <Description markdown={data.docs} />
       <Primary />
       {args && <ArgsTable story={PRIMARY_STORY} />}
+      <>{children}</>
       <Stories />
     </>
   );

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -118,12 +118,26 @@ function Guidance({ componentHref, componentName }) {
 }
 
 /**
+ * Capitalizes the first character.
+ * (There's probably a better way of doing this)
+ */
+function capitalize(text) {
+  return `${text[0].toUpperCase()}${text.slice(1)}`;
+}
+
+/**
  * Return a component with Storybook docs blocks in a standard order.
  * Accepts a JSON object as a prop representing component information
  */
 export function StoryDocs({ data, children }) {
   const args = data?.props?.length > 0;
-  const guidance = data?.guidance;
+  const guidance = data?.guidance || {};
+  const tagName = data.tag;
+  // This feels a bit awkward, but I didn't want to use a magic number
+  const componentName = tagName.slice('va-'.length);
+  if (!guidance.componentName)
+    guidance.componentName = capitalize(componentName);
+  if (!guidance.componentHref) guidance.componentHref = componentName;
   const eventsDescription = generateEventsDescription(data);
   return (
     <>

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -12,6 +12,8 @@ import {
 
 import webComponentDocs from '@department-of-veterans-affairs/web-components/component-docs.json';
 
+import { generateEventsDescription } from './events';
+
 /**
  * Return the JSON object matching a specific component tag
  */
@@ -123,6 +125,7 @@ function Guidance({ data }) {
 export function StoryDocs({ data }) {
   const args = data?.props?.length > 0;
   const guidance = data?.guidance;
+  const eventsDescription = generateEventsDescription(data);
   return (
     <>
       <Title />
@@ -132,6 +135,7 @@ export function StoryDocs({ data }) {
         Information on this component's accessibility, html output, and how it
         is used within Storybook can be viewed by clicking the Canvas tab.
       </p>
+      {eventsDescription && <p>{eventsDescription}</p>}
       <Description markdown={data.docs} />
       <Primary />
       {args && <ArgsTable story={PRIMARY_STORY} />}

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -128,6 +128,10 @@ export function StoryDocs({ data }) {
       <Title />
       <Subtitle />
       {guidance && <Guidance data={guidance} />}
+      <p>
+        Information on this component's accessibility, html output, and how it
+        is used within Storybook can be viewed by clicking the Canvas tab.
+      </p>
       <Description markdown={data.docs} />
       <Primary />
       {args && <ArgsTable story={PRIMARY_STORY} />}

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -9,6 +9,11 @@ import {
 } from '@stencil/core';
 import classnames from 'classnames';
 
+/**
+ * Use a heading element with an attribute named slot and a value of "headline" to
+ * control what is displayed for the alert's headline. Any children passed into
+ * this component without a parent slot "headline" will render in the alert's body.
+ */
 @Component({
   tag: 'va-alert',
   styleUrl: 'va-alert.css',

--- a/packages/web-components/src/components/va-banner/va-banner.tsx
+++ b/packages/web-components/src/components/va-banner/va-banner.tsx
@@ -10,6 +10,14 @@ import {
 } from '@stencil/core';
 
 const DISMISSED_BANNERS_KEY = 'DISMISSED_BANNERS';
+
+/**
+ * Reset the banners in storage by opening Developer Tools in the browser
+ * and then clicking on the Application Tab. Under Storage you will see
+ * both Local and Session Storage check each Storage to see if a
+ * DISMISSED_BANNERS Key exists. If it does right click and delete it and
+ * refresh your page to see the banners again.
+ */
 @Component({
   tag: 'va-banner',
   styleUrl: 'va-banner.css',

--- a/packages/web-components/src/components/va-promo-banner/va-promo-banner.tsx
+++ b/packages/web-components/src/components/va-promo-banner/va-promo-banner.tsx
@@ -10,6 +10,15 @@ import {
 } from '@stencil/core';
 
 const DISMISSED_PROMO_BANNERS_LOCAL_STORAGE_KEY = 'DISMISSED_PROMO_BANNERS';
+
+/**
+ * Reset the banner in storage by opening Developer Tools in the browser and
+ * then clicking on the Application Tab. Under Storage you will see Local
+ * Storage and check the Storage to see if a DISMISSED_PROMO_BANNERS Key exists.
+ * If it does right click and delete it and refresh your page to see the banner
+ * again. Alternatively you can change the id on the component since the new id
+ * would not match the id in storage.
+ */
 @Component({
   tag: 'va-promo-banner',
   styleUrl: 'va-promo-banner.css',


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/41424

There's a bit of scope creep going on, but I did it so that I was reducing the copy-paste situation instead of adding more copy-pasted pieces of text.

## Testing done

- Local storybook :eyes: 
- Clicked the links


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
