### PR TITLE
Add translation to date error message validators

### DIFF
--- a/packages/core/src/i18n/translations/en.js
+++ b/packages/core/src/i18n/translations/en.js
@@ -7,6 +7,8 @@ export default {
   'month': 'Month',
   'day': 'Day',
   'year': 'Year',
+  'month-range': 'Please enter a month between {{start}} and {{end}}',
+  'day-range': 'Please enter a day between {{start}} and {{end}}',
   'year-range': 'Please enter a year between {{start}} and {{end}}',
   'expand-all': 'Expand all',
   'collapse-all': 'Collapse all',
@@ -26,4 +28,5 @@ export default {
   'december': 'December',
   'on-this-page': 'On this page',
   'date-hint': 'Please enter two digits for the month and four digits for the year',
+  'date-error': 'Please enter a complete date',
 };

--- a/packages/core/src/i18n/translations/es.js
+++ b/packages/core/src/i18n/translations/es.js
@@ -7,6 +7,8 @@ export default {
   'month': 'Mes',
   'day': 'Día',
   'year': 'Año',
+  'month-range': 'Ingrese un mes entre {{start}} y {{end}}',
+  'day-range': 'Ingrese un día entre {{start}} y {{end}}',
   'year-range': 'Ingrese un año entre {{start}} y {{end}}',
   'expand-all': 'Expandir todo',
   'collapse-all': 'Contraer todo',
@@ -26,4 +28,5 @@ export default {
   'december': 'Diciembre',
   'on-this-page': 'En esta página',
   'date-hint': 'Ingrese dos dígitos para el mes y cuatro dígitos para el año',
+  'date-error': 'Ingrese una fecha completa',
 };

--- a/packages/core/src/i18n/translations/tl.js
+++ b/packages/core/src/i18n/translations/tl.js
@@ -7,6 +7,8 @@ export default {
   'month': 'Buwan',
   'day': 'Araw',
   'year': 'Taon',
+  'month-range': 'Mangyaring ilagay ang buwan sa pagitan ng {{start}} at {{end}}',
+  'day-range': 'Mangyaring ilagay ang araw sa pagitan ng {{start}} at {{end}}',
   'year-range': 'Mangyaring ilagay ang taon sa pagitan ng {{start}} at {{end}}',
   'expand-all': 'I-expand lahat',
   'collapse-all': 'I-collapse ang lahat',
@@ -14,4 +16,5 @@ export default {
   'collapse-all-aria-label': 'I-collapse ang lahat ng accordion',
   'on-this-page': 'Sa pahinang ito',
   'date-hint': 'Mangyaring maglagay ang dalawang numero para sa buwan at apat na numero para sa taon',
+  'date-error': 'Mangyaring maglagay ng kumpletong petsa',
 };

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -89,7 +89,7 @@ describe('va-date', () => {
       await handleYear.press('Tab');
 
       await page.waitForChanges();
-      expect(date.getAttribute('error')).toEqual(`Please enter a year between 1900 and ${maxYear}`);
+      expect(date.getAttribute('error')).toEqual(`year-range`);
     });
 
     // We don't have month or day validation here like we do for
@@ -108,7 +108,7 @@ describe('va-date', () => {
       await handleYear.press('Tab');
       await page.waitForChanges();
 
-      expect(date.getAttribute('error')).toEqual("Please enter a complete date");
+      expect(date.getAttribute('error')).toEqual("date-error");
     });
 
     it('allows for a custom required message', async () => {
@@ -147,7 +147,7 @@ describe('va-date', () => {
       await handleYear.press('Tab');
 
       await page.waitForChanges();
-      expect(date.getAttribute('error')).toEqual(`Please enter a year between 1900 and ${maxYear}`);
+      expect(date.getAttribute('error')).toEqual(`year-range`);
 
       await handleYear.press('0');
       await handleYear.press('2');
@@ -487,7 +487,7 @@ describe('va-date', () => {
       await handleYear.press('Tab');
       await page.waitForChanges();
 
-      expect(date.getAttribute('error')).toEqual(`Please enter a year between 1900 and ${maxYear}`);
+      expect(date.getAttribute('error')).toEqual(`year-range`);
     });
 
     it('checks for valid month', async () => {
@@ -507,7 +507,7 @@ describe('va-date', () => {
       await handleYear.press('Tab');
       await page.waitForChanges();
 
-      expect(date.getAttribute('error')).toEqual('Please enter a complete date');
+      expect(date.getAttribute('error')).toEqual('date-error');
     });
 
     it('is valid without a day value', async () => {

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -75,7 +75,7 @@ describe('va-memorable-date', () => {
       await handleYear.press('Tab');
 
       await page.waitForChanges();
-      expect(date.getAttribute('error')).toEqual(`Please enter a year between 1900 and ${maxYear}`);
+      expect(date.getAttribute('error')).toEqual(`year-range`);
     });
 
     it('does month validation without required prop', async () => {
@@ -94,7 +94,7 @@ describe('va-memorable-date', () => {
       await handleYear.press('Tab');
 
       await page.waitForChanges();
-      expect(date.getAttribute('error')).toEqual("Please enter a month between 1 and 12");
+      expect(date.getAttribute('error')).toEqual("month-range");
     });
 
     it('does day validation without required prop', async () => {
@@ -113,7 +113,7 @@ describe('va-memorable-date', () => {
       await handleYear.press('Tab');
 
       await page.waitForChanges();
-      expect(date.getAttribute('error')).toEqual("Please enter a day between 1 and 31");
+      expect(date.getAttribute('error')).toEqual("day-range");
     });
 
    it('does validation for required components', async () => {
@@ -128,7 +128,7 @@ describe('va-memorable-date', () => {
       await handleYear.press('Tab');
       await page.waitForChanges();
 
-      expect(date.getAttribute('error')).toEqual("Please enter a complete date");
+      expect(date.getAttribute('error')).toEqual("date-error");
     });
 
     it('allows for a custom required message', async () => {
@@ -167,7 +167,7 @@ describe('va-memorable-date', () => {
       await handleYear.press('Tab');
 
       await page.waitForChanges();
-      expect(date.getAttribute('error')).toEqual(`Please enter a year between 1900 and ${maxYear}`);
+      expect(date.getAttribute('error')).toEqual(`year-range`);
 
       await handleYear.press('0');
       await handleYear.press('2');

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -19,7 +19,7 @@ describe('validate', () => {
 
     validate(memorableDateComponent, year, month, day);
 
-    expect(memorableDateComponent.error).toEqual(`Please enter a year between 1900 and ${currentYear + 100}`);
+    expect(memorableDateComponent.error).toEqual(`year-range`);
     expect(memorableDateComponent.invalidYear).toEqual(true);
   });
 
@@ -32,7 +32,7 @@ describe('validate', () => {
 
     validate(memorableDateComponent, year, month, day);
 
-    expect(memorableDateComponent.error).toEqual(`Please enter a year between 1900 and ${currentYear + 100}`);
+    expect(memorableDateComponent.error).toEqual(`year-range`);
     expect(memorableDateComponent.invalidYear).toEqual(true);
   });
 
@@ -44,7 +44,7 @@ describe('validate', () => {
 
     validate(memorableDateComponent, year, month, day);
 
-    expect(memorableDateComponent.error).toEqual('Please enter a month between 1 and 12');
+    expect(memorableDateComponent.error).toEqual('month-range');
     expect(memorableDateComponent.invalidMonth).toEqual(true);
   });
 
@@ -56,7 +56,7 @@ describe('validate', () => {
 
     validate(memorableDateComponent, year, month, day);
 
-    expect(memorableDateComponent.error).toEqual('Please enter a day between 1 and 31');
+    expect(memorableDateComponent.error).toEqual('day-range');
     expect(memorableDateComponent.invalidDay).toEqual(true);
   });
 
@@ -68,7 +68,7 @@ describe('validate', () => {
 
     validate(memorableDateComponent, year, month, day);
 
-    expect(memorableDateComponent.error).toEqual('Please enter a day between 1 and 31');
+    expect(memorableDateComponent.error).toEqual('day-range');
     expect(memorableDateComponent.invalidDay).toEqual(true);
   });
 
@@ -92,7 +92,7 @@ describe('validate', () => {
 
       validate(memorableDateComponent, year, month, day);
 
-      expect(memorableDateComponent.error).toEqual('Please enter a complete date');
+      expect(memorableDateComponent.error).toEqual('date-error');
       expect(memorableDateComponent.invalidYear).toEqual(true);
     });
 
@@ -104,7 +104,7 @@ describe('validate', () => {
 
       validate(memorableDateComponent, year, month, day);
 
-      expect(memorableDateComponent.error).toEqual('Please enter a complete date');
+      expect(memorableDateComponent.error).toEqual('date-error');
       expect(memorableDateComponent.invalidMonth).toEqual(true);
     });
 
@@ -116,7 +116,7 @@ describe('validate', () => {
 
       validate(memorableDateComponent, year, month, day);
 
-      expect(memorableDateComponent.error).toEqual('Please enter a complete date');
+      expect(memorableDateComponent.error).toEqual('date-error');
       expect(memorableDateComponent.invalidDay).toEqual(true);
     });
 
@@ -154,7 +154,7 @@ describe('validate', () => {
 
     validate(memorableDateComponent, year, month, day);
 
-    expect(memorableDateComponent.error).toEqual('Please enter a month between 1 and 12');
+    expect(memorableDateComponent.error).toEqual('month-range');
     expect(memorableDateComponent.invalidMonth).toEqual(true);
     expect(memorableDateComponent.invalidDay).toEqual(true);
   });

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -1,4 +1,15 @@
+import i18next from 'i18next';
 import { Components } from '../components';
+
+import {
+  Build,
+} from '@stencil/core';
+
+if (Build.isTesting) {
+  // Make i18next.t() return the key instead of the value
+  i18next.init({ lng: 'cimode' });
+}
+
 const maxYear = new Date().getFullYear() + 100;
 const minYear = 1900;
 const maxMonths = 12;
@@ -162,7 +173,7 @@ export function validate(
   // Empty fields are acceptable unless the component is marked as required
   if (year && (year < minYear || year > maxYear)) {
     component.invalidYear = true;
-    component.error = `Please enter a year between ${minYear} and ${maxYear}`;
+    component.error = i18next.t('year-range', { start: minYear, end: maxYear });
   }
   else {
     component.invalidYear = false;
@@ -172,7 +183,7 @@ export function validate(
   // We don't know the upper limit on days until we know the month
   if (!monthYearOnly && (day < minMonths || day > daysForSelectedMonth)) {
     component.invalidDay = true;
-    component.error = `Please enter a day between ${minMonths} and ${daysForSelectedMonth}`;
+    component.error = i18next.t('day-range', { start: minMonths, end: daysForSelectedMonth });
   }
   else {
     component.invalidDay = false;
@@ -183,7 +194,7 @@ export function validate(
   if ((month && (month < minMonths || month > maxMonths)) ||
       (!month && component.invalidDay)) {
     component.invalidMonth = true;
-    component.error = `Please enter a month between ${minMonths} and ${maxMonths}`;
+    component.error = i18next.t('month-range', { start: minMonths, end: maxMonths });
   }
   else {
     component.invalidMonth = false;
@@ -193,7 +204,7 @@ export function validate(
     component.invalidYear = !year;
     component.invalidMonth = !month;
     component.invalidDay = monthYearOnly ? false : !day;
-    component.error = "Please enter a complete date";
+    component.error = i18next.t('date-error');
   }
 
   // Remove any error message if none of the fields are marked as invalid


### PR DESCRIPTION
## Chromatic
<!-- This `1416-error-message-i18n` is a placeholder for a CI job - it will be updated automatically -->
https://1416-error-message-i18n--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [1614](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1416)

Translation was added to the memorable date but no translation was added to the date validator utils used by the memorable date component. This PR adds all translations to the date validators. 

## Testing done
Locally
Storybook

## Screenshots
Since the translation validators only react when the validation is been performed, it was easier to use a video to test all permutations

https://user-images.githubusercontent.com/55560129/213753309-19e1a5d9-dab7-4222-9cf9-1c3b7d4cda97.mov



## Acceptance criteria
- [ ] Date validators translates to English, Spanish and Tagalog

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
