### PR TITLE
Use custom docsTags for showing native handlers

### DIFF
--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -15,9 +15,6 @@ export default {
         component:
           `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/checkbox">View guidance for the Checkbox component in the Design System</a>` +
           '\n' +
-          'This component uses the native onBlur event handler.' +
-          '\n' +
-          '\n' +
           generateEventsDescription(checkboxDocs),
       },
     },

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -1,8 +1,7 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/no-unescaped-entities */
 import React from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const checkboxDocs = getWebComponentDocs('va-checkbox');
 
@@ -11,12 +10,17 @@ export default {
   parameters: {
     componentSubtitle: `Checkbox web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/checkbox">View guidance for the Checkbox component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(checkboxDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...checkboxDocs,
+            guidance: {
+              componentName: 'Checkbox',
+              componentHref: 'form/checkbox',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -13,9 +13,6 @@ export default {
         component:
           `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/number-input">View guidance for the Number Input component in the Design System</a>` +
           '\n' +
-          'This component uses the native onInput and onBlur event handlers.' +
-          '\n' +
-          '\n' +
           generateEventsDescription(numberInputDocs),
       },
     },

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const numberInputDocs = getWebComponentDocs('va-number-input');
 
@@ -9,12 +8,17 @@ export default {
   parameters: {
     componentSubtitle: `Number Input web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/number-input">View guidance for the Number Input component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(numberInputDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...numberInputDocs,
+            guidance: {
+              componentName: 'Number Input',
+              componentHref: 'form/number-input',
+            },
+          }}
+        />
+      ),
     },
   },
   argTypes: {

--- a/packages/storybook/stories/va-select.stories.jsx
+++ b/packages/storybook/stories/va-select.stories.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect, useState } from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const selectDocs = getWebComponentDocs('va-select');
 
@@ -10,12 +9,17 @@ export default {
   parameters: {
     componentSubtitle: 'Select Box web component',
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/select">View guidance for the Select Box component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(selectDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...selectDocs,
+            guidance: {
+              componentName: 'Select Box',
+              componentHref: 'form/select',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-select.stories.jsx
+++ b/packages/storybook/stories/va-select.stories.jsx
@@ -14,9 +14,6 @@ export default {
         component:
           `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/select">View guidance for the Select Box component in the Design System</a>` +
           '\n' +
-          'This component uses the native onKeyDown event handler.' +
-          '\n' +
-          '\n' +
           generateEventsDescription(selectDocs),
       },
     },

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -14,9 +14,6 @@ export default {
         component:
           `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/text-input">View guidance for the Text Input component in the Design System</a>` +
           '\n' +
-          'This component uses the native onInput and onBlur event handlers.' +
-          '\n' +
-          '\n' +
           generateEventsDescription(textInputDocs),
       },
     },

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const textInputDocs = getWebComponentDocs('va-text-input');
 
@@ -10,12 +9,17 @@ export default {
   parameters: {
     componentSubtitle: `Text Input web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/text-input">View guidance for the Text Input component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(textInputDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...textInputDocs,
+            guidance: {
+              componentName: 'Text Input',
+              componentHref: 'form/text-input',
+            },
+          }}
+        />
+      ),
     },
   },
   argTypes: {

--- a/packages/storybook/stories/va-textarea.stories.jsx
+++ b/packages/storybook/stories/va-textarea.stories.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { generateEventsDescription } from './events';
-import { getWebComponentDocs, propStructure } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const textareaDocs = getWebComponentDocs('va-textarea');
 
@@ -10,12 +9,17 @@ export default {
   parameters: {
     componentSubtitle: `Textarea web component`,
     docs: {
-      description: {
-        component:
-          `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/textarea">View guidance for the Textarea component in the Design System</a>` +
-          '\n' +
-          generateEventsDescription(textareaDocs),
-      },
+      page: () => (
+        <StoryDocs
+          data={{
+            ...textareaDocs,
+            guidance: {
+              componentName: 'Textarea',
+              componentHref: 'form/textarea',
+            },
+          }}
+        />
+      ),
     },
   },
 };

