### PR TITLE
add function to find named React component imports

### DIFF
--- a/packages/design-system-dashboard-cli/src/find-ds-components.js
+++ b/packages/design-system-dashboard-cli/src/find-ds-components.js
@@ -128,6 +128,13 @@ function findComponents(searchStrings) {
     usedReactComponentsRegex
   );
 
+  const usedNamedReactComponentsRegex = 
+    /import { ([^;]+) } from '@department-of-veterans-affairs\/component-library'/gms;
+  const usedNamedReactComponents = findUsedReactComponents(
+    vwModules,
+    usedNamedReactComponentsRegex
+  );
+
   const usedBindingsRegex =
     /import { ([^;]+) } from '@department-of-veterans-affairs\/component-library\/dist\/react-bindings'/gms;
   const usedReactBindings = findUsedReactComponents(
@@ -141,6 +148,7 @@ function findComponents(searchStrings) {
 
   const vwComponents = [
     ...usedReactComponents,
+    ...usedNamedReactComponents,
     ...vwWebComponents,
     ...usedReactBindings,
   ];


### PR DESCRIPTION
## Chromatic
<!-- This `41999--named-imports` is a placeholder for a CI job - it will be updated automatically -->
https://41999--named-imports--60f9b557105290003b387cd5.chromatic.com

## Description
Part of the work for https://github.com/department-of-veterans-affairs/va.gov-team/issues/41999

## Testing done
Ran `yearn search`. We are now capturing the named import of the [Date React component in the check-in app](https://github.com/department-of-veterans-affairs/vets-website/blob/a3c335c76f6788facfa213f4b213832612c91f26/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx#L6).

## Screenshots
![image](https://user-images.githubusercontent.com/12739849/171668318-7b29f1ff-9e86-4ac0-be6e-51645ccb7dd4.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
