### PR TITLE
Fix va-text-input error message style

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "13.10.1",
+  "version": "13.10.2",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.26.1",
+  "version": "4.26.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/mixins/form-field-error.css
+++ b/packages/web-components/src/mixins/form-field-error.css
@@ -1,4 +1,4 @@
-#error-message {
+#error-message, #input-error-message {
     color: var(--color-secondary-dark);
     display: block;
     font-weight: 700;

--- a/packages/web-components/src/mixins/form-field-error.css
+++ b/packages/web-components/src/mixins/form-field-error.css
@@ -17,9 +17,7 @@
     }
 }
 
-:host([error]:not([error='']):not([uswds])) label,
-:host([error]:not([error=''])) span {
-    font-weight: 700;
+:host([error]:not([error='']):not([uswds])) label {
     margin-top: 0;
 }
 

--- a/packages/web-components/src/mixins/form-field-error.css
+++ b/packages/web-components/src/mixins/form-field-error.css
@@ -17,7 +17,9 @@
     }
 }
 
-:host([error]:not([error='']):not([uswds])) label {
+:host([error]:not([error='']):not([uswds])) label,
+:host([error]:not([error=''])) span {
+    font-weight: 700;
     margin-top: 0;
 }
 


### PR DESCRIPTION
## Chromatic
<!-- This `text-input-error-style` is a placeholder for a CI job - it will be updated automatically -->
https://text-input-error-style--60f9b557105290003b387cd5.chromatic.com/?path=/docs/components-va-text-input--error

## Description

We lost the red and bold style for the error message in a [previous update](https://github.com/department-of-veterans-affairs/component-library/pull/615#discussion_r1098917790) so this is adding it back:

<img width="572" alt="Screenshot 2023-02-09 at 4 24 45 PM" src="https://user-images.githubusercontent.com/872479/217954294-1bf69817-36c4-4c59-9937-4b7104f908bb.png">

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1537

## Testing done
Storybook

## Screenshots


## Acceptance criteria
- [ ] The va-text-input error message is displaying bold and red.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
