### PR TITLE
Fix font family for input elements

### DIFF
--- a/packages/web-components/src/components/va-select/va-select.css
+++ b/packages/web-components/src/components/va-select/va-select.css
@@ -39,5 +39,6 @@ select {
   background-position: right 1.3rem center;
   background-repeat: no-repeat;
   background-size: 1rem;
+  font-family: var(--font-source-sans);
   padding: 0.8rem 3rem 0.8rem 0.7em;
 }

--- a/packages/web-components/src/components/va-text-input/va-text-input.css
+++ b/packages/web-components/src/components/va-text-input/va-text-input.css
@@ -23,6 +23,7 @@ input {
   box-sizing: border-box;
   color: var(--color-base);
   display: block;
+  font-family: var(--font-source-sans);
   font-size: 1.6rem;
   height: 4.2rem;
   line-height: 1.3;


### PR DESCRIPTION
## Chromatic
<!-- This `1133-va-text-input-font` is a placeholder for a CI job - it will be updated automatically -->
https://1133-va-text-input-font--60f9b557105290003b387cd5.chromatic.com

## Description
The reported issue says that the `va-text-input` was not displaying the correct font family and I also observed that the select element in `va-date` was not displaying the correct font family as well so this update includes both.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1133

## Testing done
Storybook

## Screenshots

![Screen Shot 2022-09-26 at 1 38 56 PM](https://user-images.githubusercontent.com/872479/192354762-2e7507d4-d06e-46f8-9c4a-c7ab10cf6151.png)

![Screen Shot 2022-09-26 at 1 24 56 PM](https://user-images.githubusercontent.com/872479/192352273-8a0d5807-8bfe-4cc7-96d6-d5bfa30e1cb3.png)

![Screen Shot 2022-09-26 at 1 25 20 PM](https://user-images.githubusercontent.com/872479/192352287-e9f69ce5-7c62-41ac-841e-1dd98fce78b5.png)

## Acceptance criteria
- [ ] Update input elements to display font with the design system font stack.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
