### PR TITLE
Moving file input web component and React component in Storybook sidebar

### DIFF
--- a/packages/storybook/stories/FileInput.stories.jsx
+++ b/packages/storybook/stories/FileInput.stories.jsx
@@ -3,7 +3,7 @@ import FileInput from '../../react-components/src/components/FileInput/FileInput
 import { StoryDocs } from './wc-helpers';
 
 export default {
-  title: 'Components/File input - React',
+  title: 'Deprecated/File input - React',
   component: FileInput,
   id: 'components/fileinput',
   parameters: {

--- a/packages/storybook/stories/additional-docs.js
+++ b/packages/storybook/stories/additional-docs.js
@@ -40,8 +40,8 @@ export const additionalDocs = {
     maturityLevel: AVAILABLE,
   },
   'File input - React': {
-    maturityCategory: USE,
-    maturityLevel: DEPLOYED,
+    maturityCategory: DONT_USE,
+    maturityLevel: DEPRECATED,
     guidanceHref: 'form/file-input',
     guidanceName: 'File input',
   },

--- a/packages/storybook/stories/additional-docs.js
+++ b/packages/storybook/stories/additional-docs.js
@@ -42,8 +42,6 @@ export const additionalDocs = {
   'File input - React': {
     maturityCategory: DONT_USE,
     maturityLevel: DEPRECATED,
-    guidanceHref: 'form/file-input',
-    guidanceName: 'File input',
   },
   'Help menu': {
     maturityCategory: CAUTION,

--- a/packages/storybook/stories/va-file-input.stories.jsx
+++ b/packages/storybook/stories/va-file-input.stories.jsx
@@ -8,7 +8,7 @@ VaFileInput.displayName = 'VaFileInput';
 const fileInputDocs = getWebComponentDocs('va-file-input');
 
 export default {
-  title: 'Under development/File input',
+  title: 'Components/File input',
   id: 'components/va-file-input',
   parameters: {
     componentSubtitle: `va-file-input web component`,

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -13,7 +13,7 @@ import {
 /**
  * @componentName File input
  * @maturityCategory caution
- * @maturityLevel candidate
+ * @maturityLevel available
  * @guidanceHref form/file-input
  */
 


### PR DESCRIPTION
## Chromatic
<!-- This `1206-move-file-input-in-sidebar` is a placeholder for a CI job - it will be updated automatically -->
https://1206-move-file-input-in-sidebar--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1206

## Testing done
Storybook

## Screenshots

![Screen Shot 2022-09-20 at 2 05 53 PM](https://user-images.githubusercontent.com/872479/191343310-82189f7c-8e64-467a-9e6d-94c2e6b80912.png)

---

![Screen Shot 2022-09-20 at 2 07 02 PM](https://user-images.githubusercontent.com/872479/191343445-28f7b043-c47d-4938-979b-762623b519da.png)

---

![Screen Shot 2022-09-20 at 2 06 06 PM](https://user-images.githubusercontent.com/872479/191343526-a4790dc7-1ab6-41cb-b59f-ddd245b45647.png)


## Acceptance criteria
- [ ] Move File input web component from under development to components in Storybook
- [ ] Move React component version of File input to deprecated

## Definition of done
- [ ]  File input listed in components in the left side nav in Storybook
- [ ] React component version of File input is listed as deprecated in Storybook
