### PR TITLE
va-radio: add part attr to legend

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -211,7 +211,7 @@ export class VaRadio {
         aria-invalid={error ? 'true' : 'false'}
         aria-label={ariaLabel}
       >
-        <legend>
+        <legend part="legend">
           {label}
           {required && <span class="required">{i18next.t('required')}</span>}
         </legend>


### PR DESCRIPTION
## Chromatic
<!-- This `1324-radio-part` is a placeholder for a CI job - it will be updated automatically -->
https://1324-radio-part--60f9b557105290003b387cd5.chromatic.com

## Description
Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1324

Adding this to allow styling of the `va-radio` legend. ~Placing an H3 inside the legend may be the best solution, but we need to have a11y discussions first~ styling only, no headers inside
 
<img width="316" alt="Radio legend shown with H3 header styling for a yes-no question" src="https://user-images.githubusercontent.com/136959/204563892-6fe22920-cba5-43ec-86b2-8da9c7b01eea.png">

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Add `part` attribute to legend to allow css styling

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
