### PR TITLE
Fix va-checkbox label alignment.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.13.2",
+  "version": "4.13.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.css
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.css
@@ -35,9 +35,11 @@ label {
 
 input+label {
   cursor: pointer;
+  display: inline-flex;
   font-weight: 400;
   margin-left: 2.4rem;
   margin-top: 1.2rem;
+  width: 100%;
 }
 
 /* The actual box */
@@ -51,7 +53,8 @@ input+label::before {
   box-shadow: 0 0 0 1px var(--color-gray-medium);
   content: "\A0";
   height: var(--visible-checkbox-size);
-  width: var(--visible-checkbox-size);
+  max-width: var(--visible-checkbox-size);
+  width: 100%;
 }
 
 input:checked+label::before {

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -136,8 +136,8 @@ export class VaCheckbox {
           onChange={this.handleChange}
         />
         <label htmlFor="checkbox-element">
-          {label}
-          {required && <span class="required">(*Required)</span>}
+          <span>{label}
+          {required && <span class="required">(*Required)</span>}</span>
         </label>
       </Host>
     );

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -136,8 +136,9 @@ export class VaCheckbox {
           onChange={this.handleChange}
         />
         <label htmlFor="checkbox-element">
-          <span>{label}
-          {required && <span class="required">(*Required)</span>}</span>
+          <span>
+            {label} {required && <span class="required">(*Required)</span>}
+          </span>
         </label>
       </Host>
     );


### PR DESCRIPTION
## Chromatic
<!-- This `fix-va-checkbox-label-alignment` is a placeholder for a CI job - it will be updated automatically -->
https://fix-va-checkbox-label-alignment--60f9b557105290003b387cd5.chromatic.com

## Description

As part of the Privacy Agreement web component work, it was discovered that the `va-checkbox` label was not aligning the same as the Sketch designs as described here: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/991#issuecomment-1240758320

Related: https://github.com/department-of-veterans-affairs/component-library/pull/524#discussion_r969881058

Sketch Reference: 
https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/symbols?g=Privacy%2520agreement

## Testing done
Storybook

## Screenshots

**Old Alignment**

![Screen Shot 2022-09-13 at 2 59 17 PM](https://user-images.githubusercontent.com/872479/189999728-390156de-f5b5-4f84-a5a1-8d4a8d383851.png)

**New Alignment**
![Screen Shot 2022-09-13 at 2 58 30 PM](https://user-images.githubusercontent.com/872479/189999725-e6ac93c8-ca37-4cf8-90bd-1bd465d6dff3.png)

![Screen Shot 2022-09-13 at 3 07 57 PM](https://user-images.githubusercontent.com/872479/189999731-8b160caa-8f96-41ae-8be8-cf9bd56c59e4.png)

![Screen Shot 2022-09-13 at 3 18 00 PM](https://user-images.githubusercontent.com/872479/190001060-47b86558-7559-43c3-b3c9-71162214d5a7.png)

## Acceptance criteria
- [ ] The label aligns to the right of the checkbox and does not wrap below it.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
