### PR TITLE
Update to codeql v2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       # If you wish to specify custom queries, you can do so here or in a config file.
       # By default, queries listed here will override any specified in a config file.
       # Prefix the list here with "+" to use these queries and those in the config file.
@@ -29,7 +29,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -43,4 +43,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## Chromatic
<!-- This `codeql-v2` is a placeholder for a CI job - it will be updated automatically -->
https://codeql-v2--60f9b557105290003b387cd5.chromatic.com

## Description
This PR updates references from v1 to v2 in the CodeQL workflow file based on these docs: https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

We are not receiving PR errors yet but this preemptively updates codeql to v2 similar to what we needed to do for the documentation repo: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/1639

## Testing done
Checked that this PR passes CodeQL test

## Screenshots
N/A

## Acceptance criteria
- [ ] CodeQL updated from v1 to v2

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
