### PR TITLE
Remove fullwidth alert story & update banner stories

### DIFF
--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -327,13 +327,6 @@ DismissableBackgroundOnlyIcon.args = {
   'onCloseEvent': () => console.log('Close event triggered'),
 };
 
-export const Fullwidth = Template.bind(null);
-Fullwidth.args = {
-  ...defaultArgs,
-  ...Warning.args,
-  'full-width': true,
-};
-
 export const BackgroundOnly = BackgroundOnlyTemplate.bind(null);
 BackgroundOnly.args = {
   ...defaultArgs,

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -21,7 +21,7 @@ export default {
   },
 };
 
-const Template = ({
+const DuringTemplate = ({
   'disable-analytics': disableAnalytics,
   'show-close': showClose,
   headline,
@@ -29,6 +29,16 @@ const Template = ({
   visible,
   'window-session': windowSession,
 }) => {
+  const timeFormattingOptions = {
+    timeStyle: 'long',
+    timeZone: 'US/Eastern',
+  };
+  const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
+  const now = new Date();
+  const date = new Intl.DateTimeFormat('en-US').format(now);
+  const start = formatter.format(now.setHours(now.getHours() - 1));
+  const end = formatter.format(now.setHours(now.getHours() + 2));
+
   return (
     <va-banner
       disable-analytics={disableAnalytics}
@@ -38,17 +48,63 @@ const Template = ({
       visible={visible}
       window-session={windowSession}
     >
-      Congress shall make no law respecting an establishment of religion, or
-      prohibiting the free exercise thereof; or abridging the freedom of speech,
-      or of the press; <a href="#">LINK TEST</a> or the right of the people
-      peaceably to assemble, and to petition the Government for a redress of
-      grievances.
+      <p>
+        We’re working on VA.gov right now. If you have trouble signing in or
+        using tools, check back after we’re finished. Thank you for your
+        patience.
+      </p>
+      <p>
+        <strong>Date:</strong> {date}
+      </p>
+      <p>
+        <strong>Start/End time:</strong> {start} to {end}
+      </p>
+    </va-banner>
+  );
+};
+
+const BeforeTemplate = ({
+  'disable-analytics': disableAnalytics,
+  'show-close': showClose,
+  headline,
+  type,
+  visible,
+  'window-session': windowSession,
+}) => {
+  const timeFormattingOptions = {
+    timeStyle: 'long',
+    timeZone: 'US/Eastern',
+  };
+  const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
+  const now = new Date();
+  const date = new Intl.DateTimeFormat('en-US').format(now);
+  const start = formatter.format(now.setHours(now.getHours() + 1));
+  const end = formatter.format(now.setHours(now.getHours() + 2));
+  return (
+    <va-banner
+      disable-analytics={disableAnalytics}
+      show-close={showClose}
+      headline={headline}
+      type={type}
+      visible={visible}
+      window-session={windowSession}
+    >
+      <p>
+        We’ll be doing some work on VA.gov. The maintenance will last X hours.
+        During that time, you won’t be able to sign in or use tools.
+      </p>
+      <p>
+        <strong>Date:</strong> {date}
+      </p>
+      <p>
+        <strong>Start/End time:</strong> {start} to {end}
+      </p>
     </va-banner>
   );
 };
 
 const defaultArgs = {
-  'headline': 'This is a test',
+  'headline': 'Site maintenance',
   'show-close': false,
   'disable-analytics': false,
   'type': 'error',
@@ -56,13 +112,20 @@ const defaultArgs = {
   'window-session': false,
 };
 
-export const Default = Template.bind(null);
+export const Default = DuringTemplate.bind(null);
 Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(bannerDocs);
 
-export const Closeable = Template.bind(null);
+export const Warning = BeforeTemplate.bind(null);
+Warning.args = {
+  ...defaultArgs,
+  type: 'warning',
+  headline: 'Upcoming site maintenance',
+};
+
+export const Closeable = BeforeTemplate.bind(null);
 Closeable.args = {
   ...defaultArgs,
   'show-close': true,

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -30,7 +30,9 @@ const DuringTemplate = ({
   'window-session': windowSession,
 }) => {
   const timeFormattingOptions = {
-    timeStyle: 'long',
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZoneName: 'short',
     timeZone: 'US/Eastern',
   };
   const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
@@ -122,12 +124,16 @@ const AdvanceTemplate = ({
   'window-session': windowSession,
 }) => {
   const timeFormattingOptions = {
-    timeStyle: 'long',
+    hour: 'numeric',
+    minute: 'numeric',
     timeZone: 'US/Eastern',
+    timeZoneName: 'short',
   };
   const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
   const now = new Date();
-  const date = new Intl.DateTimeFormat('en-US').format(now);
+  const date = new Intl.DateTimeFormat('en-US', { dateStyle: 'full' }).format(
+    now,
+  );
   const start = formatter.format(now.setHours(now.getHours() + 1));
   const end = formatter.format(now.setHours(now.getHours() + 2));
   return (

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -103,6 +103,31 @@ const BeforeTemplate = ({
   );
 };
 
+const SiteAccessibleTemplate = ({
+  'disable-analytics': disableAnalytics,
+  'show-close': showClose,
+  headline,
+  type,
+  visible,
+  'window-session': windowSession,
+}) => {
+  return (
+    <va-banner
+      disable-analytics={disableAnalytics}
+      show-close={showClose}
+      headline={headline}
+      type={type}
+      visible={visible}
+      window-session={windowSession}
+    >
+      <p>
+        We’re working on VA.gov right now. You should still be able to use the
+        applications and tools. But if you have any trouble, please check back
+        soon.
+      </p>
+    </va-banner>
+  );
+};
 const defaultArgs = {
   'headline': 'Site maintenance',
   'show-close': false,
@@ -129,4 +154,11 @@ export const Closeable = BeforeTemplate.bind(null);
 Closeable.args = {
   ...defaultArgs,
   'show-close': true,
+};
+
+export const SiteStillAccessible = SiteAccessibleTemplate.bind(null);
+SiteStillAccessible.args = {
+  ...defaultArgs,
+  type: 'warning',
+  headline: 'We’re working on the site',
 };

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -74,10 +74,16 @@ const During24HourTemplate = ({
   'window-session': windowSession,
 }) => {
   const timeFormattingOptions = {
-    timeStyle: 'long',
-    dateStyle: 'full',
+    hour: 'numeric',
+    minute: 'numeric',
+    weekday: 'long',
+    month: 'long',
+    year: 'numeric',
+    day: 'numeric',
     timeZone: 'US/Eastern',
+    timeZoneName: 'short',
   };
+
   const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
   const now = new Date();
   const start = formatter.format(now.setHours(now.getHours() - 12));
@@ -156,9 +162,14 @@ const Advance24HourTemplate = ({
   'window-session': windowSession,
 }) => {
   const timeFormattingOptions = {
-    timeStyle: 'long',
-    dateStyle: 'full',
+    hour: 'numeric',
+    minute: 'numeric',
+    weekday: 'long',
+    month: 'long',
+    year: 'numeric',
+    day: 'numeric',
     timeZone: 'US/Eastern',
+    timeZoneName: 'short',
   };
   const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
   const now = new Date();

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -107,7 +107,7 @@ const During24HourTemplate = ({
   );
 };
 
-const BeforeTemplate = ({
+const AdvanceTemplate = ({
   'disable-analytics': disableAnalytics,
   'show-close': showClose,
   headline,
@@ -142,6 +142,47 @@ const BeforeTemplate = ({
       </p>
       <p>
         <strong>Start/End time:</strong> {start} to {end}
+      </p>
+    </va-banner>
+  );
+};
+
+const Advance24HourTemplate = ({
+  'disable-analytics': disableAnalytics,
+  'show-close': showClose,
+  headline,
+  type,
+  visible,
+  'window-session': windowSession,
+}) => {
+  const timeFormattingOptions = {
+    timeStyle: 'long',
+    dateStyle: 'full',
+    timeZone: 'US/Eastern',
+  };
+  const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
+  const now = new Date();
+  const start = formatter.format(now.setHours(now.getHours() + 12));
+  const end = formatter.format(now.setHours(now.getHours() + 24));
+
+  return (
+    <va-banner
+      disable-analytics={disableAnalytics}
+      show-close={showClose}
+      headline={headline}
+      type={type}
+      visible={visible}
+      window-session={windowSession}
+    >
+      <p>
+        We’ll be doing some work on VA.gov. The maintenance will last 24 hours.
+        During that time, you won’t be able to sign in or use tools.
+      </p>
+      <p>
+        <strong>Start:</strong> {start}
+      </p>
+      <p>
+        <strong>End:</strong> {end}
       </p>
     </va-banner>
   );
@@ -182,11 +223,16 @@ const defaultArgs = {
   'show-close': true,
 };
 
-export const Default = BeforeTemplate.bind(null);
+export const Default = AdvanceTemplate.bind(null);
 Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(bannerDocs);
+
+export const Advance24Hours = Advance24HourTemplate.bind(null);
+Advance24Hours.args = {
+  ...defaultArgs,
+};
 
 export const During = DuringTemplate.bind(null);
 During.args = {

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -173,12 +173,13 @@ const SiteAccessibleTemplate = ({
   );
 };
 const defaultArgs = {
-  'headline': 'Site maintenance',
+  'headline': 'Upcoming site maintenance',
   'show-close': false,
   'disable-analytics': false,
   'type': 'warning',
   'visible': true,
   'window-session': false,
+  'show-close': true,
 };
 
 export const Default = BeforeTemplate.bind(null);
@@ -190,24 +191,14 @@ Default.argTypes = propStructure(bannerDocs);
 export const During = DuringTemplate.bind(null);
 During.args = {
   ...defaultArgs,
+  headline: 'Site maintenance',
   type: 'error',
 };
 export const During24Hours = During24HourTemplate.bind(null);
 During24Hours.args = {
   ...defaultArgs,
+  headline: 'Site maintenance',
   type: 'error',
-};
-
-export const Warning = BeforeTemplate.bind(null);
-Warning.args = {
-  ...defaultArgs,
-  headline: 'Upcoming site maintenance',
-};
-
-export const Closeable = DuringTemplate.bind(null);
-Closeable.args = {
-  ...defaultArgs,
-  'show-close': true,
 };
 
 export const SiteStillAccessible = SiteAccessibleTemplate.bind(null);

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -35,7 +35,9 @@ const DuringTemplate = ({
   };
   const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
   const now = new Date();
-  const date = new Intl.DateTimeFormat('en-US').format(now);
+  const date = new Intl.DateTimeFormat('en-US', { dateStyle: 'full' }).format(
+    now,
+  );
   const start = formatter.format(now.setHours(now.getHours() - 1));
   const end = formatter.format(now.setHours(now.getHours() + 2));
 
@@ -132,7 +134,7 @@ const BeforeTemplate = ({
       window-session={windowSession}
     >
       <p>
-        We’ll be doing some work on VA.gov. The maintenance will last X hours.
+        We’ll be doing some work on VA.gov. The maintenance will last 2 hours.
         During that time, you won’t be able to sign in or use tools.
       </p>
       <p>
@@ -174,30 +176,35 @@ const defaultArgs = {
   'headline': 'Site maintenance',
   'show-close': false,
   'disable-analytics': false,
-  'type': 'error',
+  'type': 'warning',
   'visible': true,
   'window-session': false,
 };
 
-export const Default = DuringTemplate.bind(null);
+export const Default = BeforeTemplate.bind(null);
 Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(bannerDocs);
 
+export const During = DuringTemplate.bind(null);
+During.args = {
+  ...defaultArgs,
+  type: 'error',
+};
 export const During24Hours = During24HourTemplate.bind(null);
 During24Hours.args = {
   ...defaultArgs,
+  type: 'error',
 };
 
 export const Warning = BeforeTemplate.bind(null);
 Warning.args = {
   ...defaultArgs,
-  type: 'warning',
   headline: 'Upcoming site maintenance',
 };
 
-export const Closeable = BeforeTemplate.bind(null);
+export const Closeable = DuringTemplate.bind(null);
 Closeable.args = {
   ...defaultArgs,
   'show-close': true,
@@ -206,6 +213,5 @@ Closeable.args = {
 export const SiteStillAccessible = SiteAccessibleTemplate.bind(null);
 SiteStillAccessible.args = {
   ...defaultArgs,
-  type: 'warning',
   headline: 'We’re working on the site',
 };

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -63,6 +63,48 @@ const DuringTemplate = ({
   );
 };
 
+const During24HourTemplate = ({
+  'disable-analytics': disableAnalytics,
+  'show-close': showClose,
+  headline,
+  type,
+  visible,
+  'window-session': windowSession,
+}) => {
+  const timeFormattingOptions = {
+    timeStyle: 'long',
+    dateStyle: 'full',
+    timeZone: 'US/Eastern',
+  };
+  const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
+  const now = new Date();
+  const start = formatter.format(now.setHours(now.getHours() - 12));
+  const end = formatter.format(now.setHours(now.getHours() + 12));
+
+  return (
+    <va-banner
+      disable-analytics={disableAnalytics}
+      show-close={showClose}
+      headline={headline}
+      type={type}
+      visible={visible}
+      window-session={windowSession}
+    >
+      <p>
+        We’re working on VA.gov right now. If you have trouble signing in or
+        using tools, check back after we’re finished. Thank you for your
+        patience.
+      </p>
+      <p>
+        <strong>Start:</strong> {start}
+      </p>
+      <p>
+        <strong>End:</strong> {end}
+      </p>
+    </va-banner>
+  );
+};
+
 const BeforeTemplate = ({
   'disable-analytics': disableAnalytics,
   'show-close': showClose,
@@ -142,6 +184,11 @@ Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(bannerDocs);
+
+export const During24Hours = During24HourTemplate.bind(null);
+During24Hours.args = {
+  ...defaultArgs,
+};
 
 export const Warning = BeforeTemplate.bind(null);
 Warning.args = {

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -21,191 +21,7 @@ export default {
   },
 };
 
-const DuringTemplate = ({
-  'disable-analytics': disableAnalytics,
-  'show-close': showClose,
-  headline,
-  type,
-  visible,
-  'window-session': windowSession,
-}) => {
-  const timeFormattingOptions = {
-    hour: 'numeric',
-    minute: 'numeric',
-    timeZoneName: 'short',
-    timeZone: 'US/Eastern',
-  };
-  const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
-  const now = new Date();
-  const date = new Intl.DateTimeFormat('en-US', { dateStyle: 'full' }).format(
-    now,
-  );
-  const start = formatter.format(now.setHours(now.getHours() - 1));
-  const end = formatter.format(now.setHours(now.getHours() + 2));
-
-  return (
-    <va-banner
-      disable-analytics={disableAnalytics}
-      show-close={showClose}
-      headline={headline}
-      type={type}
-      visible={visible}
-      window-session={windowSession}
-    >
-      <p>
-        We’re working on VA.gov right now. If you have trouble signing in or
-        using tools, check back after we’re finished. Thank you for your
-        patience.
-      </p>
-      <p>
-        <strong>Date:</strong> {date}
-      </p>
-      <p>
-        <strong>Start/End time:</strong> {start} to {end}
-      </p>
-    </va-banner>
-  );
-};
-
-const During24HourTemplate = ({
-  'disable-analytics': disableAnalytics,
-  'show-close': showClose,
-  headline,
-  type,
-  visible,
-  'window-session': windowSession,
-}) => {
-  const timeFormattingOptions = {
-    hour: 'numeric',
-    minute: 'numeric',
-    weekday: 'long',
-    month: 'long',
-    year: 'numeric',
-    day: 'numeric',
-    timeZone: 'US/Eastern',
-    timeZoneName: 'short',
-  };
-
-  const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
-  const now = new Date();
-  const start = formatter.format(now.setHours(now.getHours() - 12));
-  const end = formatter.format(now.setHours(now.getHours() + 12));
-
-  return (
-    <va-banner
-      disable-analytics={disableAnalytics}
-      show-close={showClose}
-      headline={headline}
-      type={type}
-      visible={visible}
-      window-session={windowSession}
-    >
-      <p>
-        We’re working on VA.gov right now. If you have trouble signing in or
-        using tools, check back after we’re finished. Thank you for your
-        patience.
-      </p>
-      <p>
-        <strong>Start:</strong> {start}
-      </p>
-      <p>
-        <strong>End:</strong> {end}
-      </p>
-    </va-banner>
-  );
-};
-
-const AdvanceTemplate = ({
-  'disable-analytics': disableAnalytics,
-  'show-close': showClose,
-  headline,
-  type,
-  visible,
-  'window-session': windowSession,
-}) => {
-  const timeFormattingOptions = {
-    hour: 'numeric',
-    minute: 'numeric',
-    timeZone: 'US/Eastern',
-    timeZoneName: 'short',
-  };
-  const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
-  const now = new Date();
-  const date = new Intl.DateTimeFormat('en-US', { dateStyle: 'full' }).format(
-    now,
-  );
-  const start = formatter.format(now.setHours(now.getHours() + 1));
-  const end = formatter.format(now.setHours(now.getHours() + 2));
-  return (
-    <va-banner
-      disable-analytics={disableAnalytics}
-      show-close={showClose}
-      headline={headline}
-      type={type}
-      visible={visible}
-      window-session={windowSession}
-    >
-      <p>
-        We’ll be doing some work on VA.gov. The maintenance will last 2 hours.
-        During that time, you won’t be able to sign in or use tools.
-      </p>
-      <p>
-        <strong>Date:</strong> {date}
-      </p>
-      <p>
-        <strong>Start/End time:</strong> {start} to {end}
-      </p>
-    </va-banner>
-  );
-};
-
-const Advance24HourTemplate = ({
-  'disable-analytics': disableAnalytics,
-  'show-close': showClose,
-  headline,
-  type,
-  visible,
-  'window-session': windowSession,
-}) => {
-  const timeFormattingOptions = {
-    hour: 'numeric',
-    minute: 'numeric',
-    weekday: 'long',
-    month: 'long',
-    year: 'numeric',
-    day: 'numeric',
-    timeZone: 'US/Eastern',
-    timeZoneName: 'short',
-  };
-  const formatter = new Intl.DateTimeFormat('en-US', timeFormattingOptions);
-  const now = new Date();
-  const start = formatter.format(now.setHours(now.getHours() + 12));
-  const end = formatter.format(now.setHours(now.getHours() + 24));
-
-  return (
-    <va-banner
-      disable-analytics={disableAnalytics}
-      show-close={showClose}
-      headline={headline}
-      type={type}
-      visible={visible}
-      window-session={windowSession}
-    >
-      <p>
-        We’ll be doing some work on VA.gov. The maintenance will last 24 hours.
-        During that time, you won’t be able to sign in or use tools.
-      </p>
-      <p>
-        <strong>Start:</strong> {start}
-      </p>
-      <p>
-        <strong>End:</strong> {end}
-      </p>
-    </va-banner>
-  );
-};
-
-const SiteAccessibleTemplate = ({
+const Template = ({
   'disable-analytics': disableAnalytics,
   'show-close': showClose,
   headline,
@@ -223,49 +39,26 @@ const SiteAccessibleTemplate = ({
       window-session={windowSession}
     >
       <p>
-        We’re working on VA.gov right now. You should still be able to use the
-        applications and tools. But if you have any trouble, please check back
-        soon.
+        We have temporarily closed our Acute Psychiatry at our Lyons Campus. All
+        mental health admissions are being routed to our sister VA facilities in
+        New York, Bronx and Manhattan or to the community as appropriate.
       </p>
+      <a href="#">Get updates on affected services and facilities</a>
     </va-banner>
   );
 };
+
 const defaultArgs = {
-  'headline': 'Upcoming site maintenance',
+  'headline': 'Temporary closure of acute psychiatry at Lyons',
   'show-close': false,
   'disable-analytics': false,
-  'type': 'warning',
+  'type': 'info',
   'visible': true,
   'window-session': false,
   'show-close': true,
 };
-
-export const Default = AdvanceTemplate.bind(null);
+export const Default = Template.bind(null);
 Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(bannerDocs);
-
-export const Advance24Hours = Advance24HourTemplate.bind(null);
-Advance24Hours.args = {
-  ...defaultArgs,
-};
-
-export const During = DuringTemplate.bind(null);
-During.args = {
-  ...defaultArgs,
-  headline: 'Site maintenance',
-  type: 'error',
-};
-export const During24Hours = During24HourTemplate.bind(null);
-During24Hours.args = {
-  ...defaultArgs,
-  headline: 'Site maintenance',
-  type: 'error',
-};
-
-export const SiteStillAccessible = SiteAccessibleTemplate.bind(null);
-SiteStillAccessible.args = {
-  ...defaultArgs,
-  headline: 'We’re working on the site',
-};

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -55,10 +55,16 @@ const defaultArgs = {
   'type': 'info',
   'visible': true,
   'window-session': false,
-  'show-close': true,
 };
+
 export const Default = Template.bind(null);
 Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(bannerDocs);
+
+export const Dismissible = Template.bind(null);
+Dismissible.args = {
+  ...defaultArgs,
+  'show-close': true,
+};


### PR DESCRIPTION
## Chromatic
<!-- This `alert-banner-cleanup` is a placeholder for a CI job - it will be updated automatically -->
https://alert-banner-cleanup--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1089

This doesn't remove the `fullWidth` prop from the args table - only the "Full width" story.

## Testing done

Local storybook :eyes: 

## Screenshots

![The banner's storybook page. The default story shown has a headline of "Temporary closure of acute psychiatry at Lyons" and it is an "info" banner. The child content provides more detail on the closure and a link which would allow the user to receive more updates.](https://user-images.githubusercontent.com/2008881/187506636-1900de5a-7cb8-471b-9ffb-c531bf7671b9.png)

## Acceptance criteria
- [x] Full-width alert is no longer shown in Storybook or design.va.gov
- [ ] The Banner examples use language from the Content messages directory and the examples show all major variations
