### PR TITLE
va-textarea: Add a11y css import and font styles.

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.19.0",
+  "version": "4.19.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-textarea/va-textarea.css
+++ b/packages/web-components/src/components/va-textarea/va-textarea.css
@@ -1,3 +1,4 @@
+@import '../../mixins/accessibility.css';
 @import '../../mixins/focusable.css';
 @import '../../mixins/form-field-error.css';
 
@@ -24,7 +25,10 @@ label {
 }
 
 textarea {
-  font-family: var(--font-sans);
+  font-family: var(--font-source-sans);
+  font-size: 16px;
+  color: var(--color-base);
+  line-height: 1.3;
   display: block;
   min-height: 5.2rem;
   height: 16rem;


### PR DESCRIPTION
## Chromatic
<!-- This `1372-va-textarea-update` is a placeholder for a CI job - it will be updated automatically -->
https://1372-va-textarea-update--60f9b557105290003b387cd5.chromatic.com/?path=/docs/components-va-textarea--default

## Description
This PR will add the a11y css import so that `.sr-only` will work. It also adds font styling for the `textarea`. The styles used are [the same ones used for `va-input`](https://github.com/department-of-veterans-affairs/component-library/blob/main/packages/web-components/src/components/va-text-input/va-text-input.css#L24-L29) and also confirmed via [Sketch](https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/C6340B6C-F41E-423B-BDEA-B340A81C9714/canvas).

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1372

## Testing done
Storybook

## Screenshots

![Screen Shot 2022-12-01 at 9 58 48 AM](https://user-images.githubusercontent.com/872479/205100130-c79e8e66-5a22-4894-9a4f-0ef4715c4762.png)

## Acceptance criteria
- [ ] The "Error" text for screen readers is hidden visually.
- [ ] The textarea font size and treatment is updated to match Sketch.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
