### PR TITLE
Add nowrap to telephone component CSS

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.2.3",
+  "version": "11.2.4",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-telephone/va-telephone.css
+++ b/packages/web-components/src/components/va-telephone/va-telephone.css
@@ -1,6 +1,10 @@
 @import '../../mixins/links.css';
 @import '../../mixins/accessibility.css';
 
+a {
+  white-space: nowrap;
+}
+
 a,
 a:hover {
   text-decoration: underline;


### PR DESCRIPTION
## Chromatic
<!-- This `188-telephone-nowrap` is a placeholder for a CI job - it will be updated automatically -->
https://188-telephone-nowrap--60f9b557105290003b387cd5.chromatic.com

## Description
Closes department-of-veterans-affairs/vets-design-system-documentation#188

## Testing done
Visual

## Screenshots
**Before, without nowrap**
I made the width of the component something ridiculous (22px), as shown by the gray background
![image](https://user-images.githubusercontent.com/12739849/181600310-62571209-f3e8-4a65-bce4-a4a6a2eae036.png)

**After, with nowrap**
Again, with the same ridiculously small width, as shown by the coral background
![image](https://user-images.githubusercontent.com/12739849/181600545-fcbaa28e-8d41-41c4-9570-054e71613227.png)

## Acceptance criteria
- [ ] telephone numbers don't wrap when the width of the element is narrower than the width required for display

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
