### PR TITLE
Update va-button to be focusable when disabled

### DIFF
--- a/packages/storybook/stories/va-button.stories.jsx
+++ b/packages/storybook/stories/va-button.stories.jsx
@@ -47,6 +47,7 @@ const Template = ({
       secondary={secondary}
       submit={submit}
       text={text}
+      onClick={e => console.log(e)}
     />
   );
 };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -164,7 +164,7 @@ export namespace Components {
          */
         "disableAnalytics"?: boolean;
         /**
-          * If `true`, the button is disabled.
+          * If `true`, the click event will not fire.
          */
         "disabled"?: boolean;
         /**
@@ -1093,7 +1093,7 @@ declare namespace LocalJSX {
          */
         "disableAnalytics"?: boolean;
         /**
-          * If `true`, the button is disabled.
+          * If `true`, the click event will not fire.
          */
         "disabled"?: boolean;
         /**

--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -104,7 +104,7 @@ describe('va-button', () => {
     expect(element).toEqualHtml(`
     <va-button class="hydrated" text="Edit" disabled>
       <mock:shadow-root>
-        <button aria-label="Edit" type="button" disabled>
+        <button aria-disabled="true" aria-label="Edit" type="button">
           Edit
         </button>
       </mock:shadow-root>

--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -171,4 +171,13 @@ describe('va-button', () => {
     await button.click();
     expect(analyticsSpy).toHaveReceivedEventTimes(0);
   });
+
+  it(`doesn't fire click event when disabled is true`, async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-button text="Edit" disabled></va-button>');
+    const clickSpy = await page.spyOnEvent('click');
+    const button = await page.find('va-button >>> button');
+    await button.click();
+    expect(clickSpy).toHaveReceivedEventTimes(0);
+  });
 });

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -32,7 +32,9 @@ export class VaButton {
    */
   @Prop() continue?: boolean = false;
 
-  /** If `true`, the component-library-analytics event is disabled. */
+  /**
+   * If `true`, the component-library-analytics event is disabled.
+   */
   @Prop() disableAnalytics?: boolean = false;
 
   /**
@@ -97,13 +99,13 @@ export class VaButton {
    * Using a click handler on the button with this same check for disabled results in the event bubbling.
    */
   @Listen('click')
-  handleClickOverride(ev) {
+  handleClickOverride(e: MouseEvent) {
     if (this.disabled) {
-      ev.preventDefault();
-      ev.stopPropagation();
+      e.preventDefault();
+      e.stopPropagation();
       return;
     }
-    this.handleClick(ev);
+    this.handleClick(e);
   }
 
   render() {

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -1,4 +1,12 @@
-import { Component, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
+import {
+  Component,
+  Event,
+  EventEmitter,
+  Host,
+  h,
+  Listen,
+  Prop,
+} from '@stencil/core';
 
 /**
  * @nativeHandler onClick
@@ -28,9 +36,9 @@ export class VaButton {
   @Prop() disableAnalytics?: boolean = false;
 
   /**
-   * If `true`, the button is disabled.
+   * If `true`, the click event will not fire.
    */
-  @Prop() disabled?: boolean = false; // do we want this? double check
+  @Prop() disabled?: boolean = false;
 
   /**
    * The aria-label of the component.
@@ -82,26 +90,39 @@ export class VaButton {
     return this.text;
   };
 
+  /**
+   * A workaround for preventing the click event from bubbling.
+   * Using a click handler on the button with this same check for disabled results in the event bubbling.
+   */
+  @Listen('click')
+  handleClickOverride(ev) {
+    if (this.disabled) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      return;
+    }
+    this.handleClick(ev);
+  }
+
   render() {
     const {
       back,
       continue: _continue,
       disabled,
       getButtonText,
-      handleClick,
       label,
       submit,
     } = this;
 
+    const ariaDisabled = disabled ? 'true' : undefined;
     const buttonText = getButtonText();
     const type = submit ? 'submit' : 'button';
 
     return (
       <Host>
         <button
+          aria-disabled={ariaDisabled}
           aria-label={label || buttonText}
-          disabled={disabled}
-          onClick={handleClick}
           type={type}
         >
           {back && !_continue && (

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -91,7 +91,9 @@ export class VaButton {
   };
 
   /**
-   * A workaround for preventing the click event from bubbling.
+   * This workaround allows us to use disabled for styling and preventing the click event from firing while improving
+   * the button's accessibility by allowing it to be focusable and through the use of aria-disabled.
+   *
    * Using a click handler on the button with this same check for disabled results in the event bubbling.
    */
   @Listen('click')

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -91,7 +91,7 @@ export class VaButton {
   };
 
   /**
-   * This workaround allows us to use disabled for styling and preventing the click event from firing while improving
+   * This workaround allows us to use disabled for styling and to prevent the click event from firing while improving
    * the button's accessibility by allowing it to be focusable and through the use of aria-disabled.
    *
    * Using a click handler on the button with this same check for disabled results in the event bubbling.


### PR DESCRIPTION
## Chromatic
<!-- This `818-button-disabled` is a placeholder for a CI job - it will be updated automatically -->
https://818-button-disabled--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/818

This PR updates va-button to be focusable when `disabled` is true to improve its accessibility while providing the same functionality and styling of a disabled button. The button is no longer being disabled. If `disabled` is true, the click event will not bubble.

## Testing done
E2E, Storybook

## Acceptance criteria
- [x] va-button is focusable when `disabled`
- [x] va-button provides accessibility using `aria-disabled`

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
