### PR TITLE
Replace the "Date of Birth" label with a real one

### DIFF
--- a/packages/storybook/stories/va-date.stories.jsx
+++ b/packages/storybook/stories/va-date.stories.jsx
@@ -17,8 +17,9 @@ export default {
 };
 
 const defaultArgs = {
-  'label': 'Date of birth',
-  'name': 'test',
+  'label':
+    'What’s the date or anticipated date of your release from active duty?',
+  'name': 'discharge-date',
   'required': false,
   'error': undefined,
   'value': undefined,


### PR DESCRIPTION
## Chromatic
<!-- This `date-sb-real-example` is a placeholder for a CI job - it will be updated automatically -->
https://date-sb-real-example--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/45152

As part of the staging review for the `monthYearOnly` date variant and `<va-memorable-date>`, it was pointed out that both components were presented as "Date of birth" fields. This doesn't make the difference very obvious, so this PR changes the example for `<va-date>` to use [an example based on real code](https://github.com/department-of-veterans-affairs/vets-website/blob/f22b2c3be6be9735d52ff202d580badfce818732/src/applications/disability-benefits/wizard/pages/bdd.jsx#L109-L116).

## Testing done

Storybook :eyes: 

## Screenshots

![Screenshot from storybook of the Date web component. The label for the component reads "What's the date or anticipated date of your release from active duty".](https://user-images.githubusercontent.com/2008881/182687289-41d72fc2-e659-4e62-83fa-ba92bf05dfb5.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
