### PR TITLE
Fixed the missing code in Featured content

### DIFF
--- a/packages/storybook/stories/va-featured-content.stories.jsx
+++ b/packages/storybook/stories/va-featured-content.stories.jsx
@@ -14,8 +14,9 @@ export default {
     },
   },
 };
+const defaultArgs = {};
 
-const Template = () => (
+const Template = ({}) => (
   <va-featured-content>
     <h3 slot="headline">
       If I'm a Veteran, can I get VR&E benefits and services?


### PR DESCRIPTION
## Chromatic
<!-- This `Fix-featured-content` is a placeholder for a CI job - it will be updated automatically -->
https://Fix-featured-content--60f9b557105290003b387cd5.chromatic.com

## Description
The code display in `Featured content` is missing from Storybook. This PR fixes that.

![Screenshot 2023-03-24 at 1 02 30 PM](https://user-images.githubusercontent.com/55560129/227592985-6b49e312-5c69-413a-aa46-1a36d2915361.png)

## Testing done
Locally
Storybook

## Screenshots

![Screenshot 2023-03-24 at 1 01 06 PM](https://user-images.githubusercontent.com/55560129/227593299-0d4d5792-2f21-49c9-804e-78965ad375b1.png)


## Acceptance criteria
- [ ] The code for `Featured content` component shows up.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
