### PR TITLE
fix: text does not overlap icon in alerts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.2.0",
+  "version": "11.2.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.2.4",
+  "version": "11.2.5",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.9.4",
+  "version": "4.9.5",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -166,3 +166,7 @@ i {
 i.fa-times-circle::before {
   content: '\F057'; /* fa-times-circle*/
 }
+
+:host([closeable]:not([closeable='false'])) .alert {
+  padding-right: 5.7rem;
+}

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -59,7 +59,7 @@ export class VaAlert {
   /**
    * If `true`, a close button will be displayed.
    */
-  @Prop() closeable?: boolean = false;
+  @Prop({ reflect: true }) closeable?: boolean = false;
 
   /**
    * If `true`, the alert will be full width.


### PR DESCRIPTION
## Chromatic
<!-- This `1040-va-alert-icons` is a placeholder for a CI job - it will be updated automatically -->
https://1040-va-alert-icons--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1040

## Testing done
Storybook

## Screenshots
<img width="1027" alt="Screen Shot 2022-07-27 at 09 49 20" src="https://user-images.githubusercontent.com/36863582/181265475-dd549f1d-4cdb-4996-9ec7-6630d44b84d0.png">


## Acceptance criteria
- [x] Text in alerts does not overlap the close icon

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
