### PR TITLE
Add USWDS v3 Error color to css-library

### DIFF
--- a/packages/css-library/tokens/color.json
+++ b/packages/css-library/tokens/color.json
@@ -38,5 +38,84 @@
       "warm-light": { "value": "#e4e2e0"},
       "cool-light": { "value": "#dce4ef"}
     }
+  },
+  "v3-color": {
+    "base": {
+      "*": { "value": "#71767a"},
+      "dark": { "value": "#565c65"},
+      "darker": { "value": "#3d4551"},
+      "darkest": { "value": "#1b1b1b"},
+      "light": { "value": "#a9aeb1"},
+      "lighter": { "value": "#dfe1e2"},
+      "lightest": { "value": "#f0f0f0"},
+      "ink": { "value": "#1b1b1b"}
+    },
+    "primary": {
+      "*": { "value": "#005ea2"},
+      "dark": { "value": "#1a4480"},
+      "darker": { "value": "#162e51"},
+      "light": { "value": "#73b3e7"},
+      "lighter": { "value": "#d9e8f6"},
+      "vivid": { "value": "#0050d8"}
+    },
+    "secondary": {
+      "*": { "value": "#d83933"},
+      "dark": { "value": "#b50909"},
+      "darker": { "value": "#8b0a03"},
+      "light": { "value": "#f2938c"},
+      "lighter": { "value": "#f8dfe2"},
+      "vivid": { "value": "#e41d3d"}
+    },
+    "accent": {
+      "cool": {
+        "*": { "value": "#00bde3"},
+        "dark": { "value": "#28a0cb"},
+        "darker": { "value": "#07648d"},
+        "light": { "value": "#97d4ea"},
+        "lighter": { "value": "#e1f3f8"}
+      },
+      "warm": {
+        "*": { "value": "#fa9441"},
+        "dark": { "value": "#c05600"},
+        "darker": { "value": "#775540"},
+        "light": { "value": "#ffbc78"},
+        "lighter": { "value": "#f2e4d4"}
+      }
+    },
+    "error": {
+      "*": { "value": "#d54309"},
+      "dark": { "value": "#b50909"},
+      "darker": { "value": "#8b0a03"},
+      "light": { "value": "#f39268"},
+      "lighter": { "value": "#f4e3db"}
+    },
+    "warning": {
+      "*": { "value": "#ffbe2e"},
+      "dark": { "value": "#e5a000"},
+      "darker": { "value": "#936f38"},
+      "light": { "value": "#fee685"},
+      "lighter": { "value": "#faf3d1"}
+    },
+    "success": {
+      "*": { "value": "#00a91c"},
+      "dark": { "value": "#008817"},
+      "darker": { "value": "#216e1f"},
+      "light": { "value": "#70e17b"},
+      "lighter": { "value": "#ecf3ec"}
+    },
+    "info": {
+      "*": { "value": "#00bde3"},
+      "dark": { "value": "#009ec1"},
+      "darker": { "value": "#2e6276"},
+      "light": { "value": "#99deea"},
+      "lighter": { "value": "#e7f6f8"}
+    },
+    "disabled": {
+      "*": { "value": "#c9c9c9"},
+      "dark": { "value": "#adadad"},
+      "light": { "value": "#e6e6e6"}
+    },
+    "emergency": { "value": "#9c3d10"},
+    "emergency-dark": { "value": "#332d29"}
   }
 }

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -1,6 +1,4 @@
-
-// Do not edit directly
-// Generated on Thu, 17 Nov 2022 19:14:09 GMT from css-library
+// File generated from css-library
 
 $color-base: #212121;
 $color-white: #ffffff;
@@ -32,6 +30,7 @@ $color-gray-lightest: #f1f1f1;
 $color-gray-warm-dark: #494440;
 $color-gray-warm-light: #e4e2e0;
 $color-gray-cool-light: #dce4ef;
+$v3-color-error-dark: #b50909;
 $font-family-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
 $font-family-serif: Bitter, Georgia, Cambria, 'Times New Roman', Times, serif;
 $font-weight-normal: 400;

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -31,6 +31,7 @@
   --color-secondary-dark: #cd2026;
   --color-secondary-light: #e59393;
   --color-secondary-lightest: #f9dede;
+  --v3-color-error-dark: #b50909;
   --font-source-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto,
     Arial, sans-serif;
   --font-serif: Bitter, Georgia, Cambria, 'Times New Roman', Times, serif;

--- a/packages/web-components/src/mixins/uswds-error-border.css
+++ b/packages/web-components/src/mixins/uswds-error-border.css
@@ -1,5 +1,5 @@
 :host([error][uswds]:not([error=''])) {
-    border-left: 0.4rem solid #b50909; /* USWDS red-60v, $theme-color-error-dark */
+    border-left: 0.4rem solid var(--v3-color-error-dark); /* USWDS red-60v, $theme-color-error-dark */
     padding-left: 1rem;
     position: relative;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [1417](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1417)

## Testing done
Locally
Storybook - Text Input USWDS v3

## Screenshots
![Screen Shot 2023-01-17 at 11 36 01 AM](https://user-images.githubusercontent.com/55560129/212957907-c8e732be-0633-4a64-92c1-9ce1e98639b2.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
