### PR TITLE
Bug: Increase z-index in vaModel component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "13.5.0",
+  "version": "13.5.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.21.0",
+  "version": "4.21.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-modal/va-modal.css
+++ b/packages/web-components/src/components/va-modal/va-modal.css
@@ -17,7 +17,7 @@
   text-align: center;
   top: 0;
   width: 100%;
-  z-index: 6;
+  z-index: 9001;
 }
 
 :host([visible]:not([visible='false']))::before {


### PR DESCRIPTION
## Chromatic
<!-- This `z-index-n-vaModel-component` is a placeholder for a CI job - it will be updated automatically -->
https://z-index-n-vaModel-component--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [1374](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1374)

## Testing done
Used dev-tools in https://staging.va.gov/my-health/secure-messages/folders

## Screenshots
### Before
![Screen Shot 2022-12-14 at 3 29 55 PM](https://user-images.githubusercontent.com/55560129/207707952-d8a274b4-008e-4ae2-8a7c-0425eceb3402.png)


### After
![Screen Shot 2022-12-14 at 3 30 20 PM](https://user-images.githubusercontent.com/55560129/207707801-b2e74f9f-5103-4b90-b6aa-769fce54b96f.png)


## Acceptance criteria
- [x] z-index has been increased

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
