### PR TITLE
Fix maturity scale icons for deprecated React components

### DIFF
--- a/packages/storybook/stories/DropDownPanel.stories.jsx
+++ b/packages/storybook/stories/DropDownPanel.stories.jsx
@@ -9,7 +9,7 @@ export default {
   parameters: {
     componentSubtitle: 'Dropdown panel React component',
     docs: {
-      page: () => <StoryDocs componentName="Dropdown panel" />,
+      page: () => <StoryDocs componentName="Dropdown panel - React" />,
     },
   },
 };

--- a/packages/storybook/stories/ExpandingGroup.stories.jsx
+++ b/packages/storybook/stories/ExpandingGroup.stories.jsx
@@ -9,7 +9,7 @@ export default {
   parameters: {
     componentSubtitle: 'Expanding group React component',
     docs: {
-      page: () => <StoryDocs componentName="Expanding group" />,
+      page: () => <StoryDocs componentName="Expanding group - React" />,
     },
   },
 };

--- a/packages/storybook/stories/SystemDownView.stories.jsx
+++ b/packages/storybook/stories/SystemDownView.stories.jsx
@@ -9,7 +9,7 @@ export default {
   parameters: {
     componentSubtitle: 'System down view React component',
     docs: {
-      page: () => <StoryDocs componentName="System down view" />,
+      page: () => <StoryDocs componentName="System down view - React" />,
     },
   },
 };

--- a/packages/storybook/stories/additional-docs.js
+++ b/packages/storybook/stories/additional-docs.js
@@ -27,11 +27,11 @@ export const additionalDocs = {
     maturityCategory: USE,
     maturityLevel: BEST_PRACTICE,
   },
-  'Dropdown panel': {
+  'Dropdown panel - React': {
     maturityCategory: DONT_USE,
     maturityLevel: DEPRECATED,
   },
-  'Expanding group': {
+  'Expanding group - React': {
     maturityCategory: DONT_USE,
     maturityLevel: DEPRECATED,
   },
@@ -93,7 +93,7 @@ export const additionalDocs = {
     maturityCategory: USE,
     maturityLevel: BEST_PRACTICE,
   },
-  'System down view': {
+  'System down view - React': {
     maturityCategory: DONT_USE,
     maturityLevel: DEPRECATED,
   },


### PR DESCRIPTION
## Chromatic
<!-- This `storybook-deprecated-icons` is a placeholder for a CI job - it will be updated automatically -->
https://storybook-deprecated-icons--60f9b557105290003b387cd5.chromatic.com

## Testing done
Storybook

## Screenshots

**Before**

![Screenshot 2023-03-31 at 12 48 39 PM](https://user-images.githubusercontent.com/872479/229194877-5e5504e9-1b80-4abc-ae97-eccb93a092c9.png)

**After**

![Screenshot 2023-03-31 at 12 57 26 PM](https://user-images.githubusercontent.com/872479/229194991-4d1a120e-8768-4b16-9903-7b9598b741ec.png)


## Acceptance criteria
- [ ] Deprecated components display the red deprecated circle.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
