### PR TITLE
Accessibility updates to va-pagination to support Voice Control

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "13.7.0",
+  "version": "13.8.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-pagination.stories.jsx
+++ b/packages/storybook/stories/va-pagination.stories.jsx
@@ -33,8 +33,6 @@ const Template = ({
   };
   return (
     <>
-      <h2>Current page: {page}</h2>
-      <br />
       <VaPagination
         page={page}
         pages={pages}

--- a/packages/storybook/stories/va-pagination.stories.jsx
+++ b/packages/storybook/stories/va-pagination.stories.jsx
@@ -32,14 +32,12 @@ const Template = ({
     setPage(event.detail.page);
   };
   return (
-    <>
-      <VaPagination
-        page={page}
-        pages={pages}
-        onPageSelect={handlePageSelect}
-        showLastPage={showLastPage}
-      />
-    </>
+    <VaPagination
+      page={page}
+      pages={pages}
+      onPageSelect={handlePageSelect}
+      showLastPage={showLastPage}
+    />
   );
 };
 

--- a/packages/storybook/stories/va-pagination.stories.jsx
+++ b/packages/storybook/stories/va-pagination.stories.jsx
@@ -18,8 +18,8 @@ export default {
 
 const defaultArgs = {
   'page': 3,
-  'pages': 5,
-  'show-last-page': false,
+  'pages': 15,
+  'show-last-page': true,
 };
 
 const Template = ({
@@ -32,12 +32,16 @@ const Template = ({
     setPage(event.detail.page);
   };
   return (
-    <VaPagination
-      page={page}
-      pages={pages}
-      onPageSelect={handlePageSelect}
-      showLastPage={showLastPage}
-    />
+    <>
+      <h2>Current page: {page}</h2>
+      <br />
+      <VaPagination
+        page={page}
+        pages={pages}
+        onPageSelect={handlePageSelect}
+        showLastPage={showLastPage}
+      />
+    </>
   );
 };
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.23.0",
+  "version": "4.24.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
+++ b/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
@@ -166,8 +166,6 @@ describe('va-pagination', () => {
       'va-pagination >>> button[aria-current="true"]',
     );
 
-    console.log('*** activeButton', activeButton);
-
     expect(activeButton.textContent).toEqual('3');
   });
 

--- a/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
+++ b/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
@@ -40,41 +40,41 @@ describe('va-pagination', () => {
         <mock:shadow-root>
           <ul class="pagination-prev">
           <li>
-            <button aria-label="Previous page " class="button-prev" type="button">
-              Prev
+            <button aria-label="Previous page" class="button-prev" type="button">
+              Previous
             </button>
           </li>
           </ul>
           <ul class="pagination-inner">
             <li>
-              <button aria-label="Page 1 " class="button-inner" type="button">
+              <button aria-label="Page 1" class="button-inner" type="button">
                 1
               </button>
             </li>
             <li>
-              <button aria-label="Page 2 " class="button-inner" type="button">
+              <button aria-label="Page 2" class="button-inner" type="button">
                 2
               </button>
             </li>
             <li>
-              <button aria-current="true" aria-label="Page 3 " class="button-active button-inner" type="button">
+              <button aria-current="true" aria-label="Page 3" class="button-active button-inner" type="button">
                 3
               </button>
             </li>
             <li>
-              <button aria-label="Page 4 " class="button-inner" type="button">
+              <button aria-label="Page 4" class="button-inner" type="button">
                 4
               </button>
             </li>
             <li>
-              <button aria-label="Page 5 " class="button-inner" type="button">
+              <button aria-label="Page 5" class="button-inner" type="button">
                 5
               </button>
             </li>
           </ul>
           <ul class="pagination-next">
             <li>
-              <button aria-label="Next page " class="button-next" type="button">
+              <button aria-label="Next page" class="button-next" type="button">
                 Next
               </button>
             </li>
@@ -125,7 +125,7 @@ describe('va-pagination', () => {
     `);
     const onPageSelectSpy = await page.spyOnEvent('pageSelect');
     const page5Button = await page.find(
-      'va-pagination >>> button[aria-label="Page 5 "]',
+      'va-pagination >>> button[aria-label="Page 5"]',
     );
     await page5Button.click();
     expect(onPageSelectSpy).toHaveReceivedEventDetail({ page: 5 });
@@ -141,7 +141,7 @@ describe('va-pagination', () => {
     await component.press('Tab');
 
     const focused = await page.find('va-pagination >>> button:focus');
-    expect(focused.textContent).toEqual('Prev');
+    expect(focused.textContent).toEqual('Previous');
   });
 
   it('should tab to prev button and select it using the enter key', async () => {
@@ -165,6 +165,9 @@ describe('va-pagination', () => {
     const activeButton = await page.find(
       'va-pagination >>> button[aria-current="true"]',
     );
+
+    console.log('*** activeButton', activeButton);
+
     expect(activeButton.textContent).toEqual('3');
   });
 
@@ -175,7 +178,7 @@ describe('va-pagination', () => {
     `);
 
     const lastPageButton = await page.find(
-      'va-pagination >>> button[aria-label*="Load last page"]',
+      'va-pagination >>> button[aria-label*="Page 50"]',
     );
 
     expect(lastPageButton.textContent).toEqual('50');

--- a/packages/web-components/src/components/va-pagination/va-pagination.css
+++ b/packages/web-components/src/components/va-pagination/va-pagination.css
@@ -1,4 +1,5 @@
 @import '../../mixins/focusable.css';
+@import '../../mixins/accessibility.css';
 
 :host {
   background-color: var(--color-white);

--- a/packages/web-components/src/components/va-pagination/va-pagination.css
+++ b/packages/web-components/src/components/va-pagination/va-pagination.css
@@ -1,5 +1,4 @@
 @import '../../mixins/focusable.css';
-@import '../../mixins/accessibility.css';
 
 :host {
   background-color: var(--color-white);

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -147,16 +147,23 @@ export class VaPagination {
       return <div />;
     }
 
+    const previousAriaLabel = ariaLabelSuffix ? `Previous page ${ariaLabelSuffix}` : 'Previous page';
+    const nextAriaLabel = ariaLabelSuffix ? `Next page ${ariaLabelSuffix}` : 'Next page';
+    const lastPageAriaLabel = ariaLabelSuffix ? `Page ${pages} ${ariaLabelSuffix}` : `Page ${pages}`;
+
     const renderPages = this.pageNumbers().map(pageNumber => {
       const pageClass = classnames({
         'button-active': page === pageNumber,
         'button-inner': true,
       });
 
+      const pageAriaLabel = ariaLabelSuffix ? `Page ${pageNumber} ${ariaLabelSuffix}` : `Page ${pageNumber}`;
+
       return (
         <li>
           <button
             aria-current={page === pageNumber ? 'true' : null}
+            aria-label={pageAriaLabel}
             class={pageClass}
             onClick={() =>
               this.handlePageSelect(pageNumber, 'nav-paginate-number')
@@ -164,8 +171,7 @@ export class VaPagination {
             onKeyDown={e => this.handleKeyDown(e, pageNumber)}
             type="button"
           >
-            <span class="sr-only">Page</span>{pageNumber}
-            {ariaLabelSuffix && (<span class="sr-only"> {ariaLabelSuffix}</span>)}
+            {pageNumber}
           </button>
         </li>
       );
@@ -178,6 +184,7 @@ export class VaPagination {
           {this.page > 1 && (
             <li>
               <button
+                aria-label={previousAriaLabel}
                 class="button-prev"
                 onClick={() =>
                   this.handlePageSelect(this.page - 1, 'nav-paginate-previous')
@@ -185,8 +192,7 @@ export class VaPagination {
                 onKeyDown={e => this.handleKeyDown(e, this.page - 1)}
                 type="button"
               >
-                Previous<span class="sr-only"> Page</span>
-                {ariaLabelSuffix && (<span class="sr-only"> {ariaLabelSuffix}</span>)}
+                Previous
               </button>
             </li>
           )}
@@ -203,6 +209,7 @@ export class VaPagination {
               </li>
               <li>
                 <button
+                  aria-label={lastPageAriaLabel}
                   class="button-inner"
                   onClick={() =>
                     this.handlePageSelect(pages, 'nav-paginate-number')
@@ -210,8 +217,7 @@ export class VaPagination {
                   onKeyDown={e => this.handleKeyDown(e, pages)}
                   type="button"
                 >
-                  <span class="sr-only">Page</span>{pages}
-                  {ariaLabelSuffix && (<span class="sr-only"> {ariaLabelSuffix}</span>)}
+                  {pages}
                 </button>
               </li>
             </Fragment>
@@ -224,6 +230,7 @@ export class VaPagination {
           {this.pages > this.page && (
             <li>
               <button
+                aria-label={nextAriaLabel}
                 class="button-next"
                 onClick={() =>
                   this.handlePageSelect(this.page + 1, 'nav-paginate-next')
@@ -231,8 +238,7 @@ export class VaPagination {
                 onKeyDown={e => this.handleKeyDown(e, this.page + 1)}
                 type="button"
               >
-                Next<span class="sr-only"> Page</span>
-                {ariaLabelSuffix && (<span class="sr-only"> {ariaLabelSuffix}</span>)}
+                Next
               </button>
             </li>
           )}

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -130,7 +130,7 @@ export class VaPagination {
   };
 
   render() {
-    const { ariaLabelSuffix, page, pages, maxPageListLength, showLastPage } =
+    const { page, pages, maxPageListLength, showLastPage } =
       this;
 
     if (pages === 1) {
@@ -146,8 +146,8 @@ export class VaPagination {
       return (
         <li>
           <button
+            data-page-id={pageNumber}
             aria-current={page === pageNumber ? 'true' : null}
-            aria-label={`Page ${pageNumber} ${ariaLabelSuffix}`}
             class={pageClass}
             onClick={() =>
               this.handlePageSelect(pageNumber, 'nav-paginate-number')
@@ -155,7 +155,7 @@ export class VaPagination {
             onKeyDown={e => this.handleKeyDown(e, pageNumber)}
             type="button"
           >
-            {pageNumber}
+            <span class="sr-only">Page</span>{pageNumber}
           </button>
         </li>
       );
@@ -168,7 +168,6 @@ export class VaPagination {
           {this.page > 1 && (
             <li>
               <button
-                aria-label={`Previous page ${this.ariaLabelSuffix}`}
                 class="button-prev"
                 onClick={() =>
                   this.handlePageSelect(this.page - 1, 'nav-paginate-previous')
@@ -176,7 +175,7 @@ export class VaPagination {
                 onKeyDown={e => this.handleKeyDown(e, this.page - 1)}
                 type="button"
               >
-                Prev
+                Previous<span class="sr-only"> Page</span>
               </button>
             </li>
           )}
@@ -188,19 +187,12 @@ export class VaPagination {
           {/* START ELLIPSIS AND LAST BUTTON */}
           {showLastPage && page < pages - maxPageListLength + 1 && (
             <Fragment>
-              <li>
-                <button
-                  aria-label="..."
-                  class="button-inner"
-                  onKeyDown={e => this.handleKeyDown(e, null)}
-                  type="button"
-                >
-                  ...
-                </button>
+              <li role="presentation">
+                <span>...</span>
               </li>
               <li>
                 <button
-                  aria-label={`Load last page ${this.ariaLabelSuffix}`}
+                  data-page-id={pages}
                   class="button-inner"
                   onClick={() =>
                     this.handlePageSelect(pages, 'nav-paginate-number')
@@ -208,7 +200,7 @@ export class VaPagination {
                   onKeyDown={e => this.handleKeyDown(e, pages)}
                   type="button"
                 >
-                  {pages}
+                  <span class="sr-only">Last page, page {pages}</span>{pages}
                 </button>
               </li>
             </Fragment>
@@ -221,7 +213,6 @@ export class VaPagination {
           {this.pages > this.page && (
             <li>
               <button
-                aria-label={`Next page ${this.ariaLabelSuffix}`}
                 class="button-next"
                 onClick={() =>
                   this.handlePageSelect(this.page + 1, 'nav-paginate-next')
@@ -229,7 +220,7 @@ export class VaPagination {
                 onKeyDown={e => this.handleKeyDown(e, this.page + 1)}
                 type="button"
               >
-                Next
+                Next <span class="sr-only"> Page</span>
               </button>
             </li>
           )}

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -208,7 +208,7 @@ export class VaPagination {
                   onKeyDown={e => this.handleKeyDown(e, pages)}
                   type="button"
                 >
-                  <span class="sr-only">Last page, page {pages}</span>{pages}
+                  <span class="sr-only">Page</span>{pages}
                 </button>
               </li>
             </Fragment>

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -6,6 +6,7 @@ import {
   Host,
   h,
   Prop,
+  Element,
 } from '@stencil/core';
 import classnames from 'classnames';
 
@@ -21,6 +22,7 @@ import classnames from 'classnames';
   shadow: true,
 })
 export class VaPagination {
+  @Element() el: HTMLElement;
   /**
    * Fires when a page is selected
    */
@@ -70,6 +72,10 @@ export class VaPagination {
 
   private handlePageSelect = (page, eventID) => {
     this.pageSelect.emit({ page });
+
+    // Reset focus to the active page button.
+    (this.el.shadowRoot.activeElement as HTMLElement).blur();
+
     if (this.enableAnalytics) {
       const detail = {
         componentName: 'va-pagination',
@@ -124,6 +130,10 @@ export class VaPagination {
     if (keyCode === 'Enter' || keyCode === ' ') {
       e.preventDefault();
       if (!pageNumber) return;
+
+      // Reset focus to the active page button.
+      (this.el.shadowRoot.activeElement as HTMLElement).blur();
+
       /* eslint-disable-next-line i18next/no-literal-string */
       this.handlePageSelect(pageNumber, 'nav-paginate-number');
     }
@@ -146,7 +156,6 @@ export class VaPagination {
       return (
         <li>
           <button
-            data-page-id={pageNumber}
             aria-current={page === pageNumber ? 'true' : null}
             class={pageClass}
             onClick={() =>
@@ -192,7 +201,6 @@ export class VaPagination {
               </li>
               <li>
                 <button
-                  data-page-id={pages}
                   class="button-inner"
                   onClick={() =>
                     this.handlePageSelect(pages, 'nav-paginate-number')

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -131,9 +131,6 @@ export class VaPagination {
       e.preventDefault();
       if (!pageNumber) return;
 
-      // Reset focus to the active page button.
-      (this.el.shadowRoot.activeElement as HTMLElement).blur();
-
       /* eslint-disable-next-line i18next/no-literal-string */
       this.handlePageSelect(pageNumber, 'nav-paginate-number');
     }

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -140,7 +140,7 @@ export class VaPagination {
   };
 
   render() {
-    const { page, pages, maxPageListLength, showLastPage } =
+    const { ariaLabelSuffix, page, pages, maxPageListLength, showLastPage } =
       this;
 
     if (pages === 1) {
@@ -165,6 +165,7 @@ export class VaPagination {
             type="button"
           >
             <span class="sr-only">Page</span>{pageNumber}
+            {ariaLabelSuffix && (<span class="sr-only"> {ariaLabelSuffix}</span>)}
           </button>
         </li>
       );
@@ -185,6 +186,7 @@ export class VaPagination {
                 type="button"
               >
                 Previous<span class="sr-only"> Page</span>
+                {ariaLabelSuffix && (<span class="sr-only"> {ariaLabelSuffix}</span>)}
               </button>
             </li>
           )}
@@ -209,6 +211,7 @@ export class VaPagination {
                   type="button"
                 >
                   <span class="sr-only">Page</span>{pages}
+                  {ariaLabelSuffix && (<span class="sr-only"> {ariaLabelSuffix}</span>)}
                 </button>
               </li>
             </Fragment>
@@ -228,7 +231,8 @@ export class VaPagination {
                 onKeyDown={e => this.handleKeyDown(e, this.page + 1)}
                 type="button"
               >
-                Next <span class="sr-only"> Page</span>
+                Next<span class="sr-only"> Page</span>
+                {ariaLabelSuffix && (<span class="sr-only"> {ariaLabelSuffix}</span>)}
               </button>
             </li>
           )}


### PR DESCRIPTION
## Chromatic
<!-- This `1408-pagination-a11y` is a placeholder for a CI job - it will be updated automatically -->
https://1408-pagination-a11y--60f9b557105290003b387cd5.chromatic.com

## Description
This PR addresses some accessibility issues mentioned in the ticket below. The word `prev` was updated to `previous` and the `aria-labels` were tested using Voice Control on mac to make sure that the component could be used entirely by voice control. The `aria-labels` were mostly just refactored and the word "page" added where relevant for using the voice controls.

Voice Commands that are working:

- "Click page 3" ✅  (and other page specific numbers)
- "Click previous page" ✅ 
- "Click next page" ✅ 

The command structure that I was unable to make work:

- "Click 3" ❌ 

It also fixes a bug where the selected page was not losing its active style (making it appears like two pages were selected at the same time). 

Related Issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1408

## Testing done
Storybook - Voice Command
Storybook - Voice Over

## Screenshots
![Screenshot 2023-01-17 at 2 55 46 PM](https://user-images.githubusercontent.com/872479/213010435-5090dd41-914c-4e1c-8a40-c824eca6a855.png)


## Acceptance criteria
- [ ] The va-pagination component can be used with Voice Control.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
