### PR TITLE
Icon discovery

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -319,6 +319,9 @@ export namespace Components {
          */
         "required"?: boolean;
     }
+    interface VaIcon {
+        "icon": string;
+    }
     interface VaLink {
         /**
           * The title used in the abbr element. If filetype is PDF, the abbr title will be Portable Document Format.
@@ -917,6 +920,12 @@ declare global {
         prototype: HTMLVaFileInputElement;
         new (): HTMLVaFileInputElement;
     };
+    interface HTMLVaIconElement extends Components.VaIcon, HTMLStencilElement {
+    }
+    var HTMLVaIconElement: {
+        prototype: HTMLVaIconElement;
+        new (): HTMLVaIconElement;
+    };
     interface HTMLVaLinkElement extends Components.VaLink, HTMLStencilElement {
     }
     var HTMLVaLinkElement: {
@@ -1065,6 +1074,7 @@ declare global {
         "va-date": HTMLVaDateElement;
         "va-featured-content": HTMLVaFeaturedContentElement;
         "va-file-input": HTMLVaFileInputElement;
+        "va-icon": HTMLVaIconElement;
         "va-link": HTMLVaLinkElement;
         "va-loading-indicator": HTMLVaLoadingIndicatorElement;
         "va-memorable-date": HTMLVaMemorableDateElement;
@@ -1486,6 +1496,9 @@ declare namespace LocalJSX {
           * Sets the input to required and renders the (*Required) text.
          */
         "required"?: boolean;
+    }
+    interface VaIcon {
+        "icon": string;
     }
     interface VaLink {
         /**
@@ -2121,6 +2134,7 @@ declare namespace LocalJSX {
         "va-date": VaDate;
         "va-featured-content": VaFeaturedContent;
         "va-file-input": VaFileInput;
+        "va-icon": VaIcon;
         "va-link": VaLink;
         "va-loading-indicator": VaLoadingIndicator;
         "va-memorable-date": VaMemorableDate;
@@ -2164,6 +2178,7 @@ declare module "@stencil/core" {
             "va-date": LocalJSX.VaDate & JSXBase.HTMLAttributes<HTMLVaDateElement>;
             "va-featured-content": LocalJSX.VaFeaturedContent & JSXBase.HTMLAttributes<HTMLVaFeaturedContentElement>;
             "va-file-input": LocalJSX.VaFileInput & JSXBase.HTMLAttributes<HTMLVaFileInputElement>;
+            "va-icon": LocalJSX.VaIcon & JSXBase.HTMLAttributes<HTMLVaIconElement>;
             "va-link": LocalJSX.VaLink & JSXBase.HTMLAttributes<HTMLVaLinkElement>;
             "va-loading-indicator": LocalJSX.VaLoadingIndicator & JSXBase.HTMLAttributes<HTMLVaLoadingIndicatorElement>;
             "va-memorable-date": LocalJSX.VaMemorableDate & JSXBase.HTMLAttributes<HTMLVaMemorableDateElement>;

--- a/packages/web-components/src/components/va-icon/test/va-icon.e2e.ts
+++ b/packages/web-components/src/components/va-icon/test/va-icon.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('va-icon', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-icon></va-icon>');
+
+    const element = await page.find('va-icon');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/packages/web-components/src/components/va-icon/va-icon.css
+++ b/packages/web-components/src/components/va-icon/va-icon.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/packages/web-components/src/components/va-icon/va-icon.css
+++ b/packages/web-components/src/components/va-icon/va-icon.css
@@ -1,3 +1,13 @@
 :host {
   display: block;
 }
+
+/* Copied from USWDS styles */
+/* https://github.com/uswds/uswds/blob/358679dbb9f3918b87540004d0a211f83ea79831/packages/usa-icon/src/styles/_usa-icon.scss#L13-L21 */
+.usa-icon {
+  display: inline-block;
+  fill: currentColor;
+  height: 1em;
+  position: relative;
+  width: 1em;
+}

--- a/packages/web-components/src/components/va-icon/va-icon.tsx
+++ b/packages/web-components/src/components/va-icon/va-icon.tsx
@@ -1,5 +1,4 @@
-import { Component, Host, Prop, getAssetPath, h } from '@stencil/core';
-import ascendingIcon from '../../assets/sort-arrow-up.svg?format=text';
+import { Component, Prop, getAssetPath, h } from '@stencil/core';
 
 @Component({
   tag: 'va-icon',
@@ -12,12 +11,12 @@ export class VaIcon {
   @Prop() icon!: string;
 
   render() {
-    const path = getAssetPath(`./assets/${this.icon}.svg`);
+    const path = getAssetPath("./assets/sprite.svg");
     console.log('PATH', path)
     return (
-      <Host >
-        <div innerHTML={ascendingIcon}></div>
-    </Host>
+      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+        <use xlinkHref={`${path}#${this.icon}`}></use>
+      </svg>
     );
   }
 

--- a/packages/web-components/src/components/va-icon/va-icon.tsx
+++ b/packages/web-components/src/components/va-icon/va-icon.tsx
@@ -1,0 +1,22 @@
+import { Component, Prop, getAssetPath, h } from '@stencil/core';
+
+@Component({
+  tag: 'va-icon',
+  styleUrl: 'va-icon.css',
+  // assetsDirs: ["../../../../node_modules/@uswds/uswds"],
+  shadow: true,
+})
+export class VaIcon {
+
+  @Prop() icon!: string;
+
+  render() {
+    const path = getAssetPath(`./assets/${this.icon}.svg`);
+    console.log('PATH', path)
+    return (
+      <img src={path} class="usa-icon" aria-hidden="true" role="img">
+      </img>
+    );
+  }
+
+}

--- a/packages/web-components/src/components/va-icon/va-icon.tsx
+++ b/packages/web-components/src/components/va-icon/va-icon.tsx
@@ -1,4 +1,5 @@
-import { Component, Prop, getAssetPath, h } from '@stencil/core';
+import { Component, Host, Prop, getAssetPath, h } from '@stencil/core';
+import ascendingIcon from '../../assets/sort-arrow-up.svg?format=text';
 
 @Component({
   tag: 'va-icon',
@@ -14,8 +15,9 @@ export class VaIcon {
     const path = getAssetPath(`./assets/${this.icon}.svg`);
     console.log('PATH', path)
     return (
-      <img src={path} class="usa-icon" aria-hidden="true" role="img">
-      </img>
+      <Host >
+        <div innerHTML={ascendingIcon}></div>
+    </Host>
     );
   }
 

--- a/packages/web-components/src/index.html
+++ b/packages/web-components/src/index.html
@@ -18,6 +18,8 @@
 
   </head>
   <body>
-    <my-component first="Stencil" last="'Don't call me a framework' JS"></my-component>
+    <va-icon icon="favorite"></va-icon>
+    <va-icon icon="error"></va-icon>
+    <va-icon icon="work"></va-icon>
   </body>
 </html>

--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -36,10 +36,24 @@ export const config: Config = {
     },
     {
       type: 'dist-custom-elements-bundle',
+      copy: [
+        {
+          src: '../../../node_modules/@uswds/uswds/dist/img/usa-icons/*.svg',
+          dest: 'dist/assets',
+          warn: true,
+        }
+      ]
     },
     {
       type: 'www',
       serviceWorker: null, // disable service workers
+      copy: [
+        {
+          src: '../../../node_modules/@uswds/uswds/dist/img/usa-icons/*.svg',
+          dest: 'build/assets',
+          warn: true,
+        }
+      ]
     },
   ],
 };

--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -38,7 +38,7 @@ export const config: Config = {
       type: 'dist-custom-elements-bundle',
       copy: [
         {
-          src: '../../../node_modules/@uswds/uswds/dist/img/usa-icons/*.svg',
+          src: '../../../node_modules/@uswds/uswds/dist/img/*.svg',
           dest: 'dist/assets',
           warn: true,
         }
@@ -49,7 +49,7 @@ export const config: Config = {
       serviceWorker: null, // disable service workers
       copy: [
         {
-          src: '../../../node_modules/@uswds/uswds/dist/img/usa-icons/*.svg',
+          src: '../../../node_modules/@uswds/uswds/dist/img/*.svg',
           dest: 'build/assets',
           warn: true,
         }


### PR DESCRIPTION
## Chromatic
<!-- This `icon-discovery` is a placeholder for a CI job - it will be updated automatically -->
https://icon-discovery--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/32758

As part of this discovery I've tried a few different approaches:

### Setting the `src` attribute on an `<img>` tag

This can be seen in [the first commit](https://github.com/department-of-veterans-affairs/component-library/pull/540/commits/b1225efeae67a50d96cb80ac7d6a64d3f33e745d). It works, but having an `<img>` makes it not as easy to style the icon to be in different colors.

![img tag with src attribute doesn't accept color styling](https://user-images.githubusercontent.com/2008881/192912784-e2b12b23-fe69-49b3-96f6-8c5b7930c412.png)

### Dynamic `import()`

It doesn't look like this will work with SVG files. Here is a diff of local changes made after the second commit:

```diff
diff --git a/packages/web-components/src/components/va-icon/va-icon.tsx b/packages/web-components/src/components/va-icon/va-icon.tsx
index 476b090..9ede06d 100644
--- a/packages/web-components/src/components/va-icon/va-icon.tsx
+++ b/packages/web-components/src/components/va-icon/va-icon.tsx
@@ -1,5 +1,4 @@
 import { Component, Host, Prop, getAssetPath, h } from '@stencil/core';
-import ascendingIcon from '../../assets/sort-arrow-up.svg?format=text';
 
 @Component({
   tag: 'va-icon',
@@ -11,12 +10,13 @@ export class VaIcon {
 
   @Prop() icon!: string;
 
-  render() {
+  async render() {
     const path = getAssetPath(`./assets/${this.icon}.svg`);
-    console.log('PATH', path)
+    const importedIcon = await import(path + "?format=text");
+    console.log('icon', importedIcon)
     return (
       <Host >
-        <div innerHTML={ascendingIcon}></div>
+        <div innerHTML={importedIcon}></div>
     </Host>
     );
   }
```

And here is the output:

![Screenshot of some console logs where the svg imports were blocked due to a disallowed MIME type of "image/svg+xml"](https://user-images.githubusercontent.com/2008881/192904321-857a2f5f-b07d-4963-898e-5ecd1aea3534.png)

This was based off of the static SVG import in the table component:

https://github.com/department-of-veterans-affairs/component-library/blob/ab4a7b6f64c28e610a4c83d1cff5fb652e833dc8/packages/web-components/src/components/va-table/va-table.tsx#L3-L4


### Using a spritesheet for the icons and an inline SVG

This is the way that USWDS uses icons. The markup for icons on their [icon documentation page](https://designsystem.digital.gov/components/icon/) looks like this:

```html
      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
        <use xlink:href="/assets/img/sprite.svg#accessibility_new"></use>
      </svg>
```

We can do the same kind of thing, and an inline SVG can be easily styled:

![Inline SVG being styled to have a different size and color using CSS](https://user-images.githubusercontent.com/2008881/192913094-6897db50-52cd-4616-a5db-3f045a3cb96a.png)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
