### PR TITLE
Fix month validation

### DIFF
--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -145,4 +145,17 @@ describe('validate', () => {
     expect(memorableDateComponent.invalidMonth).toEqual(false);
     expect(memorableDateComponent.invalidDay).toEqual(false);
   });
+
+  it('overrides an invalid day message with an invalid month message', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = 2000;
+    const month = null;
+    const day = 500;
+
+    validate(memorableDateComponent, year, month, day);
+
+    expect(memorableDateComponent.error).toEqual('Please enter a month between 1 and 12');
+    expect(memorableDateComponent.invalidMonth).toEqual(true);
+    expect(memorableDateComponent.invalidDay).toEqual(true);
+  });
 });

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -1,9 +1,148 @@
-import { checkLeapYear } from './date-utils';
+import { Components } from '../components';
+import { checkLeapYear, validate } from './date-utils';
 
 describe('checkLeapYear', () => {
   it('determines an input year is a leap year', () => {
     expect(checkLeapYear(1996)).toBeTruthy();
     expect(checkLeapYear(1995)).toBeFalsy();
     expect(checkLeapYear(199)).toBeFalsy();
+  });
+});
+
+describe('validate', () => {
+  it('indicates when the year is below the accepted range', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = 1500;
+    const month = 1;
+    const day = 1;
+    const currentYear = new Date().getFullYear();
+
+    validate(memorableDateComponent, year, month, day);
+
+    expect(memorableDateComponent.error).toEqual(`Please enter a year between 1900 and ${currentYear + 100}`);
+    expect(memorableDateComponent.invalidYear).toEqual(true);
+  });
+
+  it('indicates when the year is above the accepted range', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = 3000;
+    const month = 1;
+    const day = 1;
+    const currentYear = new Date().getFullYear();
+
+    validate(memorableDateComponent, year, month, day);
+
+    expect(memorableDateComponent.error).toEqual(`Please enter a year between 1900 and ${currentYear + 100}`);
+    expect(memorableDateComponent.invalidYear).toEqual(true);
+  });
+
+  it('indicates when the month is above the accepted range', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = 2000;
+    const month = 15;
+    const day = 1;
+
+    validate(memorableDateComponent, year, month, day);
+
+    expect(memorableDateComponent.error).toEqual('Please enter a month between 1 and 12');
+    expect(memorableDateComponent.invalidMonth).toEqual(true);
+  });
+
+  it('indicates when the day is above the accepted range', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = 2000;
+    const month = 1;
+    const day = 35;
+
+    validate(memorableDateComponent, year, month, day);
+
+    expect(memorableDateComponent.error).toEqual('Please enter a day between 1 and 31');
+    expect(memorableDateComponent.invalidDay).toEqual(true);
+  });
+
+  it('indicates when the day is below the accepted range', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = 2000;
+    const month = 1;
+    const day = null;
+
+    validate(memorableDateComponent, year, month, day);
+
+    expect(memorableDateComponent.error).toEqual('Please enter a day between 1 and 31');
+    expect(memorableDateComponent.invalidDay).toEqual(true);
+  });
+
+  it('does not validate day for the monthYearOnly variant', () => {
+    const dateComponent = {} as Components.VaDate;
+    const year = 2000;
+    const month = 1;
+    const day = null;
+
+    validate(dateComponent, year, month, day, true);
+
+    expect(dateComponent.error).toEqual(null);
+  });
+
+  describe('required components', () => {
+    it('indicates when the year is missing', () => {
+      const memorableDateComponent = { required: true} as Components.VaMemorableDate;
+      const year = null;
+      const month = 1;
+      const day = 1;
+
+      validate(memorableDateComponent, year, month, day);
+
+      expect(memorableDateComponent.error).toEqual('Please enter a complete date');
+      expect(memorableDateComponent.invalidYear).toEqual(true);
+    });
+
+    it('indicates when the month is missing', () => {
+      const memorableDateComponent = { required: true} as Components.VaMemorableDate;
+      const year = 2000;
+      const month = null;
+      const day = 1;
+
+      validate(memorableDateComponent, year, month, day);
+
+      expect(memorableDateComponent.error).toEqual('Please enter a complete date');
+      expect(memorableDateComponent.invalidMonth).toEqual(true);
+    });
+
+    it('indicates when the day is missing', () => {
+      const memorableDateComponent = { required: true} as Components.VaMemorableDate;
+      const year = 2000;
+      const month = 1;
+      const day = null;
+
+      validate(memorableDateComponent, year, month, day);
+
+      expect(memorableDateComponent.error).toEqual('Please enter a complete date');
+      expect(memorableDateComponent.invalidDay).toEqual(true);
+    });
+
+    it('does not error on a missing day for the monthYearOnly variant', () => {
+      const memorableDateComponent = { required: true} as Components.VaMemorableDate;
+      const year = 2000;
+      const month = 1;
+      const day = null;
+
+      validate(memorableDateComponent, year, month, day, true);
+
+      expect(memorableDateComponent.error).toEqual(null);
+    });
+  });
+
+  it('removes error indicators when the values are valid', () => {
+    const memorableDateComponent = { error: 'Some error'} as Components.VaMemorableDate;
+    const year = 2000;
+    const month = 1;
+    const day = 1;
+
+    validate(memorableDateComponent, year, month, day);
+
+    expect(memorableDateComponent.error).toEqual(null);
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
   });
 });

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -158,7 +158,8 @@ export function validate(
   const leapYear = checkLeapYear(year);
   const daysForSelectedMonth = leapYear && month == 2 ? 29 : days[month]?.length || 0;
 
-  // Begin built-in validation
+  // Begin built-in validation.
+  // Empty fields are acceptable unless the component is marked as required
   if (year && (year < minYear || year > maxYear)) {
     component.invalidYear = true;
     component.error = `Please enter a year between ${minYear} and ${maxYear}`;
@@ -177,6 +178,8 @@ export function validate(
     component.invalidDay = false;
   }
 
+  // The month error message will trigger if the month is outside of the acceptable range,
+  // but also if the day is invalid and there isn't a month value.
   if ((month && (month < minMonths || month > maxMonths)) ||
       (!month && component.invalidDay)) {
     component.invalidMonth = true;

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -158,14 +158,10 @@ export function validate(
   const leapYear = checkLeapYear(year);
   const daysForSelectedMonth = leapYear && month == 2 ? 29 : days[month]?.length || 0;
 
-  const yearError = `Please enter a year between ${minYear} and ${maxYear}`;
-  const monthError = `Please enter a month between ${minMonths} and ${maxMonths}`;
-  const dayError = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
-
   // Begin built-in validation
   if (year && (year < minYear || year > maxYear)) {
     component.invalidYear = true;
-    component.error = yearError;
+    component.error = `Please enter a year between ${minYear} and ${maxYear}`;
   }
   else {
     component.invalidYear = false;
@@ -175,22 +171,16 @@ export function validate(
   // We don't know the upper limit on days until we know the month
   if (!monthYearOnly && (day < minMonths || day > daysForSelectedMonth)) {
     component.invalidDay = true;
-    component.error = dayError;
-
-    // We need a valid month in order to determine the day
-    if (!month || month < minMonths || month > maxMonths) {
-      component.invalidMonth = true;
-      component.error = monthError;
-    }
+    component.error = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
   }
   else {
     component.invalidDay = false;
   }
 
-  // We allow for an empty month in case the component isn't required
-  if (month && (month < minMonths || month > maxMonths)) {
+  if ((month && (month < minMonths || month > maxMonths)) ||
+      (!month && component.invalidDay)) {
     component.invalidMonth = true;
-    component.error = monthError
+    component.error = `Please enter a month between ${minMonths} and ${maxMonths}`;
   }
   else {
     component.invalidMonth = false;

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -158,10 +158,14 @@ export function validate(
   const leapYear = checkLeapYear(year);
   const daysForSelectedMonth = leapYear && month == 2 ? 29 : days[month]?.length || 0;
 
+  const yearError = `Please enter a year between ${minYear} and ${maxYear}`;
+  const monthError = `Please enter a month between ${minMonths} and ${maxMonths}`;
+  const dayError = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
+
   // Begin built-in validation
   if (year && (year < minYear || year > maxYear)) {
     component.invalidYear = true;
-    component.error = `Please enter a year between ${minYear} and ${maxYear}`;
+    component.error = yearError;
   }
   else {
     component.invalidYear = false;
@@ -171,15 +175,22 @@ export function validate(
   // We don't know the upper limit on days until we know the month
   if (!monthYearOnly && (day < minMonths || day > daysForSelectedMonth)) {
     component.invalidDay = true;
-    component.error = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
+    component.error = dayError;
+
+    // We need a valid month in order to determine the day
+    if (!month || month < minMonths || month > maxMonths) {
+      component.invalidMonth = true;
+      component.error = monthError;
+    }
   }
   else {
     component.invalidDay = false;
   }
 
+  // We allow for an empty month in case the component isn't required
   if (month && (month < minMonths || month > maxMonths)) {
     component.invalidMonth = true;
-    component.error = `Please enter a month between ${minMonths} and ${maxMonths}`;
+    component.error = monthError
   }
   else {
     component.invalidMonth = false;


### PR DESCRIPTION
## Chromatic
<!-- This `month-date-validation-fix` is a placeholder for a CI job - it will be updated automatically -->
https://month-date-validation-fix--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1173

This updates the date validation so that if the day is invalid and we don't have a month value, we override the invalid day message with the invalid month message.

The valid day range was being calculated based on the month, since for some months 31 will be valid and for others it won't.

## Testing done

- Storybook :eyes: 

## Screenshots

![The memorable date component on storybook has its day filled out but not its month. There is an error message saying "Please enter a month between 1 and 12".](https://user-images.githubusercontent.com/2008881/190273264-5ef56eff-3fc2-42bb-b275-8276f51712ec.png)

## Acceptance criteria
- [ ]