### PR TITLE
Inherit resize property from parent

### DIFF
--- a/packages/storybook/.storybook/style.scss
+++ b/packages/storybook/.storybook/style.scss
@@ -29,3 +29,7 @@ a.sbdocs-a,
 a.sbdocs-a:hover {
   text-decoration: underline;
 }
+
+.resize-y {
+  resize: vertical;
+}

--- a/packages/storybook/stories/va-textarea.stories.jsx
+++ b/packages/storybook/stories/va-textarea.stories.jsx
@@ -51,6 +51,33 @@ const Template = ({
   );
 };
 
+const ResizableTemplate = ({
+  name,
+  label,
+  'enable-analytics': enableAnalytics,
+  required,
+  error,
+  maxlength,
+  value,
+  placeholder,
+}) => {
+  return (
+    <va-textarea
+      class="resize-y"
+      name={name}
+      label={label}
+      enable-analytics={enableAnalytics}
+      required={required}
+      error={error}
+      maxlength={maxlength}
+      value={value}
+      placeholder={placeholder}
+      onBlur={e => console.log('blur event', e)}
+      onInput={e => console.log('input event value', e.target.value)}
+    />
+  );
+};
+
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(textareaDocs);
@@ -70,3 +97,6 @@ MaxLength.args = {
 
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
+
+export const ResizableControl = ResizableTemplate.bind(null);
+ResizableTemplate.args = { ...defaultArgs };

--- a/packages/web-components/src/components/va-textarea/va-textarea.css
+++ b/packages/web-components/src/components/va-textarea/va-textarea.css
@@ -3,6 +3,7 @@
 
 :host {
   display: block;
+  resize: both;
 }
 
 :host([error]) label {
@@ -28,6 +29,7 @@ textarea {
   width: 100%;
   padding: 1.2rem;
   margin: 0.4rem 0;
+  resize: inherit;
 }
 
 :host([error]:not([error=''])) textarea {


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
This allows for a better migration of [the single `vets-website` `<TextArea>`](https://github.com/department-of-veterans-affairs/vets-website/blob/e0b07c07cb2acadc6c067d1191ad187f7f27d6c6/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx#L116)

## Testing done

Storybook


## Screenshots




## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
