### PR TITLE
Remove unneeded aria-live when errors occur

### DIFF
--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -229,12 +229,12 @@ export class VaTextInput {
           part="input"
         />
         {maxlength && value?.length >= maxlength && (
-          <small aria-live="polite" part="validation">
+          <small part="validation">
             {i18next.t('max-chars', { length: maxlength })}
           </small>
         )}
         {minlength && value?.length < minlength && (
-          <small aria-live="polite" part="validation">
+          <small part="validation">
             (Min. {minlength} characters)
           </small>
         )}

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -149,7 +149,7 @@ export class VaTextarea {
           value={value}
         />
         {maxlength && value?.length >= maxlength && (
-          <small aria-live="polite">
+          <small>
             {i18next.t('max-chars', { length: maxlength })}
           </small>
         )}


### PR DESCRIPTION
## Chromatic
<!-- This `remove-aria-live` is a placeholder for a CI job - it will be updated automatically -->
https://remove-aria-live--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/39727

This removes the `aria-live` attribute from the "Min chars" and "Max chars" message in the form components:

- `va-text-input`
- `va-textarea`

From @davidakennedy 's comment on the issue:

> We should remove this additional `aria-live` region because multiple ARIA live regions on a page can get complex, and not all of them will be announced if they occur at the same time.

## Testing done

E2E

## Screenshots

There are some remaining `aria-live` attributes, but they are not related to error messaging:

![`aria-live` attributes in the alert, loading indicator, and alert-expandable components](https://user-images.githubusercontent.com/2008881/178560258-97bbfa93-ad5e-4386-aa98-bc930bd1f4e6.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
