### PR TITLE
Fix visual defect in Safari for the va-alert component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.5.1",
+  "version": "11.5.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -85,7 +85,7 @@ div.body {
 }
 
 .bg-only ::slotted(*) {
-  margin-top: 0;
+  margin-top: 0!important; /* Fix for Safari 15.3 and lower. */
 }
 
 div.info > i::before {


### PR DESCRIPTION
## Chromatic
<!-- This `1080-alert-safari-positioning` is a placeholder for a CI job - it will be updated automatically -->
https://1080-alert-safari-positioning--60f9b557105290003b387cd5.chromatic.com

## Description

The [issue reported ](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1080) describes a visual defect on the alert web component in Safari.

I could only reproduce this defect in Safari version 15.3 and earlier via Browserstack. I was unable to reproduce it in the latest version of Safari 15.6.1.

### The problem
It appears that Safari 15.3  and earlier is calculating selector specificity differently between these two selectors where the selector prepended with the `.bg-only` class _should_ be the higher of the two but that doesn't seem to be the case for those Safari versions:

```
::slotted(:not([slot])) {
  margin-top: 2rem;
}

.bg-only ::slotted(*) {
  margin-top: 0;
}
```

Closes [1080](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1080)

## Testing done
- MacOS Monterey - Safari 15.6.1
- Browserstack - Mac Monterey - Safari 15.3
- Browserstack - Mac Big Sur - Safari 14.1
- Browserstack - Mac Catalina - Safari 13.1

## Screenshots

Browserstack - Safari 15.3 

<img width="1339" alt="Screen Shot 2022-08-26 at 2 10 52 PM" src="https://user-images.githubusercontent.com/872479/186976568-d42b0565-6581-4d3d-8fc2-c99648268320.png">

<img width="1288" alt="Screen Shot 2022-08-26 at 2 18 55 PM" src="https://user-images.githubusercontent.com/872479/186976581-d3823461-3c03-4b1b-949d-15abdbf977ed.png">


## Acceptance criteria
- [ ] The alert component has a consistent style across browsers.

## Definition of done
- [ ] The Safari visual defect for the alert web component has been fixed.
