### PR TITLE
add id to featured content story

### DIFF
--- a/packages/storybook/stories/va-featured-content.stories.jsx
+++ b/packages/storybook/stories/va-featured-content.stories.jsx
@@ -6,6 +6,7 @@ const featuredContentDocs = getWebComponentDocs('va-featured-content');
 
 export default {
   title: 'Components/Featured content',
+  id: 'components/va-featured-content',
   parameters: {
     componentSubtitle: `va-featured-content web component`,
     docs: {


### PR DESCRIPTION
## Chromatic
<!-- This `featured-content-id` is a placeholder for a CI job - it will be updated automatically -->
https://featured-content-id--60f9b557105290003b387cd5.chromatic.com

## Description
A quick fix to repair the link to the featured content story in storybook.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
