### PR TITLE
Updating form web component error styles to align with USWDS.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.3.0",
+  "version": "11.3.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.css
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.css
@@ -1,4 +1,5 @@
 @import '../../mixins/accessibility.css';
+@import '../../mixins/form-field-error.css';
 
 :host {
   display: block;
@@ -6,15 +7,7 @@
   padding: 0;
 }
 
-:host([error]:not([error=''])) {
-  border-left: 4px solid var(--color-secondary-dark);
-  padding-left: 1.8rem;
-  position: relative;
-}
-
 #error-message {
-  color: var(--color-secondary-dark);
-  display: block;
   font-size: 1.6rem;
   line-height: 2.4rem;
   font-weight: 700;

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.css
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.css
@@ -1,4 +1,5 @@
 @import '../../mixins/accessibility.css';
+@import '../../mixins/form-field-error.css';
 
 :host {
   display: block;
@@ -12,8 +13,6 @@
 }
 
 #error-message {
-    color: var(--color-secondary-dark);
-    display: block;
     margin-bottom: 1.2rem;
 }
 
@@ -66,16 +65,6 @@ input:checked+label::before {
 input:not([disabled]):focus+label:before {
   outline: 2px solid var(--color-gold-light);
   outline-offset: 2px;
-}
-
-:host([error]:not([error=''])) {
-  border-left: 4px solid var(--color-secondary-dark);
-  padding-left: 1.8rem;
-  position: relative;
-}
-
-:host([error]:not([error=''])) label, :host([error]:not([error=''])) span {
-    font-weight: 700;
 }
 
 .required {

--- a/packages/web-components/src/components/va-date/va-date.css
+++ b/packages/web-components/src/components/va-date/va-date.css
@@ -1,4 +1,5 @@
 @import '../../../src/mixins/accessibility.css';
+@import '../../mixins/form-field-error.css';
 
 :host {
   display: block;
@@ -23,18 +24,7 @@ span.required {
   color: var(--color-secondary-dark);
 }
 
-:host([error]:not([error=''])) {
-  border-left: 4px solid var(--color-secondary-dark);
-  margin-top: 3rem;
-  padding-bottom: 0.8rem;
-  padding-left: 1.5rem;
-  padding-top: 0.8rem;
-  position: relative;
-  right: 1.9rem;
-}
-
-:host([error]:not([error=''])) legend,
-:host([error]:not([error=''])) span {
+:host([error]:not([error=''])) legend {
   font-weight: 700;
 }
 

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
@@ -1,4 +1,5 @@
 @import '../va-date/va-date.css';
+@import '../../mixins/form-field-error.css';
 
 .input-month,
 .input-day,

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
@@ -25,4 +25,13 @@
 #dateHint {
   padding: 0.8rem 0 0;
   color: var(--color-gray);
+  line-height: 1.5;
+}
+
+slot:not([name])::slotted(*) {
+  margin-bottom: 0.8rem;
+}
+
+#error-message {
+  margin-bottom: 0.8rem;
 }

--- a/packages/web-components/src/components/va-number-input/va-number-input.css
+++ b/packages/web-components/src/components/va-number-input/va-number-input.css
@@ -1,4 +1,5 @@
 @import '../va-text-input/va-text-input.css';
+@import '../../mixins/form-field-error.css';
 
 input[type='number'] {
   -moz-appearance: textfield;

--- a/packages/web-components/src/components/va-radio/va-radio.css
+++ b/packages/web-components/src/components/va-radio/va-radio.css
@@ -1,24 +1,10 @@
 @import '../../mixins/accessibility.css';
+@import '../../mixins/form-field-error.css';
 
 :host {
   display: block;
   border: none;
   padding: 0;
-}
-
-:host([error]:not([error=''])) {
-  border-left: 4px solid var(--color-secondary-dark);
-  padding-left: 1.8rem;
-  position: relative;
-}
-
-#error-message {
-  color: var(--color-secondary-dark);
-  display: block;
-  font-size: 1.6rem;
-  line-height: 2.4rem;
-  font-weight: 700;
-  margin-bottom: 1.2rem;
 }
 
 .required {

--- a/packages/web-components/src/components/va-select/va-select.css
+++ b/packages/web-components/src/components/va-select/va-select.css
@@ -1,5 +1,6 @@
 @import '../../mixins/inputs.css';
 @import '../../mixins/accessibility.css';
+@import '../../mixins/form-field-error.css';
 
 :host {
   display: block;
@@ -10,35 +11,16 @@
   margin: 0 0.35em;
 }
 
-:host([error]:not([error=''])) {
-  border-left: 4px solid var(--color-secondary-dark);
-  margin-top: 3rem;
-  padding-bottom: 0.8rem;
-  padding-left: 1.5rem;
-  padding-top: 0.8rem;
-  position: relative;
-  right: 1.9rem;
-}
-
-:host([error]:not([error=''])) label {
-  margin-top: 0;
-}
-
 :host([error]:not([error=''])) label,
 :host([error]:not([error=''])) > span {
   display: block;
   font-size: 1.6rem;
-  font-weight: 700;
 }
 
 :host([error]:not([error=''])) > span {
   color: var(--color-secondary-dark);
   padding-bottom: 3px;
   padding-top: 3px;
-}
-
-:host([error]:not([error=''])) select {
-  border: 4px solid var(--color-secondary-dark);
 }
 
 ::slotted(option) {

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -1,4 +1,5 @@
 @import '../../mixins/accessibility.css';
+@import '../../mixins/.css';
 
 :host {
   display: block;
@@ -34,30 +35,6 @@ input {
 input:not([disabled]):focus {
   outline: 2px solid var(--color-gold-light);
   outline-offset: 2px;
-}
-
-#error-message {
-  color: var(--color-secondary-dark);
-  display: block;
-}
-
-:host([error]:not([error=''])) {
-  border-left: 4px solid var(--color-secondary-dark);
-  margin-top: 3rem;
-  padding-bottom: 0.8rem;
-  padding-left: 1.5rem;
-  padding-top: 0.8rem;
-  position: relative;
-  right: 1.9rem;
-}
-
-:host([error]:not([error=''])) label,
-:host([error]:not([error=''])) span {
-  font-weight: 700;
-}
-
-:host([error]:not([error=''])) input {
-  border: 4px solid var(--color-secondary-dark);
 }
 
 :host([success]:not([success='false'])) input {

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -1,5 +1,5 @@
 @import '../../mixins/accessibility.css';
-@import '../../mixins/.css';
+@import '../../mixins/form-field-error.css';
 
 :host {
   display: block;

--- a/packages/web-components/src/components/va-textarea/va-textarea.css
+++ b/packages/web-components/src/components/va-textarea/va-textarea.css
@@ -34,3 +34,7 @@ textarea {
   margin: 0.4rem 0;
   resize: inherit;
 }
+
+:host([error]:not([error=''])) textarea {
+  padding-right: 0.7rem;
+}

--- a/packages/web-components/src/components/va-textarea/va-textarea.css
+++ b/packages/web-components/src/components/va-textarea/va-textarea.css
@@ -1,16 +1,19 @@
 @import '../../mixins/focusable.css';
-@import '../va-text-input/va-text-input.css';
+@import '../../mixins/form-field-error.css';
 
 :host {
   display: block;
   resize: both;
 }
 
-:host([error]) label {
-  margin-top: 0;
+label {
+  display: block;
+  max-width: 46rem;
+  margin-top: 3rem;
 }
 
-.required {
+span.required {
+  color: var(--color-secondary-dark);
   margin-left: 0.4rem;
 }
 
@@ -30,8 +33,4 @@ textarea {
   padding: 1.2rem;
   margin: 0.4rem 0;
   resize: inherit;
-}
-
-:host([error]:not([error=''])) textarea {
-  border: 4px solid var(--color-secondary-dark);
 }

--- a/packages/web-components/src/mixins/form-field-error.css
+++ b/packages/web-components/src/mixins/form-field-error.css
@@ -1,0 +1,31 @@
+#error-message {
+    color: var(--color-secondary-dark);
+    display: block;
+}
+
+:host([error]:not([error=''])) {
+    border-left: 0.4rem solid  var(--color-secondary-dark);
+    padding-left: 2rem;
+    position: relative;
+}
+
+@media screen and (min-width: 1201px) {
+    :host([error]:not([error=''])) {
+        margin-left: -2.4rem; /* padding left + border left */
+    }
+}
+
+:host([error]:not([error=''])) label {
+    margin-top: 0;
+}
+
+:host([error]:not([error=''])) label,
+:host([error]:not([error=''])) span {
+    font-weight: 700;
+}
+
+:host([error]:not([error=''])) input, 
+:host([error]:not([error=''])) textarea,
+:host([error]:not([error=''])) select {
+    border: 4px solid var(--color-secondary-dark);
+}

--- a/packages/web-components/src/mixins/form-field-error.css
+++ b/packages/web-components/src/mixins/form-field-error.css
@@ -1,6 +1,7 @@
 #error-message {
     color: var(--color-secondary-dark);
     display: block;
+    margin-bottom: 1.2rem;
 }
 
 :host([error]:not([error=''])) {
@@ -9,7 +10,7 @@
     position: relative;
 }
 
-@media screen and (min-width: 1201px) {
+@media screen and (min-width: 1008px) {
     :host([error]:not([error=''])) {
         margin-left: -2.4rem; /* padding left + border left */
     }


### PR DESCRIPTION
## Chromatic
<!-- This `957-input-error-border` is a placeholder for a CI job - it will be updated automatically -->
https://957-input-error-border--60f9b557105290003b387cd5.chromatic.com

## Description
Closes
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/957
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1055

This update will align the form field error state display with USWDS. More specifically, it addresses padding inconsistencies across the following web components:

```
va-textarea
va-text-input
va-number-input
va-select
va-date
va-radio
va-memorable-date
va-checkbox-group
va-checkbox
```

Additionally, it fixes an issue with the error left border not displaying on smaller viewports. The USWDS solves this by shifting the field to the right which is what this update does as well.

Below is the current style and responsive behavior of a [USWDS field error state](https://designsystem.digital.gov/components/text-input/):

https://user-images.githubusercontent.com/872479/181822493-1c219435-6ded-4d50-9913-0eb6e58f5f84.mov

## Testing done
- Storybook
  - Chrome, Chrome mobile emulator, Firefox, Safari, Edge

## Screenshots
![Screen Shot 2022-07-29 at 1 28 58 PM](https://user-images.githubusercontent.com/872479/181822558-db362957-c6f7-466f-85b3-b79ec7578b69.png)

![Screen Shot 2022-07-29 at 1 29 15 PM](https://user-images.githubusercontent.com/872479/181822568-f8206679-0d9e-4cbe-b8c4-bb29d7c74645.png)

![Screen Shot 2022-07-29 at 1 29 32 PM](https://user-images.githubusercontent.com/872479/181822600-8a9ffb37-2310-4a5c-b6dc-393876a1135b.png)

![Screen Shot 2022-07-29 at 1 29 43 PM](https://user-images.githubusercontent.com/872479/181822610-9c7fd0d4-9bc2-4a1e-b92c-eaa6eb01dc48.png)

![Screen Shot 2022-07-29 at 1 29 53 PM](https://user-images.githubusercontent.com/872479/181822621-dbf46a13-0ce0-4702-9075-decbf7d1f73b.png)

## Acceptance criteria
- [ ] The margin above the text input label is smaller and the left border in the error state does not appear so tall (mimic USWDS)

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
