### PR TITLE
va-button: Update the secondary hover color

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.27.4",
+  "version": "4.27.5",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-button/va-button.css
+++ b/packages/web-components/src/components/va-button/va-button.css
@@ -35,8 +35,8 @@ button:active {
 :host([secondary]:not([secondary='false'])) button:active,
 :host([secondary]:not([secondary='false'])) button:hover {
   background-color: var(--color-gray-cool-light);
-  box-shadow: inset 0 0 0 2px var(--color-primary-darkest);
-  color: var(--color-primary-darkest);
+  box-shadow: inset 0 0 0 2px var(--color-primary-darker);
+  color: var(--color-primary-darker);
 }
 
 :host([back]:not([back='false'])) button:focus,


### PR DESCRIPTION
## Chromatic
<!-- This `1585-secondary-button-hover` is a placeholder for a CI job - it will be updated automatically -->
https://1585-secondary-button-hover--60f9b557105290003b387cd5.chromatic.com

## Description
Updates the va-button secondary hover state from `--color-primary-darkest` to `--color-primary-darker`.

Sketch: https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/5317C603-D6BD-4AFF-84E6-151F7A197B91/canvas

Closes https://github.com/department-of-veterans-affairs/component-library/pull/642

## Testing done
Storybook

## Screenshots

--color-primary-darker   #003e73

![Screenshot 2023-03-08 at 2 06 59 PM](https://user-images.githubusercontent.com/872479/223836335-2facae46-d089-4980-81d8-7a2fb7869209.png)

## Acceptance criteria
- [ ] The secondary button is displaying with the correct hover state color.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
