### PR TITLE
Spanish translation for va-memorable-date & va-text-input

### DIFF
--- a/packages/core/src/i18n/translations/en.js
+++ b/packages/core/src/i18n/translations/en.js
@@ -2,6 +2,7 @@ export default {
   'error': 'Error',
   'required': '(*Required)',
   'max-chars': '(Max. {{length}} characters)',
+  'min-chars': '(Min. {{length}} characters)',
   'date-of-birth': 'Date of birth',
   'month': 'Month',
   'day': 'Day',
@@ -24,4 +25,5 @@ export default {
   'november': 'November',
   'december': 'December',
   'on-this-page': 'On this page',
+  'date-hint': 'Please enter two digits for the month and four digits for the year',
 };

--- a/packages/core/src/i18n/translations/es.js
+++ b/packages/core/src/i18n/translations/es.js
@@ -2,6 +2,7 @@ export default {
   'error': 'Error',
   'required': '(*Requerido)',
   'max-chars': '(Número máximo de caracteres: {{length}})',
+  'min-chars': '(Número mínimo de caracteres: {{length}})',
   'date-of-birth': 'Fecha de nacimiento',
   'month': 'Mes',
   'day': 'Día',
@@ -24,4 +25,5 @@ export default {
   'november': 'Noviembre',
   'december': 'Diciembre',
   'on-this-page': 'En esta página',
+  'date-hint': 'Ingrese dos dígitos para el mes y cuatro dígitos para el año',
 };

--- a/packages/storybook/stories/va-memorable-date.stories.jsx
+++ b/packages/storybook/stories/va-memorable-date.stories.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { VaMemorableDate } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
@@ -98,6 +98,29 @@ const WithHintTextTemplate = ({ name, label, error, required, value }) => {
   );
 };
 
+const I18nTemplate = ({ label, name, required, error, value }) => {
+  const [lang, setLang] = useState('en');
+
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, [lang]);
+
+  return (
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <VaMemorableDate
+      label={label}
+      name={name}
+      required={required}
+      error={error}
+      value={value}
+      onDateBlur={e => console.log(e, 'DATE BLUR FIRED')}
+      onDateChange={e => console.log(e, 'DATE CHANGE FIRED')}
+    />
+    </div>
+)};
+
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(memorableDateInputDocs);
@@ -121,4 +144,11 @@ CustomValidation.args = {
   ...defaultArgs,
   required: true,
   value: '2022-04-19',
+};
+
+export const Internationalization = I18nTemplate.bind(null);
+Internationalization.args = {
+  ...defaultArgs,
+  error: 'Error Message Example',
+  required: true,
 };

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -97,6 +97,7 @@ const I18nTemplate = ({
   required,
   error,
   maxlength,
+  minlength,
   value,
   inputmode,
   type,
@@ -118,6 +119,7 @@ const I18nTemplate = ({
         required={required}
         error={error}
         maxlength={maxlength}
+        minlength={minlength}
         value={value}
         inputmode={inputmode}
         type={type}
@@ -150,6 +152,12 @@ export const MaxLength = Template.bind(null);
 MaxLength.args = {
   ...defaultArgs,
   maxlength: '16',
+};
+
+export const MinLength = Template.bind(null);
+MinLength.args = {
+  ...defaultArgs,
+  minlength: '3',
 };
 
 export const Range = Template.bind(null);

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -13,9 +13,7 @@ describe('va-memorable-date', () => {
       <mock:shadow-root>
         <fieldset>
           <legend>
-            <div id='dateHint'>
-            Please enter two digits for the month and day and four digits for the year.
-            </div>
+            <div id='dateHint'>date-hint.</div>
           </legend>
           <slot></slot>
           <span id="error-message" role="alert"></span>

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -2,6 +2,7 @@ import {
   Component,
   Event,
   EventEmitter,
+  forceUpdate,
   Host,
   Prop,
   h,
@@ -13,6 +14,14 @@ import {
   validate,
   validKeys,
 } from '../../utils/date-utils';
+
+import i18next from 'i18next';
+import { Build } from '@stencil/core';
+
+if (Build.isTesting) {
+  // Make i18next.t() return the key instead of the value
+  i18next.init({ lng: 'cimode' });
+}
 
 /**
  * By default all date components have the following validation:
@@ -26,6 +35,8 @@ import {
  * @maturityCategory caution
  * @maturityLevel available
  * @guidanceHref form/memorable-date
+ * @translations English
+ * @translations Spanish
  */
 @Component({
   tag: 'va-memorable-date',
@@ -149,6 +160,16 @@ export class VaMemorableDate {
   })
   componentLibraryAnalytics: EventEmitter;
 
+  connectedCallback() {
+    i18next.on('languageChanged', () => {
+      forceUpdate(this.el);
+    });
+  }
+
+  disconnectedCallback() {
+    i18next.off('languageChanged');
+  }
+
   render() {
     const {
       required,
@@ -169,23 +190,20 @@ export class VaMemorableDate {
       <Host onBlur={handleDateBlur}>
         <fieldset>
           <legend>
-            {label} {required && <span class="required">(*Required)</span>}
-            <div id="dateHint">
-              Please enter two digits for the month and day and four digits for
-              the year.
-            </div>
+            {label} {required && <span class="required">{i18next.t('required')}</span>}
+            <div id="dateHint">{i18next.t('date-hint')}.</div>
           </legend>
           <slot />
           <span id="error-message" role="alert">
             {error && (
               <Fragment>
-                <span class="sr-only">Error</span> {error}
+                <span class="sr-only">{i18next.t('error')}</span> {error}
               </Fragment>
             )}
           </span>
           <div class="date-container">
             <va-text-input
-              label="Month"
+              label={i18next.t('month')}
               name={`${name}Month`}
               maxlength={2}
               minlength={2}
@@ -202,7 +220,7 @@ export class VaMemorableDate {
               type="text"
             />
             <va-text-input
-              label="Day"
+              label={i18next.t('day')}
               name={`${name}Day`}
               maxlength={2}
               minlength={2}
@@ -219,7 +237,7 @@ export class VaMemorableDate {
               type="text"
             />
             <va-text-input
-              label="Year"
+              label={i18next.t('year')}
               name={`${name}Year`}
               maxlength={4}
               minlength={4}

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -220,7 +220,7 @@ describe('va-text-input', () => {
     await inputEl.press('2');
     expect(await inputEl.getProperty('value')).toBe('2');
     expect((await page.find('va-text-input >>> small')).innerText).toContain(
-      '(Min. 2 characters)',
+      'min-chars',
     );
   });
 

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -251,7 +251,9 @@ export class VaTextInput {
           </small>
         )}
         {minlength && value?.length < minlength && (
-          <small part="validation">(Min. {minlength} characters)</small>
+          <small part="validation">
+            {i18next.t('min-chars', { length: minlength })}
+          </small>
         )}
       </Host>
     );


### PR DESCRIPTION
## Chromatic
<!-- This `add-i18next-to-va-memorable-date` is a placeholder for a CI job - it will be updated automatically -->
https://add-i18next-to-va-memorable-date--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1292

This PR adds the following functionality:

### va-memorable-date
- Adds translation functionality to component
- Adds Internationalization Story
- Adds Spanish to Internationalization Story

### va-text-input
- Adds Spanish to Internationalization Story for minimum length

## Testing done

- Storybook :eyes: 
- E2E updates

## Screenshots

### va-memorable-date
![Screen Shot 2022-11-04 at 2 50 21 PM](https://user-images.githubusercontent.com/55560129/200349056-b0f0c467-f198-4940-bf31-58dff287ab46.png)

### va-text-input
![Screen Shot 2022-11-04 at 3 28 01 PM](https://user-images.githubusercontent.com/55560129/200349007-6b16fe58-6805-4973-bab6-58ecf60963f5.png)

## Acceptance criteria
- [x] All components have translation functionality
