### PR TITLE
Fixes for va-alert-expandable

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.3.2",
+  "version": "11.3.3",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.10.2",
+  "version": "4.10.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
+++ b/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
@@ -14,10 +14,12 @@ describe('va-additional-info', () => {
       <va-additional-info trigger="More info" class="hydrated">
         <mock:shadow-root>
           <a aria-controls="info" aria-expanded="false" role="button" tabindex="0">
-            <span class="additional-info-title">
-              More info
-              <i class="fa-angle-down" role="presentation"></i>
-            </span>
+            <div>
+              <span class="additional-info-title">
+                More info
+                </span>
+            </div>
+            <i class="fa-angle-down" role="presentation"></i>
           </a>
           <div class="closed" id="info" style="--calc-max-height:calc(0px + 2rem);">
             <slot></slot>

--- a/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
+++ b/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
@@ -17,9 +17,9 @@ describe('va-additional-info', () => {
             <div>
               <span class="additional-info-title">
                 More info
-                </span>
+              </span>
+              <i class="fa-angle-down" role="presentation"></i>
             </div>
-            <i class="fa-angle-down" role="presentation"></i>
           </a>
           <div class="closed" id="info" style="--calc-max-height:calc(0px + 2rem);">
             <slot></slot>

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.css
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.css
@@ -20,7 +20,9 @@
 }
 
 a {
-  display: block;
+  align-items: flex-start;
+  cursor: pointer;
+  display: flex;
 }
 
 .additional-info-title {

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
@@ -101,10 +101,10 @@ export class VaAdditionalInfo {
           onClick={this.toggleOpen.bind(this)}
           onKeyDown={this.handleKeydown.bind(this)}
         >
-          <span class="additional-info-title">
-            {this.trigger}
-            <i class="fa-angle-down" role="presentation" />
-          </span>
+          <div>
+            <span class="additional-info-title">{this.trigger}</span>
+          </div>
+          <i class="fa-angle-down" role="presentation" />
         </a>
         <div id="info" class={this.open ? 'open' : 'closed'}>
           <slot></slot>

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
@@ -103,8 +103,8 @@ export class VaAdditionalInfo {
         >
           <div>
             <span class="additional-info-title">{this.trigger}</span>
+            <i class="fa-angle-down" role="presentation" />
           </div>
-          <i class="fa-angle-down" role="presentation" />
         </a>
         <div id="info" class={this.open ? 'open' : 'closed'}>
           <slot></slot>

--- a/packages/web-components/src/components/va-alert-expandable/test/va-alert-expandable.e2e.ts
+++ b/packages/web-components/src/components/va-alert-expandable/test/va-alert-expandable.e2e.ts
@@ -16,10 +16,12 @@ describe('va-alert-expandable', () => {
         <div class="alert-expandable warning">
           <a role="button" aria-controls="alert-body" aria-expanded="false" tabindex="0" class="alert-expandable-trigger">
             <i class="alert-status-icon" aria-hidden="true" role="img"></i>
-            <span class="alert-expandable-title">
-              <span class="sr-only">Alert:&nbsp;</span>
-              Limited services and hours
-            </span>
+            <div>
+              <span class="alert-expandable-title">
+                <span class="sr-only">Alert:&nbsp;</span>
+                Limited services and hours
+              </span>
+            </div>
             <i class="fa-angle-down" role="presentation"></i>
           </a>
           <div id="alert-body" class="alert-expandable-body closed" style="--calc-max-height:calc(0px + 2rem);">
@@ -215,7 +217,8 @@ describe('va-alert-expandable', () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-alert-expandable status="warning" trigger="Click here for a treat!" disable-analytics>
-        <div style="height:50px;padding:10px 0;margin:5px 0;">We're out of treats! Try again later.</div>
+        <div style="height:50px;padding:10px 0;margin:5px 0;">We're out of treats! Try again later.
+        </div>
       </va-alert-expandable>
     `);
     const handle = await page.waitForSelector('pierce/#alert-body');
@@ -225,7 +228,8 @@ describe('va-alert-expandable', () => {
     const calcMaxHeight = await handle.evaluate((domElement: HTMLElement) =>
       domElement.style.getPropertyValue('--calc-max-height'),
     );
-    // 50px from height + 20px from padding + 10px from margin
-    expect(calcMaxHeight).toEqual('calc(80px + 2rem)');
+    // 50px from height + 20px from padding
+    // margin-bottom and margin-top is set to 0 for first slotted child
+    expect(calcMaxHeight).toEqual('calc(70px + 2rem)');
   });
 });

--- a/packages/web-components/src/components/va-alert-expandable/test/va-alert-expandable.e2e.ts
+++ b/packages/web-components/src/components/va-alert-expandable/test/va-alert-expandable.e2e.ts
@@ -21,8 +21,8 @@ describe('va-alert-expandable', () => {
                 <span class="sr-only">Alert:&nbsp;</span>
                 Limited services and hours
               </span>
+              <i class="fa-angle-down" role="presentation"></i>
             </div>
-            <i class="fa-angle-down" role="presentation"></i>
           </a>
           <div id="alert-body" class="alert-expandable-body closed" style="--calc-max-height:calc(0px + 2rem);">
             <slot></slot>

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
@@ -132,3 +132,8 @@ div.warning i.alert-status-icon::before {
 div.error i.alert-status-icon::before {
   content: '\F06A';
 }
+
+::slotted(*) {
+  margin-bottom: 0 !important;
+  margin-top: 0 !important;
+}

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
@@ -26,7 +26,9 @@
 }
 
 .alert-expandable-trigger {
-  display: block;
+  align-items: flex-start;
+  cursor: pointer;
+  display: flex;
   padding: 1.2rem;
 }
 
@@ -101,9 +103,10 @@ a[aria-expanded='true'] i.fa-angle-down {
   transition: transform 0.15s linear;
 }
 
-i.alert-status-icon { 
+i.alert-status-icon {
   color: var(--color-gray-dark);
-  margin-right: 1.2rem; 
+  margin-top: 0.4rem;
+  margin-right: 1.2rem;
 }
 
 div.hide-icon i.alert-status-icon {

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
@@ -129,8 +129,8 @@ export class VaAlertExpandable {
                 <span class="sr-only">Alert:&nbsp;</span>
                 {this.trigger}
               </span>
+              <i class="fa-angle-down" role="presentation" />
             </div>
-            <i class="fa-angle-down" role="presentation" />
           </a>
           <div id="alert-body" class={bodyClasses}>
             <slot></slot>

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
@@ -124,10 +124,12 @@ export class VaAlertExpandable {
             class="alert-expandable-trigger"
           >
             <i class="alert-status-icon" aria-hidden="true" role="img"></i>
-            <span class="alert-expandable-title">
-              <span class="sr-only">Alert:&nbsp;</span>
-              {this.trigger}
-            </span>
+            <div>
+              <span class="alert-expandable-title">
+                <span class="sr-only">Alert:&nbsp;</span>
+                {this.trigger}
+              </span>
+            </div>
             <i class="fa-angle-down" role="presentation" />
           </a>
           <div id="alert-body" class={bodyClasses}>


### PR DESCRIPTION
## Chromatic
<!-- This `904-expandable` is a placeholder for a CI job - it will be updated automatically -->
https://904-expandable--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/904

## Screenshots

va-alert-expandable:
<img width="364" alt="Screen Shot 2022-08-11 at 16 48 22" src="https://user-images.githubusercontent.com/36863582/184239571-8bfde844-9219-4b9f-8938-3c6e3854ad10.png">

![Screen Shot 2022-08-10 at 10 30 42](https://user-images.githubusercontent.com/36863582/183927903-821a84ce-0814-4ae9-b725-9dd1f45d6385.png)


va-additional-info:
<img width="362" alt="Screen Shot 2022-08-11 at 16 47 37" src="https://user-images.githubusercontent.com/36863582/184239540-4ffe0464-d927-4954-bc64-f515ba1908e8.png">



## Acceptance criteria
- [x] va-alert-expandable carat does not wrap
- [x] va-alert-expandable trigger text does not wrap below status icon
- [x] va-alert-expandable handles margin for slotted children 

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
