### PR TITLE
1673 button pair responsive bug

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.32.0",
+  "version": "4.32.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.scss
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.scss
@@ -21,24 +21,26 @@
     margin: 0 auto;
     width: 100%;
   }
-  :host([continue]:not([continue='false'])) .usa-button-group {
+  :host([continue]:not([continue='false'])), .usa-button-group {
     flex-direction: column-reverse;
   }
 }
 
 /* Original Component Styles. */
 
-:host([continue]:not([continue='false']):not([uswds])) {
-  flex-direction: row;
-}
-
 :host(:not([uswds])) va-button::part(button) {
   width: 280px;
 }
 
-:host([continue]:not([continue='false']):not([uswds])) va-button + va-button::part(button) {
-  margin-left: 12px;
-  margin-right: 0;
+@media (min-width: 481px) {
+  :host([continue]:not([continue='false']):not([uswds])) {
+    flex-direction: row;
+  }
+
+  :host([continue]:not([continue='false']):not([uswds])) va-button + va-button::part(button) {
+    margin-left: 12px;
+    margin-right: 0;
+  }
 }
 
 @media (min-width: 481px) {
@@ -62,7 +64,7 @@
   }
 
   :host([continue]:not([continue='false']):not([uswds])) va-button::part(button) {
-    width: 210px;
+    width: 280px;
   }
 }
 

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.scss
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.scss
@@ -20,8 +20,6 @@
   .usa-button-group {
     margin: 0 auto;
     width: 100%;
-  }
-  :host([continue]:not([continue='false'])), .usa-button-group {
     flex-direction: column-reverse;
   }
 }
@@ -65,6 +63,9 @@
 
   :host([continue]:not([continue='false']):not([uswds])) va-button::part(button) {
     width: 280px;
+  }
+  :host([continue]:not([continue='false'])) {
+    flex-direction: column-reverse;
   }
 }
 

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.scss
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.scss
@@ -21,7 +21,7 @@
     margin: 0 auto;
     width: 100%;
   }
-  :host([continue]:not([continue='false'])) .usa-button-group {
+  :host([continue]:not([continue='false'])), .usa-button-group {
     flex-direction: column-reverse;
   }
 }

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.scss
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.scss
@@ -21,7 +21,7 @@
     margin: 0 auto;
     width: 100%;
   }
-  :host([continue]:not([continue='false'])), .usa-button-group {
+  :host([continue]:not([continue='false'])) .usa-button-group {
     flex-direction: column-reverse;
   }
 }
@@ -75,6 +75,6 @@
   }
 
   :host([continue]:not([continue='false']):not([uswds])) va-button::part(button) {
-    width: 130px;
+    width: 280px;
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `1673-button-pair-responsive-bug` is a placeholder for a CI job - it will be updated automatically -->
https://1673-button-pair-responsive-bug--60f9b557105290003b387cd5.chromatic.com

---
## Description
Update CSS so that the continue variation is responsive, and the buttons stack in mobile. Also update continue variation styles to match other button pair styles

Closes [1673](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1673)

## Testing done
- Story Book
- Tested in Chrome, Firefox, Edge, Safari
- Mobile responsiveness tested in all above browsers


## Screenshots
Desktop
![Screenshot 2023-04-11 at 9 29 20 AM](https://user-images.githubusercontent.com/1776069/231212999-5b2553f0-8576-4d0c-8dd8-a05d84f8f872.png)

Mobile
![Screenshot 2023-04-11 at 9 30 00 AM](https://user-images.githubusercontent.com/1776069/231213180-e5555ed6-fc2c-489e-9ac2-d2fc0f042e55.png)


## Acceptance criteria
- [x ] Buttons do not overflow the web view in mobile
- [x ] Mobile styles resemble those of other button pair variations
- [x ] Styles remain constant for other button pair variations

## Definition of done
- [x ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
