### PR TITLE
Associate date errors with sub components

### DIFF
--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -38,7 +38,7 @@ describe('va-date', () => {
     await page.setContent('<va-date error="This is a mistake" />');
 
     // Render the error message text
-    const error = await page.find('va-date >>> span.error-message');
+    const error = await page.find('va-date >>> span#error-message');
     expect(error.innerText).toContain('This is a mistake');
   });
 
@@ -66,7 +66,7 @@ describe('va-date', () => {
     await page.waitForChanges();
 
     // Assert
-    const errorSpan = await page.find('va-date >>> span.error-message');
+    const errorSpan = await page.find('va-date >>> span#error-message');
     expect(errorSpan.textContent).toContain("Fill me out");
   });
 

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -44,7 +44,7 @@ describe('va-date', () => {
 
   it('puts an aria-describedby attribute on child components when there is an error', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va--date error="This is a mistake" />');
+    await page.setContent('<va-date error="This is a mistake" />');
 
     const firstInput= await page.find('va-date >>> va-select:nth-child(1)');
     const secondInput = await page.find('va-date >>> va-select:nth-child(2)');

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -42,6 +42,18 @@ describe('va-date', () => {
     expect(error.innerText).toContain('This is a mistake');
   });
 
+  it('puts an aria-describedby attribute on child components when there is an error', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va--date error="This is a mistake" />');
+
+    const firstInput= await page.find('va-date >>> va-select:nth-child(1)');
+    const secondInput = await page.find('va-date >>> va-select:nth-child(2)');
+    const thirdInput = await page.find('va-date >>> va-text-input');
+    expect(firstInput.getAttribute('aria-describedby')).toContain('error-message');
+    expect(secondInput.getAttribute('aria-describedby')).toContain('error-message');
+    expect(thirdInput.getAttribute('aria-describedby')).toContain('error-message');
+  });
+
   it('renders a required span', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-date label="This is a field" required />');

--- a/packages/web-components/src/components/va-date/va-date.css
+++ b/packages/web-components/src/components/va-date/va-date.css
@@ -43,12 +43,12 @@ span.required {
   border: 4px solid var(--color-secondary-dark);
 }
 
-.error-message {
+#error-message {
   color: var(--color-secondary-dark);
   display: block;
 }
 
-:host([error]:not([error=''])) .error-message {
+:host([error]:not([error=''])) #error-message {
   padding-top: 0.8rem;
 }
 

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -215,13 +215,14 @@ export class VaDate {
           </legend>
           <slot />
           {error && (
-            <span class="error-message" role="alert">
+            <span id="error-message" role="alert">
               <span class="sr-only">Error</span> {error}
             </span>
           )}
           <div class="date-container">
             <va-select
               label="Month"
+              aria-describedby={error ? 'error-message' : undefined}
               name={`${name}Month`}
               // Value must be a string
               value={month?.toString()}
@@ -238,6 +239,7 @@ export class VaDate {
             {!monthYearOnly && (
               <va-select
                 label="Day"
+                aria-describedby={error ? 'error-message' : undefined}
                 name={`${name}Day`}
                 // If day value set is greater than amount of days in the month
                 // set to empty string instead
@@ -256,6 +258,7 @@ export class VaDate {
             )}
             <va-text-input
               label="Year"
+              aria-describedby={error ? 'error-message' : undefined}
               name={`${name}Year`}
               maxlength={4}
               minlength={4}

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -45,13 +45,20 @@ describe('va-memorable-date', () => {
 
     // Render the error message text
     const error = await page.find('va-memorable-date >>> span#error-message');
+
+    expect(error.innerText).toContain('This is a mistake');
+  });
+
+  it('puts an aria-describedby attribute on child components when there is an error', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-memorable-date error="This is a mistake" />');
+
     const firstInput= await page.find('va-memorable-date >>> va-text-input:nth-child(1)');
     const secondInput = await page.find('va-memorable-date >>> va-text-input:nth-child(2)');
     const thirdInput = await page.find('va-memorable-date >>> va-text-input:nth-child(3)');
     expect(firstInput.getAttribute('aria-describedby')).toContain('error-message');
     expect(secondInput.getAttribute('aria-describedby')).toContain('error-message');
     expect(thirdInput.getAttribute('aria-describedby')).toContain('error-message');
-    expect(error.innerText).toContain('This is a mistake');
   });
 
   it('renders a required span', async () => {

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -45,6 +45,12 @@ describe('va-memorable-date', () => {
 
     // Render the error message text
     const error = await page.find('va-memorable-date >>> span.error-message');
+    const firstInput= await page.find('va-memorable-date >>> va-text-input:nth-child(1)');
+    const secondInput = await page.find('va-memorable-date >>> va-text-input:nth-child(2)');
+    const thirdInput = await page.find('va-memorable-date >>> va-text-input:nth-child(3)');
+    expect(firstInput.getAttribute('aria-describedby')).toContain('error-message');
+    expect(secondInput.getAttribute('aria-describedby')).toContain('error-message');
+    expect(thirdInput.getAttribute('aria-describedby')).toContain('error-message');
     expect(error.innerText).toContain('This is a mistake');
   });
 

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -49,18 +49,6 @@ describe('va-memorable-date', () => {
     expect(error.innerText).toContain('This is a mistake');
   });
 
-  it('puts an aria-describedby attribute on child components when there is an error', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-memorable-date error="This is a mistake" />');
-
-    const firstInput= await page.find('va-memorable-date >>> va-text-input:nth-child(1)');
-    const secondInput = await page.find('va-memorable-date >>> va-text-input:nth-child(2)');
-    const thirdInput = await page.find('va-memorable-date >>> va-text-input:nth-child(3)');
-    expect(firstInput.getAttribute('aria-describedby')).toContain('error-message');
-    expect(secondInput.getAttribute('aria-describedby')).toContain('error-message');
-    expect(thirdInput.getAttribute('aria-describedby')).toContain('error-message');
-  });
-
   it('renders a required span', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -44,7 +44,7 @@ describe('va-memorable-date', () => {
     await page.setContent('<va-memorable-date error="This is a mistake" />');
 
     // Render the error message text
-    const error = await page.find('va-memorable-date >>> span.error-message');
+    const error = await page.find('va-memorable-date >>> span#error-message');
     const firstInput= await page.find('va-memorable-date >>> va-text-input:nth-child(1)');
     const secondInput = await page.find('va-memorable-date >>> va-text-input:nth-child(2)');
     const thirdInput = await page.find('va-memorable-date >>> va-text-input:nth-child(3)');

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -45,7 +45,6 @@ describe('va-memorable-date', () => {
 
     // Render the error message text
     const error = await page.find('va-memorable-date >>> span#error-message');
-
     expect(error.innerText).toContain('This is a mistake');
   });
 

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -176,6 +176,8 @@ export class VaMemorableDate {
 
     const [year, month, day] = (value || '').split('-');
 
+    const describedBy = ["dateHint", error ? "error-message" : null].join(" ")
+
     // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group
     return (
@@ -190,7 +192,7 @@ export class VaMemorableDate {
           </legend>
           <slot />
           {error && (
-            <span class="error-message" role="alert">
+            <span id="error-message" role="alert">
               <span class="sr-only">Error</span> {error}
             </span>
           )}
@@ -201,7 +203,7 @@ export class VaMemorableDate {
               maxlength={2}
               minlength={2}
               pattern="[0-9]*"
-              aria-describedby="dateHint"
+              aria-describedby={describedBy}
               // Value must be a string
               // if NaN provide empty string
               value={month?.toString()}
@@ -217,7 +219,7 @@ export class VaMemorableDate {
               maxlength={2}
               minlength={2}
               pattern="[0-9]*"
-              aria-describedby="dateHint"
+              aria-describedby={describedBy}
               // Value must be a string
               // if NaN provide empty string
               value={day?.toString()}
@@ -233,7 +235,7 @@ export class VaMemorableDate {
               maxlength={4}
               minlength={4}
               pattern="[0-9]*"
-              aria-describedby="dateHint"
+              aria-describedby={describedBy}
               // Value must be a string
               // if NaN provide empty string
               value={year?.toString()}

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -176,11 +176,6 @@ export class VaMemorableDate {
 
     const [year, month, day] = (value || '').split('-');
 
-    // Add the `error-message` to the id list if there is an error
-    const describedBy = ["dateHint", error ? "error-message" : null]
-      .filter(id => !!id)
-      .join(" ");
-
     // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group
     return (
@@ -206,7 +201,7 @@ export class VaMemorableDate {
               maxlength={2}
               minlength={2}
               pattern="[0-9]*"
-              aria-describedby={describedBy}
+              aria-describedby="dateHint"
               // Value must be a string
               // if NaN provide empty string
               value={month?.toString()}
@@ -222,7 +217,7 @@ export class VaMemorableDate {
               maxlength={2}
               minlength={2}
               pattern="[0-9]*"
-              aria-describedby={describedBy}
+              aria-describedby="dateHint"
               // Value must be a string
               // if NaN provide empty string
               value={day?.toString()}
@@ -238,7 +233,7 @@ export class VaMemorableDate {
               maxlength={4}
               minlength={4}
               pattern="[0-9]*"
-              aria-describedby={describedBy}
+              aria-describedby="dateHint"
               // Value must be a string
               // if NaN provide empty string
               value={year?.toString()}

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -176,7 +176,10 @@ export class VaMemorableDate {
 
     const [year, month, day] = (value || '').split('-');
 
-    const describedBy = ["dateHint", error ? "error-message" : null].join(" ")
+    // Add the `error-message` to the id list if there is an error
+    const describedBy = ["dateHint", error ? "error-message" : null]
+      .filter(id => !!id)
+      .join(" ");
 
     // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group


### PR DESCRIPTION
## Chromatic
<!-- This `date-errors-describedby` is a placeholder for a CI job - it will be updated automatically -->
https://date-errors-describedby--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/39727

This adds `aria-describedby` attributes to each of the child components inside of `<va-date>`. When asked if this would help improve accessibility, @davidakennedy [responded](https://github.com/department-of-veterans-affairs/va.gov-team/issues/39727#issuecomment-1183710345) and said that this solution would work.

After a [discussion with Tiffany Pender](https://github.com/department-of-veterans-affairs/component-library/pull/486#discussion_r921577719), we have decided not to apply those changes to the `<va-memorable-date>` since it doesn't help screen readers.

## Testing done

E2E


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
