### PR TITLE
fix: va-memorable-date will have empty string

### DIFF
--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -589,7 +589,7 @@ describe('va-memorable-date', () => {
     // Trigger Blur
     await handleYear.press('Tab');
     await page.waitForChanges();
-    expect(date.getAttribute('value')).toBe('--');
+    expect(date.getAttribute('value')).toBe('');
   });
 
   it('fires an analytics event when enableAnalytics is true', async () => {
@@ -1236,7 +1236,7 @@ describe('va-memorable-date', () => {
     // Trigger Blur
     await handleYear.press('Tab');
     await page.waitForChanges();
-    expect(date.getAttribute('value')).toBe('--');
+    expect(date.getAttribute('value')).toBe('');
   });
 
   it('uswds v3 fires an analytics event when enableAnalytics is true', async () => {
@@ -1774,7 +1774,7 @@ describe('va-memorable-date', () => {
     // Trigger Blur
     await handleYear.press('Tab');
     await page.waitForChanges();
-    expect(date.getAttribute('value')).toBe('--');
+    expect(date.getAttribute('value')).toBe('');
   });
 
   it('uswds v3 fires an analytics event when enableAnalytics is true with monthSelect', async () => {

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -121,9 +121,9 @@ export class VaMemorableDate {
       minimumIntegerDigits: 2,
     });
     /* eslint-disable i18next/no-literal-string */
-    this.value = `${year}-${month ? numFormatter.format(monthNum) : ''}-${
+    this.value = year || month || day ? `${year}-${month ? numFormatter.format(monthNum) : ''}-${
       day ? numFormatter.format(dayNum) : ''
-    }`;
+    }` : '';
     /* eslint-enable i18next/no-literal-string */
 
     // Run built-in validation. Any custom validation
@@ -161,9 +161,7 @@ export class VaMemorableDate {
     }
 
     /* eslint-disable i18next/no-literal-string */
-    this.value = `${currentYear}-${currentMonth ? currentMonth : ''}-${
-      currentDay ? currentDay : ''
-    }`;
+    this.value = currentYear || currentMonth || currentDay ? `${currentYear}-${currentMonth ? currentMonth : ''}-${currentDay ? currentDay : ''}` : '';
     /* eslint-enable i18next/no-literal-string */
 
     // This event should always fire to allow for validation handling


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

---
## Description

- Pull request modifies `handleDateChange` and `handleDateBlur` methods.
- Changes made to ensure correct date input formatting.
- Ternary operator used to check for existence of year, month, and day values before adding hyphen separators.
- Value property set to empty string if no values present.

Closes [1665](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1665)

## Testing done

- Storybook
- Chrome/Mozilla/Edge

## Screenshots
**Before:**

https://user-images.githubusercontent.com/22892911/234390388-9f558987-de08-4633-bcbd-fe7d05370e3a.mov


**After:**

https://user-images.githubusercontent.com/22892911/234389203-94fcb3f4-64ad-418b-9600-02450e6184c0.mov


## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
