### PR TITLE
Add icon support to va-accordion-item subheader

### DIFF
--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -73,34 +73,7 @@ const TemplateSubheader = args => {
   );
 };
 
-const TemplateSubheaderIcon = args => {
-  const { headline, level, ...rest } = args;
-  return (
-    <va-accordion {...rest} >
-      <va-accordion-item id="first" subheader="First Amendment Subheader" class="my-custom-class-example">
-        {headline}
-        <i slot="subheader-icon" className="fas fa-paperclip"></i>
-        Congress shall make no law respecting an establishment of religion, or
-        prohibiting the free exercise thereof; or abridging the freedom of
-        speech, or of the press; or the right of the people peaceably to
-        assemble, and to petition the Government for a redress of grievances.
-      </va-accordion-item>
-      <va-accordion-item id="second" level={level} header="Second Amendment" subheader="Second Amendment Subheader" class="my-custom-class">
-        <i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>
-        A well regulated Militia, being necessary to the security of a free
-        State, the right of the people to keep and bear Arms, shall not be
-        infringed.
-      </va-accordion-item>
-      <va-accordion-item id="third" level={level} header="Third Amendment" subheader="Third Amendment Subheader">
-        No Soldier shall, in time of peace be quartered in any house, without
-        the consent of the Owner, nor in time of war, but in a manner to be
-        prescribed by law.
-      </va-accordion-item>
-    </va-accordion>
-  );
-}
-
-const TemplateIconInHeader = args => {
+const TemplateIcons = args => {
   const { headline, level, ...rest } = args;
   return (
     <va-accordion {...rest}>
@@ -118,10 +91,20 @@ const TemplateIconInHeader = args => {
         State, the right of the people to keep and bear Arms, shall not be
         infringed.
       </va-accordion-item>
-      <va-accordion-item id="third" level={level} header="Third Amendment">
+      <va-accordion-item id="third" level={level} header="Third Amendment With a really long long header that is a thing that we should be planning for" subheader="Third Amendment Subheader With a really long long header that is a thing that we should be planning for">
+         <i slot='icon' className="fas fa-info-circle vads-u-color--green"></i>	
+         <i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>
         No Soldier shall, in time of peace be quartered in any house, without
         the consent of the Owner, nor in time of war, but in a manner to be
         prescribed by law.
+      </va-accordion-item>
+      <va-accordion-item id="third" level={level} header="Fourth Amendment" subheader="Fourth Amendment Subheader">
+         <i slot='icon' className="fas fa-info-circle vads-u-color--green"></i>	
+         <i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>
+         The right of the people to be secure in their persons, houses, papers, 
+         and effects, against unreasonable searches and seizures, shall not be violated,
+         and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, 
+         and particularly describing the place to be searched, and the persons or things to be seized.
       </va-accordion-item>
     </va-accordion>
   );
@@ -199,18 +182,13 @@ Subheader.args = {
   ...defaultArgs,
 };
 
-export const SubheaderIcon = TemplateSubheaderIcon.bind(null);
-SubheaderIcon.args = {
-  ...defaultArgs,
-};
-
 export const Internationalization = I18nTemplate.bind(null);
 Internationalization.args = {
   ...defaultArgs,
 };
 
-export const IconInHeader = TemplateIconInHeader.bind(null);
-IconInHeader.args = {
+export const UsingIcons = TemplateIcons.bind(null);
+UsingIcons.args = {
   ...defaultArgs,
 };
 

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -73,13 +73,40 @@ const TemplateSubheader = args => {
   );
 };
 
+const TemplateSubheaderIcon = args => {
+  const { headline, level, ...rest } = args;
+  return (
+    <va-accordion {...rest} >
+      <va-accordion-item id="first" subheader="First Amendment Subheader" class="my-custom-class-example">
+        {headline}
+        <i slot="subheader-icon" className="fas fa-paperclip"></i>
+        Congress shall make no law respecting an establishment of religion, or
+        prohibiting the free exercise thereof; or abridging the freedom of
+        speech, or of the press; or the right of the people peaceably to
+        assemble, and to petition the Government for a redress of grievances.
+      </va-accordion-item>
+      <va-accordion-item id="second" level={level} header="Second Amendment" subheader="Second Amendment Subheader" class="my-custom-class">
+        <i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>
+        A well regulated Militia, being necessary to the security of a free
+        State, the right of the people to keep and bear Arms, shall not be
+        infringed.
+      </va-accordion-item>
+      <va-accordion-item id="third" level={level} header="Third Amendment" subheader="Third Amendment Subheader">
+        No Soldier shall, in time of peace be quartered in any house, without
+        the consent of the Owner, nor in time of war, but in a manner to be
+        prescribed by law.
+      </va-accordion-item>
+    </va-accordion>
+  );
+}
+
 const TemplateIconInHeader = args => {
   const { headline, level, ...rest } = args;
   return (
     <va-accordion {...rest}>
       <va-accordion-item id="first">
         {headline}
-        <i slot="icon" className="fas fa-paperclip"></i>
+        <i slot="icon" className="fas fa-paperclip" aria-hidden="true"></i>
         Congress shall make no law respecting an establishment of religion, or
         prohibiting the free exercise thereof; or abridging the freedom of
         speech, or of the press; or the right of the people peaceably to
@@ -169,6 +196,11 @@ ChangeHeaderLevel.args = {
 
 export const Subheader = TemplateSubheader.bind(null);
 Subheader.args = {
+  ...defaultArgs,
+};
+
+export const SubheaderIcon = TemplateSubheaderIcon.bind(null);
+SubheaderIcon.args = {
   ...defaultArgs,
 };
 

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -91,20 +91,12 @@ const TemplateIcons = args => {
         State, the right of the people to keep and bear Arms, shall not be
         infringed.
       </va-accordion-item>
-      <va-accordion-item id="third" level={level} header="Third Amendment With a really long long header that is a thing that we should be planning for" subheader="Third Amendment Subheader With a really long long header that is a thing that we should be planning for">
+      <va-accordion-item id="third" level={level} header="Third Amendment" subheader="Third Amendment Subheader">
          <i slot='icon' className="fas fa-info-circle vads-u-color--green"></i>	
          <i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>
         No Soldier shall, in time of peace be quartered in any house, without
         the consent of the Owner, nor in time of war, but in a manner to be
         prescribed by law.
-      </va-accordion-item>
-      <va-accordion-item id="third" level={level} header="Fourth Amendment" subheader="Fourth Amendment Subheader">
-         <i slot='icon' className="fas fa-info-circle vads-u-color--green"></i>	
-         <i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>
-         The right of the people to be secure in their persons, houses, papers, 
-         and effects, against unreasonable searches and seizures, shall not be violated,
-         and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, 
-         and particularly describing the place to be searched, and the persons or things to be seized.
       </va-accordion-item>
     </va-accordion>
   );

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.37.1",
+  "version": "4.38.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.38.1",
+  "version": "4.38.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.css
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.css
@@ -79,6 +79,7 @@ p {
   display: none;
 }
 
-::slotted([slot='icon']){
+::slotted([slot='icon']),
+::slotted([slot='subheader-icon']){
   margin-right: 1rem;
 }

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.css
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.css
@@ -87,8 +87,8 @@ p.subheader {
 
 ::slotted([slot='icon']),
 ::slotted([slot='subheader-icon']){
-  margin-right: 1rem;
   width: 1rem;
+  margin-right: 1.5rem;
 }
 
 ::slotted([slot='subheader-icon']) {

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.css
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.css
@@ -68,10 +68,16 @@ button[aria-expanded='false'] {
   background-image: url('../../assets/plus.svg');
 }
 
-p {
+.header-text{
+  display: flex;
+}
+
+p.subheader {
   font-weight: 400;
   line-height: 26px;
   margin: 0;
+  margin-top: 0.25rem;
+  display: flex;
 }
 
 /* Hiding since element would be duplicated via the Shadow DOM */
@@ -82,4 +88,9 @@ p {
 ::slotted([slot='icon']),
 ::slotted([slot='subheader-icon']){
   margin-right: 1rem;
+  width: 1rem;
+}
+
+::slotted([slot='subheader-icon']) {
+  margin-top: 0.5rem;
 }

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -15,7 +15,9 @@ describe('va-accordion-item', () => {
       <mock:shadow-root>
         <h2>
           <button aria-controls="content" aria-expanded="false" part="accordion-header">
-             <slot name="icon"></slot>
+            <span class="header-text">
+              <slot name="icon"></slot>
+            </span>
           </button>
         </h2>
         <slot name="headline"></slot>
@@ -53,7 +55,6 @@ describe('va-accordion-item', () => {
 
     expect(header.nodeName).toEqual('H6');
   });
-
 
   it('passes an axe check when open', async () => {
     const page = await newE2EPage();
@@ -158,6 +159,71 @@ describe('va-accordion-item', () => {
 
     expect(subheader).toEqualText('The subheader');
   });
+
+  it("render the sub header icon", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-accordion-item header="The header" subheader="The subheader"><i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>Content inside</va-accordion-item>',
+    );
+    const element = await page.find('va-accordion-item');
+    expect(element).toEqualHtml(
+      `<va-accordion-item class="hydrated" header="The header" subheader="The subheader">
+        <mock:shadow-root>
+        <h2>
+          <button aria-controls="content" aria-expanded="false" part="accordion-header">
+            <span class="header-text">
+              <slot name="icon"></slot>
+              The header
+            </span>
+            <p class="subheader" part="accordion-subheader">
+              <slot name="subheader-icon"></slot>
+              The subheader
+            </p>
+          </button>
+        </h2>
+        <slot name="headline"></slot>
+        <div id="content" tabindex="0">
+          <slot></slot>
+        </div>
+      </mock:shadow-root>
+      <i aria-hidden="true" classname="fas fa-envelope" slot="subheader-icon"></i>
+      Content inside
+    </va-accordion-item>`);
+  });
+  it("does not render the sub header icon if there is no sub header", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-accordion-item header="The header"><i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>Content inside</va-accordion-item>',
+    );
+    const element = await page.find('va-accordion-item');
+    expect(element).toEqualHtml(`<va-accordion-item class="hydrated" header="The header">
+      <mock:shadow-root>
+        <h2>
+          <button aria-controls="content" aria-expanded="false" part="accordion-header">
+            <span class="header-text">
+              <slot name="icon"></slot>
+              The header
+            </span>
+          </button>
+        </h2>
+        <slot name="headline"></slot>
+        <div id="content" tabindex="0">
+          <slot></slot>
+        </div>
+      </mock:shadow-root>
+      <i aria-hidden="true" classname="fas fa-envelope" slot="subheader-icon"></i>
+      Content inside
+    </va-accordion-item>`);
+  });
+  it('passes axe check with subheader icon', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-accordion-item header="The header" subheader="The subheader"><i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>Content inside</va-accordion-item>',
+    );
+
+    await axeCheck(page);
+
+  })
 
   // Skipping Test until fix can be found via ticket 33479
   // Test sometimes succeeds and other times fails

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -116,7 +116,11 @@ export class VaAccordionItem {
           >
             < slot name="icon" />
             {this.slotHeader || this.header || ieSlotCheckHeader}
-            {this.subheader ? <p>{this.subheader}</p> : false}
+            {this.subheader &&
+              <p part='accordion-subheader'>
+                < slot name="subheader-icon" />
+                {this.subheader}
+              </p>}
           </button>
         </Tag >
       );

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -114,11 +114,13 @@ export class VaAccordionItem {
             aria-controls="content"
             part="accordion-header"
           >
-            < slot name="icon" />
-            {this.slotHeader || this.header || ieSlotCheckHeader}
+            <span class="header-text">
+              <slot name="icon" />
+              {this.slotHeader || this.header || ieSlotCheckHeader}
+            </span>
             {this.subheader &&
-              <p part='accordion-subheader'>
-                < slot name="subheader-icon" />
+              <p class="subheader" part='accordion-subheader'>
+                <slot name="subheader-icon" />
                 {this.subheader}
               </p>}
           </button>


### PR DESCRIPTION
## Chromatic
<!-- This `1709-accordion-subheader-icon` is a placeholder for a CI job - it will be updated automatically -->
https://1709-accordion-subheader-icon--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1709

## Testing done
- Storybook
- unit
- screen sizes

## Screenshots

### After
<img width="247" alt="image" src="https://user-images.githubusercontent.com/1793923/234683276-94749945-b3b1-40f7-a1ab-5d7b3183af4d.png">


## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] Icon is visible in the sub header
- [ ] formating is maintained for all screen sizes. 

## Notes
 I still need to update the unit tests and documentation. But I am getting a review early