### PR TITLE
Translate "va-checkbox", "va-checkbox-group", "va-number-input" and "va-radio" component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "13.1.0",
+  "version": "13.2.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-checkbox-group.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-group.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   getWebComponentDocs,
   componentStructure,
@@ -24,12 +24,14 @@ export default {
   },
 };
 
-const Template = ({
-  'enable-analytics': enableAnalytics,
-  error,
-  label,
-  required,
-}) => {
+const vaCheckboxGroup = args => {
+  const {
+    'enable-analytics': enableAnalytics,
+    error,
+    label,
+    required,
+    ...rest
+  } = args;
   return (
     <va-checkbox-group
       enable-analytics={enableAnalytics}
@@ -40,8 +42,26 @@ const Template = ({
       <va-checkbox label="Option one" name="example" value="1" />
       <va-checkbox label="Option two" name="example" value="2" />
     </va-checkbox-group>
-  );
-};
+  )
+}
+
+const Template = args => vaCheckboxGroup(args);
+
+const I18nTemplate = args => {
+  const [lang, setLang] = useState('en');
+
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, [lang]);
+
+  return (
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <button onClick={e => setLang('tl')}>Tagalog</button>
+      {vaCheckboxGroup(args)}
+    </div>
+)};
 
 const defaultArgs = {
   'enable-analytics': false,
@@ -61,6 +81,9 @@ Error.args = {
   ...defaultArgs,
   error: 'There has been an error',
 };
+
+export const Required = Template.bind(null);
+Required.args = { ...defaultArgs, required: true };
 
 const SingleCheckboxTemplate = ({
   'enable-analytics': enableAnalytics,
@@ -83,4 +106,11 @@ const SingleCheckboxTemplate = ({
 export const SingleCheckbox = SingleCheckboxTemplate.bind(null);
 SingleCheckbox.args = {
   ...defaultArgs,
+};
+
+export const Internationalization = I18nTemplate.bind(null);
+Internationalization.args = {
+  ...defaultArgs,
+  error: 'There has been a problem',
+  required: true,
 };

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -35,17 +35,16 @@ const vaCheckbox = args => {
     required, 
     ...rest
   } = args;
-
   return (
     <va-checkbox
-        checked={checked}
-        description={description}
-        enable-analytics={enableAnalytics}
-        error={error}
-        label={label}
-        required={required}
-        onBlur={e => console.log(e)}
-      />
+      checked={checked}
+      description={description}
+      enable-analytics={enableAnalytics}
+      error={error}
+      label={label}
+      required={required}
+      onBlur={e => console.log(e)}
+    />
   )
 }
 

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/no-unescaped-entities */
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const checkboxDocs = getWebComponentDocs('va-checkbox');
@@ -25,24 +25,47 @@ const defaultArgs = {
   'enable-analytics': false,
 };
 
-const Template = ({
-  checked,
-  description,
-  'enable-analytics': enableAnalytics,
-  error,
-  label,
-  required,
-}) => (
-  <va-checkbox
-    checked={checked}
-    description={description}
-    enable-analytics={enableAnalytics}
-    error={error}
-    label={label}
-    required={required}
-    onBlur={e => console.log(e)}
-  />
-);
+const vaCheckbox = args => {
+  const {   
+    checked,
+    description,
+    'enable-analytics': enableAnalytics,
+    error,
+    label,
+    required, 
+    ...rest
+  } = args;
+
+  return (
+    <va-checkbox
+        checked={checked}
+        description={description}
+        enable-analytics={enableAnalytics}
+        error={error}
+        label={label}
+        required={required}
+        onBlur={e => console.log(e)}
+      />
+  )
+}
+
+const Template = args => vaCheckbox(args);
+
+const I18nTemplate = args => {
+  const [lang, setLang] = useState('en');
+
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, [lang]);
+
+  return (
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <button onClick={e => setLang('tl')}>Tagalog</button>
+      {vaCheckbox(args)}
+    </div>
+)};
 
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
@@ -82,3 +105,12 @@ Required.args = { ...defaultArgs, required: true };
 
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
+
+export const Internationalization = I18nTemplate.bind(null);
+Internationalization.args = {
+  ...defaultArgs,
+  description:
+    'Notice how the red line to the left also covers this description.',
+  error: 'There has been a problem',
+  required: true,
+};

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -34,17 +34,19 @@ const defaultArgs = {
   'max': undefined,
 };
 
-const Template = ({
-  name,
-  label,
-  'enable-analytics': enableAnalytics,
-  required,
-  error,
-  value,
-  inputmode,
-  min,
-  max,
-}) => {
+const vaNumberInput = args => {
+  const {   
+    name,
+    label,
+    'enable-analytics': enableAnalytics,
+    required,
+    error,
+    value,
+    inputmode,
+    min,
+    max,
+    ...rest
+  } = args;
   return (
     <va-number-input
       name={name}
@@ -59,45 +61,26 @@ const Template = ({
       onInput={e => console.log('input event value:', e.target.value)}
       onBlur={e => console.log('blur event', e)}
     />
-  );
-};
+  )
+}
 
-const I18nTemplate = ({
-  name,
-  label,
-  'enable-analytics': enableAnalytics,
-  required,
-  error,
-  value,
-  inputmode,
-  min,
-  max,
-}) => {
+const Template = args => vaNumberInput(args);
+
+const I18nTemplate = args => {
   const [lang, setLang] = useState('en');
 
   useEffect(() => {
     document.querySelector('main').setAttribute('lang', lang);
   }, [lang]);
+
   return (
-    <>
+    <div>
       <button onClick={e => setLang('es')}>Español</button>
       <button onClick={e => setLang('en')}>English</button>
-      <va-number-input
-        name={name}
-        label={label}
-        enable-analytics={enableAnalytics}
-        required={required}
-        error={error}
-        value={value}
-        inputmode={inputmode}
-        max={max}
-        min={min}
-        onInput={e => console.log('input event value:', e.target.value)}
-        onBlur={e => console.log('blur event', e)}
-      />
-    </>
-  );
-};
+      <button onClick={e => setLang('tl')}>Tagalog</button>
+      {vaNumberInput(args)}
+    </div>
+)};
 
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -105,5 +105,6 @@ ValidRange.args = {
 export const Internationalization = I18nTemplate.bind(null);
 Internationalization.args = {
   ...defaultArgs,
+  error: 'There has been a problem',
   required: true,
 };

--- a/packages/storybook/stories/va-radio.stories.jsx
+++ b/packages/storybook/stories/va-radio.stories.jsx
@@ -168,5 +168,6 @@ IdUsage.args = {
 export const Internationalization = I18nTemplate.bind(null);
 Internationalization.args = {
   ...defaultArgs,
+  error: 'There has been a problem',
   required: true,
 };

--- a/packages/storybook/stories/va-radio.stories.jsx
+++ b/packages/storybook/stories/va-radio.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { VaRadio, VaRadioOption} from '@department-of-veterans-affairs/web-components/react-bindings';
 
 import {
@@ -26,13 +26,15 @@ export default {
   },
 };
 
-const Template = ({
-  'enable-analytics': enableAnalytics,
-  error,
-  label,
-  hint,
-  required,
-}) => {
+const vaRadioConst = args => {
+  const {   
+    'enable-analytics': enableAnalytics,
+    error,
+    label,
+    hint,
+    required,
+    ...rest
+  } = args;
   return (
     <va-radio
       enable-analytics={enableAnalytics}
@@ -44,8 +46,26 @@ const Template = ({
       <va-radio-option label="Option one" name="example" value="1" />
       <va-radio-option label="Option two" name="example" value="2" />
     </va-radio>
-  );
-};
+  )
+}
+
+const Template = args => vaRadioConst(args);
+
+const I18nTemplate = args => {
+  const [lang, setLang] = useState('en');
+
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, [lang]);
+
+  return (
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <button onClick={e => setLang('tl')}>Tagalog</button>
+      {vaRadioConst(args)}
+    </div>
+)};
 
 const ReactBindingExample = ({
   'enable-analytics': enableAnalytics,
@@ -141,6 +161,12 @@ Error.args = {
 
 export const IdUsage = IdUsageTemplate.bind(null);
 IdUsage.args = {
+  ...defaultArgs,
+  required: true,
+};
+
+export const Internationalization = I18nTemplate.bind(null);
+Internationalization.args = {
   ...defaultArgs,
   required: true,
 };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
@@ -34,7 +34,7 @@ describe('va-checkbox-group', () => {
     const element = await page.find('va-checkbox-group >>> #error-message');
     expect(element).toEqualHtml(`
      <span id="error-message" role="alert">
-       <span class="sr-only">Error</span>
+       <span class="sr-only">error</span>
        This is an error
      </span>
     `);

--- a/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
@@ -61,7 +61,7 @@ describe('va-checkbox-group', () => {
     const element = await page.find('va-checkbox-group >>> .required');
     expect(element).toEqualHtml(`
       <span class="required">
-        (*Required)
+        required
       </span>
     `);
   });

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
@@ -24,6 +24,9 @@ if (Build.isTesting) {
  * @maturityCategory use
  * @maturityLevel deployed
  * @guidanceHref form/checkbox
+ * @translations English
+ * @translations Spanish
+ * @translations Tagalog
  */
 @Component({
   tag: 'va-checkbox-group',

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
@@ -3,12 +3,20 @@ import {
   Element,
   Event,
   EventEmitter,
+  forceUpdate,
   Host,
   Listen,
   Prop,
   h,
   Fragment,
 } from '@stencil/core';
+import i18next from 'i18next';
+import { Build } from '@stencil/core';
+
+if (Build.isTesting) {
+  // Make i18next.t() return the key instead of the value
+  i18next.init({ lng: 'cimode' });
+}
 
 /**
  * @vaChange The event emitted when the input value changes.
@@ -74,18 +82,28 @@ export class VaCheckboxGroup {
     });
   }
 
+  connectedCallback() {
+    i18next.on('languageChanged', () => {
+      forceUpdate(this.el);
+    });
+  }
+
+  disconnectedCallback() {
+    i18next.off('languageChanged');
+  }
+
   render() {
     const { label, required, error } = this;
     return (
       <Host role="group">
         <legend>
           {label}
-          {required && <span class="required">(*Required)</span>}
+          {required && <span class="required">{i18next.t('required')}</span>}
         </legend>
         <span id="error-message" role="alert">
           {error && (
             <Fragment>
-              <span class="sr-only">Error</span> {error}
+              <span class="sr-only">{i18next.t('error')}</span> {error}
             </Fragment>
           )}
         </span>

--- a/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
@@ -40,7 +40,7 @@ describe('va-checkbox', () => {
     const page = await newE2EPage();
     await page.setContent('<va-checkbox label="I am Checkbox" required/>');
     const element = await page.find('va-checkbox >>> .required');
-    expect(element.textContent).toContain('(*Required)');
+    expect(element.textContent).toContain('required');
   });
 
   it('renders a description', async () => {

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -23,6 +23,9 @@ if (Build.isTesting) {
  * @maturityCategory use
  * @maturityLevel deployed
  * @guidanceHref form/checkbox
+ * @translations English
+ * @translations Spanish
+ * @translations Tagalog
  */
 @Component({
   tag: 'va-checkbox',

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -3,11 +3,19 @@ import {
   Element,
   Event,
   EventEmitter,
+  forceUpdate,
   Host,
   h,
   Prop,
   Fragment,
 } from '@stencil/core';
+import i18next from 'i18next';
+import { Build } from '@stencil/core';
+
+if (Build.isTesting) {
+  // Make i18next.t() return the key instead of the value
+  i18next.init({ lng: 'cimode' });
+}
 
 /**
  * @nativeHandler onBlur
@@ -112,6 +120,16 @@ export class VaCheckbox {
     if (this.enableAnalytics) this.fireAnalyticsEvent();
   };
 
+  connectedCallback() {
+    i18next.on('languageChanged', () => {
+      forceUpdate(this.el);
+    });
+  }
+
+  disconnectedCallback() {
+    i18next.off('languageChanged');
+  }
+
   render() {
     const { error, label, required, description, checked } = this;
 
@@ -123,7 +141,7 @@ export class VaCheckbox {
         <span id="error-message" role="alert">
           {error && (
             <Fragment>
-              <span class="sr-only">Error</span> {error}
+              <span class="sr-only">{i18next.t('error')}</span> {error}
             </Fragment>
           )}
         </span>
@@ -137,7 +155,7 @@ export class VaCheckbox {
         />
         <label htmlFor="checkbox-element">
           <span>
-            {label} {required && <span class="required">(*Required)</span>}
+            {label} {required && <span class="required">{i18next.t('required')}</span>}
           </span>
         </label>
       </Host>

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -20,6 +20,7 @@ import i18next from 'i18next';
  * @guidanceHref form/number-input
  * @translations English
  * @translations Spanish
+ * @translations Tagalog
  */
 @Component({
   tag: 'va-number-input',

--- a/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
+++ b/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
@@ -124,7 +124,7 @@ describe('va-radio', () => {
     const element = await page.find('va-radio >>> .required');
     expect(element).toEqualHtml(`
       <span class="required">
-        (*Required)
+        required
       </span>
     `);
   });

--- a/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
+++ b/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
@@ -110,7 +110,7 @@ describe('va-radio', () => {
     expect(errorElement).toEqualHtml(`
      <span id="error-message" role="alert">
        <span class="sr-only">
-         Error
+         error
        </span>
        This is an error
      </span>

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -26,6 +26,9 @@ if (Build.isTesting) {
  * @maturityCategory use
  * @maturityLevel deployed
  * @guidanceHref form/radio-button
+ * @translations English
+ * @translations Spanish
+ * @translations Tagalog
  */
 
 @Component({

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -3,6 +3,7 @@ import {
   Element,
   Event,
   EventEmitter,
+  forceUpdate,
   Host,
   Listen,
   Prop,
@@ -10,6 +11,13 @@ import {
   Fragment,
 } from '@stencil/core';
 import { getSlottedNodes } from '../../utils/utils';
+import i18next from 'i18next';
+import { Build } from '@stencil/core';
+
+if (Build.isTesting) {
+  // Make i18next.t() return the key instead of the value
+  i18next.init({ lng: 'cimode' });
+}
 
 /**
  * @keydown The event emitted when a key is pressed.
@@ -181,6 +189,16 @@ export class VaRadio {
     );
   }
 
+  connectedCallback() {
+    i18next.on('languageChanged', () => {
+      forceUpdate(this.el);
+    });
+  }
+
+  disconnectedCallback() {
+    i18next.off('languageChanged');
+  }
+
   render() {
     const { label, hint, required, error } = this;
     const ariaLabel = label + (required ? ' required' : '');
@@ -192,13 +210,13 @@ export class VaRadio {
       >
         <legend>
           {label}
-          {required && <span class="required">(*Required)</span>}
+          {required && <span class="required">{i18next.t('required')}</span>}
         </legend>
         {hint && <span class="hint-text">{hint}</span>}
         <span id="error-message" role="alert">
           {error && (
             <Fragment>
-              <span class="sr-only">Error</span> {error}
+              <span class="sr-only">{i18next.t('error')}</span> {error}
             </Fragment>
           )}
         </span>


### PR DESCRIPTION
## Chromatic
<!-- This `add-i18next-to-web-cpmponents` is a placeholder for a CI job - it will be updated automatically -->
https://add-i18next-to-web-cpmponents--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1297

This PR adds the following functionality:

### va-checkbox
- Adds translation functionality to component
- Adds Internationalization Story
- Adds Spanish, English and Tagalog languages to Internationalization Story

### va-checkbox-group
- Adds translation functionality to component
- Adds Internationalization Story
- Adds Spanish, English and Tagalog languages to Internationalization Story

### va-radio
- Adds translation functionality to component
- Adds Internationalization Story
- Adds Spanish, English and Tagalog languages to Internationalization Story

### va-number-input
- Adds `Error` param to Internationalization Story
- Adds Tagalog language to Internationalization Story

## Testing done

- Storybook :eyes: 
- E2E updates

## Screenshots
### va-checkbox
![Screen Shot 2022-11-02 at 12 04 47 PM](https://user-images.githubusercontent.com/55560129/199540669-d15d9b1e-1316-4cd2-97ad-ea5755f542b8.png)

### va-checkbox-group
![Screen Shot 2022-11-02 at 12 05 20 PM](https://user-images.githubusercontent.com/55560129/199540771-b2028215-6bf9-49e5-9df7-dea13fa2cc33.png)

### va-number-input
![Screen Shot 2022-11-02 at 12 05 55 PM](https://user-images.githubusercontent.com/55560129/199540881-9d0934ce-a02a-412e-bfb8-a6140b7e76b2.png)

### va-radio
![Screen Shot 2022-11-02 at 12 06 24 PM](https://user-images.githubusercontent.com/55560129/199540985-1e7b2cb8-a350-473d-8ff2-7c6e6a1d68d9.png)


## Acceptance criteria
- [x] All components have translation functionality
