### PR TITLE
Adding Storybook v3 override styles

### DIFF
--- a/packages/storybook/.storybook/style.scss
+++ b/packages/storybook/.storybook/style.scss
@@ -34,3 +34,11 @@ a.sbdocs-a:hover {
 .resize-y {
   resize: vertical;
 }
+/** Global styles for USWDS 3 integration into Storybook **/
+.usa-label {
+  font-size: 15px !important;
+}
+
+button {
+  padding: 10px 20px !important;
+}


### PR DESCRIPTION
## Chromatic
<!-- This `storybook-formation-v3-css-overrides` is a placeholder for a CI job - it will be updated automatically -->
https://storybook-formation-v3-css-overrides--60f9b557105290003b387cd5.chromatic.com

## Description
Some v3 override styles were accidentally removed and this PR is adding them back. Without these styles, Storybook displays buttons and labels at the wrong base font size:

Related PR: https://github.com/department-of-veterans-affairs/component-library/pull/636

## Testing done
Storybook

## Screenshots

**Before**

![Screenshot 2023-03-02 at 1 06 27 PM (1)](https://user-images.githubusercontent.com/872479/222794593-a2504025-4b03-4025-8087-c3c149eab12b.png)

![Screenshot 2023-03-02 at 1 05 55 PM](https://user-images.githubusercontent.com/872479/222794883-bf50fb76-ac35-4bda-9515-251cae068d3b.png)

**After**

![Screenshot 2023-03-03 at 12 11 41 PM](https://user-images.githubusercontent.com/872479/222796017-62c5f00d-5754-4774-b310-28abb63f9a7a.png)

![Screenshot 2023-03-03 at 12 11 45 PM](https://user-images.githubusercontent.com/872479/222796013-a371bcf0-c6b4-4e5e-83db-7b05b75de483.png)


## Acceptance criteria
- [ ] The buttons and labels on Storybook don't appear huge anymore.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
