### PR TITLE
Add vads-align-self class to css-library

### DIFF
--- a/packages/css-library/src/tokens/flexbox.scss
+++ b/packages/css-library/src/tokens/flexbox.scss
@@ -48,6 +48,15 @@ $tokens-align-content: (
   'stretch': stretch,
 );
 
+$tokens-align-self: (
+  'auto': auto,
+  'flex-start': flex-start,
+  'flex-end': flex-end,
+  'center': center,
+  'baseline': baseline,
+  'stretch': stretch
+);
+
 $tokens-order: (
   '1': 1,
   '2': 2,

--- a/packages/css-library/src/utilities/flexbox.scss
+++ b/packages/css-library/src/utilities/flexbox.scss
@@ -68,6 +68,17 @@ $u-align-content: (
   ),
 );
 
+$u-align-self: (
+  align-self: (
+    base: 'vads-align-self',
+    modifiers: null,
+    values: map-collect($tokens-align-self),
+    settings: $flex-settings,
+    property: 'align-self',
+    type: 'utility',
+  ),
+);
+
 $u-order: (
   order: (
     base: 'vads-order',
@@ -86,5 +97,6 @@ $u-flexbox: map-collect(
   $u-align-items,
   $u-justify-content,
   $u-align-content,
+  $u-align-self,
   $u-order
 );


### PR DESCRIPTION
## Chromatic
<!-- This `Add-missing-vads-align-self-class-to-css-library` is a placeholder for a CI job - it will be updated automatically -->
https://Add-missing-vads-align-self-class-to-css-library--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [1403](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1403)

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
