### PR TITLE
Move ExpandingGroup React component to deprecated section in Storybook

### DIFF
--- a/packages/storybook/stories/ExpandingGroup.stories.jsx
+++ b/packages/storybook/stories/ExpandingGroup.stories.jsx
@@ -3,7 +3,7 @@ import ExpandingGroup from '../../react-components/src/components/ExpandingGroup
 import { StoryDocs } from './wc-helpers';
 
 export default {
-  title: 'Components/Expanding group',
+  title: 'Deprecated/Expanding group',
   component: ExpandingGroup,
   id: 'components/expandinggroup',
   parameters: {

--- a/packages/storybook/stories/additional-docs.js
+++ b/packages/storybook/stories/additional-docs.js
@@ -32,8 +32,8 @@ export const additionalDocs = {
     maturityLevel: AVAILABLE,
   },
   'Expanding group': {
-    maturityCategory: CAUTION,
-    maturityLevel: AVAILABLE,
+    maturityCategory: DONT_USE,
+    maturityLevel: DEPRECATED,
   },
   'File input - React': {
     maturityCategory: DONT_USE,


### PR DESCRIPTION
## Chromatic
<!-- This `1378-move-expanding-group-deprecated` is a placeholder for a CI job - it will be updated automatically -->
https://1378-move-expanding-group-deprecated--60f9b557105290003b387cd5.chromatic.com

## Description
Related issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1378

## Testing done
Storybook

## Screenshots
<img width="251" alt="Screenshot 2023-02-16 at 3 36 21 PM" src="https://user-images.githubusercontent.com/872479/219492496-86c8f507-9342-44f8-9572-f7040f40c091.png">


<img width="707" alt="Screenshot 2023-02-16 at 3 36 35 PM" src="https://user-images.githubusercontent.com/872479/219492491-4f2dcc6a-dfed-48ea-a99c-243450733dc0.png">

## Acceptance criteria
- [ ] The ExpandingGroup react component has been moved from the active components section to the deprecated component section in Storybook.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
