### PR TITLE
va-memorable-date: add hint property

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "13.10.3",
+  "version": "13.11.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-memorable-date.stories.jsx
+++ b/packages/storybook/stories/va-memorable-date.stories.jsx
@@ -19,6 +19,7 @@ export default {
 
 const defaultArgs = {
   label: 'Date of birth',
+  hint: '',
   name: 'test',
   required: false,
   error: undefined,
@@ -30,6 +31,7 @@ const Template = ({ label, name, required, error, value, hint }) => {
     <VaMemorableDate
       label={label}
       name={name}
+      hint={hint}
       required={required}
       error={error}
       value={value}
@@ -39,7 +41,22 @@ const Template = ({ label, name, required, error, value, hint }) => {
   );
 };
 
-const CustomValidationTemplate = ({ label, name, required, error, value }) => {
+const ExtraHintTemplate = ({ label, name, required, error, value, hint }) => {
+  return (
+    <VaMemorableDate
+      label={label}
+      name={name}
+      hint={hint}
+      required={required}
+      error={error}
+      value={value}
+      onDateBlur={e => console.log(e, 'DATE BLUR FIRED')}
+      onDateChange={e => console.log(e, 'DATE CHANGE FIRED')}
+    />
+  );
+};
+
+const CustomValidationTemplate = ({ label, name, required, error, value, hint }) => {
   const [dateVal, setDateVal] = useState(value);
   const [errorVal, setErrorVal] = useState(error);
   const today = new Date();
@@ -59,6 +76,7 @@ const CustomValidationTemplate = ({ label, name, required, error, value }) => {
       <VaMemorableDate
         label={label}
         name={name}
+        hint={hint}
         required={required}
         error={errorVal}
         value={dateVal}
@@ -84,7 +102,7 @@ const CustomValidationTemplate = ({ label, name, required, error, value }) => {
   );
 };
 
-const I18nTemplate = ({ label, name, required, error, value }) => {
+const I18nTemplate = ({ label, name, required, error, value, hint }) => {
   const [lang, setLang] = useState('en');
 
   useEffect(() => {
@@ -97,14 +115,15 @@ const I18nTemplate = ({ label, name, required, error, value }) => {
       <button onClick={e => setLang('en')}>English</button>
       <button onClick={e => setLang('tl')}>Tagalog</button>
       <VaMemorableDate
-      label={label}
-      name={name}
-      required={required}
-      error={error}
-      value={value}
-      onDateBlur={e => console.log(e, 'DATE BLUR FIRED')}
-      onDateChange={e => console.log(e, 'DATE CHANGE FIRED')}
-    />
+        label={label}
+        name={name}
+        hint={hint}
+        required={required}
+        error={error}
+        value={value}
+        onDateBlur={e => console.log(e, 'DATE BLUR FIRED')}
+        onDateChange={e => console.log(e, 'DATE CHANGE FIRED')}
+      />
     </div>
 )};
 
@@ -119,6 +138,12 @@ export const WithHintTextError = Template.bind(null);
 WithHintTextError.args = {
   ...defaultArgs,
   error: 'Error Message Example',
+};
+
+export const ExtraHintText = ExtraHintTemplate.bind(null);
+ExtraHintText.args = {
+  ...defaultArgs,
+  hint: 'Extra hint text',
 };
 
 export const CustomValidation = CustomValidationTemplate.bind(null);

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.26.4",
+  "version": "4.27.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -412,6 +412,10 @@ export namespace Components {
           * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component
          */
         "error"?: string;
+        /**
+          * Hint text string
+         */
+        "hint"?: string;
         "invalidDay": boolean;
         "invalidMonth": boolean;
         "invalidYear": boolean;
@@ -1813,6 +1817,10 @@ declare namespace LocalJSX {
           * The error message to render (if any) This prop should be leveraged to display any custom validations needed for this component
          */
         "error"?: string;
+        /**
+          * Hint text string
+         */
+        "hint"?: string;
         "invalidDay"?: boolean;
         "invalidMonth"?: boolean;
         "invalidYear"?: boolean;

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -40,6 +40,35 @@ describe('va-memorable-date', () => {
     await axeCheck(page);
   });
 
+  it('renders hint text', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-memorable-date label="Label" hint="hint text" required></va-memorable-date>');
+
+    const element = await page.find('va-memorable-date');
+    expect(element).toHaveClass('hydrated');
+    expect(element).toEqualHtml(`
+      <va-memorable-date class='hydrated' label='Label' hint='hint text' required=''>
+      <mock:shadow-root>
+        <fieldset>
+          <legend>
+            Label
+            <span class="required">required</span>
+            <div id="hint">hint text</div>
+            <div id='dateHint'>date-hint.</div>
+          </legend>
+          <slot></slot>
+          <span id="error-message" role="alert"></span>
+          <div class='date-container'>
+            <va-text-input aria-describedby='dateHint hint' class='hydrated input-month'></va-text-input>
+            <va-text-input aria-describedby='dateHint hint' class='hydrated input-day'></va-text-input>
+            <va-text-input aria-describedby='dateHint hint' class='hydrated input-year' value=''></va-text-input>
+          </div>
+        </fieldset>
+      </mock:shadow-root>
+    </va-memorable-date>
+  `);
+  });
+
   it('renders an error message', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-memorable-date error="This is a mistake" />');

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.css
@@ -22,7 +22,8 @@
   padding: 0.8rem;
 }
 
-#dateHint {
+#dateHint,
+#hint {
   color: var(--color-gray);
   line-height: 1.5;
 }

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -61,6 +61,11 @@ export class VaMemorableDate {
   @Prop() name!: string;
 
   /**
+   * Hint text string
+   */
+  @Prop() hint?: string;
+
+  /**
    * The error message to render (if any)
    * This prop should be leveraged to display any custom validations needed for this component
    */
@@ -189,6 +194,7 @@ export class VaMemorableDate {
       required,
       label,
       name,
+      hint,
       error,
       handleDateBlur,
       handleDateChange,
@@ -197,6 +203,9 @@ export class VaMemorableDate {
     } = this;
 
     const [year, month, day] = (value || '').split('-');
+    const describedbyIds = ['dateHint', hint ? 'hint' : '']
+      .filter(Boolean)
+      .join(' ');
 
     // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group
@@ -205,6 +214,7 @@ export class VaMemorableDate {
         <fieldset>
           <legend>
             {label} {required && <span class="required">{i18next.t('required')}</span>}
+            {hint && <div id="hint">{hint}</div>}
             <div id="dateHint">{i18next.t('date-hint')}.</div>
           </legend>
           <slot />
@@ -222,7 +232,7 @@ export class VaMemorableDate {
               maxlength={2}
               minlength={2}
               pattern="[0-9]*"
-              aria-describedby="dateHint"
+              aria-describedby={describedbyIds}
               invalid={this.invalidMonth}
               // Value must be a string
               // if NaN provide empty string
@@ -239,7 +249,7 @@ export class VaMemorableDate {
               maxlength={2}
               minlength={2}
               pattern="[0-9]*"
-              aria-describedby="dateHint"
+              aria-describedby={describedbyIds}
               invalid={this.invalidDay}
               // Value must be a string
               // if NaN provide empty string
@@ -256,7 +266,7 @@ export class VaMemorableDate {
               maxlength={4}
               minlength={4}
               pattern="[0-9]*"
-              aria-describedby="dateHint"
+              aria-describedby={describedbyIds}
               invalid={this.invalidYear}
               // Value must be a string
               // if NaN provide empty string


### PR DESCRIPTION
## Chromatic
<!-- This `54215-memorable-hints` is a placeholder for a CI job - it will be updated automatically -->
https://54215-memorable-hints--60f9b557105290003b387cd5.chromatic.com

## Description
See [#54215](https://github.com/department-of-veterans-affairs/va.gov-team/issues/54215)

## Testing done

Added e2e test for hint property rendering

## Screenshots

![VA memorable date showing a date of decision label with required label, a second line with "Enter the date on your decision notice (the letter you received in the mail from us). and a third line with the default hint text of "Please enter two digits for the month and four digits for the year"](https://user-images.githubusercontent.com/136959/221630437-dada56c4-05b2-495e-95af-6c6e633f8b9c.png)

## Acceptance criteria
- [x] Add `hint` property to `va-memorable-date`
- [x] Add storybook entry
- [x] Add e2e tests

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
