### PR TITLE
va-alert background-only layout issue

### DIFF
--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -113,6 +113,7 @@ div.error > i::before {
 
 div.bg-only.hide-icon > i::before {
   content: '';
+  margin-right: 0;
 }
 
 div.bg-only {


### PR DESCRIPTION
## Chromatic
<!-- This `48200-va-alert-background-only-i-margin` is a placeholder for a CI job - it will be updated automatically -->
https://60f9b557105290003b387cd5-ylsmqveawh.chromatic.com/?path=/docs/components-va-alert--background-only

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/48200.

When using the `va-alert` web component with the `background-only` prop set to true
there is extra space between the content and the border on the left side of the alert versus on the right side

```jsx
<>
  <div className="usa-alert usa-alert-info background-color-only claims-alert-status">
    We’ve received your claim and are still adding some of your information.
    Check back soon to see the complete details of your claim.
  </div>

  <va-alert background-only class="claims-alert-status">
    We’ve received your claim and are still adding some of your information.
    Check back soon to see the complete details of your claim.
  </va-alert>
</>
```

produces this
![Screen Shot 2022-10-13 at 4 23 33 PM](https://user-images.githubusercontent.com/13838621/195713597-af7cc2cd-4a11-4d4c-9544-670dbda8dc15.png)

Chrome inspector
![Screen Shot 2022-10-13 at 4 31 25 PM](https://user-images.githubusercontent.com/13838621/195714851-a9555e2f-4f5b-4681-b75d-0ae8252c8831.png)


## Testing done
Visual testing

## Screenshots
<details><summary>BEFORE</summary>

![Screen Shot 2022-10-13 at 4 23 33 PM](https://user-images.githubusercontent.com/13838621/195713597-af7cc2cd-4a11-4d4c-9544-670dbda8dc15.png)</details>

<details><summary>AFTER</summary>

![Screen Shot 2022-10-13 at 4 26 54 PM](https://user-images.githubusercontent.com/13838621/195714270-91339114-1fe5-4555-b059-7204c4a45008.png)</details>

## Acceptance criteria
- [x] Hidden icon no longer affects `va-alert` layout

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
