### PR TITLE
Update va-button states to match Sketch 

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.27.2",
+  "version": "4.27.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-button/va-button.css
+++ b/packages/web-components/src/components/va-button/va-button.css
@@ -15,11 +15,13 @@ button {
   margin: 0.5em 0.5em 0.5em 0;
 }
 
-button:active,
 button:hover {
   background-color: var(--color-primary-darker);
 }
 
+button:active {
+  background-color: var(--color-primary-darkest);
+}
 :host([back]:not([back='false'])) button,
 :host([secondary]:not([secondary='false'])) button {
   background-color: var(--color-white);

--- a/packages/web-components/src/components/va-button/va-button.css
+++ b/packages/web-components/src/components/va-button/va-button.css
@@ -34,17 +34,16 @@ button:active {
 :host([back]:not([back='false'])) button:hover,
 :host([secondary]:not([secondary='false'])) button:active,
 :host([secondary]:not([secondary='false'])) button:hover {
-  box-shadow: inset 0 0 0 2px var(--color-primary-darker);
-  color: var(--color-primary-darker);
+  background-color: var(--color-gray-cool-light);
+  box-shadow: inset 0 0 0 2px var(--color-primary-darkest);
+  color: var(--color-primary-darkest);
 }
 
-:host([back]:not([back='false'])) button:active,
 :host([back]:not([back='false'])) button:focus,
-:host([back]:not([back='false'])) button:hover,
-:host([secondary]:not([secondary='false'])) button:active,
-:host([secondary]:not([secondary='false'])) button:focus,
-:host([secondary]:not([secondary='false'])) button:hover {
+:host([secondary]:not([secondary='false'])) button:focus {
   background-color: var(--color-gray-cool-light);
+  box-shadow: inset 0 0 0 2px var(--color-primary);
+  color: var(--color-primary);
 }
 
 :host([big]:not([big='false'])) button {

--- a/packages/web-components/src/components/va-button/va-button.css
+++ b/packages/web-components/src/components/va-button/va-button.css
@@ -15,7 +15,8 @@ button {
   margin: 0.5em 0.5em 0.5em 0;
 }
 
-button:hover {
+button:hover,
+button:focus {
   background-color: var(--color-primary-darker);
 }
 

--- a/packages/web-components/src/global/_settings.scss
+++ b/packages/web-components/src/global/_settings.scss
@@ -1,4 +1,5 @@
-@use "uswds-core" with ($theme-image-path: '../../../../../node_modules/@uswds/uswds/dist/img/',
+@use "uswds-core" with ($theme-show-notifications: false,
+  $theme-image-path: '../../../../../node_modules/@uswds/uswds/dist/img/',
   $theme-font-type-sans: 'source-sans-pro', // Formation override.
   $theme-font-sans-custom-stack: '"Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans', // Formation override.
 );

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -24,6 +24,7 @@
   --color-link-visited: #4c2c92;
   --color-primary: #0071bb;
   --color-primary-darker: #003e73;
+  --color-primary-darkest: #112E51;
   --color-primary-alt-dark: #00a6d2;
   --color-primary-alt-darkest: #046b99;
   --color-primary-alt-light: #9bdaf1;

--- a/packages/web-components/src/mixins/focusable.css
+++ b/packages/web-components/src/mixins/focusable.css
@@ -1,6 +1,7 @@
 /* From the USWDS styles: */
 /*   https://github.com/uswds/uswds/blob/3dc296ec56cd621fe52d918701fd94621d96a198/src/stylesheets/core/mixins/_focus.scss#L12-L13 */
 button:not([disabled]):focus,
+button:not([disabled]):active,
 select:not([disabled]):focus,
 a:not([disabled]):focus,
 h1:focus,


### PR DESCRIPTION
## Chromatic
<!-- This `1585-va-button-colors` is a placeholder for a CI job - it will be updated automatically -->
https://1585-va-button-colors--60f9b557105290003b387cd5.chromatic.com

## Description
This PR updates the `va-button` component states so that they match what is in Sketch.

Sketch: https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/5317C603-D6BD-4AFF-84E6-151F7A197B91/canvas
Related ticket: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1585
Related PR: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/909

## Testing done
Storybook

## Screenshots

### Button Primary

**Default**

--color-primary (#0071bb)

<img width="246" alt="Screenshot 2023-03-03 at 2 30 18 PM" src="https://user-images.githubusercontent.com/872479/222823246-c0d98693-f29b-42e1-9094-989c8a006e82.png">

**Hover**

--color-primary-darker (#003e73)

<img width="242" alt="Screenshot 2023-03-03 at 2 30 21 PM" src="https://user-images.githubusercontent.com/872479/222823258-415a9651-3c2b-4d16-9904-2f74cf266e47.png">

**Focus**

--color-primary-darker (#003e73)

<img width="304" alt="Screenshot 2023-03-03 at 2 33 02 PM" src="https://user-images.githubusercontent.com/872479/222823518-833c3955-e30c-410e-91db-2bd31bcf25f2.png">

**Active**

--color-primary-darkest (#112E51)

![Screenshot 2023-03-06 at 1 00 36 PM](https://user-images.githubusercontent.com/872479/223205464-e728c6f0-9876-40e0-b130-ab8ba0c1d900.png)

### Button Secondary

**Default**
bg: --color-white
Txt & border: --color-primary #0071BB

![Screenshot 2023-03-06 at 12 53 50 PM](https://user-images.githubusercontent.com/872479/223204072-47ac8351-48e3-4379-a084-90bb85326ce5.png)

**Hover**
bg: --color-gray-cool-light #DCE4EF
Txt & border: --color-primary-darkest #112E51

![Screenshot 2023-03-06 at 12 54 08 PM](https://user-images.githubusercontent.com/872479/223204141-0bd8e52e-ec92-4540-ac3d-e7bff80a2b31.png)

**Focus**
Bg: --color-gray-cool-light #DCE4EF
Txt & border: --color-primary #0071BB

![Screenshot 2023-03-06 at 12 54 42 PM](https://user-images.githubusercontent.com/872479/223204283-89ea3636-7492-4386-895d-a2befe7b83af.png)

**Active**
bg: --color-gray-cool-light #DCE4EF
Txt & border: --color-primary-darkest #112E51

![Screenshot 2023-03-06 at 1 01 20 PM](https://user-images.githubusercontent.com/872479/223205629-ed211019-ca1d-4c9c-a805-3d3a9cad3aac.png)

## Acceptance criteria
- [ ] The `va-button` component state background colors match what is in Sketch.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
