### PR TITLE
 Add va-number-input USWDS v3 variation

### DIFF
--- a/packages/storybook/stories/va-number-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-number-input-uswds.stories.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
+
+const numberInputDocs = getWebComponentDocs('va-number-input');
+
+export default {
+  title: 'USWDS/Number input USWDS',
+  id: 'uswds/va-number-input',
+  parameters: {
+    componentSubtitle: `va-number-input web component`,
+    docs: {
+      page: () => <StoryDocs data={numberInputDocs} />,
+    },
+  },
+  argTypes: {
+    inputmode: {
+      control: {
+        type: 'select',
+        options: ['decimal', 'numeric'],
+      },
+    },
+  },
+};
+
+const defaultArgs = {
+  'name': 'my-input',
+  'label': 'My input',
+  'enable-analytics': false,
+  'required': false,
+  'error': undefined,
+  'value': 0,
+  'inputmode': 'numeric',
+  'min': undefined,
+  'max': undefined,
+  hint: null,
+  uswds: true,
+};
+
+const vaNumberInput = args => {
+  const {   
+    name,
+    label,
+    'enable-analytics': enableAnalytics,
+    required,
+    error,
+    value,
+    inputmode,
+    min,
+    max,
+    hint,
+    uswds,
+    ...rest
+  } = args;
+  return (
+    <va-number-input
+      uswds={uswds}
+      name={name}
+      label={label}
+      enable-analytics={enableAnalytics}
+      required={required}
+      error={error}
+      value={value}
+      inputmode={inputmode}
+      max={max}
+      min={min}
+      hint={hint}
+      onInput={e => console.log('input event value:', e.target.value)}
+      onBlur={e => console.log('blur event', e)}
+    />
+  )
+}
+
+const Template = args => vaNumberInput(args);
+
+const I18nTemplate = args => {
+  const [lang, setLang] = useState('en');
+
+  useEffect(() => {
+    document.querySelector('main').setAttribute('lang', lang);
+  }, [lang]);
+
+  return (
+    <div>
+      <button onClick={e => setLang('es')}>Español</button>
+      <button onClick={e => setLang('en')}>English</button>
+      <button onClick={e => setLang('tl')}>Tagalog</button>
+      <div style={{marginTop: '20px'}}>
+        {vaNumberInput(args)}
+      </div>
+    </div>
+)};
+
+export const Default = Template.bind(null);
+Default.args = { ...defaultArgs };
+Default.argTypes = propStructure(numberInputDocs);
+
+export const Error = Template.bind(null);
+Error.args = { ...defaultArgs, error: 'This is an error message' };
+
+export const Required = Template.bind(null);
+Required.args = { ...defaultArgs, required: true };
+
+export const WithHintText = Template.bind(null);
+WithHintText.args = { ...defaultArgs, hint: 'This is example hint text' };
+
+export const WithAnalytics = Template.bind(null);
+WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
+
+export const ValidRange = Template.bind(null);
+ValidRange.args = {
+  ...defaultArgs,
+  min: 0,
+  max: 4,
+};
+
+export const Internationalization = I18nTemplate.bind(null);
+Internationalization.args = {
+  ...defaultArgs,
+  error: 'There has been a problem',
+  required: true,
+};
+

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.31.1",
+  "version": "4.32.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -555,6 +555,10 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
+          * Whether or not the component will use USWDS v3 styling.
+         */
+        "uswds"?: boolean;
+        /**
           * The value for the input.
          */
         "value"?: string;
