### PR TITLE
(bug) fixed styling issue for sub header

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "15.2.1",
+  "version": "15.2.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.36.0",
+  "version": "4.36.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.css
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.css
@@ -41,7 +41,7 @@ button {
   background-position: right 2rem center;
   background-repeat: no-repeat;
   background-size: 1.5rem;
-  display: flex;
+  display: block;
   /* This color assignment is for IE11 compatibility - the one in */
   /* the va-accordion's CSS with `:host` doesn't work well */
   color: var(--color-gray-dark);


### PR DESCRIPTION
## Chromatic
<!-- This `va-accordion-item&#x2F;alignment-patch` is a placeholder for a CI job - it will be updated automatically -->
https://va-accordion-item&#x2F;alignment-patch--60f9b557105290003b387cd5.chromatic.com


## Description

- Fixing a bug that was introduced by a CSS Change. 


## Screenshots

### Currently
<img width="737" alt="image" src="https://user-images.githubusercontent.com/1793923/234358719-c3878341-06f7-4967-bdd1-cd8436c3dafe.png">


### After 
<img width="548" alt="image" src="https://user-images.githubusercontent.com/1793923/234358632-3f60f454-717f-46b2-a799-f3524547cb8d.png">


