### PR TITLE
Add label prop value to va-button in the va-file-input component

### DIFF
--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -141,6 +141,7 @@ export class VaFileInput {
         <va-button
           id="fileInputButton"
           aria-label={label}
+          label={label}
           onClick={this.handleButtonClick}
           secondary
           text={text}


### PR DESCRIPTION
## Chromatic
<!-- This `file-input-button-label-prop` is a placeholder for a CI job - it will be updated automatically -->
https://file-input-button-label-prop--60f9b557105290003b387cd5.chromatic.com

## Description
As part of the following [a11y review](https://github.com/department-of-veterans-affairs/va.gov-team/issues/46990), it was mentioned that some text was not being announced by NVDA. As part of that investigation, I noticed that the `label` prop on the `va-button` component was not set in `va-file-input`. This prop is mapped to the button's `aria-label`.  This pull request adds a value to that prop.

## Testing done
Storybook

## Screenshots
N/A

## Acceptance criteria
- [ ] The button text value and button label value are both set.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
