### PR TITLE
Added autocomplete prop to va-text-input

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -741,7 +741,7 @@ export namespace Components {
     }
     interface VaTextInput {
         /**
-          * What to tell the browser to auto-complete the field with.
+          * Allows the browser to automatically complete the input.
          */
         "autocomplete"?: string;
         /**
@@ -2025,7 +2025,7 @@ declare namespace LocalJSX {
     }
     interface VaTextInput {
         /**
-          * What to tell the browser to auto-complete the field with.
+          * Allows the browser to automatically complete the input.
          */
         "autocomplete"?: string;
         /**

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -316,4 +316,16 @@ describe('va-text-input', () => {
       'rgb(46, 133, 64)',
     );
   });
+
+  it('checks for autocomplete attribute', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-text-input autocomplete="email" />',
+    );
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(await inputEl.getProperty('autocomplete')).toBe('email');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+  });
 });

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -326,6 +326,5 @@ describe('va-text-input', () => {
     // Level-setting expectations
     const inputEl = await page.find('va-text-input >>> input');
     expect(await inputEl.getProperty('autocomplete')).toBe('email');
-    expect(await page.find('va-text-input >>> small')).toBeNull();
   });
 });

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -95,7 +95,7 @@ export class VaTextInput {
   @Prop() minlength?: number;
 
   /**
-   * What to tell the browser to auto-complete the field with.
+   * Allows the browser to automatically complete the input.
    */
   @Prop() autocomplete?: string;
 

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -207,6 +207,7 @@ export class VaTextInput {
       minlength,
       pattern,
       name,
+      autocomplete,
       handleInput,
       handleBlur,
     } = this;
@@ -242,6 +243,7 @@ export class VaTextInput {
           minlength={minlength}
           pattern={pattern}
           name={name}
+          autocomplete={autocomplete}
           required={required || null}
           part="input"
         />


### PR DESCRIPTION
## Chromatic
<!-- This `va-text-input-missing-autocomplete` is a placeholder for a CI job - it will be updated automatically -->
https://va-text-input-missing-autocomplete--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1156

This PR adds the following functionality:

### va-text-input
- Adds autocomplete prop to component

## Testing done

- Storybook :eyes: 
- E2E updates

## Screenshots

![Screen Shot 2022-11-14 at 10 05 26 AM](https://user-images.githubusercontent.com/55560129/201694329-6568bca1-f216-4064-8939-086d54a55313.png)

## Acceptance criteria
- [ ] Autocomplete prop was added to va-text-input

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
