### PR TITLE
va-radio: add part attr to all elements

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "13.4.0",
+  "version": "13.5.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.20.1",
+  "version": "4.21.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
+++ b/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
@@ -123,7 +123,7 @@ describe('va-radio', () => {
 
     const element = await page.find('va-radio >>> .required');
     expect(element).toEqualHtml(`
-      <span class="required">
+      <span class="required" part="required">
         required
       </span>
     `);
@@ -436,7 +436,7 @@ describe('va-radio', () => {
 
     const element = await page.find('va-radio >>> .usa-label--required');
     expect(element).toEqualHtml(`
-      <span class="usa-label--required">
+      <span class="usa-label--required" part="required">
         required
       </span>
     `);

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -230,14 +230,14 @@ export class VaRadio {
               {label}
               {required && <span class="usa-label--required" part="required"> {i18next.t('required')}</span>}
             </legend>
-            <span class="usa-error-message" role="alert" part="error">
+            <span class="usa-error-message" role="alert">
               {error && (
                 <Fragment>
                   <span class="usa-sr-only">{i18next.t('error')}</span> {error}
                 </Fragment>
               )}
             </span>
-            {hint && <span class="usa-hint" part="hint">{hint}</span>}
+            {hint && <span class="usa-hint">{hint}</span>}
             <slot></slot>
           </fieldset>
         </Host>
@@ -253,8 +253,8 @@ export class VaRadio {
             {label}
             {required && <span class="required" part="required">{i18next.t('required')}</span>}
           </legend>
-          {hint && <span class="hint-text" part="hint">{hint}</span>}
-          <span id="error-message" role="alert" part="error">
+          {hint && <span class="hint-text">{hint}</span>}
+          <span id="error-message" role="alert">
             {error && (
               <Fragment>
                 <span class="sr-only">{i18next.t('error')}</span> {error}

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -220,24 +220,24 @@ export class VaRadio {
         'usa-legend': true,
         'usa-label--error': error
       });
-      return ( 
+      return (
         <Host
           aria-invalid={error ? 'true' : 'false'}
           aria-label={ariaLabel}
         >
           <fieldset class="usa-form usa-fieldset">
-            <legend class={legendClass}>
+            <legend class={legendClass} part="legend">
               {label}
-              {required && <span class="usa-label--required"> {i18next.t('required')}</span>}
+              {required && <span class="usa-label--required" part="required"> {i18next.t('required')}</span>}
             </legend>
-            <span class="usa-error-message" role="alert">
+            <span class="usa-error-message" role="alert" part="error">
               {error && (
                 <Fragment>
                   <span class="usa-sr-only">{i18next.t('error')}</span> {error}
                 </Fragment>
               )}
             </span>
-            {hint && <span class="usa-hint">{hint}</span>}
+            {hint && <span class="usa-hint" part="hint">{hint}</span>}
             <slot></slot>
           </fieldset>
         </Host>
@@ -251,10 +251,10 @@ export class VaRadio {
         >
           <legend part="legend">
             {label}
-            {required && <span class="required">{i18next.t('required')}</span>}
+            {required && <span class="required" part="required">{i18next.t('required')}</span>}
           </legend>
-          {hint && <span class="hint-text">{hint}</span>}
-          <span id="error-message" role="alert">
+          {hint && <span class="hint-text" part="hint">{hint}</span>}
+          <span id="error-message" role="alert" part="error">
             {error && (
               <Fragment>
                 <span class="sr-only">{i18next.t('error')}</span> {error}


### PR DESCRIPTION
## Chromatic
<!-- This `49541-req-radio` is a placeholder for a CI job - it will be updated automatically -->
https://49541-req-radio--60f9b557105290003b387cd5.chromatic.com

## Description
Related to [#49539](https://github.com/department-of-veterans-affairs/va.gov-team/issues/49539)

We're using css to enlarge the legend text to `H3` size to match the design of our form. Recently, we decided to make this question required, and thus an `H3` sized required label also appeared; but we can't modify the style using css. 

<img width="670" alt="Legend styled as an h3, but this also enlarges the required label to be the same size" src="https://user-images.githubusercontent.com/136959/207370268-309042be-e853-42e2-8141-72f79fe327a5.png">

This PR adds a `part` attribute to include the new USWDS elements, and also include hint and error messaging.

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Add `part` attribute to `va-radio` elements 
- [x] Add `part` attribute to USWDS rendered elements

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
