### PR TITLE
va-text-input: Update aria message prop name

### DIFF
--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -51,7 +51,7 @@ const defaultArgs = {
   'type': undefined,
   'success': false,
   'pattern': undefined,
-  'aria-describedby-message': 'Optional description text for screen readers',
+  'message-aria-describedby': 'Optional description text for screen readers',
   hint: null,
 };
 
@@ -70,7 +70,7 @@ const Template = ({
   success,
   pattern,
   hint,
-  'aria-describedby-message': ariaDescribedbyMessage,
+  'message-aria-describedby': messageAriaDescribedby,
 }) => {
   return (
     <va-text-input
@@ -90,7 +90,7 @@ const Template = ({
       pattern={pattern}
       onBlur={e => console.log('blur event', e)}
       onInput={e => console.log('input event value', e.target.value)}
-      aria-describedby-message={ariaDescribedbyMessage}
+      message-aria-describedby={messageAriaDescribedby}
     />
   );
 };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -807,10 +807,6 @@ export namespace Components {
     }
     interface VaTextInput {
         /**
-          * An optional message that will be read by screen readers when the input is focused.
-         */
-        "ariaDescribedbyMessage"?: string;
-        /**
           * Allows the browser to automatically complete the input.
          */
         "autocomplete"?: string;
@@ -848,6 +844,10 @@ export namespace Components {
           * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */
         "maxlength"?: number;
+        /**
+          * An optional message that will be read by screen readers when the input is focused.
+         */
+        "messageAriaDescribedby"?: string;
         /**
           * The minimum number of characters allowed in the input.
          */
@@ -2308,10 +2308,6 @@ declare namespace LocalJSX {
     }
     interface VaTextInput {
         /**
-          * An optional message that will be read by screen readers when the input is focused.
-         */
-        "ariaDescribedbyMessage"?: string;
-        /**
           * Allows the browser to automatically complete the input.
          */
         "autocomplete"?: string;
@@ -2349,6 +2345,10 @@ declare namespace LocalJSX {
           * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */
         "maxlength"?: number;
+        /**
+          * An optional message that will be read by screen readers when the input is focused.
+         */
+        "messageAriaDescribedby"?: string;
         /**
           * The minimum number of characters allowed in the input.
          */

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -89,7 +89,7 @@ describe('va-text-input', () => {
 
   it('adds aria-describedby input-message id', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-text-input aria-describedby-message="example message" />');
+    await page.setContent('<va-text-input message-aria-describedby="example message" />');
     const el = await page.find('va-text-input');
     const inputEl = await page.find('va-text-input >>> input');
 
@@ -142,7 +142,7 @@ describe('va-text-input', () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      '<va-text-input required label="This is a test" error="With an error message"/>',
+      '<va-text-input required label="This is a test" error="With an error message" message-aria-describeby="with extra aria message"/>',
     );
 
     await axeCheck(page);

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -123,7 +123,7 @@ export class VaTextInput {
   /**
    * An optional message that will be read by screen readers when the input is focused.
    */
-  @Prop() ariaDescribedbyMessage?: string;
+  @Prop() messageAriaDescribedby?: string;
 
   /**
    * The value for the input.
@@ -229,11 +229,11 @@ export class VaTextInput {
       handleBlur,
       uswds,
       success,
-      ariaDescribedbyMessage
+      messageAriaDescribedby
     } = this;
     const type = this.getInputType();
     const maxlength = this.getMaxlength();
-    const ariaDescribedbyIds = `${ariaDescribedbyMessage ? 'input-message' : ''} ${error ? 'input-error-message' : ''}`
+    const ariaDescribedbyIds = `${messageAriaDescribedby ? 'input-message' : ''} ${error ? 'input-error-message' : ''}`
       .trim() || null; // Null so we don't add the attribute if we have an empty string
 
     if (uswds) {
@@ -329,9 +329,9 @@ export class VaTextInput {
             required={required || null}
             part="input"
           />
-          {ariaDescribedbyMessage && (
+          {messageAriaDescribedby && (
             <span id='input-message' class="sr-only">
-              {ariaDescribedbyMessage}
+              {messageAriaDescribedby}
             </span>
           )}
           {maxlength && value?.length >= maxlength && (


### PR DESCRIPTION
## Chromatic
<!-- This `23381-text-input-aria-message` is a placeholder for a CI job - it will be updated automatically -->
https://23381-text-input-aria-message--60f9b557105290003b387cd5.chromatic.com

## Description
During an [Axe scan in an e2e test](https://github.com/department-of-veterans-affairs/vets-website/pull/23381), we discovered that the new prop name `aria-describedby-message` in va-text-input was failing an accessibility scan because it was not a valid aria attribute name.

I was able to confirm this locally as well:

![Screenshot 2023-02-14 at 2 37 15 PM](https://user-images.githubusercontent.com/872479/218857003-88c22f55-86ce-491f-a23b-32d61306e7a9.png)

This PR changes the prop name to `message-aria-describedby` so that it passes the a11y scan and I have also updated our component tests to check for this as well.

Confirmed that it is still working with VoiceOver.

![Screenshot 2023-02-14 at 2 43 20 PM](https://user-images.githubusercontent.com/872479/218858853-ea4b8cae-cd22-4e3b-9c38-8125c9c8d204.png)

Original issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/24502

## Testing done
Storybook
VoiceOver

## Acceptance criteria
- [x] The component passes an Axe accessibility scan.
- [x] The aria describedby message attribute adds additional text to the `aria-describedby` attribute as it was before it got renamed.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
