### PR TITLE
Add web component native events docs link

### DIFF
--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -159,10 +159,10 @@ export function CustomEventsDescription({ data }) {
   return (
     <div className="vads-u-margin-top--2">
       This component has {events.length} custom{' '}
-      {events.length > 1 ? 'events' : 'event'}: {eventNames}. Please see our
-      documentation on{' '}
+      {events.length > 1 ? 'events' : 'event'}: <strong>{eventNames}</strong>.
+      Please see our documentation on{' '}
       <a href="https://design.va.gov/about/developers#custom-events">
-        how to use web component events
+        how to use web component custom events
       </a>
       .
     </div>
@@ -189,14 +189,16 @@ function NativeHandlers({ docsTags = [] }) {
 
   if (!handlers.length) return null;
 
+  const nativeEvents = handlers.join(', ');
+
   return (
     <div className="vads-u-margin-top--2">
-      This component uses the following native handlers:
-      <ul>
-        {handlers.map((handlerName, index) => (
-          <li key={index}>{handlerName}</li>
-        ))}
-      </ul>
+      This component uses the following native handlers:{' '}
+      <strong>{nativeEvents}</strong>. Please see our documentation on{' '}
+      <a href="https://design.va.gov/about/developers#native-events">
+        how to use web component native events
+      </a>
+      .
     </div>
   );
 }


### PR DESCRIPTION
## Chromatic
<!-- This `900-native-events` is a placeholder for a CI job - it will be updated automatically -->
https://900-native-events--60f9b557105290003b387cd5.chromatic.com

## Description
Partly closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/900

## Screenshots
<img width="1013" alt="Screen Shot 2022-06-13 at 19 52 18" src="https://user-images.githubusercontent.com/36863582/173465740-32d6d5c3-e37c-4e58-94b2-92c2b319fc71.png">


## Acceptance criteria
- [x] Storybook has native events documentation link in stories

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