--- a/packages/storybook/stories/va-textarea.stories.jsx
+++ b/packages/storybook/stories/va-textarea.stories.jsx
@@ -14,9 +14,6 @@ export default {
         component:
           `<a className="vads-c-action-link--blue" href="https://design.va.gov/components/form/textarea">View guidance for the Textarea component in the Design System</a>` +
           '\n' +
-          'This component uses the native onInput and onBlur event handlers.' +
-          '\n' +
-          '\n' +
           generateEventsDescription(textareaDocs),
       },
     },

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -116,6 +116,11 @@ function Guidance({ data }) {
   );
 }
 
+/**
+ * This function looks for the `@nativeHandler` doc tag and renders
+ * them in a list. Documentation:
+ * - https://stenciljs.com/docs/docs-json#custom-jsdocs-tags
+ */
 function NativeHandlers({ docsTags }) {
   const handlers = docsTags
     .filter(item => item.name === 'nativeHandler')

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -116,6 +116,25 @@ function Guidance({ data }) {
   );
 }
 
+function NativeHandlers({ docsTags }) {
+  const handlers = docsTags
+    .filter(item => item.name === 'nativeHandler')
+    .map(item => item.text);
+
+  if (!handlers.length) return null;
+
+  return (
+    <p>
+      This component uses the following native handlers:
+      <ul>
+        {handlers.map(handlerName => (
+          <li>{handlerName}</li>
+        ))}
+      </ul>
+    </p>
+  );
+}
+
 /**
  * Return a component with Storybook docs blocks in a standard order.
  * Accepts a JSON object as a prop representing component information
@@ -129,6 +148,7 @@ export function StoryDocs({ data }) {
       <Subtitle />
       {guidance && <Guidance data={guidance} />}
       <Description markdown={data.docs} />
+      <NativeHandlers docsTags={data.docsTags} />
       <Primary />
       {args && <ArgsTable story={PRIMARY_STORY} />}
       <Stories />

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -124,14 +124,14 @@ function NativeHandlers({ docsTags }) {
   if (!handlers.length) return null;
 
   return (
-    <p>
+    <div className="vads-u-margin-top--2">
       This component uses the following native handlers:
       <ul>
-        {handlers.map(handlerName => (
-          <li>{handlerName}</li>
+        {handlers.map((handlerName, index) => (
+          <li key={index}>{handlerName}</li>
         ))}
       </ul>
-    </p>
+    </div>
   );
 }
 

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -12,6 +12,8 @@ import {
 
 import webComponentDocs from '@department-of-veterans-affairs/web-components/component-docs.json';
 
+import { generateEventsDescription } from './events';
+
 /**
  * Return the JSON object matching a specific component tag
  */
