### PR TITLE
Remove unnecessary margin on va-alert-expandable

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
@@ -3,7 +3,6 @@
 
 :host {
   display: block;
-  margin: 0 1.2rem 0.8rem;
 }
 
 :host([status='warning']) {


### PR DESCRIPTION
## Chromatic
<!-- This `longmd-clear-expandable-alert-default-margin` is a placeholder for a CI job - it will be updated automatically -->
https://longmd-clear-expandable-alert-default-margin--60f9b557105290003b387cd5.chromatic.com

## Description
This PR removes the default margin from the `va-alert-expandable` component. This margin creates unnecessary indents of the component and the need to wrap in a div with negative margin to align with surrounding components.

## Original Issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/43338

## Screenshots
![Screen Shot 2022-06-24 at 10 08 54 AM](https://user-images.githubusercontent.com/6738544/175554333-d97852a6-09b3-4352-b4be-0c8d43693894.png)

## Acceptance criteria
- [ ] Component defaults to zero margin

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
