### PR TITLE
Add add to calendar variation to va-link

### DIFF
--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -139,5 +139,6 @@ export const Calendar = VariantTemplate.bind(null);
 Calendar.args = {
   ...defaultArgs,
   calendar: true,
+  href: 'data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR',
   text: `Add to calendar`,
 };

--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -17,6 +17,7 @@ export default {
 const defaultArgs = {
   'abbr-title': undefined,
   'active': undefined,
+  'calendar': undefined,
   'channel': undefined,
   'disable-analytics': undefined,
   'download': undefined,
@@ -31,6 +32,7 @@ const defaultArgs = {
 const Template = ({
   'abbr-title': abbrTitle,
   active,
+  calendar,
   channel,
   'disable-analytics': disableAnalytics,
   download,
@@ -48,6 +50,7 @@ const Template = ({
       <va-link
         abbr-title={abbrTitle}
         active={active}
+        calendar={calendar}
         channel={channel}
         disable-analytics={disableAnalytics}
         download={download}
@@ -73,6 +76,7 @@ Default.argTypes = propStructure(linkDocs);
 const VariantTemplate = ({
   'abbr-title': abbrTitle,
   active,
+  calendar,
   channel,
   'disable-analytics': disableAnalytics,
   download,
@@ -87,6 +91,7 @@ const VariantTemplate = ({
     <va-link
       abbr-title={abbrTitle}
       active={active}
+      calendar={calendar}
       channel={channel}
       disable-analytics={disableAnalytics}
       download={download}
@@ -128,4 +133,10 @@ Channel.args = {
   ...defaultArgs,
   channel: true,
   text: `Veteran's Affairs`,
+};
+
+export const Calendar = VariantTemplate.bind(null);
+Calendar.args = {
+  ...defaultArgs,
+  calendar: true,
 };

--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -139,4 +139,5 @@ export const Calendar = VariantTemplate.bind(null);
 Calendar.args = {
   ...defaultArgs,
   calendar: true,
+  text: `Add to calendar`,
 };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.19.0",
+  "version": "4.20.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -329,6 +329,10 @@ export namespace Components {
          */
         "active"?: boolean;
         /**
+          * If `true`, a calendar icon will be displayed before the anchor text.
+         */
+        "calendar"?: boolean;
+        /**
           * If `true`, a channel icon will be displayed before the anchor text.
          */
         "channel"?: boolean;
@@ -341,7 +345,7 @@ export namespace Components {
          */
         "download"?: boolean;
         /**
-          * The suggested filename. Only valid if download is `true`.
+          * The suggested filename. Only valid if download or calendar is `true`.
          */
         "filename"?: string;
         /**
@@ -1629,6 +1633,10 @@ declare namespace LocalJSX {
          */
         "active"?: boolean;
         /**
+          * If `true`, a calendar icon will be displayed before the anchor text.
+         */
+        "calendar"?: boolean;
+        /**
           * If `true`, a channel icon will be displayed before the anchor text.
          */
         "channel"?: boolean;
@@ -1641,7 +1649,7 @@ declare namespace LocalJSX {
          */
         "download"?: boolean;
         /**
-          * The suggested filename. Only valid if download is `true`.
+          * The suggested filename. Only valid if download or calendar is `true`.
          */
         "filename"?: string;
         /**

--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -39,6 +39,25 @@ describe('va-link', () => {
     `);
   });
 
+  it('renders calendar link', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-link calendar filename="Appointment_at_Cheyenne_VA_Medical_Center.ics" href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR" text="Add to calendar" />',
+    );
+
+    const element = await page.find('va-link');
+    expect(element).toEqualHtml(`
+    <va-link class="hydrated" calendar filename="Appointment_at_Cheyenne_VA_Medical_Center.ics" href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR" text="Add to calendar">
+      <mock:shadow-root>
+        <a download="Appointment_at_Cheyenne_VA_Medical_Center.ics" href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR">
+          <i aria-hidden="true"></i>
+          Add to calendar
+        </a>
+      </mock:shadow-root>
+    </va-link>
+    `);
+  });
+
   it('renders download link', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-link/va-link.css
+++ b/packages/web-components/src/components/va-link/va-link.css
@@ -57,6 +57,10 @@ i::before {
   font-weight: 400;
 }
 
+:host([calendar]:not([calendar='false'])) i::before {
+  content: '\f133'; /* fa-calendar */
+}
+
 dfn {
   font-style: normal;
 }

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -23,6 +23,11 @@ export class VaLink {
   @Prop() active?: boolean = false;
 
   /**
+   * If `true`, a calendar icon will be displayed before the anchor text.
+   */
+  @Prop() calendar?: boolean = false;
+
+  /**
    * If `true`, a channel icon will be displayed before the anchor text.
    */
   @Prop() channel?: boolean = false;
@@ -43,7 +48,7 @@ export class VaLink {
   @Prop() href!: string;
 
   /**
-   * The suggested filename. Only valid if download is `true`.
+   * The suggested filename. Only valid if download or calendar is `true`.
    */
   @Prop() filename?: string;
 
@@ -98,6 +103,7 @@ export class VaLink {
   render() {
     const {
       active,
+      calendar,
       channel,
       download,
       filetype,
@@ -132,6 +138,18 @@ export class VaLink {
           </a>
         </Host>
       );
+    }
+
+    // Calendar link variant
+    if (calendar) {
+      return (
+        <Host>
+         <a href={href} download={filename} onClick={handleClick}>
+          <i aria-hidden="true" />
+          {text}
+        </a>
+      </Host>
+      )
     }
 
     // Download link variant


### PR DESCRIPTION
## Chromatic
<!-- This `603-add-calendar-link-to-va-link` is a placeholder for a CI job - it will be updated automatically -->
https://603-add-calendar-link-to-va-link--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [Create a component for adding a calendar event #603](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/603) by adding a `Add to calendar` variation to the `va-link` component.

This is also referenced in[department-of-veterans-affairs/va.gov-team/issues/13011](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13011)

VAOS currently uses the `fa-regular` version of the calendar icon, this uses the `fa-solid` version of the icon. Currently unsure if it is possible to use the `fa-regular` version without a [pro license](https://fontawesome.com/v5/docs/web/advanced/css-pseudo-elements) for FontAwesome.

## Testing done
- e2e testing

## Screenshots
![image](https://user-images.githubusercontent.com/587812/204849852-1383ffe0-cdf5-446e-b41a-23f3180b953f.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
