### PR TITLE
Remove aria-labelledby in form controls

### DIFF
--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -125,10 +125,9 @@ export class VaCheckbox {
           id="checkbox-element"
           checked={checked}
           aria-describedby={error ? 'error-message' : undefined}
-          aria-labelledby="checkbox-label"
           onChange={this.handleChange}
         />
-        <label htmlFor="checkbox-element" id="checkbox-label">
+        <label htmlFor="checkbox-element">
           {label}
           {required && <span class="required">(*Required)</span>}
         </label>

--- a/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
+++ b/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
@@ -11,10 +11,10 @@ describe('va-number-input', () => {
     expect(element).toEqualHtml(`
       <va-number-input class="hydrated" label="Hello, world">
         <mock:shadow-root>
-          <label for="inputField" id="inputField-label">
+          <label for="inputField">
             Hello, world
           </label>
-          <input aria-labelledby="inputField-label" id="inputField" type="number" />
+          <input id="inputField" type="number" />
         </mock:shadow-root>
       </va-number-input>
     `);

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -123,7 +123,7 @@ export class VaNumberInput {
     } = this;
     return (
       <Host>
-        <label id="inputField-label" htmlFor="inputField">
+        <label htmlFor="inputField">
           {label}{' '}
           {required && <span class="required">{i18next.t('required')}</span>}
         </label>
@@ -134,7 +134,6 @@ export class VaNumberInput {
         )}
         <input
           aria-describedby={error ? 'error-message' : undefined}
-          aria-labelledby="inputField-label"
           id="inputField"
           type="number"
           inputmode={inputmode ? inputmode : null}

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -16,11 +16,11 @@ describe('va-select', () => {
     expect(element).toEqualHtml(`
       <va-select label="A label" value="bar" class="hydrated">
         <mock:shadow-root>
-          <label for="select" part="label" id="select-label">
+          <label for="select" part="label">
             A label
           </label>
           <slot></slot>
-          <select aria-labelledby="select-label" id="select" part="select">
+          <select id="select" part="select">
             <option value="">Please choose an option</option>
             <option value="foo">Foo</option>
             <option value="bar">Bar</option>

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -139,7 +139,7 @@ export class VaSelect {
 
     return (
       <Host>
-        <label htmlFor="select" id="select-label" part="label">
+        <label htmlFor="select" part="label">
           {label}
           {required && (
             <span class="required">{i18next.t('required')}</span>
@@ -152,7 +152,6 @@ export class VaSelect {
         )}
         <slot onSlotchange={() => this.populateOptions()}></slot>
         <select
-          aria-labelledby="select-label"
           aria-describedby={error ? 'error-message' : undefined}
           id="select"
           name={name}


### PR DESCRIPTION
## Chromatic
<!-- This `remove-aria-labelledby` is a placeholder for a CI job - it will be updated automatically -->
https://remove-aria-labelledby--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/39727

This removes the redundant `aria-labelledby` attribute when the label is connected to the interactive control using the `for` attribute. From @davidakennedy's comment on the ticket:

> The select input has `aria-labelledby="select-label"` or similar. However, this isn't needed since each input is already associated with labels via the `for` attribute like this, `for="select"`. The `aria-labelledby` attributes should be removed.

## Testing done
E2E with axe testing

## Screenshots

The only remaining `aria-labelledby` is in `<va-on-this-page>`:

![grep result of "aria-labelledby" showing that it only appears in the `va-on-this-page` definition and test files](https://user-images.githubusercontent.com/2008881/178558600-34a23417-c3bf-4643-a82d-b99ebb7feceb.png)

https://github.com/department-of-veterans-affairs/component-library/blob/36614239b1ca1984ebe58a306c11860ab9178e6b/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx#L56-L58


## Acceptance criteria
- [x] Remove `aria-labelledby` attributes

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
