### PR TITLE
Update Formation to v7.0.5

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -50,7 +50,7 @@
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/preset-env": "^7.12.10",
     "@babel/preset-react": "^7.14.5",
-    "@department-of-veterans-affairs/formation": "^7.0.4",
+    "@department-of-veterans-affairs/formation": "^7.0.5",
     "@department-of-veterans-affairs/web-components": "workspace:packages/web-components",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.2.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",
-    "@department-of-veterans-affairs/formation": "^7.0.4",
+    "@department-of-veterans-affairs/formation": "^7.0.5",
     "@mdx-js/react": "^1.6.22",
     "@storybook/addon-a11y": "6.4.19",
     "@storybook/addon-actions": "^6.4.19",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.4.0",
     "@babel/core": "^7.12.13",
-    "@department-of-veterans-affairs/formation": "^7.0.4",
+    "@department-of-veterans-affairs/formation": "^7.0.5",
     "@stencil/postcss": "^2.0.0",
     "@stencil/react-output-target": "^0.0.9",
     "@stencil/sass": "^2.0.0",
@@ -60,7 +60,7 @@
     "typescript": "^4.3.5"
   },
   "peerDependencies": {
-    "@department-of-veterans-affairs/formation": "^7.0.4",
+    "@department-of-veterans-affairs/formation": "^7.0.5",
     "i18next": "*",
     "i18next-browser-languagedetector": "*"
   }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.27.3",
+  "version": "4.27.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,9 +1844,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@department-of-veterans-affairs/formation@npm:^7.0.4":
-  version: 7.0.4
-  resolution: "@department-of-veterans-affairs/formation@npm:7.0.4"
+"@department-of-veterans-affairs/formation@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "@department-of-veterans-affairs/formation@npm:7.0.5"
   dependencies:
     "@fortawesome/fontawesome-free": ^5.6.3
     domready: ^1.0.8
@@ -1856,7 +1856,7 @@ __metadata:
     "@fortawesome/fontawesome-free": ^5.6.3
     foundation-sites: 5
     uswds: ^1.6.10
-  checksum: 9558ca31d4201e49d050f31a785ae591f9f090c3434233dafa5c2a6fec77f57278fba017c77cebb48db94318ec612be5eef58cc54dfd532f7f17bc34e4f0d327
+  checksum: df331baf4a795f4f42d88e8c6c2d141b21cb388a43d00930c825aa16d8bf20d9eba921522eeb596e35e6701e1038eccd95cc20f730af3ad4f6eeff352cfa10a6
   languageName: node
   linkType: hard
 
@@ -1877,7 +1877,7 @@ __metadata:
     "@babel/plugin-syntax-import-meta": ^7.10.4
     "@babel/preset-env": ^7.12.10
     "@babel/preset-react": ^7.14.5
-    "@department-of-veterans-affairs/formation": ^7.0.4
+    "@department-of-veterans-affairs/formation": ^7.0.5
     "@department-of-veterans-affairs/web-components": "workspace:packages/web-components"
     "@testing-library/react": ^12.0.0
     "@testing-library/user-event": ^13.2.1
@@ -1934,7 +1934,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.15.8
     "@department-of-veterans-affairs/component-library": "workspace:packages/core"
-    "@department-of-veterans-affairs/formation": ^7.0.4
+    "@department-of-veterans-affairs/formation": ^7.0.5
     "@mdx-js/react": ^1.6.22
     "@storybook/addon-a11y": 6.4.19
     "@storybook/addon-actions": ^6.4.19
@@ -1962,7 +1962,7 @@ __metadata:
   dependencies:
     "@axe-core/puppeteer": ^4.4.0
     "@babel/core": ^7.12.13
-    "@department-of-veterans-affairs/formation": ^7.0.4
+    "@department-of-veterans-affairs/formation": ^7.0.5
     "@stencil/core": ^2.19.2
     "@stencil/postcss": ^2.0.0
     "@stencil/react-output-target": ^0.0.9
@@ -1989,7 +1989,7 @@ __metadata:
     react-dom: ^16.7.0
     typescript: ^4.3.5
   peerDependencies:
-    "@department-of-veterans-affairs/formation": ^7.0.4
+    "@department-of-veterans-affairs/formation": ^7.0.5
     i18next: "*"
     i18next-browser-languagedetector: "*"
   languageName: unknown


### PR DESCRIPTION
## Chromatic
<!-- This `update-formation-v7.0.5` is a placeholder for a CI job - it will be updated automatically -->
https://update-formation-v7.0.5--60f9b557105290003b387cd5.chromatic.com

## Description
This updates Formation to the latest version v7.0.5. This version adds the following updates:

- https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/909
- https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/908

## Testing done
Storybook

## Screenshots
N/A

## Acceptance criteria
- [ ] Formation is loading version 7.0.5 for all component library packages that use it.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
