### PR TITLE
Add disabled styling and story for va-button

### DIFF
--- a/packages/storybook/stories/va-button.stories.jsx
+++ b/packages/storybook/stories/va-button.stories.jsx
@@ -51,34 +51,40 @@ const Template = ({
   );
 };
 
-export const Primary = Template.bind({});
+export const Primary = Template.bind(null);
 Primary.args = {
   ...defaultArgs,
 };
 Primary.argTypes = propStructure(buttonDocs);
 
-export const Secondary = Template.bind({});
+export const Secondary = Template.bind(null);
 Secondary.args = {
   ...defaultArgs,
   secondary: true,
 };
 
-export const Big = Template.bind({});
+export const Big = Template.bind(null);
 Big.args = {
   ...defaultArgs,
   big: true,
 };
 
-export const Continue = Template.bind({});
+export const Continue = Template.bind(null);
 Continue.args = {
   ...defaultArgs,
   continue: true,
   text: undefined,
 };
 
-export const Back = Template.bind({});
+export const Back = Template.bind(null);
 Back.args = {
   ...defaultArgs,
   back: true,
   text: undefined,
+};
+
+export const Disabled = Template.bind(null);
+Disabled.args = {
+  ...defaultArgs,
+  disabled: true,
 };

--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -9,7 +9,7 @@ describe('va-button', () => {
     expect(element).toEqualHtml(`
     <va-button class="hydrated" text="Edit">
       <mock:shadow-root>
-        <button type="button">
+        <button aria-label="Edit" type="button">
           Edit
         </button>
       </mock:shadow-root>
@@ -40,7 +40,7 @@ describe('va-button', () => {
     expect(element).toEqualHtml(`
     <va-button class="hydrated" back>
       <mock:shadow-root>
-        <button type="button">
+        <button aria-label="Back" type="button">
           <i aria-hidden="true" class="fa fa-angles-left"></i>
           Back
         </button>
@@ -56,7 +56,7 @@ describe('va-button', () => {
     expect(element).toEqualHtml(`
     <va-button class="hydrated" continue>
       <mock:shadow-root>
-        <button type="button">
+        <button aria-label="Continue" type="button">
           Continue
           <i aria-hidden="true" class="fa fa-angles-right"></i>
         </button>
@@ -89,7 +89,7 @@ describe('va-button', () => {
     expect(element).toEqualHtml(`
     <va-button class="hydrated" text="Edit" submit>
       <mock:shadow-root>
-        <button type="submit">
+        <button aria-label="Edit" type="submit">
           Edit
         </button>
       </mock:shadow-root>
@@ -104,7 +104,7 @@ describe('va-button', () => {
     expect(element).toEqualHtml(`
     <va-button class="hydrated" text="Edit" disabled>
       <mock:shadow-root>
-        <button type="button" disabled>
+        <button aria-label="Edit" type="button" disabled>
           Edit
         </button>
       </mock:shadow-root>
@@ -133,7 +133,7 @@ describe('va-button', () => {
     expect(element).toEqualHtml(`
     <va-button class="hydrated" back continue>
       <mock:shadow-root>
-        <button type="button">
+        <button aria-label="Continue" type="button">
           Continue
         </button>
       </mock:shadow-root>

--- a/packages/web-components/src/components/va-button/va-button.css
+++ b/packages/web-components/src/components/va-button/va-button.css
@@ -20,29 +20,29 @@ button:hover {
   background-color: var(--color-primary-darker);
 }
 
-:host([back]) button,
-:host([secondary]) button {
+:host([back]:not([back='false'])) button,
+:host([secondary]:not([secondary='false'])) button {
   background-color: var(--color-white);
   box-shadow: inset 0 0 0 2px var(--color-primary);
   color: var(--color-primary);
 }
 
-:host([back]) button:hover,
-:host([secondary]) button:hover {
+:host([back]:not([back='false'])) button:hover,
+:host([secondary]:not([secondary='false'])) button:hover {
   box-shadow: inset 0 0 0 2px var(--color-primary-darker);
   color: var(--color-primary-darker);
 }
 
-:host([back]) button:active,
-:host([back]) button:focus,
-:host([back]) button:hover,
-:host([secondary]) button:active,
-:host([secondary]) button:focus,
-:host([secondary]) button:hover {
+:host([back]:not([back='false'])) button:active,
+:host([back]:not([back='false'])) button:focus,
+:host([back]:not([back='false'])) button:hover,
+:host([secondary]:not([secondary='false'])) button:active,
+:host([secondary]:not([secondary='false'])) button:focus,
+:host([secondary]:not([secondary='false'])) button:hover {
   background-color: var(--color-gray-cool-light);
 }
 
-:host([big]) button {
+:host([big]:not([big='false'])) button {
   border-radius: 8px;
   font-size: 2.4rem;
   padding: 1.5rem 3rem;
@@ -64,4 +64,9 @@ i.fa-angles-left::before {
 i.fa-angles-right::before {
   content: '\F101';
   margin-left: 8px;
+}
+
+:host([disabled]:not([disabled='false'])) button {
+  background-color: var(--color-gray-lighter);
+  pointer-events: none;
 }

--- a/packages/web-components/src/components/va-button/va-button.css
+++ b/packages/web-components/src/components/va-button/va-button.css
@@ -68,5 +68,5 @@ i.fa-angles-right::before {
 
 :host([disabled]:not([disabled='false'])) button {
   background-color: var(--color-gray-lighter);
-  pointer-events: none;
+  cursor: not-allowed;
 }

--- a/packages/web-components/src/components/va-button/va-button.css
+++ b/packages/web-components/src/components/va-button/va-button.css
@@ -68,5 +68,11 @@ i.fa-angles-right::before {
 
 :host([disabled]:not([disabled='false'])) button {
   background-color: var(--color-gray-lighter);
+  box-shadow: none;
+  color: var(--color-white);
+  pointer-events: none;
+}
+
+:host([disabled]:not([disabled='false'])) {
   cursor: not-allowed;
 }

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -93,12 +93,13 @@ export class VaButton {
       submit,
     } = this;
 
+    const buttonText = getButtonText();
     const type = submit ? 'submit' : 'button';
 
     return (
       <Host>
         <button
-          aria-label={label}
+          aria-label={label || buttonText}
           disabled={disabled}
           onClick={handleClick}
           type={type}
@@ -106,7 +107,7 @@ export class VaButton {
           {back && !_continue && (
             <i aria-hidden="true" class="fa fa-angles-left" />
           )}
-          {getButtonText()}
+          {buttonText}
           {_continue && !back && (
             <i aria-hidden="true" class="fa fa-angles-right" />
           )}


### PR DESCRIPTION
## Chromatic
<!-- This `va-button-disabled` is a placeholder for a CI job - it will be updated automatically -->
https://va-button-disabled--60f9b557105290003b387cd5.chromatic.com

## Description
This PR adds the missing `disabled` styling and story for `va-button`.

Tasks from https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/751#issuecomment-1149190166
- [x] Use gray background (#d6d7d9) and white text when disabled 
- [x] Disabled buttons must have an aria-label
- [x] Change cursor to `not-allowed` when button is disabled

## Testing done
Storybook

## Screenshots
<img width="1053" alt="Screen Shot 2022-06-07 at 18 12 48" src="https://user-images.githubusercontent.com/36863582/172491907-823b91ea-bd78-4d1a-90fe-43894c785173.png">


## Acceptance criteria
- [x] va-button has `disabled` styling and story

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
