### PR TITLE
fix: font size formation override for memorable date

### DIFF
--- a/packages/web-components/src/global/_formation_overrides.scss
+++ b/packages/web-components/src/global/_formation_overrides.scss
@@ -124,6 +124,10 @@
   margin-top: 0px;
 }
 
+.usa-memorable-date #dateHint {
+  font-size: rem-override(1.6rem);
+}
+
 .usa-form-group--day, .usa-form-group--month, .usa-form-group--year {
   margin-right: rem-override(1rem);
 }


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
This PR adds the font size formation override for V3 memorable date component.


## Testing done
Yes

## Screenshots
![V3 Memorable date component](https://user-images.githubusercontent.com/22892911/225736611-37277c01-1921-4dba-860f-fb0ccc215dd7.png)


## Acceptance criteria
- [ ] The font-size is meets USWDS v3 standards.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
