### PR TITLE
Rework date validation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.3.3",
+  "version": "11.4.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-date.stories.jsx
+++ b/packages/storybook/stories/va-date.stories.jsx
@@ -54,6 +54,7 @@ const Template = ({
 const CustomValidationTemplate = ({ label, name, required, error, value }) => {
   const [dateVal, setDateVal] = useState(value);
   const [errorVal, setErrorVal] = useState(error);
+  const [invalidYear, setInvalidYear] = useState(null);
   const today = new Date();
   // new Date as YYYY-MM-DD is giving the day prior to the day select
   // new Date as YYYY MM DD is giving the correct day selected
@@ -61,8 +62,11 @@ const CustomValidationTemplate = ({ label, name, required, error, value }) => {
   function handleDateBlur() {
     if (dateInput <= today) {
       setErrorVal('Date must be in the future');
+      // This won't always be the right thing, but it's just a demo
+      setInvalidYear(true);
     } else {
       setErrorVal('');
+      setInvalidYear(false);
     }
   }
 
@@ -73,6 +77,7 @@ const CustomValidationTemplate = ({ label, name, required, error, value }) => {
         name={name}
         required={required}
         error={errorVal}
+        invalidYear={invalidYear}
         value={dateVal}
         onDateBlur={() => handleDateBlur()}
         onDateChange={e => setDateVal(e.target.value)}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.10.3",
+  "version": "4.11.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -362,6 +362,9 @@ export namespace Components {
           * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component
          */
         "error"?: string;
+        "invalidDay": boolean;
+        "invalidMonth": boolean;
+        "invalidYear": boolean;
         /**
           * Label for the field.
          */
@@ -1469,6 +1472,9 @@ declare namespace LocalJSX {
           * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component
          */
         "error"?: string;
+        "invalidDay"?: boolean;
+        "invalidMonth"?: boolean;
+        "invalidYear"?: boolean;
         /**
           * Label for the field.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -263,6 +263,9 @@ export namespace Components {
           * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component
          */
         "error"?: string;
+        "invalidDay": boolean;
+        "invalidMonth": boolean;
+        "invalidYear": boolean;
         /**
           * Label for the field.
          */
@@ -1347,6 +1350,9 @@ declare namespace LocalJSX {
           * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component
          */
         "error"?: string;
+        "invalidDay"?: boolean;
+        "invalidMonth"?: boolean;
+        "invalidYear"?: boolean;
         /**
           * Label for the field.
          */

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -62,7 +62,7 @@ describe('va-date', () => {
     expect(requiredSpan).not.toBeNull();
   });
 
-  it('does not validate without required prop', async () => {
+  it('does basic validation without required prop', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-date value="1999-05-03" name="test" />',
@@ -77,7 +77,7 @@ describe('va-date', () => {
     await handleYear.press('Tab');
 
     await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual(null);
+    expect(date.getAttribute('error')).toEqual("Please enter a year between 1900 and 2122");
   });
 
   it('allows for a custom required message', async () => {
@@ -189,10 +189,10 @@ describe('va-date', () => {
     expect(elementYear.getAttribute('value')).toBe('2022');
   });
 
-  it('displays an error message onBlur if date is invalid and component is required', async () => {
+  it('displays an error message onBlur if year is invalid', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-date value="1999-05-03" name="test" required="true" />',
+      '<va-date value="1999-05-03" name="test" />',
     );
     const date = await page.find('va-date');
     const handleYear = await page.$('pierce/[name="testYear"]');
@@ -204,7 +204,7 @@ describe('va-date', () => {
     await handleYear.press('Tab');
 
     await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('Please enter a valid date');
+    expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
 
     await handleYear.press('0');
     await handleYear.press('2');
@@ -212,7 +212,7 @@ describe('va-date', () => {
     // Trigger Blur
     await handleYear.press('Tab');
     await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('');
+    expect(date.getAttribute('error')).toEqual(null);
   });
 
   describe('invalid subcomponents', () => {
@@ -432,8 +432,10 @@ describe('va-date', () => {
     const handleDay = await page.$('pierce/[name="testDay"]');
     const handleYear = await page.$('pierce/[name="testYear"]');
     // Month
+    // This is a blank option
     await handleMonth.select();
     // Day
+    // This is a blank option
     await handleDay.select();
     // Year
     await handleYear.press('3');
@@ -443,7 +445,7 @@ describe('va-date', () => {
     // Trigger Blur
     await handleYear.press('Tab');
     await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('Please enter a valid date');
+    expect(date.getAttribute('error')).toEqual('Please enter a complete date');
   });
 
   describe('monthYearOnly variant', () => {
@@ -498,7 +500,7 @@ describe('va-date', () => {
       // Trigger Blur
       await handleYear.press('Tab');
       await page.waitForChanges();
-      expect(date.getAttribute('error')).toEqual('Please enter a valid date');
+      expect(date.getAttribute('error')).toEqual('Please enter a complete date');
     });
 
     it('sets the value as ISO-8601 date with reduced precision', async () => {

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -126,6 +126,7 @@ describe('va-date', () => {
       await page.waitForChanges();
       expect(date.getAttribute('error')).toEqual(null);
     });
+
     describe('invalid subcomponents', () => {
       it('correctly indicates an invalid year', async () => {
         const page = await newE2EPage();
@@ -157,48 +158,6 @@ describe('va-date', () => {
         await handleYear.press('0');
         await handleYear.press('2');
         await handleYear.press('2');
-        // Trigger Blur
-        await handleYear.press('Tab');
-        await page.waitForChanges();
-
-        invalidYear = await handleYear.evaluate(getAriaInvalid);
-        invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-        invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-        expect(invalidYear).toEqual('false');
-        expect(invalidMonth).toEqual('false');
-        expect(invalidDay).toEqual('false');
-      });
-
-      it('correctly indicates an invalid month', async () => {
-        const page = await newE2EPage();
-        await page.setContent(
-          '<va-date value="1999-05-03" name="test" required="true" />',
-        );
-        const handleYear = await page.$('pierce/[name="testYear"]');
-        const handleMonth = await page.$('pierce/[name="testMonth"]');
-        const handleDay = await page.$('pierce/[name="testDay"]');
-        const getAriaInvalid =
-          (element: HTMLElement) => element.getAttribute('aria-invalid');
-
-        // Click three times to select all text in input
-        await handleMonth.click({ clickCount: 3 });
-        await handleMonth.select('0');
-        // Trigger Blur
-        await handleYear.press('Tab');
-
-        // Month only has one character - should be invalid
-        await page.waitForChanges();
-        let invalidYear = await handleYear.evaluate(getAriaInvalid);
-        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-        let invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-        expect(invalidYear).toEqual('false');
-        expect(invalidMonth).toEqual('true');
-        // Day is also invalid because month is 0
-        expect(invalidDay).toEqual('true');
-
-        await handleMonth.select('4');
         // Trigger Blur
         await handleYear.press('Tab');
         await page.waitForChanges();
@@ -468,15 +427,17 @@ describe('va-date', () => {
       const handleYear = await page.$('pierce/[name="testYear"]');
 
       // Month
-      await handleMonth.select();
+      await handleMonth.select('3');
       // Year
       await handleYear.press('3');
       await handleYear.press('0');
       await handleYear.press('0');
       await handleYear.press('0');
+
       // Trigger Blur
       await handleYear.press('Tab');
       await page.waitForChanges();
+
       expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
     });
 

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -191,49 +191,8 @@ describe('va-date', () => {
         expect(invalidDay).toEqual('false');
       });
 
-      // Month invalidation isn't here since a select box prevents
+      // Month & day invalidation isn't here since a select box prevents
       // an invalid month from being selected.
-
-      it('correctly indicates an invalid day', async () => {
-        const page = await newE2EPage();
-        await page.setContent(
-          '<va-date name="test" />',
-        );
-        const handleYear = await page.$('pierce/[name="testYear"]');
-        const handleMonth = await page.$('pierce/[name="testMonth"]');
-        const handleDay = await page.$('pierce/[name="testDay"]');
-        const getAriaInvalid =
-          (element: HTMLElement) => element.getAttribute('aria-invalid');
-
-        // We need a month in order to determine if the day is valid
-        await handleMonth.select('3');
-        // Trigger Blur
-        await handleYear.type('1995');
-        await handleYear.press('Tab');
-
-        // Month only has one character - should be invalid
-        await page.waitForChanges();
-        let invalidYear = await handleYear.evaluate(getAriaInvalid);
-        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-        let invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-        expect(invalidYear).toEqual('false');
-        expect(invalidMonth).toEqual('false');
-        expect(invalidDay).toEqual('true');
-
-        await handleDay.select('4');
-        // Trigger Blur
-        await handleYear.press('Tab');
-        await page.waitForChanges();
-
-        invalidYear = await handleYear.evaluate(getAriaInvalid);
-        invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-        invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-        expect(invalidYear).toEqual('false');
-        expect(invalidMonth).toEqual('false');
-        expect(invalidDay).toEqual('false');
-      });
 
       it('passes the invalidDay prop correctly', async () => {
         const page = await newE2EPage();

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -62,42 +62,198 @@ describe('va-date', () => {
     expect(requiredSpan).not.toBeNull();
   });
 
-  it('does basic validation without required prop', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-date value="1999-05-03" name="test" />',
-    );
-    const date = await page.find('va-date');
-    const handleYear = await page.$('pierce/[name="testYear"]');
+  describe('validation', () => {
+    it('does year validation without required prop', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-date value="1999-05-03" name="test" />',
+      );
+      const date = await page.find('va-date');
+      const handleYear = await page.$('pierce/[name="testYear"]');
 
-    // Click three times to select all text in input
-    await handleYear.click({ clickCount: 3 });
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
+      // Click three times to select all text in input
+      await handleYear.click({ clickCount: 3 });
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
 
-    await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual("Please enter a year between 1900 and 2122");
-  });
-
-  it('allows for a custom required message', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-date value="2000-01-01" name="test" label="This is a field" required="Fill me out" />');
-
-    // Act
-    const handleYear = await page.$('pierce/[name="testYear"]');
-    // Click three times to select all text in input
-    await handleYear.click({ clickCount: 3 });
-    await handleYear.press('2');
-    await handleYear.press('Tab');
-    await page.$eval('va-date', (elm: any) => {
-      elm.error= 'Fill me out';
+      await page.waitForChanges();
+      expect(date.getAttribute('error')).toEqual("Please enter a year between 1900 and 2122");
     });
-    await page.waitForChanges();
 
-    // Assert
-    const errorSpan = await page.find('va-date >>> span#error-message');
-    expect(errorSpan.textContent).toContain("Fill me out");
+    it('allows for a custom required message', async () => {
+      const page = await newE2EPage();
+      await page.setContent('<va-date value="2000-01-01" name="test" label="This is a field" required="Fill me out" />');
+
+      // Act
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      // Click three times to select all text in input
+      await handleYear.click({ clickCount: 3 });
+      await handleYear.press('2');
+      await handleYear.press('Tab');
+      await page.$eval('va-date', (elm: any) => {
+        elm.error= 'Fill me out';
+      });
+      await page.waitForChanges();
+
+      // Assert
+      const errorSpan = await page.find('va-date >>> span#error-message');
+      expect(errorSpan.textContent).toContain("Fill me out");
+    });
+    
+    it('displays an error message onBlur if year is invalid', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-date value="1999-05-03" name="test" />',
+      );
+      const date = await page.find('va-date');
+      const handleYear = await page.$('pierce/[name="testYear"]');
+
+      // Click three times to select all text in input
+      await handleYear.click({ clickCount: 3 });
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
+
+      await page.waitForChanges();
+      expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
+
+      await handleYear.press('0');
+      await handleYear.press('2');
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
+      expect(date.getAttribute('error')).toEqual(null);
+    });
+    describe('invalid subcomponents', () => {
+      it('correctly indicates an invalid year', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-date value="1999-05-03" name="test" required="true" />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid =
+          (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+        // Click three times to select all text in input
+        await handleYear.click({ clickCount: 3 });
+        await handleYear.press('2');
+        // Trigger Blur
+        await handleYear.press('Tab');
+
+        // Year only has one character - should be invalid
+        await page.waitForChanges();
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('true');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
+
+        await handleYear.press('0');
+        await handleYear.press('2');
+        await handleYear.press('2');
+        // Trigger Blur
+        await handleYear.press('Tab');
+        await page.waitForChanges();
+
+        invalidYear = await handleYear.evaluate(getAriaInvalid);
+        invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
+      });
+
+      it('correctly indicates an invalid month', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-date value="1999-05-03" name="test" required="true" />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid =
+          (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+        // Click three times to select all text in input
+        await handleMonth.click({ clickCount: 3 });
+        await handleMonth.select('0');
+        // Trigger Blur
+        await handleYear.press('Tab');
+
+        // Month only has one character - should be invalid
+        await page.waitForChanges();
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('true');
+        // Day is also invalid because month is 0
+        expect(invalidDay).toEqual('true');
+
+        await handleMonth.select('4');
+        // Trigger Blur
+        await handleYear.press('Tab');
+        await page.waitForChanges();
+
+        invalidYear = await handleYear.evaluate(getAriaInvalid);
+        invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
+      });
+
+      it.only('correctly indicates an invalid day', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-date value="1999-05-03" name="test" />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid =
+          (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+        // Click three times to select all text in input
+        await handleDay.click({ clickCount: 3 });
+        await handleDay.select('0');
+        // Trigger Blur
+        await handleYear.press('Tab');
+
+        // Month only has one character - should be invalid
+        await page.waitForChanges();
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('true');
+
+        await handleDay.select('4');
+        // Trigger Blur
+        await handleYear.press('Tab');
+        await page.waitForChanges();
+
+        invalidYear = await handleYear.evaluate(getAriaInvalid);
+        invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
+      });
+    });
+
   });
 
   it('sets a label', async () => {
@@ -189,160 +345,6 @@ describe('va-date', () => {
     expect(elementYear.getAttribute('value')).toBe('2022');
   });
 
-  it('displays an error message onBlur if year is invalid', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-date value="1999-05-03" name="test" />',
-    );
-    const date = await page.find('va-date');
-    const handleYear = await page.$('pierce/[name="testYear"]');
-
-    // Click three times to select all text in input
-    await handleYear.click({ clickCount: 3 });
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
-
-    await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
-
-    await handleYear.press('0');
-    await handleYear.press('2');
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
-    await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual(null);
-  });
-
-  describe('invalid subcomponents', () => {
-    it('correctly indicates an invalid year', async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        '<va-date value="1999-05-03" name="test" required="true" />',
-      );
-      const handleYear = await page.$('pierce/[name="testYear"]');
-      const handleMonth = await page.$('pierce/[name="testMonth"]');
-      const handleDay = await page.$('pierce/[name="testDay"]');
-      const getAriaInvalid =
-        (element: HTMLElement) => element.getAttribute('aria-invalid');
-
-      // Click three times to select all text in input
-      await handleYear.click({ clickCount: 3 });
-      await handleYear.press('2');
-      // Trigger Blur
-      await handleYear.press('Tab');
-
-      // Year only has one character - should be invalid
-      await page.waitForChanges();
-      let invalidYear = await handleYear.evaluate(getAriaInvalid);
-      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      let invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('true');
-      expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('false');
-
-      await handleYear.press('0');
-      await handleYear.press('2');
-      await handleYear.press('2');
-      // Trigger Blur
-      await handleYear.press('Tab');
-      await page.waitForChanges();
-
-      invalidYear = await handleYear.evaluate(getAriaInvalid);
-      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('false');
-    });
-
-    it('correctly indicates an invalid month', async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        '<va-date value="1999-05-03" name="test" required="true" />',
-      );
-      const handleYear = await page.$('pierce/[name="testYear"]');
-      const handleMonth = await page.$('pierce/[name="testMonth"]');
-      const handleDay = await page.$('pierce/[name="testDay"]');
-      const getAriaInvalid =
-        (element: HTMLElement) => element.getAttribute('aria-invalid');
-
-      // Click three times to select all text in input
-      await handleMonth.click({ clickCount: 3 });
-      await handleMonth.select('0');
-      // Trigger Blur
-      await handleYear.press('Tab');
-
-      // Month only has one character - should be invalid
-      await page.waitForChanges();
-      let invalidYear = await handleYear.evaluate(getAriaInvalid);
-      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      let invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('true');
-      // Day is also invalid because month is 0
-      expect(invalidDay).toEqual('true');
-
-      await handleMonth.select('4');
-      // Trigger Blur
-      await handleYear.press('Tab');
-      await page.waitForChanges();
-
-      invalidYear = await handleYear.evaluate(getAriaInvalid);
-      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('false');
-    });
-
-    it('correctly indicates an invalid day', async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        '<va-date value="1999-05-03" name="test" required="true" />',
-      );
-      const handleYear = await page.$('pierce/[name="testYear"]');
-      const handleMonth = await page.$('pierce/[name="testMonth"]');
-      const handleDay = await page.$('pierce/[name="testDay"]');
-      const getAriaInvalid =
-        (element: HTMLElement) => element.getAttribute('aria-invalid');
-
-      // Click three times to select all text in input
-      await handleDay.click({ clickCount: 3 });
-      await handleDay.select('0');
-      // Trigger Blur
-      await handleYear.press('Tab');
-
-      // Month only has one character - should be invalid
-      await page.waitForChanges();
-      let invalidYear = await handleYear.evaluate(getAriaInvalid);
-      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      let invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('true');
-
-      await handleDay.select('4');
-      // Trigger Blur
-      await handleYear.press('Tab');
-      await page.waitForChanges();
-
-      invalidYear = await handleYear.evaluate(getAriaInvalid);
-      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('false');
-    });
-  })
-
   it('emits dateBlur event', async () => {
     const page = await newE2EPage();
 
@@ -423,31 +425,6 @@ describe('va-date', () => {
     expect(date.getAttribute('value')).toBeNull();
   });
 
-  it('checks for valid year month and day', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<va-date name="test" required/>');
-    const date = await page.find('va-date');
-    const handleMonth = await page.$('pierce/[name="testMonth"]');
-    const handleDay = await page.$('pierce/[name="testDay"]');
-    const handleYear = await page.$('pierce/[name="testYear"]');
-    // Month
-    // This is a blank option
-    await handleMonth.select();
-    // Day
-    // This is a blank option
-    await handleDay.select();
-    // Year
-    await handleYear.press('3');
-    await handleYear.press('0');
-    await handleYear.press('0');
-    await handleYear.press('0');
-    // Trigger Blur
-    await handleYear.press('Tab');
-    await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('Please enter a complete date');
-  });
-
   describe('monthYearOnly variant', () => {
     it('only displays month and year fields', async () => {
       const page = await newE2EPage();
@@ -500,7 +477,7 @@ describe('va-date', () => {
       // Trigger Blur
       await handleYear.press('Tab');
       await page.waitForChanges();
-      expect(date.getAttribute('error')).toEqual('Please enter a complete date');
+      expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
     });
 
     it('sets the value as ISO-8601 date with reduced precision', async () => {

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -85,6 +85,21 @@ describe('va-date', () => {
     // memorable-date because select components prevent the wrong thing
     // from being chosen
 
+   it('does validation for required components', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-date name="test" required />',
+      );
+      const date = await page.find('va-date');
+      const handleYear = await page.$('pierce/[name="testYear"]');
+
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
+
+      expect(date.getAttribute('error')).toEqual("Please enter a complete date");
+    });
+
     it('allows for a custom required message', async () => {
       const page = await newE2EPage();
       await page.setContent('<va-date value="2000-01-01" name="test" label="This is a field" required />');

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -81,6 +81,10 @@ describe('va-date', () => {
       expect(date.getAttribute('error')).toEqual("Please enter a year between 1900 and 2122");
     });
 
+    // We don't have month or day validation here like we do for
+    // memorable-date because select components prevent the wrong thing
+    // from being chosen
+
     it('allows for a custom required message', async () => {
       const page = await newE2EPage();
       await page.setContent('<va-date value="2000-01-01" name="test" label="This is a field" required />');

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -83,7 +83,7 @@ describe('va-date', () => {
 
     it('allows for a custom required message', async () => {
       const page = await newE2EPage();
-      await page.setContent('<va-date value="2000-01-01" name="test" label="This is a field" required="Fill me out" />');
+      await page.setContent('<va-date value="2000-01-01" name="test" label="This is a field" required />');
 
       // Act
       const handleYear = await page.$('pierce/[name="testYear"]');
@@ -101,7 +101,7 @@ describe('va-date', () => {
       expect(errorSpan.textContent).toContain("Fill me out");
     });
     
-    it('displays an error message onBlur if year is invalid', async () => {
+    it('resets error to null when fixed', async () => {
       const page = await newE2EPage();
       await page.setContent(
         '<va-date value="1999-05-03" name="test" />',

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -234,8 +234,67 @@ describe('va-date', () => {
         expect(invalidMonth).toEqual('false');
         expect(invalidDay).toEqual('false');
       });
-    });
 
+      it('passes the invalidDay prop correctly', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-date name="test" invalid-day />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid =
+          (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('true');
+     });
+
+      it('passes the invalidMonth prop correctly', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-date name="test" invalid-month />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid =
+          (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('true');
+        expect(invalidDay).toEqual('false');
+     });
+
+      it('passes the invalidYear prop correctly', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-date name="test" invalid-year />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid =
+          (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('true');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
+     });
+    });
   });
 
   it('sets a label', async () => {

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -212,10 +212,10 @@ describe('va-date', () => {
         expect(invalidDay).toEqual('false');
       });
 
-      it.only('correctly indicates an invalid day', async () => {
+      it('correctly indicates an invalid day', async () => {
         const page = await newE2EPage();
         await page.setContent(
-          '<va-date value="1999-05-03" name="test" />',
+          '<va-date name="test" />',
         );
         const handleYear = await page.$('pierce/[name="testYear"]');
         const handleMonth = await page.$('pierce/[name="testMonth"]');
@@ -224,9 +224,9 @@ describe('va-date', () => {
           (element: HTMLElement) => element.getAttribute('aria-invalid');
 
         // Click three times to select all text in input
-        await handleDay.click({ clickCount: 3 });
-        await handleDay.select('0');
+        await handleMonth.select('3');
         // Trigger Blur
+        await handleYear.type('1995');
         await handleYear.press('Tab');
 
         // Month only has one character - should be invalid

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -128,7 +128,7 @@ export class VaDate {
   private handleDateBlur = (event: FocusEvent) => {
     const [year, month, day] = (this.value || '')
       .split('-')
-      .map(val => parseInt(val) || null);
+      .map(val => parseInt(val));
 
     this.setValue(year, month, day);
     // Run built-in validation. Any custom validation

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -53,7 +53,7 @@ export class VaDate {
    * The error message to render (if any)
    * This prop should be leveraged to display any custom validations needed for this component
    */
-  @Prop() error?: string;
+  @Prop({ reflect: true }) error?: string;
 
   /**
    * Whether or not only the Month and Year inputs should be displayed.
@@ -225,7 +225,7 @@ export class VaDate {
     // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group
     return (
-      <Host value={value} error={error} onBlur={handleDateBlur}>
+      <Host value={value} onBlur={handleDateBlur}>
         <fieldset>
           <legend>
             {label} {required && <span class="required">(*Required)</span>}

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -86,6 +86,22 @@ export class VaDate {
   @Prop({ mutable: true }) invalidYear: boolean = false;
 
   /**
+   * Whether or not an analytics event will be fired.
+   */
+  @Prop() enableAnalytics: boolean = false;
+
+  /**
+   * The event used to track usage of the component. This is emitted when an
+   * input value changes and enableAnalytics is true.
+   */
+  @Event({
+    eventName: 'component-library-analytics',
+    composed: true,
+    bubbles: true,
+  })
+  componentLibraryAnalytics: EventEmitter;
+
+  /**
    * Set the value prop as an ISO-8601 date using provided arguments.
    * Strips trailing hyphens and sets date to be null if the
    * date values are all NaNs.
@@ -146,22 +162,6 @@ export class VaDate {
       return false;
     }
   };
-
-  /**
-   * Whether or not an analytics event will be fired.
-   */
-  @Prop() enableAnalytics: boolean = false;
-
-  /**
-   * The event used to track usage of the component. This is emitted when an
-   * input value changes and enableAnalytics is true.
-   */
-  @Event({
-    eventName: 'component-library-analytics',
-    composed: true,
-    bubbles: true,
-  })
-  componentLibraryAnalytics: EventEmitter;
 
   render() {
     const {

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -111,38 +111,49 @@ export class VaDate {
   private handleDateBlur = (event: FocusEvent) => {
     const [year, month, day] = (this.value || '')
       .split('-')
-      .map(val => parseInt(val));
+      .map(val => parseInt(val) || null);
     this.setValue(year, month, day);
 
-    const daysForSelectedMonth = month > 0 ? days[month] : [];
     const leapYear = checkLeapYear(year);
+    const daysForSelectedMonth = leapYear && month == 2 ? 29 : days[month]?.length || 0;
 
-    if (this.required) {
-      this.invalidYear = !year || year < minYear || year > maxYear;
-
-      this.invalidMonth = !month || month < minMonths || month > maxMonths;
-
-      this.invalidDay =
-        !this.monthYearOnly &&
-        (!day || day < minMonths || day > daysForSelectedMonth.length);
-
-      if (!leapYear && month === 2 && day > 28) {
-        this.invalidYear = true;
-        this.invalidMonth = true;
-        this.invalidDay = true;
-      }
+    // Begin built-in validation
+    if (year && (year < minYear || year > maxYear)) {
+      this.invalidYear = true;
+      this.error = `Please enter a year between ${minYear} and ${maxYear}`;
+    }
+    else {
+      this.invalidYear = false;
     }
 
-    if (
-      !this.error &&
-      (this.invalidYear || this.invalidMonth || this.invalidDay)
-    ) {
-      this.error = 'Please enter a valid date';
-    } else if (this.error !== 'Please enter a valid date') {
-      this.error;
-    } else {
-      this.error = '';
+    if (month && (month < minMonths || month > maxMonths)) {
+      this.invalidMonth = true;
+      this.error = `Please enter a month between ${minMonths} and ${maxMonths}`;
     }
+    else {
+      this.invalidMonth = false;
+    }
+
+    if (!this.monthYearOnly && (day &&
+      (day < minMonths || day > daysForSelectedMonth))) {
+      this.invalidDay = true;
+      this.error = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
+    }
+    else {
+      this.invalidDay = false;
+    }
+
+    if (this.required && (!year || !month || (!this.monthYearOnly && !day))) {
+      this.invalidYear = !year;
+      this.invalidMonth = !month;
+      this.invalidDay = this.monthYearOnly ? false : !day;
+      this.error = "Please enter a complete date";
+    }
+
+    if (!this.invalidYear && !this.invalidMonth && !this.invalidDay) {
+      this.error = null;
+    }
+
     this.dateBlur.emit(event);
   };
 

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -4,7 +4,6 @@ import {
   EventEmitter,
   Host,
   Prop,
-  State,
   h,
   Element,
   Fragment,
@@ -13,11 +12,7 @@ import {
 import {
   months,
   days,
-  checkLeapYear,
-  maxMonths,
-  maxYear,
-  minMonths,
-  minYear,
+  validate,
   validKeys,
 } from '../../utils/date-utils';
 
@@ -86,9 +81,9 @@ export class VaDate {
   })
   dateBlur: EventEmitter;
 
-  @State() invalidDay: boolean = false;
-  @State() invalidMonth: boolean = false;
-  @State() invalidYear: boolean = false;
+  @Prop({ mutable: true }) invalidDay: boolean = false;
+  @Prop({ mutable: true }) invalidMonth: boolean = false;
+  @Prop({ mutable: true }) invalidYear: boolean = false;
 
   /**
    * Set the value prop as an ISO-8601 date using provided arguments.
@@ -115,48 +110,9 @@ export class VaDate {
     const [year, month, day] = (this.value || '')
       .split('-')
       .map(val => parseInt(val) || null);
+
     this.setValue(year, month, day);
-
-    const leapYear = checkLeapYear(year);
-    const daysForSelectedMonth = leapYear && month == 2 ? 29 : days[month]?.length || 0;
-
-    // Begin built-in validation
-    if (year && (year < minYear || year > maxYear)) {
-      this.invalidYear = true;
-      this.error = `Please enter a year between ${minYear} and ${maxYear}`;
-    }
-    else {
-      this.invalidYear = false;
-    }
-
-    if (month && (month < minMonths || month > maxMonths)) {
-      this.invalidMonth = true;
-      this.error = `Please enter a month between ${minMonths} and ${maxMonths}`;
-    }
-    else {
-      this.invalidMonth = false;
-    }
-
-    if (!this.monthYearOnly && (day &&
-      (day < minMonths || day > daysForSelectedMonth))) {
-      this.invalidDay = true;
-      this.error = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
-    }
-    else {
-      this.invalidDay = false;
-    }
-
-    if (this.required && (!year || !month || (!this.monthYearOnly && !day))) {
-      this.invalidYear = !year;
-      this.invalidMonth = !month;
-      this.invalidDay = this.monthYearOnly ? false : !day;
-      this.error = "Please enter a complete date";
-    }
-
-    if (!this.invalidYear && !this.invalidMonth && !this.invalidDay) {
-      this.error = null;
-    }
-
+    validate(this, year, month, day);
     this.dateBlur.emit(event);
   };
 

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -112,7 +112,7 @@ export class VaDate {
       .map(val => parseInt(val) || null);
 
     this.setValue(year, month, day);
-    validate(this, year, month, day);
+    validate(this, year, month, day, this.monthYearOnly);
     this.dateBlur.emit(event);
   };
 

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -48,7 +48,10 @@ export class VaDate {
    * The error message to render (if any)
    * This prop should be leveraged to display any custom validations needed for this component
    */
-  @Prop({ reflect: true }) error?: string;
+  @Prop({
+    mutable: true,
+    reflect: true
+  }) error?: string;
 
   /**
    * Whether or not only the Month and Year inputs should be displayed.
@@ -128,6 +131,8 @@ export class VaDate {
       .map(val => parseInt(val) || null);
 
     this.setValue(year, month, day);
+    // Run built-in validation. Any custom validation
+    // will happen afterwards
     validate(this, year, month, day, this.monthYearOnly);
     this.dateBlur.emit(event);
   };

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -63,7 +63,10 @@ export class VaDate {
   /**
    * Set the default date value must be in YYYY-MM-DD format.
    */
-  @Prop({ mutable: true }) value?: string;
+  @Prop({
+    mutable: true,
+    reflect: true
+  }) value?: string;
 
   /**
    * Fires when the date input loses focus after its value was changed
@@ -222,10 +225,9 @@ export class VaDate {
       .map(val => parseInt(val));
     const daysForSelectedMonth = month > 0 ? days[month] : [];
 
-    // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group
     return (
-      <Host value={value} onBlur={handleDateBlur}>
+      <Host onBlur={handleDateBlur}>
         <fieldset>
           <legend>
             {label} {required && <span class="required">(*Required)</span>}

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -97,6 +97,25 @@ describe('va-memorable-date', () => {
       expect(date.getAttribute('error')).toEqual("Please enter a month between 1 and 12");
     });
 
+    it('does day validation without required prop', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-memorable-date value="1999-05-03" name="test" />',
+      );
+      const date = await page.find('va-memorable-date');
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      const handleDay = await page.$('pierce/[name="testDay"]');
+
+      // Click three times to select all text in input
+      await handleDay.click({ clickCount: 3 });
+      await handleDay.type('50');
+      // Trigger Blur
+      await handleYear.press('Tab');
+
+      await page.waitForChanges();
+      expect(date.getAttribute('error')).toEqual("Please enter a day between 1 and 31");
+    });
+
     it('resets error to null when fixed', async () => {
       const page = await newE2EPage();
       await page.setContent(

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -60,7 +60,6 @@ describe('va-memorable-date', () => {
   });
 
   describe('validation', () => {
-
     it('does year validation without required prop', async () => {
       const page = await newE2EPage();
       await page.setContent(
@@ -79,7 +78,26 @@ describe('va-memorable-date', () => {
       expect(date.getAttribute('error')).toEqual("Please enter a year between 1900 and 2122");
     });
 
-    it('displays an error message onBlur if date is invalid', async () => {
+    it('does month validation without required prop', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-memorable-date value="1999-05-03" name="test" />',
+      );
+      const date = await page.find('va-memorable-date');
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      const handleMonth = await page.$('pierce/[name="testMonth"]');
+
+      // Click three times to select all text in input
+      await handleMonth.click({ clickCount: 3 });
+      await handleMonth.type('50');
+      // Trigger Blur
+      await handleYear.press('Tab');
+
+      await page.waitForChanges();
+      expect(date.getAttribute('error')).toEqual("Please enter a month between 1 and 12");
+    });
+
+    it('resets error to null when fixed', async () => {
       const page = await newE2EPage();
       await page.setContent(
         '<va-memorable-date value="1999-05-03" name="test" required="true" />',

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -116,6 +116,42 @@ describe('va-memorable-date', () => {
       expect(date.getAttribute('error')).toEqual("Please enter a day between 1 and 31");
     });
 
+   it('does validation for required components', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-memorable-date name="test" required />',
+      );
+      const date = await page.find('va-memorable-date');
+      const handleYear = await page.$('pierce/[name="testYear"]');
+
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
+
+      expect(date.getAttribute('error')).toEqual("Please enter a complete date");
+    });
+
+    it('allows for a custom required message', async () => {
+      const page = await newE2EPage();
+      await page.setContent('<va-memorable-date value="2000-01-01" name="test" label="This is a field" required />');
+
+      // Act
+      const handleYear = await page.$('pierce/[name="testYear"]');
+      // Click three times to select all text in input
+      await handleYear.click({ clickCount: 3 });
+      await handleYear.press('2');
+      await handleYear.press('Tab');
+      // This would be done in the onDateChange handler
+      await page.$eval('va-memorable-date', (elm: any) => {
+        elm.error= 'Fill me out';
+      });
+      await page.waitForChanges();
+
+      // Assert
+      const errorSpan = await page.find('va-memorable-date >>> span#error-message');
+      expect(errorSpan.textContent).toContain("Fill me out");
+    });
+
     it('resets error to null when fixed', async () => {
       const page = await newE2EPage();
       await page.setContent(

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -252,26 +252,24 @@ describe('va-memorable-date', () => {
       );
       const handleYear = await page.$('pierce/[name="testYear"]');
       const handleMonth = await page.$('pierce/[name="testMonth"]');
-      const handleDay = await page.$('pierce/[name="testDay"]');
       const getAriaInvalid = (element: HTMLElement) =>
         element.getAttribute('aria-invalid');
 
       // Click three times to select all text in input
       await handleMonth.click({ clickCount: 3 });
-      await handleMonth.press('0');
+      await handleMonth.press('3');
+      await handleMonth.press('9');
       // Trigger Blur
       await handleYear.press('Tab');
 
       await page.waitForChanges();
       let invalidYear = await handleYear.evaluate(getAriaInvalid);
       let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      let invalidDay = await handleDay.evaluate(getAriaInvalid);
 
       expect(invalidYear).toEqual('false');
       expect(invalidMonth).toEqual('true');
-      // Day is invalid because month is 0
-      expect(invalidDay).toEqual('true');
 
+      await handleMonth.press('Backspace');
       await handleMonth.press('Backspace');
       await handleMonth.press('4');
       // Trigger Blur
@@ -280,11 +278,9 @@ describe('va-memorable-date', () => {
 
       invalidYear = await handleYear.evaluate(getAriaInvalid);
       invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      invalidDay = await handleDay.evaluate(getAriaInvalid);
 
       expect(invalidYear).toEqual('false');
       expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('false');
     });
 
     it('correctly indicates an invalid day', async () => {
@@ -423,31 +419,5 @@ describe('va-memorable-date', () => {
     await handleYear.press('Tab');
     await page.waitForChanges();
     expect(date.getAttribute('value')).toBe('--');
-  });
-
-  it.only('checks for valid year month and day', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<va-memorable-date name="test" required/>');
-    const date = await page.find('va-memorable-date');
-    const handleMonth = await page.$('pierce/[name="testMonth"]');
-    const handleDay = await page.$('pierce/[name="testDay"]');
-    const handleYear = await page.$('pierce/[name="testYear"]');
-    // Month
-    await handleMonth.press('0');
-    await handleMonth.press('Tab');
-    // Day
-    await handleDay.press('9');
-    await handleDay.press('9');
-    await handleDay.press('Tab');
-    // Year
-    await handleYear.press('3');
-    await handleYear.press('0');
-    await handleYear.press('0');
-    await handleYear.press('0');
-    // Trigger Blur
-    await handleYear.press('Tab');
-    await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
   });
 });

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -307,6 +307,66 @@ describe('va-memorable-date', () => {
         expect(invalidMonth).toEqual('false');
         expect(invalidDay).toEqual('false');
       });
+
+      it('passes the invalidDay prop correctly', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-memorable-date name="test" invalid-day />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid =
+          (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('true');
+     });
+
+      it('passes the invalidMonth prop correctly', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-memorable-date name="test" invalid-month />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid =
+          (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('true');
+        expect(invalidDay).toEqual('false');
+     });
+
+      it('passes the invalidYear prop correctly', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-memorable-date name="test" invalid-year />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid =
+          (element: HTMLElement) => element.getAttribute('aria-invalid');
+
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('true');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
+     });
     });
   });
 

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -59,7 +59,7 @@ describe('va-memorable-date', () => {
     expect(requiredSpan).not.toBeNull();
   });
 
-  it('does not validate without required prop', async () => {
+  it('does basic validation without required prop', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-memorable-date value="1999-05-03" name="test" />',
@@ -74,7 +74,7 @@ describe('va-memorable-date', () => {
     await handleYear.press('Tab');
 
     await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual(null);
+    expect(date.getAttribute('error')).toEqual("Please enter a year between 1900 and 2122");
   });
 
   it('sets a label', async () => {
@@ -175,7 +175,7 @@ describe('va-memorable-date', () => {
     expect(elementDay.getAttribute('value')).toBe('12');
   });
 
-  it('fires an error message onBlur if date is invalid and component is required', async () => {
+  it('displays an error message onBlur if date is invalid', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-memorable-date value="1999-05-03" name="test" required="true" />',
@@ -190,7 +190,7 @@ describe('va-memorable-date', () => {
     await handleYear.press('Tab');
 
     await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('Please enter a valid date');
+    expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
 
     await handleYear.press('0');
     await handleYear.press('2');
@@ -198,7 +198,7 @@ describe('va-memorable-date', () => {
     // Trigger Blur
     await handleYear.press('Tab');
     await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('');
+    expect(date.getAttribute('error')).toEqual(null);
   });
 
   describe('invalid subcomponents', () => {
@@ -425,7 +425,7 @@ describe('va-memorable-date', () => {
     expect(date.getAttribute('value')).toBe('--');
   });
 
-  it('checks for valid year month and day', async () => {
+  it.only('checks for valid year month and day', async () => {
     const page = await newE2EPage();
 
     await page.setContent('<va-memorable-date name="test" required/>');
@@ -448,6 +448,6 @@ describe('va-memorable-date', () => {
     // Trigger Blur
     await handleYear.press('Tab');
     await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('Please enter a valid date');
+    expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
   });
 });

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -59,22 +59,176 @@ describe('va-memorable-date', () => {
     expect(requiredSpan).not.toBeNull();
   });
 
-  it('does basic validation without required prop', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-memorable-date value="1999-05-03" name="test" />',
-    );
-    const date = await page.find('va-memorable-date');
-    const handleYear = await page.$('pierce/[name="testYear"]');
+  describe('validation', () => {
 
-    // Click three times to select all text in input
-    await handleYear.click({ clickCount: 3 });
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
+    it('does year validation without required prop', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-memorable-date value="1999-05-03" name="test" />',
+      );
+      const date = await page.find('va-memorable-date');
+      const handleYear = await page.$('pierce/[name="testYear"]');
 
-    await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual("Please enter a year between 1900 and 2122");
+      // Click three times to select all text in input
+      await handleYear.click({ clickCount: 3 });
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
+
+      await page.waitForChanges();
+      expect(date.getAttribute('error')).toEqual("Please enter a year between 1900 and 2122");
+    });
+
+    it('displays an error message onBlur if date is invalid', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<va-memorable-date value="1999-05-03" name="test" required="true" />',
+      );
+      const date = await page.find('va-memorable-date');
+      const handleYear = await page.$('pierce/[name="testYear"]');
+
+      // Click three times to select all text in input
+      await handleYear.click({ clickCount: 3 });
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
+
+      await page.waitForChanges();
+      expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
+
+      await handleYear.press('0');
+      await handleYear.press('2');
+      await handleYear.press('2');
+      // Trigger Blur
+      await handleYear.press('Tab');
+      await page.waitForChanges();
+      expect(date.getAttribute('error')).toEqual(null);
+    });
+
+    describe('invalid subcomponents', () => {
+      it('correctly indicates an invalid year', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-memorable-date value="1999-05-03" name="test" required="true" />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid = (element: HTMLElement) =>
+          element.getAttribute('aria-invalid');
+
+        // Click three times to select all text in input
+        await handleYear.click({ clickCount: 3 });
+        await handleYear.press('2');
+        // Trigger Blur
+        await handleYear.press('Tab');
+
+        // Year only has one character - should be invalid
+        await page.waitForChanges();
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('true');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
+
+        await handleYear.press('0');
+        await handleYear.press('2');
+        await handleYear.press('2');
+        // Trigger Blur
+        await handleYear.press('Tab');
+        await page.waitForChanges();
+
+        invalidYear = await handleYear.evaluate(getAriaInvalid);
+        invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
+      });
+
+      it('correctly indicates an invalid month', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-memorable-date value="1999-05-03" name="test" required="true" />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const getAriaInvalid = (element: HTMLElement) =>
+          element.getAttribute('aria-invalid');
+
+        // Click three times to select all text in input
+        await handleMonth.click({ clickCount: 3 });
+        await handleMonth.press('3');
+        await handleMonth.press('9');
+        // Trigger Blur
+        await handleYear.press('Tab');
+
+        await page.waitForChanges();
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('true');
+
+        await handleMonth.press('Backspace');
+        await handleMonth.press('Backspace');
+        await handleMonth.press('4');
+        // Trigger Blur
+        await handleYear.press('Tab');
+        await page.waitForChanges();
+
+        invalidYear = await handleYear.evaluate(getAriaInvalid);
+        invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+      });
+
+      it('correctly indicates an invalid day', async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          '<va-memorable-date value="1999-05-03" name="test" required="true" />',
+        );
+        const handleYear = await page.$('pierce/[name="testYear"]');
+        const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
+        const getAriaInvalid = (element: HTMLElement) =>
+          element.getAttribute('aria-invalid');
+
+        // Click three times to select all text in input
+        await handleDay.click({ clickCount: 3 });
+        await handleDay.press('3');
+        await handleDay.press('9');
+        // Trigger Blur
+        await handleYear.press('Tab');
+
+        await page.waitForChanges();
+        let invalidYear = await handleYear.evaluate(getAriaInvalid);
+        let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('true');
+
+        await handleDay.press('Backspace');
+        await handleDay.press('1');
+        // Trigger Blur
+        await handleYear.press('Tab');
+        await page.waitForChanges();
+
+        invalidYear = await handleYear.evaluate(getAriaInvalid);
+        invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        invalidDay = await handleDay.evaluate(getAriaInvalid);
+
+        expect(invalidYear).toEqual('false');
+        expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
+      });
+    });
   });
 
   it('sets a label', async () => {
@@ -173,157 +327,6 @@ describe('va-memorable-date', () => {
     await page.waitForChanges();
     expect(elementMonth.getAttribute('value')).toBe('20');
     expect(elementDay.getAttribute('value')).toBe('12');
-  });
-
-  it('displays an error message onBlur if date is invalid', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-memorable-date value="1999-05-03" name="test" required="true" />',
-    );
-    const date = await page.find('va-memorable-date');
-    const handleYear = await page.$('pierce/[name="testYear"]');
-
-    // Click three times to select all text in input
-    await handleYear.click({ clickCount: 3 });
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
-
-    await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual('Please enter a year between 1900 and 2122');
-
-    await handleYear.press('0');
-    await handleYear.press('2');
-    await handleYear.press('2');
-    // Trigger Blur
-    await handleYear.press('Tab');
-    await page.waitForChanges();
-    expect(date.getAttribute('error')).toEqual(null);
-  });
-
-  describe('invalid subcomponents', () => {
-    it('correctly indicates an invalid year', async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        '<va-memorable-date value="1999-05-03" name="test" required="true" />',
-      );
-      const handleYear = await page.$('pierce/[name="testYear"]');
-      const handleMonth = await page.$('pierce/[name="testMonth"]');
-      const handleDay = await page.$('pierce/[name="testDay"]');
-      const getAriaInvalid = (element: HTMLElement) =>
-        element.getAttribute('aria-invalid');
-
-      // Click three times to select all text in input
-      await handleYear.click({ clickCount: 3 });
-      await handleYear.press('2');
-      // Trigger Blur
-      await handleYear.press('Tab');
-
-      // Year only has one character - should be invalid
-      await page.waitForChanges();
-      let invalidYear = await handleYear.evaluate(getAriaInvalid);
-      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      let invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('true');
-      expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('false');
-
-      await handleYear.press('0');
-      await handleYear.press('2');
-      await handleYear.press('2');
-      // Trigger Blur
-      await handleYear.press('Tab');
-      await page.waitForChanges();
-
-      invalidYear = await handleYear.evaluate(getAriaInvalid);
-      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('false');
-    });
-
-    it('correctly indicates an invalid month', async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        '<va-memorable-date value="1999-05-03" name="test" required="true" />',
-      );
-      const handleYear = await page.$('pierce/[name="testYear"]');
-      const handleMonth = await page.$('pierce/[name="testMonth"]');
-      const getAriaInvalid = (element: HTMLElement) =>
-        element.getAttribute('aria-invalid');
-
-      // Click three times to select all text in input
-      await handleMonth.click({ clickCount: 3 });
-      await handleMonth.press('3');
-      await handleMonth.press('9');
-      // Trigger Blur
-      await handleYear.press('Tab');
-
-      await page.waitForChanges();
-      let invalidYear = await handleYear.evaluate(getAriaInvalid);
-      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('true');
-
-      await handleMonth.press('Backspace');
-      await handleMonth.press('Backspace');
-      await handleMonth.press('4');
-      // Trigger Blur
-      await handleYear.press('Tab');
-      await page.waitForChanges();
-
-      invalidYear = await handleYear.evaluate(getAriaInvalid);
-      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('false');
-    });
-
-    it('correctly indicates an invalid day', async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        '<va-memorable-date value="1999-05-03" name="test" required="true" />',
-      );
-      const handleYear = await page.$('pierce/[name="testYear"]');
-      const handleMonth = await page.$('pierce/[name="testMonth"]');
-      const handleDay = await page.$('pierce/[name="testDay"]');
-      const getAriaInvalid = (element: HTMLElement) =>
-        element.getAttribute('aria-invalid');
-
-      // Click three times to select all text in input
-      await handleDay.click({ clickCount: 3 });
-      await handleDay.press('3');
-      await handleDay.press('9');
-      // Trigger Blur
-      await handleYear.press('Tab');
-
-      await page.waitForChanges();
-      let invalidYear = await handleYear.evaluate(getAriaInvalid);
-      let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      let invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('true');
-
-      await handleDay.press('Backspace');
-      await handleDay.press('1');
-      // Trigger Blur
-      await handleYear.press('Tab');
-      await page.waitForChanges();
-
-      invalidYear = await handleYear.evaluate(getAriaInvalid);
-      invalidMonth = await handleMonth.evaluate(getAriaInvalid);
-      invalidDay = await handleDay.evaluate(getAriaInvalid);
-
-      expect(invalidYear).toEqual('false');
-      expect(invalidMonth).toEqual('false');
-      expect(invalidDay).toEqual('false');
-    });
   });
 
   it('emits dateBlur event', async () => {

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -193,6 +193,7 @@ describe('va-memorable-date', () => {
         );
         const handleYear = await page.$('pierce/[name="testYear"]');
         const handleMonth = await page.$('pierce/[name="testMonth"]');
+        const handleDay = await page.$('pierce/[name="testDay"]');
         const getAriaInvalid = (element: HTMLElement) =>
           element.getAttribute('aria-invalid');
 
@@ -206,9 +207,12 @@ describe('va-memorable-date', () => {
         await page.waitForChanges();
         let invalidYear = await handleYear.evaluate(getAriaInvalid);
         let invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        let invalidDay = await handleDay.evaluate(getAriaInvalid);
 
         expect(invalidYear).toEqual('false');
         expect(invalidMonth).toEqual('true');
+        // Day is invalid because we don't know the upper limit based on a valid month
+        expect(invalidDay).toEqual('true');
 
         await handleMonth.press('Backspace');
         await handleMonth.press('Backspace');
@@ -219,9 +223,11 @@ describe('va-memorable-date', () => {
 
         invalidYear = await handleYear.evaluate(getAriaInvalid);
         invalidMonth = await handleMonth.evaluate(getAriaInvalid);
+        invalidDay = await handleDay.evaluate(getAriaInvalid);
 
         expect(invalidYear).toEqual('false');
         expect(invalidMonth).toEqual('false');
+        expect(invalidDay).toEqual('false');
       });
 
       it('correctly indicates an invalid day', async () => {

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -4,19 +4,13 @@ import {
   EventEmitter,
   Host,
   Prop,
-  State,
   h,
   Element,
   Fragment,
 } from '@stencil/core';
 
 import {
-  days,
-  checkLeapYear,
-  maxMonths,
-  maxYear,
-  minMonths,
-  minYear,
+  validate,
   validKeys,
 } from '../../utils/date-utils';
 
@@ -77,9 +71,9 @@ export class VaMemorableDate {
   })
   dateBlur: EventEmitter;
 
-  @State() invalidDay: boolean = false;
-  @State() invalidMonth: boolean = false;
-  @State() invalidYear: boolean = false;
+  @Prop({ mutable: true }) invalidDay: boolean = false;
+  @Prop({ mutable: true }) invalidMonth: boolean = false;
+  @Prop({ mutable: true }) invalidYear: boolean = false;
 
   private handleDateBlur = (event: FocusEvent) => {
     const [year, month, day] = (this.value || '').split('-');
@@ -96,33 +90,8 @@ export class VaMemorableDate {
     }`;
     /* eslint-enable i18next/no-literal-string */
 
-    const daysForSelectedMonth = monthNum > 0 ? days[monthNum] : [];
-    const leapYear = checkLeapYear(yearNum);
+    validate(this, yearNum, monthNum, dayNum);
 
-    if (this.required) {
-      // Set the state so that we can set aria-invalid on the right component
-      this.invalidYear = !year || yearNum < minYear || yearNum > maxYear;
-
-      this.invalidMonth =
-        !month || monthNum < minMonths || monthNum > maxMonths;
-
-      this.invalidDay =
-        !day || dayNum < minMonths || dayNum > daysForSelectedMonth.length;
-
-      if (!leapYear && monthNum === 2 && dayNum > 28) {
-        this.invalidYear = true;
-        this.invalidMonth = true;
-        this.invalidDay = true;
-      }
-    }
-
-    if (this.invalidYear || this.invalidMonth || this.invalidDay) {
-      this.error = 'Please enter a valid date';
-    } else if (this.error !== 'Please enter a valid date') {
-      this.error;
-    } else {
-      this.error = '';
-    }
     this.dateBlur.emit(event);
   };
 

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -90,8 +90,9 @@ export class VaMemorableDate {
     }`;
     /* eslint-enable i18next/no-literal-string */
 
+    // Run built-in validation. Any custom validation
+    // will happen afterwards
     validate(this, yearNum, monthNum, dayNum);
-
     this.dateBlur.emit(event);
   };
 

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -46,12 +46,12 @@ export class VaMemorableDate {
    * The error message to render (if any)
    * This prop should be leveraged to display any custom validations needed for this component
    */
-  @Prop() error?: string;
+  @Prop({ reflect: true, mutable: true }) error?: string;
 
   /**
    * Set the default date value must be in YYYY-MM-DD format.
    */
-  @Prop({ mutable: true }) value?: string;
+  @Prop({ mutable: true, reflect: true }) value?: string;
 
   /**
    * Fires when the date input loses focus after its value was changed
@@ -158,7 +158,7 @@ export class VaMemorableDate {
     // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group
     return (
-      <Host value={value} error={error} onBlur={handleDateBlur}>
+      <Host onBlur={handleDateBlur}>
         <fieldset>
           <legend>
             {label} {required && <span class="required">(*Required)</span>}

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -2,9 +2,8 @@ import { checkLeapYear } from './date-utils';
 
 describe('checkLeapYear', () => {
   it('determines an input year is a leap year', () => {
-    expect(checkLeapYear('1996')).toBeTruthy();
-    expect(checkLeapYear('ABCD')).toBeFalsy();
-    expect(checkLeapYear('1995')).toBeFalsy();
-    expect(checkLeapYear('199')).toBeFalsy();
+    expect(checkLeapYear(1996)).toBeTruthy();
+    expect(checkLeapYear(1995)).toBeFalsy();
+    expect(checkLeapYear(199)).toBeFalsy();
   });
 });

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -167,7 +167,6 @@ export function validate(component: Components.VaDate | Components.VaMemorableDa
     component.invalidDay = false;
   }
 
-
   if (month && (month < minMonths || month > maxMonths)) {
     component.invalidMonth = true;
     component.error = `Please enter a month between ${minMonths} and ${maxMonths}`;
@@ -179,7 +178,7 @@ export function validate(component: Components.VaDate | Components.VaMemorableDa
   if (component.required && (!year || !month || (!monthYearOnly && !day))) {
     component.invalidYear = !year;
     component.invalidMonth = !month;
-    component.invalidDay = this.monthYearOnly ? false : !day;
+    component.invalidDay = monthYearOnly ? false : !day;
     component.error = "Please enter a complete date";
   }
 

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -157,6 +157,17 @@ export function validate(component: Components.VaDate | Components.VaMemorableDa
     component.invalidYear = false;
   }
 
+  // Check day before month so that the month error message has a change to override
+  // We don't know the upper limit on days until we know the month
+  if (day && (day < minMonths || day > daysForSelectedMonth)) {
+    component.invalidDay = true;
+    component.error = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
+  }
+  else {
+    component.invalidDay = false;
+  }
+
+
   if (month && (month < minMonths || month > maxMonths)) {
     component.invalidMonth = true;
     component.error = `Please enter a month between ${minMonths} and ${maxMonths}`;

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -132,7 +132,11 @@ export const days = {
   12: thirtyOneDays,
 };
 
-function checkLeapYear(year) {
+/**
+ * Return true if the year is a leap year.
+ * (Exported for testing purposes)
+ */
+export function checkLeapYear(year: number) {
   //three conditions to find out the leap year
   return (0 == year % 4 && 0 != year % 100) || 0 == year % 400;
 }

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -159,7 +159,7 @@ export function validate(component: Components.VaDate | Components.VaMemorableDa
 
   // Check day before month so that the month error message has a change to override
   // We don't know the upper limit on days until we know the month
-  if (day && (day < minMonths || day > daysForSelectedMonth)) {
+  if (!monthYearOnly && (!day || day < minMonths || day > daysForSelectedMonth)) {
     component.invalidDay = true;
     component.error = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
   }

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -141,13 +141,23 @@ export function checkLeapYear(year: number) {
   return (0 == year % 4 && 0 != year % 100) || 0 == year % 400;
 }
 
-export function validate(component: Components.VaDate | Components.VaMemorableDate, year: number, month: number, day: number, monthYearOnly : boolean = false) : void {
+/**
+ * This is used to validate date components and:
+ * 1. Indicate which field fails the built-in validation
+ * 1. Supply an error message to help resolve the issue
+ *
+ * It relies on the component's mutable props.
+ */
+export function validate(
+  component: Components.VaDate | Components.VaMemorableDate,
+  year: number,
+  month: number,
+  day: number,
+  monthYearOnly : boolean = false) : void {
 
   const leapYear = checkLeapYear(year);
   const daysForSelectedMonth = leapYear && month == 2 ? 29 : days[month]?.length || 0;
 
-  console.log('Validation', component.required, year, month, day)
-  console.log('days for selected month', daysForSelectedMonth)
   // Begin built-in validation
   if (year && (year < minYear || year > maxYear)) {
     component.invalidYear = true;
@@ -182,6 +192,7 @@ export function validate(component: Components.VaDate | Components.VaMemorableDa
     component.error = "Please enter a complete date";
   }
 
+  // Remove any error message if none of the fields are marked as invalid
   if (!component.invalidYear && !component.invalidMonth && !component.invalidDay) {
     component.error = null;
   }

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -1,8 +1,8 @@
 import { Components } from '../components';
-export const maxYear = new Date().getFullYear() + 100;
-export const minYear = 1900;
-export const maxMonths = 12;
-export const minMonths = 1;
+const maxYear = new Date().getFullYear() + 100;
+const minYear = 1900;
+const maxMonths = 12;
+const minMonths = 1;
 
 export const months = [
   { label: 'January', value: 1 },
@@ -20,7 +20,7 @@ export const months = [
 ];
 
 /* eslint-disable i18next/no-literal-string */
-export const twentyNineDays = [
+const twentyNineDays = [
   '1',
   '2',
   '3',
@@ -51,7 +51,7 @@ export const twentyNineDays = [
   '28',
   '29',
 ];
-export const thirtyDays = [
+const thirtyDays = [
   '1',
   '2',
   '3',
@@ -83,7 +83,7 @@ export const thirtyDays = [
   '29',
   '30',
 ];
-export const thirtyOneDays = [
+const thirtyOneDays = [
   '1',
   '2',
   '3',
@@ -132,12 +132,12 @@ export const days = {
   12: thirtyOneDays,
 };
 
-export function checkLeapYear(year) {
+function checkLeapYear(year) {
   //three conditions to find out the leap year
   return (0 == year % 4 && 0 != year % 100) || 0 == year % 400;
 }
 
-export function validate(component: Components.VaDate, year: number, month: number, day: number) : void {
+export function validate(component: Components.VaDate | Components.VaMemorableDate, year: number, month: number, day: number, monthYearOnly : boolean = false) : void {
 
   const leapYear = checkLeapYear(year);
   const daysForSelectedMonth = leapYear && month == 2 ? 29 : days[month]?.length || 0;
@@ -161,7 +161,7 @@ export function validate(component: Components.VaDate, year: number, month: numb
     component.invalidMonth = false;
   }
 
-  if (component.required && (!year || !month || (!component.monthYearOnly && !day))) {
+  if (component.required && (!year || !month || (!monthYearOnly && !day))) {
     component.invalidYear = !year;
     component.invalidMonth = !month;
     component.invalidDay = this.monthYearOnly ? false : !day;

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -1,3 +1,4 @@
+import { Components } from '../components';
 export const maxYear = new Date().getFullYear() + 100;
 export const minYear = 1900;
 export const maxMonths = 12;
@@ -134,6 +135,42 @@ export const days = {
 export function checkLeapYear(year) {
   //three conditions to find out the leap year
   return (0 == year % 4 && 0 != year % 100) || 0 == year % 400;
+}
+
+export function validate(component: Components.VaDate, year: number, month: number, day: number) : void {
+
+  const leapYear = checkLeapYear(year);
+  const daysForSelectedMonth = leapYear && month == 2 ? 29 : days[month]?.length || 0;
+
+  console.log('Validation', component.required, year, month, day)
+  console.log('days for selected month', daysForSelectedMonth)
+  // Begin built-in validation
+  if (year && (year < minYear || year > maxYear)) {
+    component.invalidYear = true;
+    component.error = `Please enter a year between ${minYear} and ${maxYear}`;
+  }
+  else {
+    component.invalidYear = false;
+  }
+
+  if (month && (month < minMonths || month > maxMonths)) {
+    component.invalidMonth = true;
+    component.error = `Please enter a month between ${minMonths} and ${maxMonths}`;
+  }
+  else {
+    component.invalidMonth = false;
+  }
+
+  if (component.required && (!year || !month || (!component.monthYearOnly && !day))) {
+    component.invalidYear = !year;
+    component.invalidMonth = !month;
+    component.invalidDay = this.monthYearOnly ? false : !day;
+    component.error = "Please enter a complete date";
+  }
+
+  if (!component.invalidYear && !component.invalidMonth && !component.invalidDay) {
+    component.error = null;
+  }
 }
 
 // Allow 0-9, Backspace, Delete, Left and Right Arrow, and Tab to clear data or move to next field

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -169,7 +169,7 @@ export function validate(
 
   // Check day before month so that the month error message has a change to override
   // We don't know the upper limit on days until we know the month
-  if (!monthYearOnly && (!day || day < minMonths || day > daysForSelectedMonth)) {
+  if (!monthYearOnly && (day < minMonths || day > daysForSelectedMonth)) {
     component.invalidDay = true;
     component.error = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
   }


### PR DESCRIPTION
## Chromatic
<!-- This `date-validation` is a placeholder for a CI job - it will be updated automatically -->
https://date-validation--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/44929
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/848
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/875

This reworks the validation of our date components. Both `<va-date>` and `<va-memorable-date>` now run the same build-in validation, and users can apply any custom validation afterwards on the handler for `dateBlur`. The built-in validation consists of:

- An error message when year is incomplete
- An error message when month is provided but outside of a range (only really useful for memorable date)
- An error message when day is provided but outside of a range (only really useful for memorable date)
- An error message when the component is required but has missing fields

## Testing done

- Storybook :eyes: 
- E2E testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
