### PR TITLE
Remove left padding and adjust option spacing in va-radio and va-radio-option

### DIFF
--- a/packages/web-components/src/components/va-radio-option/va-radio-option.css
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.css
@@ -2,7 +2,7 @@
 
 :host {
   display: block;
-  margin-top: 1rem;
+  margin-top: 12px;
 }
 
 :host(:focus) {
@@ -15,7 +15,7 @@ label {
   display: inline-block;
   margin: 0;
   width: 100%;
-  padding-left: 2.4rem;
+  padding-left: 6px;
 }
 
 label::before {

--- a/packages/web-components/src/components/va-radio/va-radio.css
+++ b/packages/web-components/src/components/va-radio/va-radio.css
@@ -23,5 +23,4 @@ legend {
   font-size: inherit;
   color: inherit;
   line-height: inherit;
-  margin-bottom: 1.2rem;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `1345-va-radio-spacing` is a placeholder for a CI job - it will be updated automatically -->
https://1345-va-radio-spacing--60f9b557105290003b387cd5.chromatic.com/?path=/docs/components-va-radio--default

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1345
Related Design Issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1346
Related Formation PR: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/891

## Testing done
Storybook

## Screenshots
![Screen Shot 2022-11-30 at 3 31 01 PM](https://user-images.githubusercontent.com/872479/204913519-e32468b0-2d8a-4bdc-9b08-98ec3fb9b64d.png)


## Acceptance criteria
- [ ] The va-radio and va-radio-option components have left padding and option spacing matching the [Sketch designs](https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/a/R18WG5Z).

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
