### PR TITLE
add aria-controls and aria-expanded to expand/collapse all button

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.32.2",
+  "version": "4.32.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
@@ -13,7 +13,7 @@ describe('va-accordion', () => {
     expect(element).toEqualHtml(`
       <va-accordion class="hydrated">
         <mock:shadow-root>
-          <button aria-label="expand-all-aria-label">
+          <button aria-controls="" aria-expanded="false" aria-label="expand-all-aria-label">
             expand-all +
           </button>
           <slot></slot>

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -188,6 +188,7 @@ export class VaAccordion {
   }
 
   render() {
+    const accordionItemIDs = [...this.el.children].map((el) => {return el.id});
     return (
       <Host>
         {!this.openSingle && (
@@ -199,6 +200,8 @@ export class VaAccordion {
                 ? i18next.t('collapse-all-aria-label')
                 : i18next.t('expand-all-aria-label')
             }
+            aria-controls={accordionItemIDs.join(' ')}
+            aria-expanded={`${this.expanded}`}
           >
             {this.expanded
               ? `${i18next.t('collapse-all')} -`

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -188,7 +188,9 @@ export class VaAccordion {
   }
 
   render() {
-    const accordionItemIDs = [...this.el.children].map((el) => {return el.id});
+    const accordionItemIDs = [...this.el.children]
+      .filter((el) => el.tagName.toLowerCase() === 'va-accordion-item')
+      .map((el) => el.id);
     return (
       <Host>
         {!this.openSingle && (


### PR DESCRIPTION
## Chromatic
<!-- This `1663-accordion-button-accessibility` is a placeholder for a CI job - it will be updated automatically -->
https://1663-accordion-button-accessibility--60f9b557105290003b387cd5.chromatic.com

---
## Description
Update 'Expand all' and 'Close all' button on the accordion to include `aria-controls` and `aria-expanded` attributes.

Closes [1663](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1663)

## Testing done
- Tested with Chrome ChromeVox extension and Mac Voice-over


## Screenshots
- No visual changes

## Acceptance criteria
- [ x] The expand/collapse button includes a aria-controls attribute that is set to a space separated list containing the IDs of all accordion item button IDs
- [ x] The expand/collapse button includes the aria-expanded attribute that changes value when the button is clicked

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
