### PR TITLE
Update contact prop documentation

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -711,7 +711,7 @@ export namespace Components {
     }
     interface VaTelephone {
         /**
-          * 3 or 10 digit string representing the contact number
+          * Numeric string representing the contact number. Typical length is 3 or 10 digits - SMS short codes will be 5 or 6 digits.
          */
         "contact": string;
         /**
@@ -1991,7 +1991,7 @@ declare namespace LocalJSX {
     }
     interface VaTelephone {
         /**
-          * 3 or 10 digit string representing the contact number
+          * Numeric string representing the contact number. Typical length is 3 or 10 digits - SMS short codes will be 5 or 6 digits.
          */
         "contact": string;
         /**

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -20,7 +20,7 @@ import {
 })
 export class VaTelephone {
   /**
-   * 3 or 10 digit string representing the contact number
+   * Numeric string representing the contact number. Typical length is 3 or 10 digits - SMS short codes will be 5 or 6 digits.
    */
   @Prop() contact!: string;
 


### PR DESCRIPTION
We now support numbers other than 3 or 10 digits.

## Chromatic
<!-- This `telephone-contact-update` is a placeholder for a CI job - it will be updated automatically -->
https://telephone-contact-update--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1298

This updates documentation which will be reflected in storybook and on design.va.gov

## Testing done
- Storybook :eyes: 

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/200385077-47658a80-7bfb-44db-a2f6-cb204ccb3085.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
