### PR TITLE
Align web component labels, descriptions, and error message font weights.

### DIFF
--- a/packages/web-components/src/components/va-checkbox/va-checkbox.css
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.css
@@ -16,10 +16,6 @@
   margin-bottom: 1.2rem;
 }
 
-:host([error]:not([error=""])) label > span {
-  font-weight: normal;
-}
-
 input {
   /* Make the clickable element the same size and position as the box */
   height: var(--visible-checkbox-size);

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.css
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.css
@@ -16,6 +16,10 @@
     margin-bottom: 1.2rem;
 }
 
+:host([error]:not([error=""])) label > span {
+  font-weight: normal;
+}
+
 input {
   /* Make the clickable element the same size and position as the box */
   height: var(--visible-checkbox-size);

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.css
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.css
@@ -13,7 +13,16 @@
 }
 
 #error-message {
-    margin-bottom: 1.2rem;
+    margin-bottom: 0;
+    font-weight: 700;
+}
+
+:host([error]:not([error=""])) input + label {
+  margin-top: 1.2rem;
+}
+
+:host([error]:not([error=""])) label > span {
+  font-weight: normal;
 }
 
 :host([error]:not([error=""])) label > span {

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.css
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.css
@@ -13,8 +13,7 @@
 }
 
 #error-message {
-    margin-bottom: 0;
-    font-weight: 700;
+  margin-bottom: 0;
 }
 
 :host([error]:not([error=""])) input + label {

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.css
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.css
@@ -25,10 +25,6 @@
   font-weight: normal;
 }
 
-:host([error]:not([error=""])) label > span {
-  font-weight: normal;
-}
-
 input {
   /* Make the clickable element the same size and position as the box */
   height: var(--visible-checkbox-size);

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.css
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.css
@@ -13,11 +13,7 @@
 }
 
 #error-message {
-  margin-bottom: 0;
-}
-
-:host([error]:not([error=""])) input + label {
-  margin-top: 1.2rem;
+  margin-bottom: 1.2rem;
 }
 
 :host([error]:not([error=""])) label > span {

--- a/packages/web-components/src/components/va-date/va-date.css
+++ b/packages/web-components/src/components/va-date/va-date.css
@@ -24,10 +24,6 @@ span.required {
   color: var(--color-secondary-dark);
 }
 
-:host([error]:not([error=''])) legend {
-  font-weight: 700;
-}
-
 :host([error]:not([error=''])) va-select::part(select),
 :host([error]:not([error=''])) va-text-input::part(input) {
   border: 4px solid var(--color-secondary-dark);

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
@@ -25,6 +25,7 @@
 #dateHint {
   padding: 0.8rem 0 0;
   color: var(--color-gray);
+  font-weight: 700;
   line-height: 1.5;
 }
 

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
@@ -25,7 +25,6 @@
 #dateHint {
   padding: 0.8rem 0 0;
   color: var(--color-gray);
-  font-weight: 700;
   line-height: 1.5;
 }
 

--- a/packages/web-components/src/mixins/form-field-error.css
+++ b/packages/web-components/src/mixins/form-field-error.css
@@ -1,6 +1,7 @@
 #error-message {
     color: var(--color-secondary-dark);
     display: block;
+    font-weight: 700;
     margin-bottom: 1.2rem;
 }
 
@@ -18,11 +19,6 @@
 
 :host([error]:not([error=''])) label {
     margin-top: 0;
-}
-
-:host([error]:not([error=''])) label,
-:host([error]:not([error=''])) span {
-    font-weight: 700;
 }
 
 :host([error]:not([error=''])) input, 


### PR DESCRIPTION
## Chromatic
<!-- This `va-checkbox-error-bold` is a placeholder for a CI job - it will be updated automatically -->
https://va-checkbox-error-bold--60f9b557105290003b387cd5.chromatic.com

## Description
This update resolves the comment from the [Policy Agreement web component work](https://github.com/department-of-veterans-affairs/component-library/pull/524) as well as [this comment regarding aligning all of the components](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1115#issuecomment-1246993947).

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/991#issuecomment-1246993075
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1115#issuecomment-1246993947

> the team has discussed and decided that the error message will be in bold but not the checkbox label or the description. This means the single checkbox component should be updated so that the label is not in bold when an error has occurred.

> During standup on 9/14/22, the team decided that only the error message should be bold for all of these components. Neither the description nor the label should be bold in an error state.

**Components checked and/or updated**

```
va-textarea
va-text-input
va-number-input
va-select
va-date
va-radio
va-memorable-date
va-checkbox-group
va-checkbox
va-file-input
```

## Testing done
Storybook

## Screenshots

**va-textarea**
![Screen Shot 2022-09-16 at 8 34 20 AM](https://user-images.githubusercontent.com/872479/190651272-2249b01a-7e04-4a7e-b483-2373a0121912.png)

**va-text-input**
![Screen Shot 2022-09-16 at 8 35 01 AM](https://user-images.githubusercontent.com/872479/190651442-718d8c2d-13e7-4837-a57d-0283a573d00d.png)

**va-number-input**
![Screen Shot 2022-09-16 at 8 35 42 AM](https://user-images.githubusercontent.com/872479/190651579-e49319cc-781b-4173-b767-8c3388aec282.png)

**va-select**
![Screen Shot 2022-09-16 at 8 36 19 AM](https://user-images.githubusercontent.com/872479/190651693-12faaa4c-f095-4e82-96a7-2577b468ef84.png)

**va-date**
![Screen Shot 2022-09-16 at 8 36 54 AM](https://user-images.githubusercontent.com/872479/190651828-2eaf039e-db4d-4b8e-9288-a72b3cb23804.png)

**va-radio**
![Screen Shot 2022-09-16 at 8 37 39 AM](https://user-images.githubusercontent.com/872479/190651946-646c9a60-593e-44b3-a7a7-8d7ac3d1f8f9.png)

**va-memorable-date**
![Screen Shot 2022-09-16 at 11 24 21 AM](https://user-images.githubusercontent.com/872479/190685507-84a1f03d-ec6c-456a-aaa6-214d30c94546.png)

**va-checkbox-group**
![Screen Shot 2022-09-16 at 8 38 49 AM](https://user-images.githubusercontent.com/872479/190652163-2cecab99-b430-4164-8061-58f3ae9cae2b.png)

**va-checkbox**
![Screen Shot 2022-09-16 at 8 39 37 AM](https://user-images.githubusercontent.com/872479/190652348-26fdee45-5bea-4392-a7fb-c6c6a12c61a0.png)

**va-file-input**
![Screen Shot 2022-09-16 at 8 40 18 AM](https://user-images.githubusercontent.com/872479/190652485-a238c94b-7acd-482b-ac64-d3cab4f1335a.png)

## Acceptance criteria
- [ ] Form web component labels are not bold.
- [ ] Form web component descriptions are not bold.
- [ ] Form web component error messages are bold.
- [ ] Spacing remains the same.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
