### PR TITLE
Upgrade React to v18 in component-library

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@department-of-veterans-affairs/formation": "*",
-    "react": "^17",
+    "react": "^18",
     "react-dom": "*"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1829,7 +1829,7 @@ __metadata:
     webpack-cli: ^4.8.0
   peerDependencies:
     "@department-of-veterans-affairs/formation": "*"
-    react: ^17
+    react: ^18
     react-dom: "*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Chromatic
<!-- This `1415-react-18-upgrade` is a placeholder for a CI job - it will be updated automatically -->
https://1415-react-18-upgrade--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [1415](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1415)
Closes [1479](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1479)

Fixes [dependency issue](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1479) of a fresh install of `vets-design-system-documentation`

## Testing done
Locally

Run all installation to ensure nothing breaks

1. `cd packages/web-components/`
    1. `yarn install`
    2. `yarn build`
    3. `yarn build-bindings` (build React bindings)
2. `cd ../react-components/`
    1. `yarn install`
    2. `yarn build`
3. `cd ../core/`
    1. `yarn install`
    2. `yarn build`
4. `cd ../storybook/`
    1. `yarn install`
    2. `yarn storybook`


## Screenshots


## Acceptance criteria
- [x] Upgraded React to version 18

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