@@ -2052,6 +2056,10 @@ declare namespace LocalJSX {
           * Set the input to required and render the (Required) text.
          */
         "required"?: boolean;
+        /**
+          * Whether or not the component will use USWDS v3 styling.
+         */
+        "uswds"?: boolean;
         /**
           * The value for the input.
          */

--- a/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
+++ b/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
@@ -175,4 +175,171 @@ describe('va-number-input', () => {
     const currencyTextElement = await page.find('va-number-input >>> div > span');
     expect(currencyTextElement.innerText).toContain('$');
   });
+
+  // Begin USWDS tests
+
+  it('uswds renders', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<va-number-input label="Hello, world" uswds />');
+    const element = await page.find('va-number-input');
+
+    expect(element).toEqualHtml(`
+      <va-number-input class="hydrated" label="Hello, world" uswds="">
+        <mock:shadow-root>
+          <label for="inputField" class="usa-label">
+            Hello, world
+          </label>
+          <span id="input-error-message" role="alert"></span>
+          <input aria-invalid="false" class="usa-input" id="inputField" type="number">
+        </mock:shadow-root>
+      </va-number-input>
+    `);
+  });
+
+  it('uswds renders an error message', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input error="This is a mistake" uswds />');
+
+    // Render the error message text
+    const error = await page.find('va-number-input >>> .usa-error-message');
+    const input = await page.find('va-number-input >>> input');
+    expect(error.innerText).toContain('This is a mistake');
+    expect(input.getAttribute('aria-invalid')).toEqual('true');
+  });
+
+  it('uswds renders hint text', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input hint="This is hint text" uswds />');
+
+    // Render the hint text
+    const hintTextElement = await page.find('va-number-input >>> span.usa-hint');
+    expect(hintTextElement.innerText).toContain('This is hint text');
+  });
+
+  it('uswds renders a required span', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-number-input label="This is a field" required uswds />',
+    );
+
+    const requiredSpan = await page.find(
+      'va-number-input >>> label > span.usa-label--required',
+    );
+    // The actual text value depends on the language of the document
+    expect(requiredSpan).not.toBeNull();
+  });
+
+  it('uswds passes an aXe check', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<va-number-input required label="This is a test" error="With an error message" uswds />',
+    );
+
+    await axeCheck(page);
+  });
+
+  it('uswds fires an analytics event when enableAnalytics is true', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<va-number-input label="Input Field" enable-analytics uswds />',
+    );
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const inputEl = await page.find('va-number-input >>> input');
+    await inputEl.press('1');
+    await inputEl.press('2');
+    await inputEl.press('3');
+    await inputEl.press('Tab');
+
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      action: 'blur',
+      componentName: 'va-number-input',
+      details: {
+        label: 'Input Field',
+        value: '123',
+      },
+    });
+  });
+
+  it('uswds emits blur event', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<va-number-input label="Input Field" uswds />');
+
+    const inputEl = await page.find('va-number-input >>> input');
+    const blurSpy = await page.spyOnEvent('blur');
+    await inputEl.press('Tab');
+
+    expect(blurSpy).toHaveReceivedEvent();
+  });
+
+  it('uswds emits input event with value updated', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<va-number-input label="Input Field" uswds />');
+
+    const inputEl = await page.find('va-number-input >>> input');
+    const inputSpy = await page.spyOnEvent('input');
+    // Act
+    await inputEl.press('1');
+    const firstValue = await page.$eval(
+      'va-number-input',
+      (comp: HTMLInputElement) => comp.value,
+    );
+    await inputEl.press('2');
+    const secondValue = await page.$eval(
+      'va-number-input',
+      (comp: HTMLInputElement) => comp.value,
+    );
+
+    // Assert
+    expect(inputSpy).toHaveReceivedEventTimes(2);
+    expect(firstValue).toEqual('1');
+    expect(secondValue).toEqual('12');
+  });
+
+  it("uswds doesn't fire analytics events", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<va-number-input label="Input Field" uswds />');
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+    const inputEl = await page.find('va-number-input >>> input');
+    await inputEl.press('1');
+    await inputEl.press('Tab');
+
+    expect(analyticsSpy).not.toHaveReceivedEvent();
+  });
+
+  it('uswds defaults to type of number', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input uswds />');
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-number-input >>> input');
+    expect(inputEl.getAttribute('type')).toBe('number');
+  });
+
+  it('uswds sets a range based on min and max attributes', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input min="0" max="4" uswds />');
+
+    const inputEl = await page.find('va-number-input >>> input');
+    expect(inputEl.getAttribute('min')).toBe('0');
+    expect(inputEl.getAttribute('max')).toBe('4');
+  });
+
+  it('uswds allows manually setting the inputmode attribute', async () => {
+    const inputModes = ['decimal', 'numeric'];
+    for (const inputMode of inputModes) {
+      const page = await newE2EPage();
+      await page.setContent(`<va-number-input inputmode="${inputMode}" uswds />`);
+      const inputEl = await page.find('va-number-input >>> input');
+      expect(inputEl.getAttribute('inputmode')).toBe(inputMode);
+    }
+  });
 });

