### PR TITLE
Add part attribute to textarea component (#1410)

### DIFF
--- a/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
+++ b/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
@@ -12,11 +12,11 @@ describe('va-textarea', () => {
     expect(element).toEqualHtml(`
       <va-textarea class="hydrated" label="Describe your situation">
         <mock:shadow-root>
-          <label for="textarea">
+          <label for="textarea" part="label">
             Describe your situation
           </label>
           <span id="error-message" role="alert"></span>
-          <textarea id="textarea" aria-invalid="false"></textarea>
+          <textarea id="textarea" part="textarea" aria-invalid="false"></textarea>
         </mock:shadow-root>
       </va-textarea>
     `);

--- a/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
+++ b/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
@@ -12,7 +12,7 @@ describe('va-textarea', () => {
     expect(element).toEqualHtml(`
       <va-textarea class="hydrated" label="Describe your situation">
         <mock:shadow-root>
-          <label for="textarea" part="label">
+          <label for="textarea">
             Describe your situation
           </label>
           <span id="error-message" role="alert"></span>

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -28,7 +28,7 @@ if (Build.isTesting) {
  * @translations English
  * @translations Spanish
  */
- 
+
 @Component({
   tag: 'va-textarea',
   styleUrl: 'va-textarea.css',
@@ -142,7 +142,7 @@ export class VaTextarea {
 
     return (
       <Host>
-        <label htmlFor="textarea">
+        <label htmlFor="textarea" part="label">
           {label}
           {required && <span class="required">{i18next.t('required')}</span>}
         </label>
@@ -165,9 +165,12 @@ export class VaTextarea {
           name={name}
           maxLength={maxlength}
           value={value}
+          part="textarea"
         />
         {maxlength && value?.length >= maxlength && (
-          <small>{i18next.t('max-chars', { length: maxlength })}</small>
+          <small part="validation">
+            {i18next.t('max-chars', { length: maxlength })}
+          </small>
         )}
       </Host>
     );

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -142,7 +142,7 @@ export class VaTextarea {
 
     return (
       <Host>
-        <label htmlFor="textarea" part="label">
+        <label htmlFor="textarea">
           {label}
           {required && <span class="required">{i18next.t('required')}</span>}
         </label>
@@ -168,9 +168,7 @@ export class VaTextarea {
           part="textarea"
         />
         {maxlength && value?.length >= maxlength && (
-          <small part="validation">
-            {i18next.t('max-chars', { length: maxlength })}
-          </small>
+          <small>{i18next.t('max-chars', { length: maxlength })}</small>
         )}
       </Host>
     );


### PR DESCRIPTION
## Chromatic
<!-- This `1410-add-part-attr-to-textarea` is a placeholder for a CI job - it will be updated automatically -->
https://1410-add-part-attr-to-textarea--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1410
I added a "part" attribute to the label, textarea, and small (validation) elements, copying the pattern of "part" attributes in the va-text-input component. 

## Testing done
E2e tests for the textarea component have been updated to include the "part" attribute. 

## Screenshots
No UI changes. 

## Acceptance criteria
- [x] Textarea component has a "part" attribute

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
