### PR TITLE
Tagalog translation for va-memorable-date & va-text-input

### DIFF
--- a/packages/core/src/i18n/translations/tl.js
+++ b/packages/core/src/i18n/translations/tl.js
@@ -1,7 +1,8 @@
 export default {
   'error': 'Error',
   'required': '(*Kailangan)',
-  'max-chars': '(Pinakamarami ang {{length}} character)',
+  'max-chars': '(Pinakamarami ang {{length}} karakter)',
+  'min-chars': '(Pinakamababa ang {{length}}) karakter)',
   'date-of-birth': 'Petsa ng Kapanganakan',
   'month': 'Buwan',
   'day': 'Araw',
@@ -12,4 +13,5 @@ export default {
   'expand-all-aria-label': 'I-expand ang lahat ng accordion',
   'collapse-all-aria-label': 'I-collapse ang lahat ng accordion',
   'on-this-page': 'Sa pahinang ito',
+  'date-hint': 'Mangyaring maglagay ang dalawang numero para sa buwan at apat na numero para sa taon',
 };

--- a/packages/core/src/i18n/translations/tl.js
+++ b/packages/core/src/i18n/translations/tl.js
@@ -2,7 +2,7 @@ export default {
   'error': 'Error',
   'required': '(*Kailangan)',
   'max-chars': '(Pinakamarami ang {{length}} karakter)',
-  'min-chars': '(Pinakamababa ang {{length}}) karakter)',
+  'min-chars': '(Pinakamababa ang {{length}} karakter)',
   'date-of-birth': 'Petsa ng Kapanganakan',
   'month': 'Buwan',
   'day': 'Araw',

--- a/packages/storybook/stories/va-memorable-date.stories.jsx
+++ b/packages/storybook/stories/va-memorable-date.stories.jsx
@@ -95,6 +95,7 @@ const I18nTemplate = ({ label, name, required, error, value }) => {
     <div>
       <button onClick={e => setLang('es')}>Español</button>
       <button onClick={e => setLang('en')}>English</button>
+      <button onClick={e => setLang('tl')}>Tagalog</button>
       <VaMemorableDate
       label={label}
       name={name}


### PR DESCRIPTION
## Chromatic
<!-- This `1291-Tagalog-translations` is a placeholder for a CI job - it will be updated automatically -->
https://1291-Tagalog-translations--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1291

This PR adds the following functionality:

### va-memorable-date
- Adds Tagalog to Internationalization Story for hint text

### va-text-input
- Adds Tagalog to Internationalization Story for minimum length

## Testing done

- Storybook :eyes: 
- E2E updates

## Screenshots

### va-memorable-date
![Screen Shot 2023-01-12 at 1 00 23 PM](https://user-images.githubusercontent.com/55560129/212145247-6eeb7259-4640-4c27-9c1f-4038c6ad8c82.png)


### va-text-input
![Screen Shot 2023-01-12 at 12 58 47 PM](https://user-images.githubusercontent.com/55560129/212145282-c5987683-84f7-482e-bc4a-2b7e25bae713.png)


## Acceptance criteria
- [x] All components have translation functionality

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
