### PR TITLE
add aria-label to va-pagination navigation landmark

### DIFF
--- a/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
+++ b/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
@@ -36,7 +36,7 @@ describe('va-pagination', () => {
 
     const element = await page.find('va-pagination');
     expect(element).toEqualHtml(`
-      <va-pagination class="hydrated" page="3" pages="5" role="navigation">
+      <va-pagination class="hydrated" page="3" pages="5" role="navigation" aria-label="Pagination">
         <mock:shadow-root>
           <ul class="pagination-prev">
           <li>

--- a/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
+++ b/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
@@ -8,7 +8,7 @@ describe('va-pagination', () => {
 
     const element = await page.find('va-pagination');
     expect(element).toEqualHtml(`
-      <va-pagination class="hydrated" role="navigation">
+      <va-pagination class="hydrated" role="navigation" aria-label="Pagination">
         <mock:shadow-root>
           <ul class="pagination-prev"></ul>
           <ul class="pagination-inner"></ul>

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -160,7 +160,7 @@ export class VaPagination {
     });
 
     return (
-      <Host role="navigation">
+      <Host role="navigation" aria-label="Pagination">
         <ul class="pagination-prev">
           {/* START PREV BUTTON */}
           {this.page > 1 && (


### PR DESCRIPTION
## Chromatic
<!-- This `1332-aria-label-va-pagination` is a placeholder for a CI job - it will be updated automatically -->
https://1332-aria-label-va-pagination--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [1332](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1332)

## Testing done
- Updated unit tests to include `aria-label="Pagination"`

## Screenshots
<img width="1166" alt="Screen Shot 2022-11-10 at 2 55 21 PM" src="https://user-images.githubusercontent.com/1094951/201193434-a6b3eb9f-a224-40e8-9fb9-0d34ff78c89b.png">


## Acceptance criteria
- [x] Tests continue to pass
- [x] Pagination navigation landmark has name of "Pagination"

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
