### PR TITLE
Add VA favicons to Storybook

### DIFF
--- a/packages/storybook/.storybook/manager-head.html
+++ b/packages/storybook/.storybook/manager-head.html
@@ -1,0 +1,5 @@
+<link href="https://design.va.gov/assets/img/favicons/apple-touch-icon.png" rel="apple-touch-icon-precomposed">
+<link href="https://design.va.gov/assets/img/favicons/apple-touch-icon-72x72.png" rel="apple-touch-icon-precomposed" sizes="72x72">
+<link href="https://design.va.gov/assets/img/favicons/apple-touch-icon-114x114.png" rel="apple-touch-icon-precomposed" sizes="114x114">
+<link href="https://design.va.gov/assets/img/favicons/apple-touch-icon-152x152.png" rel="apple-touch-icon-precomposed" sizes="144x144">
+<link rel="shortcut icon" href="https://design.va.gov/assets/img/favicons/favicon.ico">


### PR DESCRIPTION
## Chromatic
<!-- This `dst-storybook-favicons` is a placeholder for a CI job - it will be updated automatically -->
https://dst-storybook-favicons--60f9b557105290003b387cd5.chromatic.com

## Description
There is no related ticket to this update. I just noticed that the design.va.gov Storybook instance was not displaying a favicon instead of one for VA. This PR adds a `manager-head.html` file which will allow us to add additional meta items to the `head` markup of Storybook.


## Testing done
Storybook

## Screenshots

### Before

<img width="618" alt="Screenshot 2023-01-19 at 4 52 35 PM" src="https://user-images.githubusercontent.com/872479/213580176-51847350-5086-4bc4-b22a-809ace8b5670.png">

### After

<img width="614" alt="Screenshot 2023-01-19 at 4 54 58 PM" src="https://user-images.githubusercontent.com/872479/213580526-0b98d33d-4917-4522-aed1-03daee38d617.png">

### Added markup

<img width="797" alt="Screenshot 2023-01-19 at 5 00 56 PM" src="https://user-images.githubusercontent.com/872479/213581252-a8f7b68d-96cd-46f2-beca-95f094577f1e.png">

## Acceptance criteria
- [ ] The VA design system Storybook docs site displays the VA favicon.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
