### PR TITLE
Display default value and type in Storybook args table

### DIFF
--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -84,13 +84,16 @@ export const propStructure = comp => {
     propObj[prop.attr] = {
       description: prop.docs,
       required: prop.required,
-      defaultValue: { value: prop.default },
-      type: {
-        name: prop.type,
-      },
       // Assigns the argType to the Properties category
       table: {
         category: 'Properties',
+        defaultValue: {
+          summary: prop.default,
+        },
+        type: { summary: prop.type },
+      },
+      control: {
+        type: prop.values[0].type === 'string' ? 'text' : prop.values[0].type,
       },
     };
     return propObj;


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/923

## Screenshots
<img width="1037" alt="Screen Shot 2022-06-29 at 15 12 50" src="https://user-images.githubusercontent.com/36863582/176517461-d3682e51-d027-4aea-be89-bc8fdf8d9a0e.png">

## Acceptance criteria
- [x] Storybook displays web component default values and types for props

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
