### PR TITLE
Add Storybook style overrides for USWDS v3 components

### DIFF
--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -41,18 +41,16 @@ applyPolyfills().then(() => {
  * The native events `hashchange` and `popstate` were not reliable.
  */
  (() => {
-  const oldPushState = history.pushState;
-  history.pushState = function pushState() {
-    const ret = oldPushState.apply(this, arguments);
+  const pushState = history.pushState;
+  history.pushState = function () {
+    pushState.apply(this, arguments);
     window.dispatchEvent(new Event('locationchange'));
-    return ret;
   };
 
-  const oldReplaceState = history.replaceState;
-  history.replaceState = function replaceState() {
-    const ret = oldReplaceState.apply(this, arguments);
+  const replaceState = history.replaceState;
+  history.replaceState = function () {
+    replaceState.apply(this, arguments);
     window.dispatchEvent(new Event('locationchange'));
-    return ret;
   };
 
   window.addEventListener('popstate', () => {

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -44,7 +44,6 @@ applyPolyfills().then(() => {
   const oldPushState = history.pushState;
   history.pushState = function pushState() {
     const ret = oldPushState.apply(this, arguments);
-    window.dispatchEvent(new Event('pushstate'));
     window.dispatchEvent(new Event('locationchange'));
     return ret;
   };
@@ -52,7 +51,6 @@ applyPolyfills().then(() => {
   const oldReplaceState = history.replaceState;
   history.replaceState = function replaceState() {
     const ret = oldReplaceState.apply(this, arguments);
-    window.dispatchEvent(new Event('replacestate'));
     window.dispatchEvent(new Event('locationchange'));
     return ret;
   };

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -36,6 +36,32 @@ applyPolyfills().then(() => {
   window.CustomEvent = CustomEvent;
 })();
 
+/**
+ * The custom event locationchange will dispatch when the URL changes.
+ * The native events `hashchange` and `popstate` were not reliable.
+ */
+ (() => {
+  const oldPushState = history.pushState;
+  history.pushState = function pushState() {
+    const ret = oldPushState.apply(this, arguments);
+    window.dispatchEvent(new Event('pushstate'));
+    window.dispatchEvent(new Event('locationchange'));
+    return ret;
+  };
+
+  const oldReplaceState = history.replaceState;
+  history.replaceState = function replaceState() {
+    const ret = oldReplaceState.apply(this, arguments);
+    window.dispatchEvent(new Event('replacestate'));
+    window.dispatchEvent(new Event('locationchange'));
+    return ret;
+  };
+
+  window.addEventListener('popstate', () => {
+    window.dispatchEvent(new Event('locationchange'));
+  });
+})();
+
 const viewports = {
   xsmall: {
     name: 'XSmall Screen',
@@ -108,9 +134,34 @@ export const decorators = [
   ),
 ];
 
-// Fix for React 17/NVDA bug where React root is read as "clickable"
-// https://github.com/nvaccess/nvda/issues/13262
-// https://github.com/facebook/react/issues/20895
+/**
+ * The dynamic CSS added when the URL has "uswds" in it.
+ * Specifically updates body and html tags.
+ */
+ function addUswdsStyles() {
+  document.documentElement.style.fontSize = '16px';
+  document.body.style.fontSize = '16px';
+}
+
+/**
+ * The dynamic CSS added when the URL does not have "uswds" in it.
+ * Specifically updates body and html tags.
+ */
+function addFormationStyles() {
+  document.documentElement.style.fontSize = '10px';
+  document.body.style.fontSize = '1.6rem';
+}
+
 document.body.onload = function () {
+  // Fix for React 17/NVDA bug where React root is read as "clickable"
+  // https://github.com/nvaccess/nvda/issues/13262
+  // https://github.com/facebook/react/issues/20895
   document.querySelector('#root').setAttribute('role', 'presentation');
+
+  // Styles added for USWDS v3 integration into Storybook
+  location.href.includes('uswds') ? addUswdsStyles() : addFormationStyles();
+
+  window.addEventListener('locationchange', (event) => {
+    location.href.includes('uswds') ? addUswdsStyles() : addFormationStyles();
+  });
 };

--- a/packages/storybook/.storybook/style.scss
+++ b/packages/storybook/.storybook/style.scss
@@ -37,7 +37,7 @@ a.sbdocs-a:hover {
 
 /** Global styles for USWDS 3 integration into Storybook **/
 .usa-label {
-  font-size: 16px!important;
+  font-size: 15px!important;
 }
 
 button {

--- a/packages/storybook/.storybook/style.scss
+++ b/packages/storybook/.storybook/style.scss
@@ -43,7 +43,3 @@ a.sbdocs-a:hover {
 button {
   padding: 10px 20px!important;
 }
-
-h1 {
-  font-size: 32px!important;
-}

--- a/packages/storybook/.storybook/style.scss
+++ b/packages/storybook/.storybook/style.scss
@@ -34,3 +34,16 @@ a.sbdocs-a:hover {
 .resize-y {
   resize: vertical;
 }
+
+/** Global styles for USWDS 3 integration into Storybook **/
+.usa-label {
+  font-size: 16px!important;
+}
+
+button {
+  padding: 10px 20px!important;
+}
+
+h1 {
+  font-size: 32px!important;
+}


### PR DESCRIPTION
## Chromatic
<!-- This `1331-storybook-u-s-w-d-s-style` is a placeholder for a CI job - it will be updated automatically -->
https://1331-storybook-u-s-w-d-s-style--60f9b557105290003b387cd5.chromatic.com

## Description
This PR includes a script that will dynamically update the `body` and `html` tags in Storybook when the URL contains the value "uswds" as well as some global CSS required to reset Formation values to pixels. 

**Note:** We will need to be mindful of the branch names we're creating as we are developing for USWDS v3. If the branch name has "uswds" in it, the Chromatic link will trigger the dynamic CSS update on all pages.

This branch does not include the work in progress for the USWDS v3 va-radio component so testing for this can be done on the Chromatic link generated from the discovery ticket draft PR (which includes the va-radio USWDS section):
https://github.com/department-of-veterans-affairs/component-library/pull/573

If we feel like this would be easier to validate as part of the [va-radio USWDS v3 work](https://github.com/department-of-veterans-affairs/component-library/pull/563), then I can close this PR and integrate it into https://github.com/department-of-veterans-affairs/component-library/pull/563 for overall testing.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1331

## Testing done
Storybook.

## Screenshots
![Screen Shot 2022-11-16 at 1 23 53 PM](https://user-images.githubusercontent.com/872479/202274797-c0d1572e-d785-4cf7-97da-19e2f4257c39.png)
![Screen Shot 2022-11-16 at 1 23 42 PM](https://user-images.githubusercontent.com/872479/202274798-82a4250c-dcbf-44ed-af3a-8fbe2cae46ba.png)

## Acceptance criteria
- [ ] Dynamic and global base styles are added so that Storybook pages are displaying as expected between Formation and USWDS v3 components.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
