### PR TITLE
Add yarn watch:stencil to build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If the version numbers have been updated in `main` and you're ready to publish, 
     1. `yarn install`
     2. `yarn build`
     3. `yarn build-bindings` (build React bindings)
-    4. (optional) `yarn watch:stencil`
+    4. `yarn watch:stencil` (optional)
 2. `cd ../react-components/`
     1. `yarn install`
     2. `yarn build`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If the version numbers have been updated in `main` and you're ready to publish, 
     1. `yarn install`
     2. `yarn build`
     3. `yarn build-bindings` (build React bindings)
+    4. (optional) `yarn watch:stencil`
 2. `cd ../react-components/`
     1. `yarn install`
     2. `yarn build`


### PR DESCRIPTION
## Chromatic
<!-- This `build-steps-readme-update` is a placeholder for a CI job - it will be updated automatically -->
https://build-steps-readme-update--60f9b557105290003b387cd5.chromatic.com

## Description
This PR will add an optional step to the web components build step `yarn watch:stencil` which will watch for changes in the stencil component files and refresh the build.

## Acceptance criteria
- [ ] Readme build steps update for component library web compoents.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
