### PR TITLE
change sign in alert button color to green

### DIFF
--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -231,7 +231,7 @@ SignInOrToolPrompt.args = {
         appeals on your mobile device. Download the{' '}
         <strong>VA: Health and Benefits</strong> mobile app to get started.
       </p>
-      <button className="usa-button-primary">Sign in to VA.gov</button>
+      <button className="va-button-primary">Sign in to VA.gov</button>
     </div>
   ),
   status: 'continue',


### PR DESCRIPTION
## Chromatic
<!-- This `sign-in-button-color` is a placeholder for a CI job - it will be updated automatically -->
https://sign-in-button-color--60f9b557105290003b387cd5.chromatic.com

## Description
Updates button color on the sign in alert to green to match [guidance](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/653#issuecomment-1147863128).

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/12739849/172244684-e26a3413-54d4-4a90-9162-a92a68bb9896.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
