### PR TITLE
Translate "On this page" component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.6.0-0",
+  "version": "11.6.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"
@@ -33,6 +33,5 @@
     "@department-of-veterans-affairs/formation": "*",
     "react": "^17",
     "react-dom": "*"
-  },
-  "stableVersion": "11.5.5"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "11.5.5",
+  "version": "11.6.0-0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"
@@ -33,5 +33,6 @@
     "@department-of-veterans-affairs/formation": "*",
     "react": "^17",
     "react-dom": "*"
-  }
+  },
+  "stableVersion": "11.5.5"
 }

--- a/packages/core/src/i18n/i18n-setup.js
+++ b/packages/core/src/i18n/i18n-setup.js
@@ -4,6 +4,7 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import mainTag from './language-detector';
 import enTranslation from './translations/en';
 import esTranslation from './translations/es';
+import tlTranslation from './translations/tl';
 
 const languageDetector = new LanguageDetector();
 languageDetector.addDetector(mainTag);
@@ -15,6 +16,7 @@ i18next.use(languageDetector).init({
   resources: {
     en: { translation: enTranslation },
     es: { translation: esTranslation },
+    tl: { translation: tlTranslation },
   },
 });
 

--- a/packages/core/src/i18n/translations/en.js
+++ b/packages/core/src/i18n/translations/en.js
@@ -23,4 +23,5 @@ export default {
   'october': 'October',
   'november': 'November',
   'december': 'December',
+  'on-this-page': 'On this page',
 };

--- a/packages/core/src/i18n/translations/es.js
+++ b/packages/core/src/i18n/translations/es.js
@@ -23,4 +23,5 @@ export default {
   'october': 'Octubre',
   'november': 'Noviembre',
   'december': 'Diciembre',
+  'on-this-page': 'En esta página',
 };

--- a/packages/core/src/i18n/translations/tl.js
+++ b/packages/core/src/i18n/translations/tl.js
@@ -1,0 +1,3 @@
+export default {
+  'on-this-page': 'Sa pahinang ito',
+};

--- a/packages/storybook/stories/va-on-this-page.stories.jsx
+++ b/packages/storybook/stories/va-on-this-page.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { getWebComponentDocs, StoryDocs } from './wc-helpers';
 
 const otpDocs = getWebComponentDocs('va-on-this-page');
@@ -14,43 +14,65 @@ export default {
   },
 };
 
+const articleJSX = (
+  <article>
+    <va-on-this-page></va-on-this-page>
+    <h2 id="if-im-a-veteran">
+      If I’m a Veteran, can I get VR&amp;E benefits and services?
+    </h2>
+    <p>
+      You may be eligible for VR&amp;E benefits and services if you’re a
+      Veteran, and you meet all of the requirements listed below.
+    </p>
+    <p>
+      <strong>All of these must be true. You:</strong>
+    </p>
+    <ul>
+      <li>
+        Didn’t receive a dishonorable discharge, <strong>and</strong>
+      </li>
+      <li>
+        Have a service-connected disability rating of at least 10% from VA,
+        <strong>and</strong>
+      </li>
+      <li>
+        <a href="#">Apply for VR&amp;E services</a>
+      </li>
+    </ul>
+    <h2 id="telephone-contacts">Telephone Contacts</h2>
+    <p>Here is a table of phone numbers</p>
+    <h2 id="some-additional-info">Some additional information</h2>
+    <p>Placeholder for additional content.</p>
+    <ol>
+      <li>Alpha</li>
+      <li>Beta</li>
+      <li>Gamma</li>
+    </ol>
+  </article>
+);
+
 const Template = () => {
+  return articleJSX;
+};
+
+const I18nTemplate = args => {
+  const { headline, level, ...rest } = args;
+  const [lang, setLang] = useState('en');
+
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, [lang]);
+
   return (
-    <article>
-      <va-on-this-page></va-on-this-page>
-      <h2 id="if-im-a-veteran">
-        If I’m a Veteran, can I get VR&amp;E benefits and services?
-      </h2>
-      <p>
-        You may be eligible for VR&amp;E benefits and services if you’re a
-        Veteran, and you meet all of the requirements listed below.
-      </p>
-      <p>
-        <strong>All of these must be true. You:</strong>
-      </p>
-      <ul>
-        <li>
-          Didn’t receive a dishonorable discharge, <strong>and</strong>
-        </li>
-        <li>
-          Have a service-connected disability rating of at least 10% from VA,
-          <strong>and</strong>
-        </li>
-        <li>
-          <a href="#">Apply for VR&amp;E services</a>
-        </li>
-      </ul>
-      <h2 id="telephone-contacts">Telephone Contacts</h2>
-      <p>Here is a table of phone numbers</p>
-      <h2 id="some-additional-info">Some additional information</h2>
-      <p>Placeholder for additional content.</p>
-      <ol>
-        <li>Alpha</li>
-        <li>Beta</li>
-        <li>Gamma</li>
-      </ol>
-    </article>
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+
+      {articleJSX}
+    </div>
   );
 };
 
 export const Default = Template.bind(null);
