### PR TITLE
Add radio option description

### DIFF
--- a/packages/storybook/stories/va-radio.stories.jsx
+++ b/packages/storybook/stories/va-radio.stories.jsx
@@ -27,7 +27,7 @@ export default {
 };
 
 const vaRadioConst = args => {
-  const {   
+  const {
     'enable-analytics': enableAnalytics,
     error,
     label,
@@ -75,11 +75,11 @@ const ReactBindingExample = ({
 }) => {
   return (
     <>
-    <VaRadio 
+    <VaRadio
       enableAnalytics={enableAnalytics}
       error={error}
       label={label}
-      required={required} 
+      required={required}
       onVaValueChange={e => console.log('Selected radio option:', e?.detail?.value)}>
       <VaRadioOption label="Option one" name="example" value="1" />
       <VaRadioOption label="Option two" name="example" value="2" />
@@ -128,6 +128,41 @@ const IdUsageTemplate = ({
   );
 };
 
+const DescriptionTemplate = args => {
+  const {
+    'enable-analytics': enableAnalytics,
+    error,
+    label,
+    hint,
+    required,
+    description1,
+    description2,
+    ...rest
+  } = args;
+  return (
+    <va-radio
+      enable-analytics={enableAnalytics}
+      error={error}
+      label={label}
+      required={required}
+      hint={hint}
+    >
+      <va-radio-option
+        label="Option one"
+        description={description1}
+        name="example"
+        value="1"
+      />
+      <va-radio-option
+        label="Option two"
+        description={description2}
+        name="example"
+        value="2"
+      />
+    </va-radio>
+  )
+}
+
 const defaultArgs = {
   'enable-analytics': false,
   'label': 'This is a label',
@@ -146,6 +181,13 @@ export const Hint = Template.bind(null);
 Hint.args = {
   ...defaultArgs,
   hint: "We're asking this because of XYZ",
+};
+
+export const Description = DescriptionTemplate.bind(null);
+Description.args = {
+  ...defaultArgs,
+  description1: "Option 1 description",
+  description2: "Option 2 description",
 };
 
 export const ReactWithCustomEvent = ReactBindingExample.bind(null);

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.17.0",
+  "version": "4.18.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -615,6 +615,10 @@ export namespace Components {
          */
         "checked"?: boolean;
         /**
+          * The description text for the option
+         */
+        "description": string;
+        /**
           * The text label for the input element.
          */
         "label": string;
@@ -1874,6 +1878,10 @@ declare namespace LocalJSX {
           * Whether or not the option is selected.
          */
         "checked"?: boolean;
+        /**
+          * The description text for the option
+         */
+        "description"?: string;
         /**
           * The text label for the input element.
          */

--- a/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
+++ b/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
@@ -41,13 +41,15 @@ describe('va-radio-option', () => {
     await page.setContent(`
       <va-radio-option
         id="opt1"
+        name="opts"
         label="An option"
         description="This is an option description"
+        value="option1"
       />
     `);
     const element = await page.find('va-radio-option');
     expect(element).toEqualHtml(`
-    <va-radio-option id="opt1" label="An option" name="yes" value="2" aria-checked="false" role="radio" class="hydrated">
+    <va-radio-option id="opt1" name="opts" label="An option" description="This is an option description" name="opt1" value="option1" aria-checked="false" role="radio" class="hydrated">
       <mock:shadow-root>
         <label part="label" for="opt1">
           An option

--- a/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
+++ b/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
@@ -17,7 +17,7 @@ describe('va-radio-option', () => {
     expect(element).toEqualHtml(`
     <va-radio-option id="yes2" label="Yes - Any Veteran" name="yes" value="2" aria-checked="false" role="radio" class="hydrated">
       <mock:shadow-root>
-        <label for="yes2">
+        <label part="label" for="yes2">
           Yes - Any Veteran
         </label>
       </mock:shadow-root>
@@ -34,6 +34,30 @@ describe('va-radio-option', () => {
     const inputEl = await page.find('va-radio-option');
 
     expect(await inputEl.getProperty('id')).toEqual('test1');
+  });
+
+  it('renders description', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-radio-option
+        id="opt1"
+        label="An option"
+        description="This is an option description"
+      />
+    `);
+    const element = await page.find('va-radio-option');
+    expect(element).toEqualHtml(`
+    <va-radio-option id="opt1" label="An option" name="yes" value="2" aria-checked="false" role="radio" class="hydrated">
+      <mock:shadow-root>
+        <label part="label" for="opt1">
+          An option
+          <div class="description" part="description">
+            This is an option description
+          </div>
+        </label>
+      </mock:shadow-root>
+    </va-radio-option>
+  `);
   });
 
   it('sets checked to true based on prop', async () => {

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.css
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.css
@@ -37,6 +37,10 @@ label::before {
   box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-primary);
 }
 
+:host .description {
+  margin-left: 1.5em;
+}
+
 :host(:focus) label::before {
   outline: 2px solid var(--color-gold-light);
   outline-offset: 6px;

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -27,6 +27,11 @@ export class VaRadioOption {
   @Prop() label!: string;
 
   /**
+   * The description text for the option
+   */
+  @Prop() description: string;
+
+  /**
    * The value attribute for the input element.
    */
   @Prop() value!: string;
@@ -55,7 +60,7 @@ export class VaRadioOption {
   }
 
   render() {
-    const { checked, ariaDescribedby, name, value, label } = this;
+    const { checked, ariaDescribedby, name, value, label, description } = this;
     const id = this.el.id || (name + value);
     return (
       <Host
@@ -68,7 +73,12 @@ export class VaRadioOption {
         value={value}
         id={id}
       >
-        <label htmlFor={id}>{label}</label>
+        <label part="label" htmlFor={id}>
+          {label}
+          {description && (
+            <div class="description" part="description">{description}</div>
+          )}
+        </label>
       </Host>
     );
   }

--- a/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
+++ b/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
@@ -108,7 +108,7 @@ describe('va-radio', () => {
     const errorElement = await page.find('va-radio >>> #error-message');
     expect(element.getAttribute('aria-invalid')).toEqual('true');
     expect(errorElement).toEqualHtml(`
-     <span id="error-message" role="alert">
+     <span id="error-message" part="error" role="alert">
        <span class="sr-only">
          error
        </span>

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -211,12 +211,12 @@ export class VaRadio {
         aria-invalid={error ? 'true' : 'false'}
         aria-label={ariaLabel}
       >
-        <legend>
+        <legend part="legend">
           {label}
           {required && <span class="required">{i18next.t('required')}</span>}
         </legend>
-        {hint && <span class="hint-text">{hint}</span>}
-        <span id="error-message" role="alert">
+        {hint && <span part="hint" class="hint-text">{hint}</span>}
+        <span id="error-message" part="error" role="alert">
           {error && (
             <Fragment>
               <span class="sr-only">{i18next.t('error')}</span> {error}


### PR DESCRIPTION
## Chromatic
<!-- This `1324-radio-option-description` is a placeholder for a CI job - it will be updated automatically -->
https://1324-radio-option-description--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1324

## Testing done

Added tests

## Screenshots
<img width="428" alt="storybook showing va-radio with an option including a description property. The description is rendered below, but within the label" src="https://user-images.githubusercontent.com/136959/200043130-2141d002-d2eb-4333-a2d8-38f24bf3ed13.png">

## Acceptance criteria

- [x] Add description text property
- [x]  Update web component in Storybook
- [x]  Write any necessary tests
- [x]  Add Chromatic link to #[add accessibility ticket number] and request review from an accessibility specialist
- [x]  Ping designer for design review (if necessary) @GnatalieH 

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
