### PR TITLE
Update usage report regex for bindings import

### DIFF
--- a/packages/design-system-dashboard-cli/src/find-ds-components.js
+++ b/packages/design-system-dashboard-cli/src/find-ds-components.js
@@ -155,9 +155,10 @@ if (require.main === module) {
     { name: 'csv', type: Boolean },
     { name: 'sql', type: Boolean },
     { name: 'update', type: Boolean },
-    { name: 'date',
+    {
+      name: 'date',
       type: String,
-      defaultValue: new Date().toISOString().substr(0, 'xxxx-xx-xx'.length)
+      defaultValue: new Date().toISOString().substr(0, 'xxxx-xx-xx'.length),
     },
     {
       name: 'output',
@@ -172,7 +173,7 @@ if (require.main === module) {
 
   const data = findComponents(options.searchTerms);
 
-  const date = options.date
+  const date = options.date;
   if (options.csv) {
     toCSV(flattenData(data, date), options.output);
   } else if (options.update) {

--- a/packages/design-system-dashboard-cli/src/find-ds-components.js
+++ b/packages/design-system-dashboard-cli/src/find-ds-components.js
@@ -129,7 +129,7 @@ function findComponents(searchStrings) {
   );
 
   const usedBindingsRegex =
-    /import { ([^;]+) } from '(?:@department-of-veterans-affairs\/)?web-components\/react-bindings'/gms;
+    /import { ([^;]+) } from '@department-of-veterans-affairs\/component-library\/dist\/react-bindings'/gms;
   const usedReactBindings = findUsedReactComponents(
     vwModules,
     usedBindingsRegex


### PR DESCRIPTION
## Chromatic
<!-- This `bindings-import-scan` is a placeholder for a CI job - it will be updated automatically -->
https://bindings-import-scan--60f9b557105290003b387cd5.chromatic.com

## Description
As of https://github.com/department-of-veterans-affairs/vets-website/pull/21127 `vets-website` code is importing the bindings directly from `component-library` instead of through the alias. This updates the regex to match the import path.

## Testing done

Ran the report and got results showing bindings.

## Screenshots

### Before

![Report not showing React bindings in results](https://user-images.githubusercontent.com/2008881/170792578-fc8654bf-123b-45dc-8ed9-2f7d65ab7fdb.png)

### After

![Report results showing React bindings](https://user-images.githubusercontent.com/2008881/170792535-64331ca2-6124-4bed-9a6e-906c9a1a9441.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