@@ -149,6 +151,7 @@ export function StoryDocs({ data }) {
       {guidance && <Guidance data={guidance} />}
       <Description markdown={data.docs} />
       <NativeHandlers docsTags={data.docsTags} />
+      {generateEventsDescription(data)}
       <Primary />
       {args && <ArgsTable story={PRIMARY_STORY} />}
       <Stories />

--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -12,8 +12,6 @@ import {
 
 import webComponentDocs from '@department-of-veterans-affairs/web-components/component-docs.json';
 
-import { generateEventsDescription } from './events';
-
 /**
  * Return the JSON object matching a specific component tag
  */
@@ -137,6 +135,26 @@ function NativeHandlers({ docsTags }) {
   );
 }
 
+export function CustomEventsDescription({ data }) {
+  let events = [];
+
+  if (data.events) events = [...data.events];
+  if (data.listeners) events = [...events, ...data.listeners];
+  const eventNames = events.map(event => event.event).join(', ');
+
+  return (
+    <div className="vads-u-margin-top--2">
+      This component has {events.length} custom{' '}
+      {events.length > 1 ? 'events' : 'event'}: {eventNames}. Please see our
+      documentation on{' '}
+      <a href="https://design.va.gov/about/developers#custom-events">
+        how to use web component events
+      </a>
+      .
+    </div>
+  );
+}
+
 /**
  * Return a component with Storybook docs blocks in a standard order.
  * Accepts a JSON object as a prop representing component information
@@ -144,6 +162,8 @@ function NativeHandlers({ docsTags }) {
 export function StoryDocs({ data }) {
   const args = data?.props?.length > 0;
   const guidance = data?.guidance;
+  const events = data?.events?.length > 0 || data?.listeners?.length > 0;
+
   return (
     <>
       <Title />
@@ -151,7 +171,7 @@ export function StoryDocs({ data }) {
       {guidance && <Guidance data={guidance} />}
       <Description markdown={data.docs} />
       <NativeHandlers docsTags={data.docsTags} />
-      {generateEventsDescription(data)}
+      {events && <CustomEventsDescription data={data} />}
       <Primary />
       {args && <ArgsTable story={PRIMARY_STORY} />}
       <Stories />

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -8,6 +8,9 @@ import {
   Prop,
 } from '@stencil/core';
 
+/**
+ * @nativeHandler onBlur
+ */
 @Component({
   tag: 'va-checkbox',
   styleUrl: 'va-checkbox.css',

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -10,6 +10,10 @@ import {
 } from '@stencil/core';
 import i18next from 'i18next';
 
+/**
+ * @nativeHandler onInput
+ * @nativeHandler onBlur
+ */
 @Component({
   tag: 'va-number-input',
   styleUrl: 'va-number-input.css',

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -12,6 +12,9 @@ import {
 import i18next from 'i18next';
 import { getSlottedNodes } from '../../utils/utils';
 
+/**
+ * @nativeHandler onKeyDown
+ */
 @Component({
   tag: 'va-select',
   styleUrl: 'va-select.css',

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -17,6 +17,10 @@ if (Build.isTesting) {
   i18next.init({ lng: 'cimode' });
 }
 
+/**
+ * @nativeHandler onInput
+ * @nativeHandler onBlur
+ */
 @Component({
   tag: 'va-text-input',
   styleUrl: 'va-text-input.css',

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -6,6 +6,10 @@ if (Build.isTesting) {
   i18next.init({ lng: 'cimode' });
 }
 
+/**
+ * @nativeHandler onInput
+ * @nativeHandler onBlur
+ */
 @Component({
   tag: 'va-textarea',
   styleUrl: 'va-textarea.css',


### PR DESCRIPTION
## Chromatic
<!-- This `sb-nativehandler-followup` is a placeholder for a CI job - it will be updated automatically -->
https://sb-nativehandler-followup--60f9b557105290003b387cd5.chromatic.com

## Description
This is a followup to https://github.com/department-of-veterans-affairs/va.gov-team/issues/38913.

This PR uses [custom JSDocs tags](https://stenciljs.com/docs/docs-json#custom-jsdocs-tags) to define the relevant native handlers in the source code, then parses the generated JSON doc file to display it in storybook. This should help with consistency and also allow us to show this information in design.va.gov if we want it there eventually.

I know that the way we're passing the `guidance` prop is changing in some other current PRs, so I tried to leave that alone and just make sure that we weren't removing anything that was being displayed. I also copied Andrés' custom event description code from #437 so that this doesn't break that link.

## Testing done

Storybook :eyes: 


## Screenshots

![Documentation on Checkbox story page](https://user-images.githubusercontent.com/2008881/170512001-941ee064-0d47-4bda-af9f-c8fd6ce71e9c.png)

![Documentation on Number Input story page](https://user-images.githubusercontent.com/2008881/170512145-ead3151e-6093-4581-af2d-6e3f2c673ca5.png)

![Documentation on Select story page](https://user-images.githubusercontent.com/2008881/170512270-7eb8bc20-1bd2-4297-b65f-6afedaeb31e9.png)

![Documentation on Text Input story page](https://user-images.githubusercontent.com/2008881/170512368-ffa9a252-39eb-44f5-8a05-6c1671497aea.png)

![Documentation on Textarea story page](https://user-images.githubusercontent.com/2008881/170512521-6e23ccf9-0d6e-4b2b-af4c-a725caa244bb.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
