### PR TITLE
Adding Tagalog Translations to va-text-input and va-accordion

### DIFF
--- a/packages/core/src/i18n/translations/tl.js
+++ b/packages/core/src/i18n/translations/tl.js
@@ -1,3 +1,15 @@
 export default {
+  'error': 'Error',
+  'required': '(*Kailangan)',
+  'max-chars': '(Pinakamarami ang {{length}} character)',
+  'date-of-birth': 'Petsa ng Kapanganakan',
+  'month': 'Buwan',
+  'day': 'Araw',
+  'year': 'Taon',
+  'year-range': 'Mangyaring ilagay ang taon sa pagitan ng {{start}} at {{end}}',
+  'expand-all': 'I-expand lahat',
+  'collapse-all': 'I-collapse ang lahat',
+  'expand-all-aria-label': 'I-expand ang lahat ng accordion',
+  'collapse-all-aria-label': 'I-collapse ang lahat ng accordion',
   'on-this-page': 'Sa pahinang ito',
 };

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -85,6 +85,7 @@ const I18nTemplate = args => {
     <div>
       <button onClick={e => setLang('es')}>Español</button>
       <button onClick={e => setLang('en')}>English</button>
+      <button onClick={e => setLang('tl')}>Tagalog</button>
       <va-accordion {...rest}>
         <va-accordion-item id="first">
           {headline}

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const textInputDocs = getWebComponentDocs('va-text-input');
@@ -102,17 +102,14 @@ const I18nTemplate = ({
   type,
 }) => {
   const [lang, setLang] = useState('en');
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, [lang]);
   return (
     <>
-      <button
-        onClick={() => {
-          const newLang = lang === 'en' ? 'es' : 'en';
-          setLang(newLang);
-          document.querySelector('main').setAttribute('lang', newLang);
-        }}
-      >
-        Switch language
-      </button>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <button onClick={e => setLang('tl')}>Tagalog</button>
       <va-text-input
         name={name}
         label={label}

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -44,6 +44,7 @@ if (Build.isTesting) {
  * @maturityLevel best_practice
  * @translations English
  * @translations Spanish
+ * @translations Tagalog
  */
 @Component({
   tag: 'va-accordion',

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -27,8 +27,9 @@ if (Build.isTesting) {
  * @guidanceHref form/text-input
  * @translations English
  * @translations Spanish
+ * @translations Tagalog
  */
- 
+
 @Component({
   tag: 'va-text-input',
   styleUrl: 'va-text-input.css',


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Adding provided Tagalog translations to `/i18n/translations/tl.js` file and updating the storybook examples to toggle Tagalog as well.

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1282

## Testing done
Storybook

## Screenshots

![Screen Shot 2022-10-13 at 3 05 08 PM](https://user-images.githubusercontent.com/872479/195699116-cb9cc8fe-a9e4-40bd-b537-42e9860fcac2.png)

![Screen Shot 2022-10-13 at 3 02 53 PM](https://user-images.githubusercontent.com/872479/195699164-35f1bd8d-87c6-49be-8d13-8e7ff4df9d74.png)

## Acceptance criteria
- [ ] The provided Tagalog translations have been added to the `tl.js` file and are mapping correctly.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
