### PR TITLE
Move margin from error-message to label in va-checkbox.

### DIFF
--- a/packages/web-components/src/components/va-checkbox/va-checkbox.css
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.css
@@ -13,7 +13,11 @@
 }
 
 #error-message {
-  margin-bottom: 1.2rem;
+  margin-bottom: 0;
+}
+
+:host([error]:not([error=""])) input + label {
+  margin-top: 1.2rem;
 }
 
 input {


### PR DESCRIPTION
## Chromatic
<!-- This `adjust-va-checkbox-error-margin` is a placeholder for a CI job - it will be updated automatically -->
https://adjust-va-checkbox-error-margin--60f9b557105290003b387cd5.chromatic.com

## Description
This update will adjust the margin between the `#error-message` and the `label` element as discussed in the comment here: https://github.com/department-of-veterans-affairs/component-library/pull/524#issuecomment-1251085519

## Testing done
Storybook

## Screenshots

![Screen Shot 2022-09-20 at 4 43 37 PM](https://user-images.githubusercontent.com/872479/191370225-e6b30a14-0cd5-4cb4-8cbd-2c25e742fe60.png)

## Acceptance criteria
- [ ] The margin between the `#error-message` element and the `label` is applied to the label instead of the error-message.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
