### PR TITLE
Add "Source Sans Pro" to USWDS v3 font stack

### DIFF
--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -1,3 +1,5 @@
+@forward 'settings';
+
 @use 'uswds-core/src/styles/mixins/helpers/checkbox-and-radio-colors';
 @use 'usa-radio/src/styles/usa-radio';
 

--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -1,3 +1,5 @@
+@forward 'settings';
+
 @use 'uswds-helpers/src/styles/usa-sr-only';
 @use 'usa-form/src/styles/usa-form';
 @use 'usa-fieldset/src/styles/usa-fieldset';

--- a/packages/web-components/src/components/va-text-input/va-text-input.scss
+++ b/packages/web-components/src/components/va-text-input/va-text-input.scss
@@ -1,3 +1,5 @@
+@forward 'settings';
+
 @use 'uswds-helpers/src/styles/usa-sr-only';
 @use 'usa-label/src/styles/usa-label';
 @use 'usa-input/src/styles/usa-input';

--- a/packages/web-components/src/global/_settings.scss
+++ b/packages/web-components/src/global/_settings.scss
@@ -1,3 +1,5 @@
 @use "uswds-core" with (
   $theme-image-path: '../../../../../node_modules/@uswds/uswds/dist/img/',
+  $theme-font-type-sans: 'source-sans-pro',
+  $theme-font-sans-custom-stack: '"Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans',
 );


### PR DESCRIPTION
## Chromatic
<!-- This `1411-v3-font` is a placeholder for a CI job - it will be updated automatically -->
https://1411-v3-font--60f9b557105290003b387cd5.chromatic.com

## Description

USWDS Reference for custom font stacks: https://github.com/uswds/uswds/blob/develop/packages/uswds-core/src/styles/settings/_settings-typography.scss#L175-L191

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1411

## Testing done
Storybook

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
