### PR TITLE
style: update va-breadcrumbs padding

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.2.0",
+  "version": "11.2.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.css
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.css
@@ -14,8 +14,8 @@ ul {
   list-style: square;
   margin: 0 auto;
   max-width: 100rem;
-  padding-left: 0.9375rem;
-  padding-right: 0.9375rem;
+  padding-left: 0.8rem;
+  padding-right: 0.8rem;
   position: relative;
   width: 100%;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `1002-breadcrumb-padding` is a placeholder for a CI job - it will be updated automatically -->
https://1002-breadcrumb-padding--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1002

## Testing done
Storybook

## Screenshots
<img width="490" alt="Screen Shot 2022-07-27 at 10 54 38" src="https://user-images.githubusercontent.com/36863582/181279499-56967f7f-5b9f-4891-b0c6-b9367a8f8539.png">



## Acceptance criteria
- [x] va-breadcrumbs padding has been updated to .8rem

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
