### PR TITLE
Prevent breadcrumb line break on mobile

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "10.6.3",
+  "version": "10.6.4",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs-slot.css
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs-slot.css
@@ -22,7 +22,7 @@ va-breadcrumbs .va-breadcrumbs-li:last-child::after {
   }
 
   va-breadcrumbs .va-breadcrumbs-li:nth-last-child(2) {
-    display: inline-block;
+    display: flex;
   }
 
   va-breadcrumbs .va-breadcrumbs-li:nth-last-child(2)::before {


### PR DESCRIPTION
## Chromatic
<!-- This `469-breadcrumbs` is a placeholder for a CI job - it will be updated automatically -->
https://469-breadcrumbs--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/469

## Testing done
Storybook

## Screenshots
<img width="350" alt="Screen Shot 2022-06-24 at 11 30 04" src="https://user-images.githubusercontent.com/36863582/175568906-ec255e1e-fff8-4c4c-832a-632b3f0018a5.png">


## Acceptance criteria
- [x] va-breadcrumbs overflow text wraps to the next line

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
