### PR TITLE
Add maxlength hint text to va-text-input

### DIFF
--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -253,7 +253,7 @@ export class VaTextInput {
               {i18next.t('max-chars', { length: maxlength })}
             </small>
             <p class="sr-only" role="alert">
-              Limit reached. You can only use 16 characters in this field.
+              Limit reached. You can only use {maxlength} characters in this field.
             </p>
           </Fragment>
         )}

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -248,9 +248,14 @@ export class VaTextInput {
           part="input"
         />
         {maxlength && value?.length >= maxlength && (
-          <small part="validation">
-            {i18next.t('max-chars', { length: maxlength })}
-          </small>
+          <Fragment>
+            <small part="validation">
+              {i18next.t('max-chars', { length: maxlength })}
+            </small>
+            <p class="sr-only" role="alert">
+              Limit reached. You can only use 16 characters in this field.
+            </p>
+          </Fragment>
         )}
         {minlength && value?.length < minlength && (
           <small part="validation">


### PR DESCRIPTION
## Chromatic
<!-- This `38775-va-text-input-maxlength` is a placeholder for a CI job - it will be updated automatically -->
https://38775-va-text-input-maxlength--60f9b557105290003b387cd5.chromatic.com

## Description
Closes <ticket>

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
