### PR TITLE
Prepare css-library for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Yarn publish
 on:
   release:
     types: [published]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   publish:
@@ -34,6 +36,7 @@ jobs:
     - run: yarn workspace @department-of-veterans-affairs/web-components run build
     - run: yarn workspace @department-of-veterans-affairs/web-components run build-bindings
     - run: yarn workspace @department-of-veterans-affairs/component-library run build
-    - run: yarn workspaces foreach --verbose --no-private npm publish --access public --tolerate-republish
+    - run: yarn workspace @department-of-veterans-affairs/css-library run build:minify
+    - run: yarn workspaces foreach --verbose --no-private npm publish --access public --tolerate-republish --dry-run
       env:
         YARN_NPM_AUTH_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,6 @@ name: Yarn publish
 on:
   release:
     types: [published]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   publish:
@@ -38,6 +36,6 @@ jobs:
     - run: yarn workspace @department-of-veterans-affairs/component-library run build
     - run: yarn workspace @department-of-veterans-affairs/css-library run build:tokens
     - run: yarn workspace @department-of-veterans-affairs/css-library run build:minify
-    - run: yarn workspaces foreach --verbose --no-private npm publish --access public --tolerate-republish --dry-run
+    - run: yarn workspaces foreach --verbose --no-private npm publish --access public --tolerate-republish
       env:
         YARN_NPM_AUTH_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
     - run: yarn workspace @department-of-veterans-affairs/web-components run build
     - run: yarn workspace @department-of-veterans-affairs/web-components run build-bindings
     - run: yarn workspace @department-of-veterans-affairs/component-library run build
+    - run: yarn workspace @department-of-veterans-affairs/css-library run build:tokens
     - run: yarn workspace @department-of-veterans-affairs/css-library run build:minify
     - run: yarn workspaces foreach --verbose --no-private npm publish --access public --tolerate-republish --dry-run
       env:

--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/css-library",
-  "version": "0.1.0",
+  "private": true,
   "packageManager": "yarn@3.2.0",
   "files": [
     "dist/*.css"

--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/css-library",
-  "private": true,
+  "version": "0.1.0",
   "packageManager": "yarn@3.2.0",
   "files": [
     "dist/*.css"


### PR DESCRIPTION
## Chromatic
<!-- This `css-library-prerelease` is a placeholder for a CI job - it will be updated automatically -->
https://css-library-prerelease--60f9b557105290003b387cd5.chromatic.com

## Description
This is getting us ready to be able to publish the `css-library` package by tagging a pre-release. We still haven't solved the problem of publishing it as a full release yet since we can't distinguish between release notes/changes for the `component-library` package and the `css-library` package.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
