### PR TITLE
Move aria attributes for va-modal to host

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.3.1",
+  "version": "11.3.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-modal/test/va-modal.e2e.ts
+++ b/packages/web-components/src/components/va-modal/test/va-modal.e2e.ts
@@ -14,9 +14,9 @@ describe('va-modal', () => {
 
     const element = await page.find('va-modal');
     expect(element).toEqualHtml(`
-      <va-modal class="hydrated" modal-title="Example Title" visible>
+      <va-modal aria-label="Example Title modal" aria-modal="true" class="hydrated" modal-title="Example Title" role="dialog" visible="">
         <mock:shadow-root>
-          <div aria-label="Example Title modal" aria-modal="true" class="va-modal" role="dialog">
+          <div class="va-modal">
             <div class="va-modal-inner" tabindex="-1">
               <button aria-label="Close Example Title modal" class="va-modal-close" type="button">
                 <i aria-hidden="true"></i>

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -354,12 +354,13 @@ export class VaModal {
       : 'Close modal';
 
     return (
-      <Host>
+      <Host
+      aria-label={ariaLabel}
+      aria-modal="true"
+      role={ariaRole(status)}
+      >
         <div
-          aria-label={ariaLabel}
-          aria-modal="true"
           class="va-modal"
-          role={ariaRole(status)}
         >
           <div class={wrapperClass} tabIndex={-1}>
             <button


### PR DESCRIPTION
## Chromatic
<!-- This `a11y-fix-modal` is a placeholder for a CI job - it will be updated automatically -->
https://a11y-fix-modal--60f9b557105290003b387cd5.chromatic.com

## Description
Moves the `aria-label`, `aria-modal` and `role` attributes to the `host` element.

## Testing done
Visual in storybook

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
