### PR TITLE
Bump puppeteer version

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -53,7 +53,7 @@
     "jest-cli": "^26.6.3",
     "lit-html": "^1.3.0",
     "postcss-url": "^10.1.1",
-    "puppeteer": "10.0.0",
+    "puppeteer": "^10.0.0",
     "react-dom": "^16.7.0",
     "typescript": "^4.3.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,7 +1983,7 @@ __metadata:
     jest-cli: ^26.6.3
     lit-html: ^1.3.0
     postcss-url: ^10.1.1
-    puppeteer: 10.0.0
+    puppeteer: ^10.0.0
     react-dom: ^16.7.0
     typescript: ^4.3.5
   peerDependencies:
@@ -8486,10 +8486,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devtools-protocol@npm:0.0.883894":
-  version: 0.0.883894
-  resolution: "devtools-protocol@npm:0.0.883894"
-  checksum: 18f06c2d51c6037e6a0cfd3177bceea9c12d4758a858db8023a3f79bcee867f2cc0e92f9a118eb0952057726225ca19202d994eb2e0fa03b862bd9925983fdc4
+"devtools-protocol@npm:0.0.901419":
+  version: 0.0.901419
+  resolution: "devtools-protocol@npm:0.0.901419"
+  checksum: de68331ddfb35b828ad743d939d9237e122f76d4a6cbf1e64f6c6d8e9c2c5cc65a5f1994db0fead90192cca1aa9dbed2ea822a7da7b58104cd041a90e215b9a3
   languageName: node
   linkType: hard
 
@@ -16312,12 +16312,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"puppeteer@npm:10.0.0":
-  version: 10.0.0
-  resolution: "puppeteer@npm:10.0.0"
+"puppeteer@npm:^10.0.0":
+  version: 10.4.0
+  resolution: "puppeteer@npm:10.4.0"
   dependencies:
     debug: 4.3.1
-    devtools-protocol: 0.0.883894
+    devtools-protocol: 0.0.901419
     extract-zip: 2.0.1
     https-proxy-agent: 5.0.0
     node-fetch: 2.6.1
@@ -16328,7 +16328,7 @@ fsevents@^1.2.7:
     tar-fs: 2.0.0
     unbzip2-stream: 1.3.3
     ws: 7.4.6
-  checksum: 10c01e42b01da798d634b4da87c0ab2f02f02fecbdeef033fd972007db2d6eb35657832f4cbfd5592d6a8549ba3005adc2d77d6e451fa72de459916234497aac
+  checksum: 3b7b628f07b3e1f960110691363c1eb07a485fa2f24b5a083558a56841cc46bfcac7a3ab8ae5c687f39621972b35327ce934ea731c831dcd8b75d897920bdc26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Chromatic
<!-- This `puppeteer-bump` is a placeholder for a CI job - it will be updated automatically -->
https://puppeteer-bump--60f9b557105290003b387cd5.chromatic.com

## Description

With my new laptop on Ubuntu 22.04, I'm unable to run puppeteer tests locally in the `web-components` package. I get the following error:

```
Protocol error (Target.setDiscoverTargets): Target closed. Error: Protocol error
```

![More detailed error output of running `yarn test` inside of the `packages/web-components` directory. Contains the error message above along with a stack trace.](https://user-images.githubusercontent.com/2008881/179117148-29018e8e-714a-462d-b5f4-c0d819186cde.png)

With the newer puppeteer version from this branch, I'm able to successfully run the tests:

![Terminal output of running `yarn test`. This time the build finishes and we see the beginnings of "PASS" indicators for individual test files.](https://user-images.githubusercontent.com/2008881/179117631-b6eb34b2-17f5-4c3c-a2c0-a3e845dce9be.png)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