+
+export const Internationalization = I18nTemplate.bind(null);

--- a/packages/storybook/stories/va-on-this-page.stories.jsx
+++ b/packages/storybook/stories/va-on-this-page.stories.jsx
@@ -67,6 +67,7 @@ const I18nTemplate = args => {
     <div>
       <button onClick={e => setLang('es')}>Español</button>
       <button onClick={e => setLang('en')}>English</button>
+      <button onClick={e => setLang('tl')}>Tagalog</button>
 
       {articleJSX}
     </div>

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.12.5",
+  "version": "4.13.0-0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -61,5 +61,6 @@
     "@department-of-veterans-affairs/formation": "^7.0.1",
     "i18next": "*",
     "i18next-browser-languagedetector": "*"
-  }
+  },
+  "stableVersion": "4.12.5"
 }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.13.0-0",
+  "version": "4.13.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -61,6 +61,5 @@
     "@department-of-veterans-affairs/formation": "^7.0.1",
     "i18next": "*",
     "i18next-browser-languagedetector": "*"
-  },
-  "stableVersion": "4.12.5"
+  }
 }

--- a/packages/web-components/src/components/va-on-this-page/test/va-on-this-page.e2e.ts
+++ b/packages/web-components/src/components/va-on-this-page/test/va-on-this-page.e2e.ts
@@ -13,7 +13,7 @@ describe('va-on-this-page', () => {
         <mock:shadow-root>
           <nav aria-labelledby="on-this-page">
             <dl>
-              <dt id="on-this-page">On this page</dt>
+              <dt id="on-this-page">on-this-page</dt>
               <dd role="definition"></dd>
             </dl>
           </nav>
@@ -60,7 +60,7 @@ describe('va-on-this-page', () => {
         <mock:shadow-root>
           <nav aria-labelledby="on-this-page">
             <dl>
-              <dt id="on-this-page">On this page</dt>
+              <dt id="on-this-page">on-this-page</dt>
               <dd role="definition">
                 <a href="#an-id">
                   <i aria-hidden="true" class="fa-arrow-down fas"></i>
@@ -99,7 +99,7 @@ describe('va-on-this-page', () => {
     <mock:shadow-root>
       <nav aria-labelledby="on-this-page">
         <dl>
-          <dt id="on-this-page">On this page</dt>
+          <dt id="on-this-page">on-this-page</dt>
           <dd role="definition">
             <a href="#foo">
               <i aria-hidden="true" class="fa-arrow-down fas"></i>
@@ -136,7 +136,7 @@ describe('va-on-this-page', () => {
         <mock:shadow-root>
           <nav aria-labelledby="on-this-page">
             <dl>
-              <dt id="on-this-page">On this page</dt>
+              <dt id="on-this-page">on-this-page</dt>
               <dd role="definition">
                 <a href="#an-id">
                   <i aria-hidden="true" class="fa-arrow-down fas"></i>

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
@@ -1,5 +1,20 @@
-import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  forceUpdate,
+  h,
+  Prop
+} from '@stencil/core';
+import i18next from 'i18next';
+import { Build } from '@stencil/core';
 import { consoleDevError } from '../../utils/utils';
+
+if (Build.isTesting) {
+  // Make i18next.t() return the key instead of the value
+  i18next.init({ lng: 'cimode' });
+}
 
 /**
  * This component will render links based on the content around it. It scans the document for any `<h2>`
@@ -17,6 +32,8 @@ import { consoleDevError } from '../../utils/utils';
   shadow: true,
 })
 export class VaOnThisPage {
+  @Element() el: HTMLElement;
+
   /**
    * The event used to track usage of the component. This is emitted when the
    * user clicks on a link and enableAnalytics is true.
@@ -46,6 +63,16 @@ export class VaOnThisPage {
     });
   };
 
+  connectedCallback() {
+    i18next.on('languageChanged', () => {
+      forceUpdate(this.el);
+    });
+  }
+
+  disconnectedCallback() {
+    i18next.off('languageChanged');
+  }
+
   render() {
     const { handleOnClick } = this;
 
@@ -61,7 +88,7 @@ export class VaOnThisPage {
     return (
       <nav aria-labelledby="on-this-page">
         <dl>
-          <dt id="on-this-page">On this page</dt>
+          <dt id="on-this-page">{i18next.t('on-this-page')}</dt>
           <dd role="definition">
             {h2s.map(heading => (
               <a href={`#${heading.id}`} onClick={handleOnClick}>


### PR DESCRIPTION
## Chromatic
<!-- This `on-this-page-translation` is a placeholder for a CI job - it will be updated automatically -->
https://on-this-page-translation--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1100

This PR adds translation functionality to the "On this page" component. It is the first component to offer Tagalog translation, and this doesn't have any impact on other components which don't have translations for the new language. The specific translation values used are from [this comment](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1100#issuecomment-1220903449).

## Testing done

- Storybook :eyes: 
- E2E updates
- Prerelease testing in `vets-website` and `content-build`


## Screenshots

### Storybook

![Storybook story with Spanish selected showing "En esta página"](https://user-images.githubusercontent.com/2008881/187774088-a0c05b36-4279-49a8-ae54-8874f44c83a3.png)

![Storybook story with English selected showing "On this page"](https://user-images.githubusercontent.com/2008881/187774118-95934842-3916-425a-a15c-f6db5106784f.png)

![Storybook story with Tagalog selected showing "Sa pahinang ito"](https://user-images.githubusercontent.com/2008881/187774302-eab6fde7-e013-451d-be08-0ed88c8cda06.png)


### Static translation

I modified the built HTML pages to so that the `<main>` tag had an appropriate `lang` attribute for each of the pages in this recording.

[The view is of the Covid-19 English page. The "On this page" text is visible, and an accordion on the page has an "Expand all" button. A link is click which navigates to the Spanish Covid-19 page. We see "En esta página", and an accordion has an "Expandir todo" button. The final link is clicked which opens the Tagalog Covid-19 page. We see "Sa pahinang ito" in place of "On this page", but the accordion button reads "Expand all" since we don't have a Tagalog translation for that text.](https://user-images.githubusercontent.com/2008881/187768794-d3a54b79-f706-4cbe-b699-15327a3ab1a6.webm)

### Dynamic translation

The component supporting dynamically translated pages in `vets-website`:

<details>

<summary>Diff</summary>

```diff
diff --git a/package.json b/package.json
index 379b0863e0..3ce36b0f2a 100644
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@department-of-veterans-affairs/component-library": "^11.4.0",
+    "@department-of-veterans-affairs/component-library": "11.6.0-0",
     "@department-of-veterans-affairs/formation": "^7.0.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.4.3",
diff --git a/src/applications/check-in/components/layout/Wrapper.jsx b/src/applications/check-in/components/layout/Wrapper.jsx
index 6c5ad74d7a..f0e0a3f983 100644
--- a/src/applications/check-in/components/layout/Wrapper.jsx
+++ b/src/applications/check-in/components/layout/Wrapper.jsx
@@ -23,7 +23,7 @@ const Wrapper = props => {
     : ' vads-u-padding-y--3';
 
   return (
-    <>
+    <article>
       <div
         className={`vads-l-grid-container ${classNames} ${topPadding}`}
         data-testid={testID}
@@ -35,7 +35,7 @@ const Wrapper = props => {
         </h1>
         {children}
       </div>
-    </>
+    </article>
   );
 };
 
diff --git a/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx b/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
index 50e9c5a304..43d1dcc48f 100644
--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.jsx
@@ -93,6 +93,7 @@ export default function ValidateDisplay({
   };
   return (
     <Wrapper pageTitle={header || t('check-in-at-va')}>
+      <va-on-this-page />
       <p>
         {subtitle ||
           t(
@@ -186,6 +187,9 @@ export default function ValidateDisplay({
       </form>
 
       {Footer && <Footer />}
+
+      <h2 id="foo">Foo</h2>
+      <h2 id="bar">Bar</h2>
     </Wrapper>
   );
 }
```
</details>

[Screencast 2022-08-31 10:51:51.webm](https://user-images.githubusercontent.com/2008881/187746162-cc60774b-eef7-41e4-bba0-8bb8b079b464.webm)


## Acceptance criteria
- [x] "On this page" component has translation functionality