### PR TITLE
va-official-gov-banner: Update mobile close icon so it matches USWDS

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "13.10.2",
+  "version": "13.10.3",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.26.2",
+  "version": "4.26.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.scss
+++ b/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.scss
@@ -144,6 +144,7 @@ button {
     border-radius: 0;
     box-shadow: none;
     margin: 0;
+    margin-bottom: -4px;
     text-align: left;
     left: 0;
     position: absolute;
@@ -249,17 +250,20 @@ button:hover {
   button[aria-expanded=true]::after, button[aria-expanded=true]:before {
     position: absolute;
     content: '';
-    height: 44px;
-    width: 44px;
+    height: 48px;
+    width: 48px;
     bottom: 0;
     top: 0;
     right: 0;
   }
   button[aria-expanded=true]::after {
-    background: url('../../../../../node_modules/@uswds/uswds/dist/img/usa-icons/close.svg') no-repeat center/24px 24px;
+    background: 0 0;
+    background-color: #005ea2;
+    -webkit-mask: url('../../../../../node_modules/@uswds/uswds/dist/img/usa-icons/close.svg') no-repeat center/contain;
+    mask: url('../../../../../node_modules/@uswds/uswds/dist/img/usa-icons/close.svg') no-repeat center/contain;
     display: inline-block;
-    height: 44px;
-    width: 44px;
+    height: 48px;
+    width: 48px;
     content: '';
     vertical-align: middle;
     margin-left: 0;


### PR DESCRIPTION
## Chromatic
<!-- This `banner-official-gov-close-icon` is a placeholder for a CI job - it will be updated automatically -->
https://banner-official-gov-close-icon--60f9b557105290003b387cd5.chromatic.com

## Description
This updates the close icon "X" to what is currently displayed in the [USWDS v3 version](https://designsystem.digital.gov/components/banner/). There is no associated issue ticket. We just noticed that it was not [matching the design](https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/B87991F3-2AC5-4C6D-94AE-43B5A4B2EFD3/canvas) (the close icon was displaying much smaller than it should have been).

## Testing done
Storybook

## Screenshots

![Screenshot 2023-02-15 at 9 20 31 AM](https://user-images.githubusercontent.com/872479/219070696-26c551ae-eb3d-4fa3-9a0a-c3f90faf6d72.png)

## Acceptance criteria
- [ ] The close icon X on mobile matches the USWDS v3 version.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
