### PR TITLE
Fix styling for va-select and va-text-input when required is true

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-date/va-date.css
+++ b/packages/web-components/src/components/va-date/va-date.css
@@ -40,7 +40,7 @@ span.required {
 
 :host([error]:not([error=''])) va-select::part(select),
 :host([error]:not([error=''])) va-text-input::part(input) {
-  border: 2px solid var(--color-secondary-dark);
+  border: 4px solid var(--color-secondary-dark);
 }
 
 .error-message {

--- a/packages/web-components/src/components/va-select/va-select.css
+++ b/packages/web-components/src/components/va-select/va-select.css
@@ -57,5 +57,5 @@ select {
   background-position: right 1.3rem center;
   background-repeat: no-repeat;
   background-size: 1rem;
-  padding-right: 3rem;
+  padding: 0.8rem 3rem 0.8rem 0.8em;
 }

--- a/packages/web-components/src/components/va-select/va-select.css
+++ b/packages/web-components/src/components/va-select/va-select.css
@@ -38,7 +38,7 @@
 }
 
 :host([error]:not([error=''])) select {
-  border: 3px solid var(--color-secondary-dark);
+  border: 4px solid var(--color-secondary-dark);
 }
 
 ::slotted(option) {

--- a/packages/web-components/src/components/va-select/va-select.css
+++ b/packages/web-components/src/components/va-select/va-select.css
@@ -10,7 +10,7 @@
   margin: 0 0.35em;
 }
 
-:host([error]) {
+:host([error]:not([error=''])) {
   border-left: 4px solid var(--color-secondary-dark);
   margin-top: 3rem;
   padding-bottom: 0.8rem;
@@ -20,24 +20,24 @@
   right: 1.9rem;
 }
 
-:host([error]) label {
+:host([error]:not([error=''])) label {
   margin-top: 0;
 }
 
-:host([error]) label,
-:host([error]) > span {
+:host([error]:not([error=''])) label,
+:host([error]:not([error=''])) > span {
   display: block;
   font-size: 1.6rem;
   font-weight: 700;
 }
 
-:host([error]) > span {
+:host([error]:not([error=''])) > span {
   color: var(--color-secondary-dark);
   padding-bottom: 3px;
   padding-top: 3px;
 }
 
-:host([error]) select {
+:host([error]:not([error=''])) select {
   border: 3px solid var(--color-secondary-dark);
 }
 

--- a/packages/web-components/src/components/va-select/va-select.css
+++ b/packages/web-components/src/components/va-select/va-select.css
@@ -37,8 +37,7 @@
   padding-top: 3px;
 }
 
-:host([error]) select,
-select:invalid {
+:host([error]) select {
   border: 3px solid var(--color-secondary-dark);
 }
 

--- a/packages/web-components/src/components/va-select/va-select.css
+++ b/packages/web-components/src/components/va-select/va-select.css
@@ -57,5 +57,5 @@ select {
   background-position: right 1.3rem center;
   background-repeat: no-repeat;
   background-size: 1rem;
-  padding: 0.8rem 3rem 0.8rem 0.8em;
+  padding: 0.8rem 3rem 0.8rem 0.8rem;
 }

--- a/packages/web-components/src/components/va-select/va-select.css
+++ b/packages/web-components/src/components/va-select/va-select.css
@@ -57,5 +57,5 @@ select {
   background-position: right 1.3rem center;
   background-repeat: no-repeat;
   background-size: 1rem;
-  padding: 0.8rem 3rem 0.8rem 0.8rem;
+  padding: 0.8rem 3rem 0.8rem 0.7em;
 }

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -61,15 +61,15 @@ describe('va-text-input', () => {
     const page = await newE2EPage();
     await page.setContent('<va-text-input />');
     // Check that error is empty
-    const el = await page.find('va-text-input'); 
+    const el = await page.find('va-text-input');
     const inputEl = await page.find('va-text-input >>> input');
     expect(inputEl.getAttribute('aria-describedby')).toBeNull();
     // Render the error message text as empty string
-    el.setProperty('error', "");
+    el.setProperty('error', '');
     await page.waitForChanges();
     expect(inputEl.getAttribute('aria-describedby')).toBeNull();
     // Render the error message text as real value
-    el.setProperty('error', "Testing Error");
+    el.setProperty('error', 'Testing Error');
     await page.waitForChanges();
     expect(inputEl.getAttribute('aria-describedby')).not.toBeNull();
     expect(inputEl.getAttribute('aria-describedby')).toContain('error-message');
@@ -155,9 +155,15 @@ describe('va-text-input', () => {
 
     // Act
     await inputEl.press('a');
-    const firstValue = await page.$eval("va-text-input", (comp : HTMLInputElement) => comp.value)
+    const firstValue = await page.$eval(
+      'va-text-input',
+      (comp: HTMLInputElement) => comp.value,
+    );
     await inputEl.press('s');
-    const secondValue = await page.$eval("va-text-input", (comp : HTMLInputElement) => comp.value)
+    const secondValue = await page.$eval(
+      'va-text-input',
+      (comp: HTMLInputElement) => comp.value,
+    );
 
     // Assert
     expect(inputSpy).toHaveReceivedEventTimes(2);
@@ -255,17 +261,18 @@ describe('va-text-input', () => {
     await page.setContent('<va-text-input success />');
 
     const input = await page.find('va-text-input >>> input');
+    // rgb(46, 133, 64) is equal to #2e8540 and --color-green CSS variable
     expect((await input.getComputedStyle()).borderBottomColor).toEqual(
-      'rgb(91, 97, 107)',
+      'rgb(46, 133, 64)',
     );
     expect((await input.getComputedStyle()).borderLeftColor).toEqual(
-      'rgb(91, 97, 107)',
+      'rgb(46, 133, 64)',
     );
     expect((await input.getComputedStyle()).borderRightColor).toEqual(
-      'rgb(91, 97, 107)',
+      'rgb(46, 133, 64)',
     );
     expect((await input.getComputedStyle()).borderTopColor).toEqual(
-      'rgb(91, 97, 107)',
+      'rgb(46, 133, 64)',
     );
   });
 });

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -57,9 +57,9 @@ input:not([disabled]):focus {
 }
 
 :host([error]:not([error=''])) input {
-  border: 2px solid var(--color-secondary-dark);
+  border: 4px solid var(--color-secondary-dark);
 }
 
 :host([success='true']) input {
-  border: 2px solid var(--color-green);
+  border: 4px solid var(--color-green);
 }

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -56,8 +56,7 @@ input:not([disabled]):focus {
   font-weight: 700;
 }
 
-:host([error]:not([error=''])) input,
-input:invalid {
+:host([error]:not([error=''])) input {
   border: 2px solid var(--color-secondary-dark);
 }
 

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -60,6 +60,6 @@ input:not([disabled]):focus {
   border: 4px solid var(--color-secondary-dark);
 }
 
-:host([success='true']) input {
+:host([success]:not([success='false'])) input {
   border: 4px solid var(--color-green);
 }

--- a/packages/web-components/src/components/va-textarea/va-textarea.css
+++ b/packages/web-components/src/components/va-textarea/va-textarea.css
@@ -29,3 +29,7 @@ textarea {
   padding: 1.2rem;
   margin: 0.4rem 0;
 }
+
+:host([error]:not([error=''])) textarea {
+  border: 4px solid var(--color-secondary-dark);
+}


### PR DESCRIPTION
## Chromatic
<!-- This `956-inputs` is a placeholder for a CI job - it will be updated automatically -->
https://956-inputs--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/956

- Updated input border from 2px to 4px for `va-date`, `va-date-text-input`, `va-text-input`
- Updated input border from 3px to 4px for `va-select`
- Fixed `va-select` styles when error is an empty string
- Fixed `va-text-input` styles for success state
- Added 4px border when `error` is true to `va-text-area` - We weren't showing a border previously

I've verified that this is not affecting our other web component inputs: va-checkbox, va-checkbox-group, va-date, va-date-text-input, va-radio and va-text-area.

## Testing done
Storybook

## Screenshots
There were the affected components:
![Screen Shot 2022-06-16 at 17 37 54](https://user-images.githubusercontent.com/36863582/174170599-abd3564c-306f-4a5b-9d38-b7079e4ee851.png)
![Screen Shot 2022-06-16 at 17 37 36](https://user-images.githubusercontent.com/36863582/174170630-8f7a5c83-ad72-4eaa-8882-ce14f33763aa.png)



## Acceptance criteria
- [x] `va-select` and `va-text-input` have the correct styling when required is true
- [x] Web component inputs have a 4px border when `error` or `success` is true

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
