### PR TITLE
Remove redundant textarea attribute & validate maxlength

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -603,7 +603,7 @@ export namespace Components {
          */
         "label"?: string;
         /**
-          * The maximum number of characters allowed in the input.
+          * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */
         "maxlength"?: number;
         /**
@@ -649,7 +649,7 @@ export namespace Components {
          */
         "label"?: string;
         /**
-          * The maximum number of characters allowed in the input.
+          * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */
         "maxlength"?: number;
         /**
@@ -1652,7 +1652,7 @@ declare namespace LocalJSX {
          */
         "label"?: string;
         /**
-          * The maximum number of characters allowed in the input.
+          * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */
         "maxlength"?: number;
         /**
@@ -1702,7 +1702,7 @@ declare namespace LocalJSX {
          */
         "label"?: string;
         /**
-          * The maximum number of characters allowed in the input.
+          * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */
         "maxlength"?: number;
         /**

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -205,6 +205,34 @@ describe('va-text-input', () => {
     );
   });
 
+  it('ignores negative maxlength values', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input maxlength="-5"/>');
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+
+    // Test the functionality
+    await inputEl.type('Hello, nice to meet you');
+    expect(await inputEl.getProperty('value')).toBe('Hello, nice to meet you');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+  });
+
+  it('ignores a maxlength of zero', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input maxlength="0"/>');
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+
+    // Test the functionality
+    await inputEl.type('Hello, nice to meet you');
+    expect(await inputEl.getProperty('value')).toBe('Hello, nice to meet you');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+  });
+
   it('allows manually setting the type attribute', async () => {
     const allowedInputTypes = [
       'email',

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -69,6 +69,7 @@ export class VaTextInput {
 
   /**
    * The maximum number of characters allowed in the input.
+   * Negative and zero values will be ignored.
    */
   @Prop() maxlength?: number;
 
@@ -137,6 +138,19 @@ export class VaTextInput {
     return this.type;
   }
 
+  /**
+   * This ensures that the `maxlength` property will be positive
+   * or it won't be used at all
+   */
+  private getMaxlength() {
+    if (this.maxlength <= 0) {
+      consoleDevError("The maxlength prop must be positive!");
+      return undefined;
+    }
+
+    return this.maxlength;
+  }
+
   private handleInput = (e: Event) => {
     const target = e.target as HTMLInputElement;
     this.value = target.value;
@@ -172,7 +186,6 @@ export class VaTextInput {
       inputmode,
       required,
       value,
-      maxlength,
       minlength,
       pattern,
       name,
@@ -180,6 +193,7 @@ export class VaTextInput {
       handleBlur,
     } = this;
     const type = this.getInputType();
+    const maxlength = this.getMaxlength();
 
     return (
       <Host>

--- a/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
+++ b/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
@@ -10,10 +10,10 @@ describe('va-textarea', () => {
     expect(element).toEqualHtml(`
       <va-textarea class="hydrated" label="Describe your situation">
         <mock:shadow-root>
-          <label for="textarea" id="textarea-label">
+          <label for="textarea">
             Describe your situation
           </label>
-          <textarea aria-labelledby="textarea-label" id="textarea"></textarea>
+          <textarea id="textarea"></textarea>
         </mock:shadow-root>
       </va-textarea>
     `);

--- a/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
+++ b/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
@@ -149,4 +149,31 @@ describe('va-textarea', () => {
     );
   });
 
+  it('ensures that negative maxlength values are ignored', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-textarea maxlength="-5"/>');
+
+    // Level-setting expectations
+    const textareaEl = await page.find('va-textarea >>> textarea');
+    expect(await page.find('va-textarea >>> small')).toBeNull();
+
+    // Test the functionality
+    await textareaEl.type('Hello, nice to meet you');
+    expect(await textareaEl.getProperty('value')).toBe('Hello, nice to meet you');
+    expect(await page.find('va-textarea >>> small')).toBeNull();
+  });
+
+  it('ensures that a maxlength of zero is ignored', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-textarea maxlength="0"/>');
+
+    // Level-setting expectations
+    const textareaEl = await page.find('va-textarea >>> textarea');
+    expect(await page.find('va-textarea >>> small')).toBeNull();
+
+    // Test the functionality
+    await textareaEl.type('Hello, nice to meet you');
+    expect(await textareaEl.getProperty('value')).toBe('Hello, nice to meet you');
+    expect(await page.find('va-textarea >>> small')).toBeNull();
+  });
 });

--- a/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
+++ b/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
@@ -149,7 +149,7 @@ describe('va-textarea', () => {
     );
   });
 
-  it('ensures that negative maxlength values are ignored', async () => {
+  it('ignores negative maxlength values', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-textarea maxlength="-5"/>');
 
@@ -163,7 +163,7 @@ describe('va-textarea', () => {
     expect(await page.find('va-textarea >>> small')).toBeNull();
   });
 
-  it('ensures that a maxlength of zero is ignored', async () => {
+  it('ignores a maxlength of zero', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-textarea maxlength="0"/>');
 

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -103,10 +103,7 @@ export class VaTextarea {
 
     return (
       <Host>
-        <label
-          id="textarea-label"
-          htmlFor="textarea"
-        >
+        <label htmlFor="textarea">
           {label}
           {required && <span class="required">(*{i18next.t('required')})</span>}
         </label>
@@ -116,7 +113,6 @@ export class VaTextarea {
         }
         <textarea
           aria-describedby={error ? 'error-message' : undefined}
-          aria-labelledby="textarea-label"
           onInput={this.handleInput}
           onBlur={this.handleBlur}
           id="textarea"

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -46,6 +46,7 @@ export class VaTextarea {
 
   /**
    * The maximum number of characters allowed in the input.
+   * Negative and zero values will be ignored.
    */
   @Prop() maxlength?: number;
 

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -1,5 +1,6 @@
 import { Build, Component, Event, EventEmitter, Host, Prop, Element, forceUpdate, h } from '@stencil/core';
 import i18next from 'i18next';
+import { consoleDevError } from '../../utils/utils';
 
 if (Build.isTesting) {
   // Make i18next.t() return the key instead of the value
@@ -98,8 +99,22 @@ export class VaTextarea {
     }
   }
 
+  /**
+   * This ensures that the `maxlength` property will be positive
+   * or it won't be used at all
+   */
+  private getMaxlength() {
+    if (this.maxlength <= 0) {
+      consoleDevError("The maxlength prop must be positive!");
+      return undefined;
+    }
+
+    return this.maxlength;
+  }
+
   render() {
-    const {label, error, placeholder, maxlength, name, required, value} = this;
+    const {label, error, placeholder, name, required, value} = this;
+    const maxlength = this.getMaxlength();
 
     return (
       <Host>


### PR DESCRIPTION
## Chromatic
<!-- This `textarea-review` is a placeholder for a CI job - it will be updated automatically -->
https://textarea-review--60f9b557105290003b387cd5.chromatic.com

## Description
- Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/42520
- Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/42812
- Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/42811
- Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/872

This PR:
- Removes the redundant `aria-labelledby` attribute (redundant due to the `htmlFor` attribute on the label)
- Ensures that only positive `maxlength` values will be used when displaying the validation message
  - This feedback is only a "consider", so it's up to us whether we want to implement it or not. See review comments below

## Testing done

- E2E tests
- Storybook :eyes: 

## Screenshots

### Current behavior if a negative maxlength value is used

![Validation message appearing below the textarea showing that the maxlength of "-5" has been exceeded](https://user-images.githubusercontent.com/2008881/173707245-0dd3e621-94e0-4eb8-95b7-5d1682429ce4.gif)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
