### PR TITLE
Dispose of loading indicator observer - 1664

### DIFF
--- a/.yarn/versions/916472c4.yml
+++ b/.yarn/versions/916472c4.yml
@@ -1,0 +1,3 @@
+undecided:
+  - "@department-of-veterans-affairs/component-library-monorepo"
+  - "@department-of-veterans-affairs/web-components"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.33.0",
+  "version": "4.33.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-loading-indicator/va-loading-indicator.tsx
+++ b/packages/web-components/src/components/va-loading-indicator/va-loading-indicator.tsx
@@ -103,7 +103,8 @@ export class VaLoadingIndicator {
 
   disconnectedCallback() {
     // Don't disconnect the observer before the callback runs
-    setTimeout(() => this.observer.disconnect());
+    const observer = this.observer;
+    setTimeout(() => observer.disconnect());
   }
 
   render() {


### PR DESCRIPTION
## Chromatic
<!-- This `asteele-dispose-of-loading-indicator-observer-1664` is a placeholder for a CI job - it will be updated automatically -->
https://asteele-dispose-of-loading-indicator-observer-1664--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes [#1664](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1664)

## Testing done
Ran 'yarn test'

## Acceptance criteria
- [X] Appears to work better