### PR TITLE
Add tty prop to telephone component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -51,6 +51,7 @@ const Template = ({
   international,
   ariaDescribedby,
   vanity,
+  tty,
 }) => {
   return (
     <div>
@@ -64,6 +65,7 @@ const Template = ({
         international={international}
         aria-describedby={ariaDescribedby}
         vanity={vanity}
+        tty={tty}
       ></va-telephone>
     </div>
   );
@@ -74,6 +76,7 @@ const defaultArgs = {
   'extension': undefined,
   'not-clickable': false,
   'international': false,
+  'tty': false,
   'vanity': undefined,
 };
 
@@ -105,6 +108,12 @@ export const International = Template.bind(null);
 International.args = {
   ...defaultArgs,
   international: true,
+};
+
+export const TTY = Template.bind(null);
+TTY.args = {
+  ...defaultArgs,
+  tty: true,
 };
 
 export const AriaDescribedBy = Template.bind(null);

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -643,6 +643,10 @@ export namespace Components {
          */
         "notClickable"?: boolean;
         /**
+          * Indicates if this is a number meant to be called from a teletypewriter for deaf users.
+         */
+        "tty"?: boolean;
+        /**
           * Optional vanity phone number. Replaces the last 4 digits with the vanity text input
          */
         "vanity"?: string;
@@ -1793,6 +1797,10 @@ declare namespace LocalJSX {
           * The event used to track usage of the component. This is emitted when clicking on an anchor link.
          */
         "onComponent-library-analytics"?: (event: CustomEvent<any>) => void;
+        /**
+          * Indicates if this is a number meant to be called from a teletypewriter for deaf users.
+         */
+        "tty"?: boolean;
         /**
           * Optional vanity phone number. Replaces the last 4 digits with the vanity text input
          */

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -132,6 +132,16 @@ describe('va-telephone', () => {
     expect(link.innerText).toEqual('711');
   });
 
+  it('handles a TTY contact', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-telephone contact="711" tty></va-telephone>');
+
+    const link = await page.find('va-telephone >>> a');
+    expect(link.getAttribute('aria-label')).toEqual('TTY. 7 1 1.');
+    expect(link.getAttribute('href')).toEqual('tel:711');
+    expect(link.innerText).toEqual('TTY: 711');
+  });
+
   it('handles a vanity number as a contact prop', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-telephone contact="8772228387" vanity="VETS"></va-telephone>');

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -30,6 +30,10 @@ describe('formatPhoneNumber', () => {
   it('formats a contact number with vanity prop', () => {
     expect(VaTelephone.formatPhoneNumber(contact, null, null, vanity)).toBe('888-555-ABCD (1234)');
   });
+
+  it('formats a TTY number', () => {
+    expect(VaTelephone.formatPhoneNumber(N11, null, null, null, true)).toBe('TTY: 911');
+  });
 });
 
 describe('formatTelLabel', () => {
@@ -44,6 +48,7 @@ describe('formatTelLabel', () => {
     null
   );
   const formattedNumberWithVanity = VaTelephone.formatPhoneNumber(contact, null, null, vanity);
+  const formattedTTYNumber = VaTelephone.formatPhoneNumber(contact, null, null, null, true);
   it('formats a phone number into an assistive tech label', () => {
     expect(VaTelephone.formatTelLabel(formattedNumber, null)).toBe(
       '8 8 8. 5 5 5. 1 2 3 4',
@@ -59,6 +64,12 @@ describe('formatTelLabel', () => {
   it('formats a phone number into an assistive tech label with vanity', () => {
     expect(VaTelephone.formatTelLabel(formattedNumberWithVanity, vanity)).toBe(
       '8 8 8. 5 5 5. 1 2 3 4',
+    );
+  });
+
+  it('formats a TTY phone number', () => {
+    expect(VaTelephone.formatTelLabel(formattedTTYNumber, null)).toBe(
+      'TTY. 8 8 8. 5 5 5. 1 2 3 4',
     );
   });
 });

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -39,39 +39,30 @@ describe('formatPhoneNumber', () => {
 describe('formatTelLabel', () => {
   const contact = '8885551234';
   const extension = 123;
-  const vanity = 'ABCD';
-  const formattedNumber = VaTelephone.formatPhoneNumber(contact, null, null, null);
-  const formattedNumberWithExt = VaTelephone.formatPhoneNumber(
-    contact,
-    extension,
-    null,
-    null
-  );
-  const formattedNumberWithVanity = VaTelephone.formatPhoneNumber(contact, null, null, vanity);
-  const formattedTTYNumber = VaTelephone.formatPhoneNumber(contact, null, null, null, true);
   it('formats a phone number into an assistive tech label', () => {
-    expect(VaTelephone.formatTelLabel(formattedNumber, null)).toBe(
+    expect(VaTelephone.formatTelLabel(contact, null, false, false)).toBe(
       '8 8 8. 5 5 5. 1 2 3 4',
     );
   });
 
   it('formats a phone number with extension into an assistive tech label', () => {
-    expect(VaTelephone.formatTelLabel(formattedNumberWithExt, null)).toBe(
+    expect(VaTelephone.formatTelLabel(contact, extension, false, false)).toBe(
       '8 8 8. 5 5 5. 1 2 3 4. extension. 1 2 3',
     );
   });
 
-  it('formats a phone number into an assistive tech label with vanity', () => {
-    expect(VaTelephone.formatTelLabel(formattedNumberWithVanity, vanity)).toBe(
-      '8 8 8. 5 5 5. 1 2 3 4',
-    );
-  });
-
   it('formats a TTY phone number', () => {
-    expect(VaTelephone.formatTelLabel(formattedTTYNumber, null)).toBe(
+    expect(VaTelephone.formatTelLabel(contact, null, true, false)).toBe(
       'TTY. 8 8 8. 5 5 5. 1 2 3 4',
     );
   });
+
+  it('formats an international phone number', () => {
+    expect(VaTelephone.formatTelLabel(contact, null, false, true)).toBe(
+      '1. 8 8 8. 5 5 5. 1 2 3 4',
+    );
+  });
+
 });
 
 describe('createHref', () => {

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -35,6 +35,12 @@ export class VaTelephone {
   @Prop() international?: boolean = false;
 
   /**
+   * Indicates if this is a number meant to be called
+   * from a teletypewriter for deaf users.
+   */
+  @Prop() tty?: boolean = false;
+
+  /**
    * Optional vanity phone number.
    * Replaces the last 4 digits with the vanity text input
    */
@@ -60,6 +66,7 @@ export class VaTelephone {
     extension: number,
     international: boolean = false,
     vanity: string,
+    tty: boolean = false,
   ): string {
     let formattedNum = num;
     if (num.length === 10) {
@@ -72,12 +79,15 @@ export class VaTelephone {
         formattedNum = `${area}-${local}-${vanity} (${last4})`;
       }
     }
+    if (tty) {
+      formattedNum = `TTY: ${formattedNum}`;
+    }
     return formattedNum;
   }
 
   /**
    * Format telephone number for screen readers
-   * @param {string} number - Expected a formatted phone number with or without extension
+   * @param {string} number - Expected a formatted phone number with or without extension or TTY pretext
    * @param {string} vanity - Using vanity prop set on the component to remove extra text added
    * via formatPhoneNumber to create the vanity number
    * @return {string} - Combined phone number parts within the label separated by
@@ -87,9 +97,14 @@ export class VaTelephone {
     const numberType = vanity
       ? number.split(/[^\d]+/)
       : number.split(/[^\d\w]+/);
+
     return numberType
       .filter(n => n)
-      .map(chunk => (chunk === 'ext' ? 'extension' : chunk.split('').join(' ')))
+      .map(chunk => {
+        if (chunk === 'ext')
+          return 'extension';
+        return chunk === 'TTY' ? 'TTY' : chunk.split('').join(' ');
+      })
       .join('. ');
   }
 
@@ -114,12 +129,13 @@ export class VaTelephone {
   }
 
   render() {
-    const { contact, extension, notClickable, international, vanity } = this;
+    const { contact, extension, notClickable, international, tty, vanity } = this;
     const formattedNumber = VaTelephone.formatPhoneNumber(
       contact,
       extension,
       international,
       vanity,
+      tty
     );
     const formattedAriaLabel = `${VaTelephone.formatTelLabel(
       formattedNumber,


### PR DESCRIPTION
## Chromatic
<!-- This `telephone-tty` is a placeholder for a CI job - it will be updated automatically -->
https://telephone-tty--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/775

This allows consumers of the telephone component to indicate that it is for a TTY number. This will add some `TTY` text to the `aria-label` and the link text, but not to the `href`.

## Testing done

- Unit tests
- E2E test
- Storybook :eyes: 

## Screenshots

![A screenshot of storybook where a telephone component with the tty prop has TTY in its aria-label and in the actual link text](https://user-images.githubusercontent.com/2008881/180311736-7b703ae5-f44a-4694-a6e3-c8d432899a4b.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
