### PR TITLE
Bump core version to v14.0.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "13.12.0",
+  "version": "14.0.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"


### PR DESCRIPTION
## Chromatic
<!-- This `core-version-bump-v14.0.0` is a placeholder for a CI job - it will be updated automatically -->
https://core-version-bump-v14.0.0--60f9b557105290003b387cd5.chromatic.com


## Description
I forgot to bump the `core` version as part of this PR: https://github.com/department-of-veterans-affairs/component-library/pull/650

With the removal of a React component, that was a major release bump so I'm doing that here and will create a release for it afterward.

## Testing done
Storybook

## Screenshots
N/A

## Acceptance criteria
- [ ] Core has major version bump.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