--- a/packages/web-components/src/components/va-number-input/va-number-input.scss
+++ b/packages/web-components/src/components/va-number-input/va-number-input.scss
@@ -1,28 +1,31 @@
 @import '../va-text-input/va-text-input.scss';
+
+/** Original Component Style **/
+
 @import '../../mixins/form-field-error.css';
 @import '../../mixins/hint-text.css';
 
-input[type='number'] {
+:host(:not([uswds])) input[type='number'] {
   -moz-appearance: textfield;
 }
 
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
+:host(:not([uswds])) input::-webkit-outer-spin-button,
+:host(:not([uswds])) input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-:host > div {
+:host(:not([uswds])) > div {
   position: relative;
   display: flex;
   align-items: center;
 }
 
-:host > div > span {
+:host(:not([uswds])) > div > span {
   position: absolute;
   left: 1rem;
 }
 
-:host > div > input.currency-input {
+:host(:not([uswds])) > div > input.currency-input {
   padding-left: 2.5rem;
 }

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -9,6 +9,7 @@ import {
   forceUpdate,
   Fragment,
 } from '@stencil/core';
+import classnames from 'classnames';
 import i18next from 'i18next';
 
 /**
@@ -88,6 +89,11 @@ export class VaNumberInput {
   @Prop() currency?: boolean = false;
 
   /**
+   * Whether or not the component will use USWDS v3 styling.
+   */
+  @Prop() uswds?: boolean = false;
+
+  /**
    * The event used to track usage of the component. This is emitted when the
    * input is blurred and enableAnalytics is true.
    */
@@ -139,30 +145,45 @@ export class VaNumberInput {
       value,
       hint,
       currency,
+      uswds,
       handleBlur,
       handleInput,
     } = this;
-    return (
-      <Host>
-        <label htmlFor="inputField">
-          {label}{' '}
-          {required && <span class="required">{i18next.t('required')}</span>}
-        </label>
-        {hint && <span class="hint-text">{hint}</span>}
-        <span id="error-message" role="alert">
-          {error && (
-            <Fragment>
-              <span class="sr-only">{i18next.t('error')}</span> {error}
-            </Fragment>
+
+    if (uswds) {
+      const labelClasses = classnames({
+        'usa-label': true,
+        'usa-label--error': error,
+      });
+      const inputClasses = classnames({
+        'usa-input': true,
+        'usa-input--error': error,
+      });
+      return (
+        <Host>
+          {label && (
+            <label htmlFor="inputField" class={labelClasses}>
+              {label}
+              {required && (
+                <span class="usa-label--required">
+                  {' '}
+                  {i18next.t('required')}
+                </span>
+              )}
+            </label>
           )}
-        </span>
-        <div>
-          {/* eslint-disable-next-line i18next/no-literal-string */}
-          {currency && <span id="symbol">$</span>}
+          {hint && <span class="usa-hint">{hint}</span>}
+          <span id="input-error-message" role="alert">
+            {error && (
+              <Fragment>
+                <span class="usa-sr-only">{i18next.t('error')}</span>
+                <span class="usa-error-message">{error}</span>
+              </Fragment>
+            )}
+          </span>
           <input
-            class={currency ? 'currency-input' : ''}
-            aria-labelledby={currency ? 'inputField symbol' : undefined}
-            aria-describedby={error ? 'error-message' : undefined}
+            class={inputClasses}
+            aria-describedby={error ? 'input-error-message' : undefined}
             aria-invalid={error ? 'true' : 'false'}
             id="inputField"
             type="number"
@@ -175,8 +196,45 @@ export class VaNumberInput {
             onInput={handleInput}
             onBlur={handleBlur}
             />
-          </div>
-      </Host>
-    );
+        </Host>
+      );
+    } else {
+      return (
+        <Host>
+          <label htmlFor="inputField">
+            {label}{' '}
+            {required && <span class="required">{i18next.t('required')}</span>}
+          </label>
+          {hint && <span class="hint-text">{hint}</span>}
+          <span id="error-message" role="alert">
+            {error && (
+              <Fragment>
+                <span class="sr-only">{i18next.t('error')}</span> {error}
+              </Fragment>
+            )}
+          </span>
+          <div>
+            {/* eslint-disable-next-line i18next/no-literal-string */}
+            {currency && <span id="symbol">$</span>}
+            <input
+              class={currency ? 'currency-input' : ''}
+              aria-labelledby={currency ? 'inputField symbol' : undefined}
+              aria-describedby={error ? 'error-message' : undefined}
+              aria-invalid={error ? 'true' : 'false'}
+              id="inputField"
+              type="number"
+              inputmode={inputmode ? inputmode : null}
+              name={name}
+              max={max}
+              min={min}
+              value={value}
+              required={required || null}
+              onInput={handleInput}
+              onBlur={handleBlur}
+              />
+            </div>
+        </Host>
+      );
+    }
   }
 }

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -355,7 +355,7 @@ describe('va-text-input', () => {
     expect(await inputEl.getProperty('autocomplete')).toBe('email');
   });
 
-  // Begin USWDS v3 test
+  // Begin USWDS tests
   it('uswds v3 renders', async () => {
     const page = await newE2EPage();
 
@@ -374,6 +374,300 @@ describe('va-text-input', () => {
         </mock:shadow-root>
       </va-text-input>
     `);
+  });
+
+  it('uswds renders an error message', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input error="This is a mistake" uswds />');
+
+    // Render the error message text
+    const error = await page.find('va-text-input >>> .usa-error-message');
+    const input = await page.find('va-text-input >>> input');
+    expect(error.innerText).toContain('This is a mistake');
+    expect(input.getAttribute('aria-invalid')).toEqual('true');
+  });
+
+  it('uswds sets aria-invalid based on invalid prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input invalid uswds />');
+
+    const input = await page.find('va-text-input >>> input');
+    expect(input.getAttribute('aria-invalid')).toEqual('true');
+  });
+
+  it('uswds adds aria-describedby for error message', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input uswds />');
+    // Check that error is empty
+    const el = await page.find('va-text-input');
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(inputEl.getAttribute('aria-describedby')).toBeNull();
+    // Render the error message text as empty string
+    el.setProperty('error', '');
+    await page.waitForChanges();
+    expect(inputEl.getAttribute('aria-describedby')).toBeNull();
+    // Render the error message text as real value
+    el.setProperty('error', 'Testing Error');
+    await page.waitForChanges();
+    expect(inputEl.getAttribute('aria-describedby')).not.toBeNull();
+    expect(inputEl.getAttribute('aria-describedby')).toContain('error-message');
+  });
+
+  it('uswds adds aria-describedby input-message id', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input message-aria-describedby="example message" uswds />');
+    const el = await page.find('va-text-input');
+    const inputEl = await page.find('va-text-input >>> input');
+
+    // Render the example message aria-describedby id.
+    expect(inputEl.getAttribute('aria-describedby')).not.toBeNull();
+    expect(inputEl.getAttribute('aria-describedby')).toContain('input-message');
+
+    // If an error and aria-describedby-message is set, id's exist in aria-describedby.
+    el.setProperty('error', 'Testing Error');
+    await page.waitForChanges();
+    expect(inputEl.getAttribute('aria-describedby')).not.toBeNull();
+    expect(inputEl.getAttribute('aria-describedby')).toContain('error-message');
+    expect(inputEl.getAttribute('aria-describedby')).toContain('input-message');
+  });
+
+  it('uswds renders a required span', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-text-input label="This is a field" required uswds />',
+    );
+
+    const requiredSpan = await page.find(
+      'va-text-input >>> label > span.usa-label--required',
+    );
+    // The actual text value depends on the language of the document
+    expect(requiredSpan).not.toBeNull();
+  });
+
+  it('uswds renders hint text', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input hint="This is hint text" uswds />');
+
+    // Render the hint text
+    const hintTextElement = await page.find('va-text-input >>> .usa-hint');
+    expect(hintTextElement.innerText).toContain('This is hint text');
+  });
+
+  it('uswds passes an aXe check', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<va-text-input required label="This is a test" error="With an error message" message-aria-describeby="with extra aria message" uswds />',
+    );
+
+    await axeCheck(page);
+  });
+
+  it('uswds fires an analytics event when enableAnalytics is true', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(
+      '<va-text-input label="Input Field" enable-analytics uswds />',
+    );
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const inputEl = await page.find('va-text-input >>> input');
+    await inputEl.press('1');
+    await inputEl.press('2');
+    await inputEl.press('3');
+    await inputEl.press('Tab');
+
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      action: 'blur',
+      componentName: 'va-text-input',
+      details: {
+        label: 'Input Field',
+        value: '123',
+      },
+    });
+  });
+
+  it('uswds emits blur event uswds', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<va-text-input label="Input Field" uswds />');
+
+    const inputEl = await page.find('va-text-input >>> input');
+    const blurSpy = await page.spyOnEvent('blur');
+    await inputEl.press('Tab');
+
+    expect(blurSpy).toHaveReceivedEvent();
+  });
+
+  it('uswds emits input event with value updated', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<va-text-input label="Input Field" uswds />');
+
+    const inputEl = await page.find('va-text-input >>> input');
+    const inputSpy = await page.spyOnEvent('input');
+
+    // Act
+    await inputEl.press('a');
+    const firstValue = await page.$eval(
+      'va-text-input',
+      (comp: HTMLInputElement) => comp.value,
+    );
+    await inputEl.press('s');
+    const secondValue = await page.$eval(
+      'va-text-input',
+      (comp: HTMLInputElement) => comp.value,
+    );
+
+    // Assert
+    expect(inputSpy).toHaveReceivedEventTimes(2);
+    expect(firstValue).toEqual('a');
+    expect(secondValue).toEqual('as');
+  });
+
+  it("uswds doesn't fire analytics events", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<va-text-input label="Input Field" uswds />');
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+    const inputEl = await page.find('va-text-input >>> input');
+    await inputEl.press('1');
+    await inputEl.press('Tab');
+
+    expect(analyticsSpy).not.toHaveReceivedEvent();
+  });
+
+  it('uswds adds a character limit with descriptive text', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-text-input minlength="2" maxlength="3" value="22" uswds />',
+    );
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(await inputEl.getProperty('value')).toBe('22');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+
+    // Test the functionality
+    await inputEl.press('2');
+    expect(await inputEl.getProperty('value')).toBe('222');
+    expect((await page.find('va-text-input >>> small')).innerText).toContain(
+      'max-chars',
+    );
+
+    // Click three times to select all text in input
+    await inputEl.click({ clickCount: 3 });
+    await inputEl.press('2');
+    expect(await inputEl.getProperty('value')).toBe('2');
+    expect((await page.find('va-text-input >>> small')).innerText).toContain(
+      'min-chars',
+    );
+  });
+
+  it('uswds ignores negative maxlength values', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input maxlength="-5" uswds />');
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+
+    // Test the functionality
+    await inputEl.type('Hello, nice to meet you');
+    expect(await inputEl.getProperty('value')).toBe('Hello, nice to meet you');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+  });
+
+  it('uswds ignores a maxlength of zero', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input maxlength="0" uswds />');
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+
+    // Test the functionality
+    await inputEl.type('Hello, nice to meet you');
+    expect(await inputEl.getProperty('value')).toBe('Hello, nice to meet you');
+    expect(await page.find('va-text-input >>> small')).toBeNull();
+  });
+
+  it('uswds allows manually setting the type attribute', async () => {
+    const allowedInputTypes = [
+      'email',
+      'number',
+      'search',
+      'tel',
+      'text',
+      'url',
+    ];
+    for (const inputType of allowedInputTypes) {
+      const page = await newE2EPage();
+      await page.setContent(`<va-text-input type="${inputType}" uswds />`);
+      const inputEl = await page.find('va-text-input >>> input');
+      expect(inputEl.getAttribute('type')).toBe(inputType);
+    }
+  });
+
+  it('uswds defaults to text when the type attribute is invalid or unsupported', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input type="textual" uswds />');
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(inputEl.getAttribute('type')).toBe('text');
+  });
+
+  it('uswds allows manually setting the inputmode attribute', async () => {
+    const inputModes = [
+      'decimal',
+      'email',
+      'none',
+      'numeric',
+      'search',
+      'tel',
+      'text',
+      'url',
+    ];
+    for (const inputMode of inputModes) {
+      const page = await newE2EPage();
+      await page.setContent(`<va-text-input inputmode="${inputMode}" uswds />`);
+      const inputEl = await page.find('va-text-input >>> input');
+      expect(inputEl.getAttribute('inputmode')).toBe(inputMode);
+    }
+  });
+
+  it('uswds displays a green border around input when success is true', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input success uswds />');
+
+    const input = await page.find('va-text-input >>> input');
+    // rgb(0, 169, 28) is equal to #00A91C from the USWDS v3 system.
+    expect((await input.getComputedStyle()).borderBottomColor).toEqual(
+      'rgb(0, 169, 28)',
+    );
+    expect((await input.getComputedStyle()).borderLeftColor).toEqual(
+      'rgb(0, 169, 28)',
+    );
+    expect((await input.getComputedStyle()).borderRightColor).toEqual(
+      'rgb(0, 169, 28)',
+    );
+    expect((await input.getComputedStyle()).borderTopColor).toEqual(
+      'rgb(0, 169, 28)',
+    );
+  });
+
+  it('uswds checks for autocomplete attribute', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-text-input autocomplete="email" uswds />',
+    );
+
+    // Level-setting expectations
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(await inputEl.getProperty('autocomplete')).toBe('email');
   });
 
 });


### PR DESCRIPTION
## Chromatic
<!-- This `1625-uswds-va-number-input` is a placeholder for a CI job - it will be updated automatically -->
https://1625-uswds-va-number-input--60f9b557105290003b387cd5.chromatic.com/?path=/docs/uswds-va-number-input--default

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1625

Below is the Sketch file for `va-text-input`. This component does not have all of the same states but it inherits the same general style modules for USWDS:
- https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/a/nRYozkW

## Testing done
Storybook

## Screenshots

### Focus
![Screenshot 2023-04-07 at 2 18 17 PM](https://user-images.githubusercontent.com/872479/230665048-0ed8eb30-34cf-46f4-bb6f-bed39c2c27e9.png)

![Screenshot 2023-04-07 at 12 48 20 PM](https://user-images.githubusercontent.com/872479/230654238-bb9411ee-71d0-44db-82db-3b315f671e78.png)

![Screenshot 2023-04-07 at 12 48 23 PM](https://user-images.githubusercontent.com/872479/230654242-f6101b47-47d1-45f2-9a9c-faf2694a5ea5.png)

![Screenshot 2023-04-07 at 12 48 16 PM](https://user-images.githubusercontent.com/872479/230654248-a2664085-8481-46f2-b7c6-b32147b6c8d7.png)


## Acceptance criteria
- [ ] A USWDS v3 variation of va-number-input exists.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
