### PR TITLE
add option for currency

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -509,6 +509,10 @@ export namespace Components {
     }
     interface VaNumberInput {
         /**
+          * Is this input used for a currency value?
+         */
+        "currency"?: boolean;
+        /**
           * Emit component-library-analytics events on the blur event.
          */
         "enableAnalytics"?: boolean;
@@ -1977,6 +1981,10 @@ declare namespace LocalJSX {
         "visible"?: boolean;
     }
     interface VaNumberInput {
+        /**
+          * Is this input used for a currency value?
+         */
+        "currency"?: boolean;
         /**
           * Emit component-library-analytics events on the blur event.
          */

--- a/packages/web-components/src/components/va-number-input/va-number-input.scss
+++ b/packages/web-components/src/components/va-number-input/va-number-input.scss
@@ -11,3 +11,18 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+:host > div {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+:host > div > span {
+  position: absolute;
+  left: 1rem;
+}
+
+:host > div > input.currency-input {
+  padding-left: 2.5rem;
+}

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -83,6 +83,11 @@ export class VaNumberInput {
   @Prop({ mutable: true, reflect: true }) value?: string;
 
   /**
+   * Is this input used for a currency value?
+   */
+  @Prop() currency?: boolean = false;
+
+  /**
    * The event used to track usage of the component. This is emitted when the
    * input is blurred and enableAnalytics is true.
    */
@@ -133,6 +138,7 @@ export class VaNumberInput {
       min,
       value,
       hint,
+      currency,
       handleBlur,
       handleInput,
     } = this;
@@ -150,20 +156,25 @@ export class VaNumberInput {
             </Fragment>
           )}
         </span>
-        <input
-          aria-describedby={error ? 'error-message' : undefined}
-          aria-invalid={error ? 'true' : 'false'}
-          id="inputField"
-          type="number"
-          inputmode={inputmode ? inputmode : null}
-          name={name}
-          max={max}
-          min={min}
-          value={value}
-          required={required || null}
-          onInput={handleInput}
-          onBlur={handleBlur}
-        />
+        <div>
+          {/* eslint-disable-next-line i18next/no-literal-string */}
+          {currency && <span>$</span>}
+          <input
+            class={currency ? 'currency-input' : ''}
+            aria-describedby={error ? 'error-message' : undefined}
+            aria-invalid={error ? 'true' : 'false'}
+            id="inputField"
+            type="number"
+            inputmode={inputmode ? inputmode : null}
+            name={name}
+            max={max}
+            min={min}
+            value={value}
+            required={required || null}
+            onInput={handleInput}
+            onBlur={handleBlur}
+            />
+          </div>
       </Host>
     );
   }


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com
This PR updates the `va-number-input` component to add currency support as described in [this ticket](https://app.zenhub.com/workspaces/platform-design-system-5f8de67192551b0012ebb802/issues/gh/department-of-veterans-affairs/vets-design-system-documentation/1280).
---

## Description
Closes [1280](https://app.zenhub.com/workspaces/platform-design-system-5f8de67192551b0012ebb802/issues/gh/department-of-veterans-affairs/vets-design-system-documentation/1280)

## Testing done
manual testing in updated versions of Chrome, FireFox, Safari, Edge

## Screenshots
<img width="509" alt="Screenshot 2023-03-16 at 12 08 58 PM" src="https://user-images.githubusercontent.com/8867779/225698139-19fc899f-6889-4f8a-a6e6-8b57ccd399b5.png">

<img width="506" alt="Screenshot 2023-03-16 at 12 09 32 PM" src="https://user-images.githubusercontent.com/8867779/225698254-ee2747a1-b280-46b5-8373-10737b84e28a.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
