### PR TITLE
Add focus style to va-alert close button

### DIFF
--- a/packages/web-components/src/components/va-alert/va-alert.css
+++ b/packages/web-components/src/components/va-alert/va-alert.css
@@ -1,4 +1,5 @@
 @import '../../mixins/accessibility.css';
+@import '../../mixins/buttons.css';
 
 :host {
   display: block;


### PR DESCRIPTION
## Chromatic
<!-- This `1106-alert-close-focus-style` is a placeholder for a CI job - it will be updated automatically -->
https://1106-alert-close-focus-style--60f9b557105290003b387cd5.chromatic.com

## Description
This PR fixes the focus style missing from the va-alert close button. The component was not importing the button mixin which contained the focus styles. 

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1106

## Testing done
Storybook (Firefox and Chrome)

## Screenshots

Chrome
![Screenshot 2023-01-09 at 2 25 56 PM](https://user-images.githubusercontent.com/872479/211401418-f57e5cb0-e0e1-4524-9a1c-c56b8f6fee73.png)

Firefox
![Screenshot 2023-01-09 at 2 26 31 PM](https://user-images.githubusercontent.com/872479/211401519-9432fc19-0960-40c4-99eb-81861c01395e.png)


## Acceptance criteria
- [ ] The `va-alert` component displays our custom focus state style.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
