### PR TITLE
chore: add v3 border, display and font utilities

### DIFF
--- a/packages/css-library/src/stylesheets/utilities.scss
+++ b/packages/css-library/src/stylesheets/utilities.scss
@@ -1,10 +1,13 @@
-@use "uswds-core/src/styles/mixins/utility-builder" as *;
-@use "uswds-core/src/styles/functions" as *;
-@use "../utilities" as *;
+@use 'uswds-core/src/styles/mixins/utility-builder' as *;
+@use 'uswds-core/src/styles/functions' as *;
+@use '../utilities' as *;
 
 $utilities-package: map-collect(
   $u-color,
-  $u-bg-color
+  $u-bg-color,
+  $u-display,
+  $u-border,
+  $u-font
 );
 
 // Generate all utility classes

--- a/packages/css-library/src/tokens/border.scss
+++ b/packages/css-library/src/tokens/border.scss
@@ -1,0 +1,18 @@
+@use './_variables' as *;
+
+$tokens-border: (
+  '0': '0',
+  '1px': '1px solid',
+  '2px': '2px solid',
+  '3px': '3px solid',
+  '4px': '4px solid',
+  '5px': '5px solid',
+  '7px': '7px solid',
+  '10px': '10px solid',
+);
+
+$tokens-border-style: (
+  'solid': 'solid',
+  'dashed': 'dashed',
+  'dotted': 'dotted',
+);

--- a/packages/css-library/src/tokens/display.scss
+++ b/packages/css-library/src/tokens/display.scss
@@ -1,0 +1,7 @@
+$tokens-display: (
+  'block': 'block',
+  'inline': 'inline',
+  'inline-block': 'inline-block',
+  'flex': 'flex',
+  'none': 'none',
+);

--- a/packages/css-library/src/tokens/font.scss
+++ b/packages/css-library/src/tokens/font.scss
@@ -1,0 +1,31 @@
+@use './_variables' as *;
+
+$tokens-font-family: (
+  'sans': $font-family-sans,
+  'serif': $font-family-serif,
+);
+
+$tokens-font-size: (
+  'sm': $font-size-sm,
+  'base': $font-size-base,
+  'md': $font-size-md,
+  'lg': $font-size-lg,
+  'xl': $font-size-xl,
+  '2xl': $font-size-2xl,
+  'h1': $font-size-h1,
+  'h2': $font-size-h2,
+  'h3': $font-size-h3,
+  'h4': $font-size-h4,
+  'h5': $font-size-h5,
+  'h6': $font-size-h6,
+);
+
+$tokens-font-style: (
+  'italic': $font-style-italic,
+  'normal': $font-style-normal,
+);
+
+$tokens-font-weight: (
+  'bold': $font-weight-bold,
+  'normal': $font-weight-normal,
+);

--- a/packages/css-library/src/utilities/_index.scss
+++ b/packages/css-library/src/utilities/_index.scss
@@ -1,2 +1,5 @@
-@forward "color";
-@forward "background-color";
+@forward 'color';
+@forward 'background-color';
+@forward 'display';
+@forward 'border';
+@forward 'font';

--- a/packages/css-library/src/utilities/border.scss
+++ b/packages/css-library/src/utilities/border.scss
@@ -6,54 +6,16 @@
 $u-border-base: (
   border: (
     base: 'vads-border',
-    modifiers: null,
+    modifiers: (
+      noModifier: '',
+      'top': '-top',
+      'right': '-right',
+      'bottom': '-bottom',
+      'left': '-left',
+    ),
     values: map-collect($tokens-border),
     settings: $responsive,
     property: 'border',
-    type: 'utility',
-  ),
-);
-
-$u-border-top: (
-  border-top: (
-    base: 'vads-border-top',
-    modifiers: null,
-    values: map-collect($tokens-border),
-    settings: $color-settings,
-    property: 'border-top',
-    type: 'utility',
-  ),
-);
-
-$u-border-right: (
-  border-right: (
-    base: 'vads-border-right',
-    modifiers: null,
-    values: map-collect($tokens-border),
-    settings: $color-settings,
-    property: 'border-right',
-    type: 'utility',
-  ),
-);
-
-$u-border-bottom: (
-  border-bottom: (
-    base: 'vads-border-bottom',
-    modifiers: null,
-    values: map-collect($tokens-border),
-    settings: $color-settings,
-    property: 'border-bottom',
-    type: 'utility',
-  ),
-);
-
-$u-border-left: (
-  border-left: (
-    base: 'vads-border-left',
-    modifiers: null,
-    values: map-collect($tokens-border),
-    settings: $color-settings,
-    property: 'border-left',
     type: 'utility',
   ),
 );
