### PR TITLE
add padding to alert for close button

### DIFF
--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -50,7 +50,7 @@
 ::slotted([slot='headline']) {
   font-size: 2rem !important;
   line-height: 26px !important;
-  padding: 0 !important;
+  padding: 0 4rem 0 0 !important;
   margin: 0 !important;
 }
 
@@ -117,7 +117,7 @@ div.bg-only.hide-icon > i::before {
 
 div.bg-only {
   border: none;
-  padding: 2rem;
+  padding: 2rem 4rem 2rem 2rem;
 }
 
 .info.bg-only {


### PR DESCRIPTION
## Chromatic
<!-- This `alert-padding-fix` is a placeholder for a CI job - it will be updated automatically -->
https://alert-padding-fix--60f9b557105290003b387cd5.chromatic.com

This fixes a problem we were seeing with closable background-only alerts with longer text. Further examination confirmed that the same problem would occur with the headline on closable default alerts.

## Description
Closes <ticket>

## Testing done
Visual testing, manual

## Screenshots
Background-only alert before:
![image](https://user-images.githubusercontent.com/12739849/170353482-3f3e14fe-9c3f-4bf6-9f76-7d9013158686.png)

Background-only alert after:
![image](https://user-images.githubusercontent.com/12739849/170353661-d1456369-680e-477e-8387-cc5ba00bd9a4.png)

Default alert with long headline before:
![image](https://user-images.githubusercontent.com/12739849/170353709-93c40b2f-4463-44f6-b01a-df5146249f34.png)

Default alert with long headline after:
![image](https://user-images.githubusercontent.com/12739849/170353746-747daf58-7625-4dd4-a9a2-0191f1082f6b.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
