### PR TITLE
Update va-omb-info maturity and location in Storybook

### DIFF
--- a/packages/storybook/stories/va-omb-info.stories.jsx
+++ b/packages/storybook/stories/va-omb-info.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const ombInfoDocs = getWebComponentDocs('va-omb-info');
 
 export default {
-  title: 'Under development/OMB info',
+  title: 'Components/OMB info',
   id: 'components/va-omb-info',
   parameters: {
     componentSubtitle: `va-omb-info web component`,

--- a/packages/web-components/src/components/va-omb-info/va-omb-info.tsx
+++ b/packages/web-components/src/components/va-omb-info/va-omb-info.tsx
@@ -2,8 +2,8 @@ import { Component, Host, h, Prop, State, Element } from '@stencil/core';
 
 /**
  * @componentName OMB info
- * @maturityCategory caution
- * @maturityLevel candidate
+ * @maturityCategory use
+ * @maturityLevel best_practice
  */
 @Component({
   tag: 'va-omb-info',


### PR DESCRIPTION
## Chromatic
<!-- This `storybook-move-va-omb-info` is a placeholder for a CI job - it will be updated automatically -->
https://storybook-move-va-omb-info--60f9b557105290003b387cd5.chromatic.com

## Description
- Moves `va-omb-info` from "Under Development" to the "Components" section in Storybook
- Updates the maturity to "Use: Best Practice"

## Testing done
Storybook

## Screenshots
![Screen Shot 2022-11-09 at 1 19 41 PM](https://user-images.githubusercontent.com/55560129/200910333-b6bee390-86d6-4ed7-8622-e20ef11c2fa8.png)

## Acceptance criteria
- [ ] The web component version of OMB Info is moved from Under Development to the Components section in Storybook.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
