### PR TITLE
Add aria-invalid to most form components

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -671,6 +671,10 @@ export namespace Components {
     | 'text'
     | 'url';
         /**
+          * Whether or not `aria-invalid` will be set on the inner input. Useful when composing the component into something larger, like a date component.
+         */
+        "invalid"?: boolean;
+        /**
           * The label for the text input.
          */
         "label"?: string;
@@ -1821,6 +1825,10 @@ declare namespace LocalJSX {
     | 'tel'
     | 'text'
     | 'url';
+        /**
+          * Whether or not `aria-invalid` will be set on the inner input. Useful when composing the component into something larger, like a date component.
+         */
+        "invalid"?: boolean;
         /**
           * The label for the text input.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -593,6 +593,10 @@ export namespace Components {
          */
         "error"?: string;
         /**
+          * Whether or not `aria-invalid` will be set on the inner select. Useful when composing the component into something larger, like a date component.
+         */
+        "invalid"?: boolean;
+        /**
           * Text label for the field.
          */
         "label": string;
@@ -1731,6 +1735,10 @@ declare namespace LocalJSX {
           * Error message to display. When defined, this indicates an error.
          */
         "error"?: string;
+        /**
+          * Whether or not `aria-invalid` will be set on the inner select. Useful when composing the component into something larger, like a date component.
+         */
+        "invalid"?: boolean;
         /**
           * Text label for the field.
          */

--- a/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
@@ -10,6 +10,14 @@ describe('va-checkbox', () => {
     expect(element).toHaveClass('hydrated');
   });
 
+  it('renders with aria-invalid set to false by default', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-checkbox></va-checkbox>');
+
+    const input = await page.find('va-checkbox >>> input');
+    expect(input.getAttribute('aria-invalid')).toEqual('false');
+  });
+
   it('renders a label', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-checkbox label="Cool label, right?" />');
@@ -23,6 +31,8 @@ describe('va-checkbox', () => {
       '<va-checkbox error="Something went horribly wrong" />',
     );
     const element = await page.find('va-checkbox >>> #error-message');
+    const input = await page.find('va-checkbox >>> input');
+    expect(input.getAttribute('aria-invalid')).toEqual('true');
     expect(element.textContent).toContain('Something went horribly wrong');
   });
 

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -125,6 +125,7 @@ export class VaCheckbox {
           id="checkbox-element"
           checked={checked}
           aria-describedby={error ? 'error-message' : undefined}
+          aria-invalid={error ? 'true' : 'false'}
           onChange={this.handleChange}
         />
         <label htmlFor="checkbox-element">

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -50,6 +50,24 @@ describe('va-date', () => {
     expect(requiredSpan).not.toBeNull();
   });
 
+  it('does not validate without required prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-date value="1999-05-03" name="test" />',
+    );
+    const date = await page.find('va-date');
+    const handleYear = await page.$('pierce/[name="testYear"]');
+
+    // Click three times to select all text in input
+    await handleYear.click({ clickCount: 3 });
+    await handleYear.press('2');
+    // Trigger Blur
+    await handleYear.press('Tab');
+
+    await page.waitForChanges();
+    expect(date.getAttribute('error')).toEqual(null);
+  });
+
   it('allows for a custom required message', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-date value="2000-01-01" name="test" label="This is a field" required="Fill me out" />');
@@ -396,7 +414,7 @@ describe('va-date', () => {
   it('checks for valid year month and day', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<va-date name="test"/>');
+    await page.setContent('<va-date name="test" required/>');
     const date = await page.find('va-date');
     const handleMonth = await page.$('pierce/[name="testMonth"]');
     const handleDay = await page.$('pierce/[name="testDay"]');
@@ -419,7 +437,7 @@ describe('va-date', () => {
   describe('monthYearOnly variant', () => {
     it('only displays month and year fields', async () => {
       const page = await newE2EPage();
-      await page.setContent('<va-date month-year-only/>');
+      await page.setContent('<va-date month-year-only required/>');
       const monthInput = await page.find('va-date >>> va-select.select-month')
       const dayInput = await page.find('va-date >>> va-select.select-day');
       const yearInput = await page.find('va-date >>> va-text-input.input-year')
@@ -452,7 +470,7 @@ describe('va-date', () => {
  
     it('checks for valid year and month', async () => {
       const page = await newE2EPage();
-      await page.setContent('<va-date month-year-only name="test"/>');
+      await page.setContent('<va-date month-year-only name="test" required/>');
 
       const date = await page.find('va-date');
       const handleMonth = await page.$('pierce/[name="testMonth"]');

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -185,48 +185,133 @@ describe('va-date', () => {
     expect(date.getAttribute('error')).toEqual('');
   });
 
-  it('sets the appropriate aria-invalid attribute', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-date value="1999-05-03" name="test" required="true" />',
-    );
-    const handleYear = await page.$('pierce/[name="testYear"]');
-    const handleMonth = await page.$('pierce/[name="testMonth"]');
-    const handleDay = await page.$('pierce/[name="testDay"]');
-    const getAriaInvalid =
-      (element: HTMLElement) => element.getAttribute('aria-invalid');
+  describe('invalid subcomponents', () => {
+    it('correctly indicates an invalid year', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-date value="1999-05-03" name="test" required="true" />',
+      );
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      const handleMonth = await page.$('pierce/[name="testMonth"]');
+      const handleDay = await page.$('pierce/[name="testDay"]');
+      const getAriaInvalid =
+        (element: HTMLElement) => element.getAttribute('aria-invalid');
 
-    // Click three times to select all text in input
-    await handleYear.click({ clickCount: 3 });
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
+      // Click three times to select all text in input
+      await handleYear.click({ clickCount: 3 });
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
 
-    // Year only has one character - should be invalid
-    await page.waitForChanges();
-    let invalidYear = await handleYear.evaluate(getAriaInvalid);
-    let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-    let invalidDay = await handleDay.evaluate(getAriaInvalid);
+      // Year only has one character - should be invalid
+      await page.waitForChanges();
+      let invalidYear = await handleYear.evaluate(getAriaInvalid);
+      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      let invalidDay = await handleDay.evaluate(getAriaInvalid);
 
-    expect(invalidYear).toEqual('true');
-    expect(invalidMonth).toEqual('false');
-    expect(invalidDay).toEqual('false');
+      expect(invalidYear).toEqual('true');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('false');
 
-    await handleYear.press('0');
-    await handleYear.press('2');
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
-    await page.waitForChanges();
+      await handleYear.press('0');
+      await handleYear.press('2');
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
 
-    invalidYear = await handleYear.evaluate(getAriaInvalid);
-    invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-    invalidDay = await handleDay.evaluate(getAriaInvalid);
+      invalidYear = await handleYear.evaluate(getAriaInvalid);
+      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      invalidDay = await handleDay.evaluate(getAriaInvalid);
 
-    expect(invalidYear).toEqual('false');
-    expect(invalidMonth).toEqual('false');
-    expect(invalidDay).toEqual('false');
-  });
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('false');
+    });
+
+    it('correctly indicates an invalid month', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-date value="1999-05-03" name="test" required="true" />',
+      );
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      const handleMonth = await page.$('pierce/[name="testMonth"]');
+      const handleDay = await page.$('pierce/[name="testDay"]');
+      const getAriaInvalid =
+        (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+      // Click three times to select all text in input
+      await handleMonth.click({ clickCount: 3 });
+      await handleMonth.select('0');
+      // Trigger Blur
+      await handleYear.press('Tab');
+
+      // Month only has one character - should be invalid
+      await page.waitForChanges();
+      let invalidYear = await handleYear.evaluate(getAriaInvalid);
+      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('true');
+      // Day is also invalid because month is 0
+      expect(invalidDay).toEqual('true');
+
+      await handleMonth.select('4');
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
+
+      invalidYear = await handleYear.evaluate(getAriaInvalid);
+      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('false');
+    });
+
+    it('correctly indicates an invalid day', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-date value="1999-05-03" name="test" required="true" />',
+      );
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      const handleMonth = await page.$('pierce/[name="testMonth"]');
+      const handleDay = await page.$('pierce/[name="testDay"]');
+      const getAriaInvalid =
+        (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+      // Click three times to select all text in input
+      await handleDay.click({ clickCount: 3 });
+      await handleDay.select('0');
+      // Trigger Blur
+      await handleYear.press('Tab');
+
+      // Month only has one character - should be invalid
+      await page.waitForChanges();
+      let invalidYear = await handleYear.evaluate(getAriaInvalid);
+      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('true');
+
+      await handleDay.select('4');
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
+
+      invalidYear = await handleYear.evaluate(getAriaInvalid);
+      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('false');
+    });
+  })
 
   it('emits dateBlur event', async () => {
     const page = await newE2EPage();

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -185,6 +185,49 @@ describe('va-date', () => {
     expect(date.getAttribute('error')).toEqual('');
   });
 
+  it('sets the appropriate aria-invalid attribute', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-date value="1999-05-03" name="test" required="true" />',
+    );
+    const handleYear = await page.$('pierce/[name="testYear"]');
+    const handleMonth = await page.$('pierce/[name="testMonth"]');
+    const handleDay = await page.$('pierce/[name="testDay"]');
+    const getAriaInvalid =
+      (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+    // Click three times to select all text in input
+    await handleYear.click({ clickCount: 3 });
+    await handleYear.press('2');
+    // Trigger Blur
+    await handleYear.press('Tab');
+
+    // Year only has one character - should be invalid
+    await page.waitForChanges();
+    let invalidYear = await handleYear.evaluate(getAriaInvalid);
+    let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+    let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+    expect(invalidYear).toEqual('true');
+    expect(invalidMonth).toEqual('false');
+    expect(invalidDay).toEqual('false');
+
+    await handleYear.press('0');
+    await handleYear.press('2');
+    await handleYear.press('2');
+    // Trigger Blur
+    await handleYear.press('Tab');
+    await page.waitForChanges();
+
+    invalidYear = await handleYear.evaluate(getAriaInvalid);
+    invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+    invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+    expect(invalidYear).toEqual('false');
+    expect(invalidMonth).toEqual('false');
+    expect(invalidDay).toEqual('false');
+  });
+
   it('emits dateBlur event', async () => {
     const page = await newE2EPage();
 

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -4,6 +4,7 @@ import {
   EventEmitter,
   Host,
   Prop,
+  State,
   h,
   Element,
 } from '@stencil/core';
@@ -11,8 +12,8 @@ import {
 import {
   months,
   days,
-  isFullDate,
-  isMonthYearDate,
+  // isFullDate,
+  // isMonthYearDate,
   checkLeapYear,
   maxMonths,
   maxYear,
@@ -83,6 +84,10 @@ export class VaDate {
   })
   dateBlur: EventEmitter;
 
+  @State() invalidDay: boolean = false;
+  @State() invalidMonth: boolean = false;
+  @State() invalidYear: boolean = false;
+
   /**
    * Set the value prop as an ISO-8601 date using provided arguments.
    * Strips trailing hyphens and sets date to be null if the
@@ -113,23 +118,36 @@ export class VaDate {
     const daysForSelectedMonth = month > 0 ? days[month] : [];
     const leapYear = checkLeapYear(year);
 
-    const expectedDateFormat = this.monthYearOnly
-      ? isMonthYearDate
-      : isFullDate;
+    this.invalidYear = (
+      !year ||
+      year < minYear ||
+      year > maxYear
+    );
 
-    // Check validity of date if invalid provide message and error state styling
+    this.invalidMonth = (
+      !month ||
+      month < minMonths ||
+      month > maxMonths
+    );
+
+    this.invalidDay = (
+      !this.monthYearOnly && (
+        !day ||
+        day < minMonths ||
+        day > daysForSelectedMonth.length)
+    );
+
+    if (!leapYear && month === 2 && day > 28) {
+      this.invalidYear = true;
+      this.invalidMonth = true;
+      this.invalidDay = true;
+    }
+
     if (
       !this.error &&
-      (year < minYear ||
-        year > maxYear ||
-        month < minMonths ||
-        month > maxMonths ||
-        (!this.monthYearOnly &&
-          (day < minMonths || day > daysForSelectedMonth.length || !day)) ||
-        !month ||
-        !year ||
-        (!leapYear && month === 2 && day > 28) ||
-        (this.required && !expectedDateFormat(this.value)))
+      (this.invalidYear ||
+        this.invalidMonth ||
+        this.invalidDay)
     ) {
       this.error = 'Please enter a valid date';
     } else if (this.error !== 'Please enter a valid date') {
@@ -226,6 +244,7 @@ export class VaDate {
               // Value must be a string
               value={month?.toString()}
               onVaSelect={handleDateChange}
+              invalid={this.invalidMonth}
               class="select-month"
               aria-label="Please enter two digits for the month"
             >
@@ -244,6 +263,7 @@ export class VaDate {
                 // Value must be a string
                 value={daysForSelectedMonth.length < day ? '' : day?.toString()}
                 onVaSelect={handleDateChange}
+                invalid={this.invalidDay}
                 class="select-day"
                 aria-label="Please enter two digits for the day"
               >
@@ -263,6 +283,7 @@ export class VaDate {
               // Value must be a string
               // Checking is NaN if so provide empty string
               value={year ? year.toString() : ''}
+              invalid={this.invalidYear}
               onInput={handleDateChange}
               onKeyDown={handleDateKey}
               class="input-year"

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -12,8 +12,6 @@ import {
 import {
   months,
   days,
-  // isFullDate,
-  // isMonthYearDate,
   checkLeapYear,
   maxMonths,
   maxYear,

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -118,29 +118,31 @@ export class VaDate {
     const daysForSelectedMonth = month > 0 ? days[month] : [];
     const leapYear = checkLeapYear(year);
 
-    this.invalidYear = (
-      !year ||
-      year < minYear ||
-      year > maxYear
-    );
+    if (this.required) {
+      this.invalidYear = (
+        !year ||
+        year < minYear ||
+        year > maxYear
+      );
 
-    this.invalidMonth = (
-      !month ||
-      month < minMonths ||
-      month > maxMonths
-    );
+      this.invalidMonth = (
+        !month ||
+        month < minMonths ||
+        month > maxMonths
+      );
 
-    this.invalidDay = (
-      !this.monthYearOnly && (
-        !day ||
-        day < minMonths ||
-        day > daysForSelectedMonth.length)
-    );
+      this.invalidDay = (
+        !this.monthYearOnly && (
+          !day ||
+          day < minMonths ||
+          day > daysForSelectedMonth.length)
+      );
 
-    if (!leapYear && month === 2 && day > 28) {
-      this.invalidYear = true;
-      this.invalidMonth = true;
-      this.invalidDay = true;
+      if (!leapYear && month === 2 && day > 28) {
+        this.invalidYear = true;
+        this.invalidMonth = true;
+        this.invalidDay = true;
+      }
     }
 
     if (

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -184,47 +184,133 @@ describe('va-memorable-date', () => {
     expect(date.getAttribute('error')).toEqual('');
   });
 
-  it('sets the appropriate aria-invalid attribute', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-memorable-date value="1999-05-03" name="test" required="true" />',
-    );
-    const handleYear = await page.$('pierce/[name="testYear"]');
-    const handleMonth = await page.$('pierce/[name="testMonth"]');
-    const handleDay = await page.$('pierce/[name="testDay"]');
-    const getAriaInvalid =
-      (element: HTMLElement) => element.getAttribute('aria-invalid');
+  describe('invalid subcomponents', () => {
+    it('correctly indicates an invalid year', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-memorable-date value="1999-05-03" name="test" required="true" />',
+      );
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      const handleMonth = await page.$('pierce/[name="testMonth"]');
+      const handleDay = await page.$('pierce/[name="testDay"]');
+      const getAriaInvalid =
+        (element: HTMLElement) => element.getAttribute('aria-invalid');
 
-    // Click three times to select all text in input
-    await handleYear.click({ clickCount: 3 });
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
+      // Click three times to select all text in input
+      await handleYear.click({ clickCount: 3 });
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
 
-    // Year only has one character - should be invalid
-    await page.waitForChanges();
-    let invalidYear = await handleYear.evaluate(getAriaInvalid);
-    let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-    let invalidDay = await handleDay.evaluate(getAriaInvalid);
+      // Year only has one character - should be invalid
+      await page.waitForChanges();
+      let invalidYear = await handleYear.evaluate(getAriaInvalid);
+      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      let invalidDay = await handleDay.evaluate(getAriaInvalid);
 
-    expect(invalidYear).toEqual('true');
-    expect(invalidMonth).toEqual('false');
-    expect(invalidDay).toEqual('false');
+      expect(invalidYear).toEqual('true');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('false');
 
-    await handleYear.press('0');
-    await handleYear.press('2');
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
-    await page.waitForChanges();
+      await handleYear.press('0');
+      await handleYear.press('2');
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
 
-    invalidYear = await handleYear.evaluate(getAriaInvalid);
-    invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-    invalidDay = await handleDay.evaluate(getAriaInvalid);
+      invalidYear = await handleYear.evaluate(getAriaInvalid);
+      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      invalidDay = await handleDay.evaluate(getAriaInvalid);
 
-    expect(invalidYear).toEqual('false');
-    expect(invalidMonth).toEqual('false');
-    expect(invalidDay).toEqual('false');
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('false');
+    });
+
+    it('correctly indicates an invalid month', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-memorable-date value="1999-05-03" name="test" required="true" />',
+      );
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      const handleMonth = await page.$('pierce/[name="testMonth"]');
+      const handleDay = await page.$('pierce/[name="testDay"]');
+      const getAriaInvalid =
+        (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+      // Click three times to select all text in input
+      await handleMonth.click({ clickCount: 3 });
+      await handleMonth.press('0');
+      // Trigger Blur
+      await handleYear.press('Tab');
+
+      await page.waitForChanges();
+      let invalidYear = await handleYear.evaluate(getAriaInvalid);
+      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('true');
+      // Day is invalid because month is 0
+      expect(invalidDay).toEqual('true');
+
+      await handleMonth.press('Backspace');
+      await handleMonth.press('4');
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
+
+      invalidYear = await handleYear.evaluate(getAriaInvalid);
+      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('false');
+    });
+
+    it.only('correctly indicates an invalid day', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-memorable-date value="1999-05-03" name="test" required="true" />',
+      );
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      const handleMonth = await page.$('pierce/[name="testMonth"]');
+      const handleDay = await page.$('pierce/[name="testDay"]');
+      const getAriaInvalid =
+        (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+      // Click three times to select all text in input
+      await handleDay.click({ clickCount: 3 });
+      await handleDay.press('3');
+      await handleDay.press('9');
+      // Trigger Blur
+      await handleYear.press('Tab');
+
+      await page.waitForChanges();
+      let invalidYear = await handleYear.evaluate(getAriaInvalid);
+      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('true');
+
+      await handleDay.press('Backspace');
+      await handleDay.press('1');
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
+
+      invalidYear = await handleYear.evaluate(getAriaInvalid);
+      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+      invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+      expect(invalidYear).toEqual('false');
+      expect(invalidMonth).toEqual('false');
+      expect(invalidDay).toEqual('false');
+    });
   });
 
   it('emits dateBlur event', async () => {

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -158,7 +158,7 @@ describe('va-memorable-date', () => {
     expect(elementDay.getAttribute('value')).toBe('12');
   });
 
-  it('fires a error message onBlur if date is invalid and component is required', async () => {
+  it('fires an error message onBlur if date is invalid and component is required', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-memorable-date value="1999-05-03" name="test" required="true" />',
@@ -182,6 +182,49 @@ describe('va-memorable-date', () => {
     await handleYear.press('Tab');
     await page.waitForChanges();
     expect(date.getAttribute('error')).toEqual('');
+  });
+
+  it('sets the appropriate aria-invalid attribute', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-memorable-date value="1999-05-03" name="test" required="true" />',
+    );
+    const handleYear = await page.$('pierce/[name="testYear"]');
+    const handleMonth = await page.$('pierce/[name="testMonth"]');
+    const handleDay = await page.$('pierce/[name="testDay"]');
+    const getAriaInvalid =
+      (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+    // Click three times to select all text in input
+    await handleYear.click({ clickCount: 3 });
+    await handleYear.press('2');
+    // Trigger Blur
+    await handleYear.press('Tab');
+
+    // Year only has one character - should be invalid
+    await page.waitForChanges();
+    let invalidYear = await handleYear.evaluate(getAriaInvalid);
+    let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+    let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+    expect(invalidYear).toEqual('true');
+    expect(invalidMonth).toEqual('false');
+    expect(invalidDay).toEqual('false');
+
+    await handleYear.press('0');
+    await handleYear.press('2');
+    await handleYear.press('2');
+    // Trigger Blur
+    await handleYear.press('Tab');
+    await page.waitForChanges();
+
+    invalidYear = await handleYear.evaluate(getAriaInvalid);
+    invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+    invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+    expect(invalidYear).toEqual('false');
+    expect(invalidMonth).toEqual('false');
+    expect(invalidDay).toEqual('false');
   });
 
   it('emits dateBlur event', async () => {

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -60,6 +60,24 @@ describe('va-memorable-date', () => {
     expect(requiredSpan).not.toBeNull();
   });
 
+  it('does not validate without required prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-memorable-date value="1999-05-03" name="test" />',
+    );
+    const date = await page.find('va-memorable-date');
+    const handleYear = await page.$('pierce/[name="testYear"]');
+
+    // Click three times to select all text in input
+    await handleYear.click({ clickCount: 3 });
+    await handleYear.press('2');
+    // Trigger Blur
+    await handleYear.press('Tab');
+
+    await page.waitForChanges();
+    expect(date.getAttribute('error')).toEqual('');
+  });
+
   it('sets a label', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-memorable-date label="This is a label" />');

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -75,7 +75,7 @@ describe('va-memorable-date', () => {
     await handleYear.press('Tab');
 
     await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('');
+    expect(date.getAttribute('error')).toEqual(null);
   });
 
   it('sets a label', async () => {
@@ -288,7 +288,7 @@ describe('va-memorable-date', () => {
       expect(invalidDay).toEqual('false');
     });
 
-    it.only('correctly indicates an invalid day', async () => {
+    it('correctly indicates an invalid day', async () => {
       const page = await newE2EPage();
       await page.setContent(
         '<va-memorable-date value="1999-05-03" name="test" required="true" />',
@@ -429,7 +429,7 @@ describe('va-memorable-date', () => {
   it('checks for valid year month and day', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<va-memorable-date name="test"/>');
+    await page.setContent('<va-memorable-date name="test" required/>');
     const date = await page.find('va-memorable-date');
     const handleMonth = await page.$('pierce/[name="testMonth"]');
     const handleDay = await page.$('pierce/[name="testDay"]');

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -98,30 +98,32 @@ export class VaMemorableDate {
 
     const daysForSelectedMonth = monthNum > 0 ? days[monthNum] : [];
     const leapYear = checkLeapYear(yearNum);
-    // Check validity of date if invalid provide message and error state styling
-    // Set the state so that we can set aria-invalid on the right component
-    this.invalidYear = (
-      !year ||
-      yearNum < minYear ||
-      yearNum > maxYear
-    );
 
-    this.invalidMonth = (
-      !month ||
-      monthNum < minMonths ||
-      monthNum > maxMonths
-    );
+    if (this.required) {
+      // Set the state so that we can set aria-invalid on the right component
+      this.invalidYear = (
+        !year ||
+        yearNum < minYear ||
+        yearNum > maxYear
+      );
 
-    this.invalidDay =  (
-      !day ||
-      dayNum < minMonths ||
-      dayNum > daysForSelectedMonth.length
-    );
+      this.invalidMonth = (
+        !month ||
+        monthNum < minMonths ||
+        monthNum > maxMonths
+      );
 
-    if (!leapYear && monthNum === 2 && dayNum > 28) {
-      this.invalidYear = true;
-      this.invalidMonth = true;
-      this.invalidDay = true;
+      this.invalidDay =  (
+        !day ||
+        dayNum < minMonths ||
+        dayNum > daysForSelectedMonth.length
+      );
+
+      if (!leapYear && monthNum === 2 && dayNum > 28) {
+        this.invalidYear = true;
+        this.invalidMonth = true;
+        this.invalidDay = true;
+      }
     }
 
     if (

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -11,7 +11,6 @@ import {
 
 import {
   days,
-  // isFullDate,
   checkLeapYear,
   maxMonths,
   maxYear,

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -103,8 +103,7 @@ export class VaMemorableDate {
     this.invalidYear = (
       !year ||
       yearNum < minYear ||
-      yearNum > maxYear ||
-      (!leapYear && monthNum === 2 && dayNum > 28)
+      yearNum > maxYear
     );
 
     this.invalidMonth = (

--- a/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
+++ b/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
@@ -14,7 +14,7 @@ describe('va-number-input', () => {
           <label for="inputField">
             Hello, world
           </label>
-          <input id="inputField" type="number" />
+          <input id="inputField" type="number" aria-invalid="false" />
         </mock:shadow-root>
       </va-number-input>
     `);
@@ -26,7 +26,9 @@ describe('va-number-input', () => {
 
     // Render the error message text
     const error = await page.find('va-number-input >>> span#error-message');
+    const input = await page.find('va-number-input >>> input');
     expect(error.innerText).toContain('This is a mistake');
+    expect(input.getAttribute('aria-invalid')).toEqual('true');
   });
 
   it('renders a required span', async () => {

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -134,6 +134,7 @@ export class VaNumberInput {
         )}
         <input
           aria-describedby={error ? 'error-message' : undefined}
+          aria-invalid={error ? 'true' : 'false'}
           id="inputField"
           type="number"
           inputmode={inputmode ? inputmode : null}

--- a/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
+++ b/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
@@ -72,8 +72,10 @@ describe('va-radio', () => {
     const page = await newE2EPage();
     await page.setContent('<va-radio error="This is an error"></va-radio>');
 
-    const element = await page.find('va-radio >>> #error-message');
-    expect(element).toEqualHtml(`
+    const element = await page.find('va-radio');
+    const errorElement = await page.find('va-radio >>> #error-message');
+    expect(element.getAttribute('aria-invalid')).toEqual('true');
+    expect(errorElement).toEqualHtml(`
      <span id="error-message" role="alert">
        <span class="sr-only">
          Error

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -172,7 +172,7 @@ export class VaRadio {
   render() {
     const { label, required, error } = this;
     return (
-      <Host role="radiogroup">
+      <Host role="radiogroup" aria-invalid={error ? 'true' : 'false'}>
         <legend>
           {label}
           {required && <span class="required">(*Required)</span>}

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -44,6 +44,17 @@ describe('va-select', () => {
     expect(input.getAttribute('aria-invalid')).toEqual('true');
   });
 
+  it('sets aria-invalid based on invalid prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-select invalid />');
+
+    // Render the error message text
+    const error = await page.find('va-select >>> span#error-message');
+    const input = await page.find('va-select >>> select');
+    expect(error).toEqual(null);
+    expect(input.getAttribute('aria-invalid')).toEqual('true');
+  });
+
   it('changes its value prop when selected', async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -20,7 +20,7 @@ describe('va-select', () => {
             A label
           </label>
           <slot></slot>
-          <select id="select" part="select">
+          <select id="select" part="select" aria-invalid="false">
             <option value="">Please choose an option</option>
             <option value="foo">Foo</option>
             <option value="bar">Bar</option>
@@ -31,6 +31,17 @@ describe('va-select', () => {
         <option value="bar">Bar</option>
       </va-select>
     `);
+  });
+
+  it('renders an error message', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-select error="This is a mistake" />');
+
+    // Render the error message text
+    const error = await page.find('va-select >>> span#error-message');
+    const input = await page.find('va-select >>> select');
+    expect(error.innerText).toContain('This is a mistake');
+    expect(input.getAttribute('aria-invalid')).toEqual('true');
   });
 
   it('changes its value prop when selected', async () => {

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -153,6 +153,7 @@ export class VaSelect {
         <slot onSlotchange={() => this.populateOptions()}></slot>
         <select
           aria-describedby={error ? 'error-message' : undefined}
+          aria-invalid={error ? 'true' : 'false'}
           id="select"
           name={name}
           required={required || null}

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -50,6 +50,12 @@ export class VaSelect {
   @Prop() error?: string;
 
   /**
+   * Whether or not `aria-invalid` will be set on the inner select. Useful when
+   * composing the component into something larger, like a date component.
+   */
+  @Prop() invalid?: boolean = false;
+
+  /**
    * Whether or not to fire the analytics events
    */
   @Prop() enableAnalytics?: boolean = false;
@@ -135,7 +141,7 @@ export class VaSelect {
   }
 
   render() {
-    const { error, label, required, name } = this;
+    const { error, invalid, label, required, name } = this;
 
     return (
       <Host>
@@ -153,7 +159,7 @@ export class VaSelect {
         <slot onSlotchange={() => this.populateOptions()}></slot>
         <select
           aria-describedby={error ? 'error-message' : undefined}
-          aria-invalid={error ? 'true' : 'false'}
+          aria-invalid={(invalid || error) ? 'true' : 'false'}
           id="select"
           name={name}
           required={required || null}

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -59,7 +59,7 @@ describe('va-text-input', () => {
     expect(input.getAttribute('aria-invalid')).toEqual('true');
   });
 
-  it('sets aria-invalid based on error prop', async () => {
+  it('sets aria-invalid based on invalid prop', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-text-input invalid />');
 

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -59,6 +59,16 @@ describe('va-text-input', () => {
     expect(input.getAttribute('aria-invalid')).toEqual('true');
   });
 
+  it('sets aria-invalid based on error prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input invalid />');
+
+    const error = await page.find('va-text-input >>> span#error-message');
+    const input = await page.find('va-text-input >>> input');
+    expect(error).toEqual(null);
+    expect(input.getAttribute('aria-invalid')).toEqual('true');
+  });
+
   it('adds new aria-describedby for error message', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-text-input />');

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -15,7 +15,7 @@ describe('va-text-input', () => {
             Hello, world
           </label>
           <slot></slot>
-          <input id="inputField" type="text" part="input" />
+          <input id="inputField" type="text" part="input" aria-invalid="false" />
         </mock:shadow-root>
       </va-text-input>
     `);
@@ -38,7 +38,7 @@ describe('va-text-input', () => {
             Name of issue
           </label>
           <slot></slot>
-          <input id="inputField" type="text" part="input" />
+          <input id="inputField" type="text" part="input" aria-invalid="false" />
         </mock:shadow-root>
         <p className="vads-u-font-weight--normal label-description">
           You can only add an issue that you've already received a VA decision
@@ -54,7 +54,9 @@ describe('va-text-input', () => {
 
     // Render the error message text
     const error = await page.find('va-text-input >>> span#error-message');
+    const input = await page.find('va-text-input >>> input');
     expect(error.innerText).toContain('This is a mistake');
+    expect(input.getAttribute('aria-invalid')).toEqual('true');
   });
 
   it('adds new aria-describedby for error message', async () => {
@@ -88,7 +90,7 @@ describe('va-text-input', () => {
             This is a field <span class="required">required</span>
           </label>
           <slot></slot>
-          <input id="inputField" type="text" required="" part="input" />
+          <input id="inputField" type="text" required="" part="input" aria-invalid="false" />
         </mock:shadow-root>
       </va-text-input>
     `);

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -46,6 +46,12 @@ export class VaTextInput {
   @Prop() error?: string;
 
   /**
+   * Whether or not `aria-invalid` will be set on the inner input. Useful when
+   * composing the component into something larger, like a date component.
+   */
+  @Prop() invalid?: boolean = false;
+
+  /**
    * Set the input to required and render the (Required) text.
    */
   @Prop() required?: boolean = false;
@@ -185,6 +191,7 @@ export class VaTextInput {
     const {
       label,
       error,
+      invalid,
       inputmode,
       required,
       value,
@@ -220,7 +227,7 @@ export class VaTextInput {
           onInput={handleInput}
           onBlur={handleBlur}
           aria-describedby={error ? 'error-message' : undefined}
-          aria-invalid={error ? 'true' : 'false'}
+          aria-invalid={(invalid || error) ? 'true' : 'false'}
           inputmode={inputmode ? inputmode : undefined}
           maxlength={maxlength}
           minlength={minlength}

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -220,6 +220,7 @@ export class VaTextInput {
           onInput={handleInput}
           onBlur={handleBlur}
           aria-describedby={error ? 'error-message' : undefined}
+          aria-invalid={error ? 'true' : 'false'}
           inputmode={inputmode ? inputmode : undefined}
           maxlength={maxlength}
           minlength={minlength}

--- a/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
+++ b/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
@@ -13,7 +13,7 @@ describe('va-textarea', () => {
           <label for="textarea">
             Describe your situation
           </label>
-          <textarea id="textarea"></textarea>
+          <textarea id="textarea" aria-invalid="false"></textarea>
         </mock:shadow-root>
       </va-textarea>
     `);
@@ -25,7 +25,9 @@ describe('va-textarea', () => {
 
     // Render the error message text
     const error = await page.find('va-textarea >>> span#error-message');
+    const textarea = await page.find('va-textarea >>> textarea');
     expect(error.innerText).toContain('This is a mistake');
+    expect(textarea.getAttribute('aria-invalid')).toEqual('true');
   });
 
   it('adds new aria-describedby for error message', async () => {

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -140,6 +140,7 @@ export class VaTextarea {
         )}
         <textarea
           aria-describedby={error ? 'error-message' : undefined}
+          aria-invalid={error ? 'true' : 'false'}
           onInput={this.handleInput}
           onBlur={this.handleBlur}
           id="textarea"

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -1,13 +1,4 @@
-import { isFullDate, checkLeapYear } from './date-utils';
-
-describe('isFullDate', () => {
-  it('determines if a full YYYY-MM-DD string is provided for a complete date', () => {
-    expect(isFullDate('1995-05-03')).toBeTruthy();
-    expect(isFullDate('ABCD-05-03')).toBeFalsy();
-    expect(isFullDate('1995-05-')).toBeFalsy();
-    expect(isFullDate('19950503')).toBeFalsy();
-  });
-});
+import { checkLeapYear } from './date-utils';
 
 describe('checkLeapYear', () => {
   it('determines an input year is a leap year', () => {

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -131,14 +131,6 @@ export const days = {
   12: thirtyOneDays,
 };
 
-export function isFullDate(date) {
-  return /\d{4}-\d{1,2}-\d{1,2}/.test(date);
-}
-
-export function isMonthYearDate(date) {
-  return /\d{4}-\d{1,2}/.test(date);
-}
-
 export function checkLeapYear(year) {
   //three conditions to find out the leap year
   return (0 == year % 4 && 0 != year % 100) || 0 == year % 400;


### PR DESCRIPTION
## Chromatic
<!-- This `aria-invalid` is a placeholder for a CI job - it will be updated automatically -->
https://aria-invalid--60f9b557105290003b387cd5.chromatic.com

## Description
Part of:

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/844
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/39727

This adds the `aria-invalid` attribute to the `<input>`/`<select>` part of components as well as to the `radiogroup` role for radio buttons. This attribute defaults to false and is set to true when there is an error message. The `<va-checkbox-group>` component doesn't have this update because it looked like the `group` role didn't match the [associated roles of the aria attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid#associated_roles).

The form components which haven't received `aria-invalid` are:

- `va-checkbox-group`
- `va-radio-option`

## Testing done

- Storybook :eyes: 
- E2E tests

## Screenshots

### va-date

[aria-invalid appearing on year field](https://user-images.githubusercontent.com/2008881/179854632-860c8327-6e09-413e-b04a-7d57d2864332.webm)

### va-memorable-date

[aria-invalid appears on each text-input component when the the memorable date component is blurred. If all fields are missing then they all receive aria-invalid. If only the year is missing then the year will be marked as invalid while month and day are left alone.](https://user-images.githubusercontent.com/2008881/179855401-2bf7cd3c-4c1a-43bb-9ea9-659f4b2ae889.webm)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