@@ -86,12 +48,4 @@ $u-border-color: (
   ),
 );
 
-$u-border: map-collect(
-  $u-border-base,
-  $u-border-top,
-  $u-border-right,
-  $u-border-bottom,
-  $u-border-left,
-  $u-border-style,
-  $u-border-color
-);
+$u-border: map-collect($u-border-base, $u-border-style, $u-border-color);

--- a/packages/css-library/src/utilities/border.scss
+++ b/packages/css-library/src/utilities/border.scss
@@ -14,7 +14,7 @@ $u-border-base: (
       'left': '-left',
     ),
     values: map-collect($tokens-border),
-    settings: $responsive,
+    settings: $border-settings,
     property: 'border',
     type: 'utility',
   ),
@@ -22,10 +22,10 @@ $u-border-base: (
 
 $u-border-style: (
   border-style: (
-    base: 'vads-border-style',
+    base: 'vads-border',
     modifiers: null,
     values: map-collect($tokens-border-style),
-    settings: $color-settings,
+    settings: $border-other-settings,
     property: 'border-style',
     type: 'utility',
   ),
@@ -33,7 +33,7 @@ $u-border-style: (
 
 $u-border-color: (
   border-color: (
-    base: 'vads-border-color',
+    base: 'vads-border',
     modifiers: null,
     values:
       map-collect(
@@ -42,7 +42,7 @@ $u-border-color: (
         $tokens-color-tertiary,
         $tokens-color-hub
       ),
-    settings: $color-settings,
+    settings: $border-other-settings,
     property: 'border-color',
     type: 'utility',
   ),

--- a/packages/css-library/src/utilities/border.scss
+++ b/packages/css-library/src/utilities/border.scss
@@ -1,0 +1,97 @@
+@use 'uswds-core/src/styles/functions' as *;
+@use '../tokens/border' as *;
+@use '../tokens/color' as *;
+@use './settings' as *;
+
+$u-border-base: (
+  border: (
+    base: 'vads-border',
+    modifiers: null,
+    values: map-collect($tokens-border),
+    settings: $responsive,
+    property: 'border',
+    type: 'utility',
+  ),
+);
+
+$u-border-top: (
+  border-top: (
+    base: 'vads-border-top',
+    modifiers: null,
+    values: map-collect($tokens-border),
+    settings: $color-settings,
+    property: 'border-top',
+    type: 'utility',
+  ),
+);
+
+$u-border-right: (
+  border-right: (
+    base: 'vads-border-right',
+    modifiers: null,
+    values: map-collect($tokens-border),
+    settings: $color-settings,
+    property: 'border-right',
+    type: 'utility',
+  ),
+);
+
+$u-border-bottom: (
+  border-bottom: (
+    base: 'vads-border-bottom',
+    modifiers: null,
+    values: map-collect($tokens-border),
+    settings: $color-settings,
+    property: 'border-bottom',
+    type: 'utility',
+  ),
+);
+
+$u-border-left: (
+  border-left: (
+    base: 'vads-border-left',
+    modifiers: null,
+    values: map-collect($tokens-border),
+    settings: $color-settings,
+    property: 'border-left',
+    type: 'utility',
+  ),
+);
+
+$u-border-style: (
+  border-style: (
+    base: 'vads-border-style',
+    modifiers: null,
+    values: map-collect($tokens-border-style),
+    settings: $color-settings,
+    property: 'border-style',
+    type: 'utility',
+  ),
+);
+
+$u-border-color: (
+  border-color: (
+    base: 'vads-border-color',
+    modifiers: null,
+    values:
+      map-collect(
+        $tokens-color-basic,
+        $tokens-color-grayscale,
+        $tokens-color-tertiary,
+        $tokens-color-hub
+      ),
+    settings: $color-settings,
+    property: 'border-color',
+    type: 'utility',
+  ),
+);
+
+$u-border: map-collect(
+  $u-border-base,
+  $u-border-top,
+  $u-border-right,
+  $u-border-bottom,
+  $u-border-left,
+  $u-border-style,
+  $u-border-color
+);

--- a/packages/css-library/src/utilities/display.scss
+++ b/packages/css-library/src/utilities/display.scss
@@ -4,10 +4,10 @@
 
 $u-display: (
   display: (
-    base: 'vads-display',
+    base: 'vads',
     modifiers: null,
     values: map-collect($tokens-display),
-    settings: $responsive,
+    settings: $display-settings,
     property: 'display',
     type: 'utility',
   ),

--- a/packages/css-library/src/utilities/display.scss
+++ b/packages/css-library/src/utilities/display.scss
@@ -1,0 +1,14 @@
+@use 'uswds-core/src/styles/functions' as *;
+@use '../tokens/display' as *;
+@use './settings' as *;
+
+$u-display: (
+  display: (
+    base: 'vads-display',
+    modifiers: null,
+    values: map-collect($tokens-display),
+    settings: $responsive,
+    property: 'display',
+    type: 'utility',
+  ),
+);

--- a/packages/css-library/src/utilities/font.scss
+++ b/packages/css-library/src/utilities/font.scss
@@ -1,0 +1,54 @@
+@use 'uswds-core/src/styles/functions' as *;
+@use '../tokens/font' as *;
+@use './settings' as *;
+
+$u-font-family: (
+  font-family: (
+    base: 'vads-font-family',
+    modifiers: null,
+    values: map-collect($tokens-font-family),
+    settings: $color-settings,
+    property: 'font-family',
+    type: 'utility',
+  ),
+);
+
+$u-font-size: (
+  font-size: (
+    base: 'vads-font-size',
+    modifiers: null,
+    values: map-collect($tokens-font-size),
+    settings: $responsive,
+    property: 'font-size',
+    type: 'utility',
+  ),
+);
+
+$u-font-style: (
+  font-style: (
+    base: 'vads-font-style',
+    modifiers: null,
+    values: map-collect($tokens-font-style),
+    settings: $color-settings,
+    property: 'font-style',
+    type: 'utility',
+  ),
+);
+
+$u-font-weight: (
+  font-weight: (
+    base: 'vads-font-weight',
+    modifiers: null,
+    values: map-collect($tokens-font-weight),
+    settings: $color-settings,
+    property: 'font-weight',
+    type: 'utility',
+  ),
+);
+
+$u-font: map-collect(
+  $u-font-family,
+  $u-font-size,
+  $u-font-style,
+  $u-font-weight
+);

--- a/packages/css-library/src/utilities/font.scss
+++ b/packages/css-library/src/utilities/font.scss
@@ -4,10 +4,10 @@
 
 $u-font-family: (
   font-family: (
-    base: 'vads-font-family',
+    base: 'vads-font',
     modifiers: null,
     values: map-collect($tokens-font-family),
-    settings: $color-settings,
+    settings: $font-settings,
     property: 'font-family',
     type: 'utility',
   ),
@@ -15,10 +15,10 @@ $u-font-family: (
 
 $u-font-size: (
   font-size: (
-    base: 'vads-font-size',
+    base: 'vads-font',
     modifiers: null,
     values: map-collect($tokens-font-size),
-    settings: $responsive,
+    settings: $font-size-settings,
     property: 'font-size',
     type: 'utility',
   ),
@@ -29,7 +29,7 @@ $u-font-style: (
     base: 'vads-font-style',
     modifiers: null,
     values: map-collect($tokens-font-style),
-    settings: $color-settings,
+    settings: $font-settings,
     property: 'font-style',
     type: 'utility',
   ),
@@ -40,7 +40,7 @@ $u-font-weight: (
     base: 'vads-font-weight',
     modifiers: null,
     values: map-collect($tokens-font-weight),
-    settings: $color-settings,
+    settings: $font-settings,
     property: 'font-weight',
     type: 'utility',
   ),

--- a/packages/css-library/src/utilities/settings.scss
+++ b/packages/css-library/src/utilities/settings.scss
@@ -6,3 +6,12 @@ $color-settings: (
   hover: false,
   visited: false,
 ) !default;
+
+$responsive: (
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+) !default;

--- a/packages/css-library/src/utilities/settings.scss
+++ b/packages/css-library/src/utilities/settings.scss
@@ -1,3 +1,21 @@
+$border-settings: (
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+) !default;
+
+$border-other-settings: (
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+) !default;
+
 $color-settings: (
   output: true,
   responsive: false,
@@ -7,7 +25,25 @@ $color-settings: (
   visited: false,
 ) !default;
 
-$responsive: (
+$display-settings: (
+  output: true,
+  responsive: true,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+) !default;
+
+$font-settings: (
+  output: true,
+  responsive: false,
+  active: false,
+  focus: false,
+  hover: false,
+  visited: false,
+) !default;
+
+$font-size-settings: (
   output: true,
   responsive: true,
   active: false,


### PR DESCRIPTION
## Chromatic
<!-- This `1027-bdf-utilities` is a placeholder for a CI job - it will be updated automatically -->
https://1027-bdf-utilities--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1027

## Acceptance criteria
- [x] `css-library` has v3 utilities for border, display, font-family, font-size, font-style, font-weight properties

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
