### PR TITLE
Converting selected components to use px instead of rem - 906

### DIFF
--- a/packages/css-library/tokens/color.json
+++ b/packages/css-library/tokens/color.json
@@ -1,42 +1,53 @@
 {
   "color": {
-    "base": { "value": "#212121"},
-    "white": { "value": "#ffffff"},
-    "black": { "value": "#000000"},
-    "orange": { "value": "#eb7f29"},
-    "link-default": { "value": "#004795"},
-    "warning-message": { "value": "#fac922"},
-    "gibill-accent": { "value": "#fff1d2"},
+    "base": { "value": "#212121" },
+    "white": { "value": "#ffffff" },
+    "black": { "value": "#000000" },
+    "orange": { "value": "#eb7f29" },
+    "link-default": { "value": "#004795" },
+    "warning-message": { "value": "#fac922" },
+    "gibill-accent": { "value": "#fff1d2" },
     "primary": {
-      "*": { "value": "#0071bb"},
-      "darker": { "value": "#003e73"},
-      "darkest": { "value": "#112e51"},
+      "*": { "value": "#0071bb" },
+      "darker": { "value": "#003e73" },
+      "darkest": { "value": "#112e51" },
       "alt": {
-        "*": { "value": "#02bfe7"},
-        "dark": { "value": "#00a6d2"},
-        "darkest": { "value": "#046b99"},
-        "light": { "value": "#9bdaf1"},
-        "lightest": { "value": "#e1f3f8"}
+        "*": { "value": "#02bfe7" },
+        "dark": { "value": "#00a6d2" },
+        "darkest": { "value": "#046b99" },
+        "light": { "value": "#9bdaf1" },
+        "lightest": { "value": "#e1f3f8" }
       }
     },
     "secondary": {
-      "*": { "value": "#e31c3d"},
-      "dark": { "value": "#cd2026"},
-      "darkest": { "value": "#981b1e"},
-      "light": { "value": "#e59393"},
-      "lightest": { "value": "#f9dede"}
+      "*": { "value": "#e31c3d" },
+      "dark": { "value": "#cd2026" },
+      "darkest": { "value": "#981b1e" },
+      "light": { "value": "#e59393" },
+      "lightest": { "value": "#f9dede" }
     },
     "gray": {
-      "*": { "value": "#5b616b"},
-      "dark": { "value": "#323a45"},
-      "medium": { "value": "#757575"},
-      "light": { "value": "#aeb0b5"},
-      "light-alt": { "value": "#eeeeee"},
-      "lighter": { "value": "#d6d7d9"},
-      "lightest": { "value": "#f1f1f1"},
-      "warm-dark": { "value": "#494440"},
-      "warm-light": { "value": "#e4e2e0"},
-      "cool-light": { "value": "#dce4ef"}
+      "*": { "value": "#5b616b" },
+      "dark": { "value": "#323a45" },
+      "medium": { "value": "#757575" },
+      "light": { "value": "#aeb0b5" },
+      "light-alt": { "value": "#eeeeee" },
+      "lighter": { "value": "#d6d7d9" },
+      "lightest": { "value": "#f1f1f1" },
+      "warm-dark": { "value": "#494440" },
+      "warm-light": { "value": "#e4e2e0" },
+      "cool-light": { "value": "#dce4ef" }
+    },
+    "gold": {
+      "*": { "value": "#fdb81e" },
+      "light": { "value": "#f9c642" },
+      "lighter": { "value": "#fad980" },
+      "lightest": { "value": "#fff1d2" }
+    },
+    "green": {
+      "*": { "value": "#2e8540" },
+      "lighter": { "value": "#94bfa2" },
+      "lightest": { "value": "#e7f4e4" }
     }
   },
   "v3-color": {

--- a/packages/css-library/tokens/fonts.json
+++ b/packages/css-library/tokens/fonts.json
@@ -27,6 +27,11 @@
       "h6": { "value": "{font.size.sm}" }
     }
   },
+   "v1-font": {
+    "base": {
+      "size": { "value": "10px" }
+    }
+  },
   "v3-font": {
     "base": {
       "size": { "value": "16px"}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.36.0",
+  "version": "4.36.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-button/va-button.scss
+++ b/packages/web-components/src/components/va-button/va-button.scss
@@ -1,7 +1,5 @@
 @forward 'settings';
-
 @use 'usa-button/src/styles/usa-button';
-
 @import '../../global/formation_overrides';
 
 :host {
@@ -17,65 +15,78 @@
 
 // Override transparent background from USWDS v3
 .usa-button--outline {
-  background-color: var(--color-white);
+  background-color: $color-white;
 }
 
-/* Original Component Styles. */
+:host(:not([uswds])) {
+  button {
+    align-items: center;
+    appearance: none;
+    background-color: $color_primary;
+    border-radius: 5px;
+    border: 0;
+    color: $color-white;
+    cursor: pointer;
+    display: flex;
+    font-family: $font-family-sans;
+    font-size: v1_rem_to_px(1.6rem);
+    font-weight: 700;
+    justify-content: center;
+    line-height: 1;
+    margin: 0.5em 0.5em 0.5em 0;
+    padding:  v1_rem_to_px(1rem)  v1_rem_to_px(2rem);
+    text-align: center;
+    text-decoration: none;
+  }
 
-@import '../../mixins/buttons.css';
-
-:host(:not([uswds])) button {
-  align-items: center;
-  background-color: var(--color-primary);
-  border-radius: 5px;
-  color: var(--color-white);
-  display: flex;
-  font-size: 1.6rem;
-  justify-content: center;
-  margin: 0.5em 0.5em 0.5em 0;
-}
-
-:host(:not([uswds])) button:hover,
-:host(:not([uswds])) button:focus {
-  background-color: var(--color-primary-darker);
+  button:hover,
+  button:focus {
+    background-color: $color-primary-darker;
+  }
 }
 
 :host(:not([uswds])) button:active {
-  background-color: var(--color-primary-darkest);
+  background-color: $color-primary-darkest;
 }
 
 :host(:not([uswds])[back]:not([back='false'])) button,
 :host(:not([uswds])[secondary]:not([secondary='false'])) button {
-  background-color: var(--color-white);
-  box-shadow: inset 0 0 0 2px var(--color-primary);
-  color: var(--color-primary);
+  background-color: $color-white;
+  box-shadow: inset 0 0 0 2px $color-primary;
+  color: $color-primary;
 }
 
 :host(:not([uswds])[back]:not([back='false'])) button:active,
 :host(:not([uswds])[back]:not([back='false'])) button:hover,
 :host(:not([uswds])[secondary]:not([secondary='false'])) button:active,
 :host(:not([uswds])[secondary]:not([secondary='false'])) button:hover {
-  background-color: var(--color-gray-cool-light);
-  box-shadow: inset 0 0 0 2px var(--color-primary-darker);
-  color: var(--color-primary-darker);
+  background-color: $color-gray-cool-light;
+  box-shadow: inset 0 0 0 2px $color-primary-darker;
+  color: $color-primary-darker;
 }
 
 :host(:not([uswds])[back]:not([back='false'])) button:focus,
 :host(:not([uswds])[secondary]:not([secondary='false'])) button:focus {
-  background-color: var(--color-gray-cool-light);
-  box-shadow: inset 0 0 0 2px var(--color-primary);
-  color: var(--color-primary);
+  background-color: $color-gray-cool-light;
+  box-shadow: inset 0 0 0 2px $color-primary;
+  color: $color-primary;
 }
 
 :host(:not([uswds])[big]:not([big='false'])) button {
   border-radius: 8px;
-  font-size: 2.4rem;
-  padding: 1.5rem 3rem;
+  font-size: v1_rem_to_px($units-3);
+  padding: v1_rem_to_px(1.5rem) v1_rem_to_px(3rem);
+}
+
+:host(:not([uswds])[disabled]:not([disabled='false'])) button {
+  background-color: $color-gray-lighter;
+  box-shadow: none;
+  color: $color-white;
 }
 
 i {
   font-family: 'Font Awesome 5 Free';
-  font-size: 1.6rem;
+  font-size: v1_rem_to_px(1.6rem);
   font-style: normal;
   font-weight: 900;
   line-height: 1;
@@ -91,8 +102,3 @@ i.fa-angles-right::before {
   margin-left: 8px;
 }
 
-:host(:not([uswds])[disabled]:not([disabled='false'])) button {
-  background-color: var(--color-gray-lighter);
-  box-shadow: none;
-  color: var(--color-white);
-}

--- a/packages/web-components/src/components/va-text-input/va-text-input.scss
+++ b/packages/web-components/src/components/va-text-input/va-text-input.scss
@@ -10,12 +10,12 @@
 @import '../../global/formation_overrides';
 
 :host([uswds]) {
-  color: var(--v3-color-base-darkest);
+  color: $v3-color-base-darkest;
 }
 
 :host {
   display: block;
-  font-family: var(--font-source-sans);
+  font-family: $font-family-sans;
 }
 
 :host(:focus) {
@@ -23,7 +23,7 @@
 }
 
 :host([uswds]) input:not([disabled]):focus {
-  outline: 2px solid var(--color-gold-light);
+  outline: 2px solid $color-gold-light;
   outline-offset: 2px;
 }
 
@@ -32,7 +32,7 @@ input {
 }
 
 input.usa-input {
-  color: var(--color-base);
+  color: $color-base;
 }
 
 /** Original Component Style **/
@@ -43,36 +43,36 @@ input.usa-input {
 
 :host(:not([uswds])) label {
   display: block;
-  max-width: 46rem;
-  margin-top: 3rem;
+  max-width: v1_rem_to_px(46rem);
+  margin-top: v1_rem_to_px(3rem);
 }
 
 span.required {
-  color: var(--color-secondary-dark);
+  color: $color-secondary-dark;
 }
 
 :host(:not([uswds])) input {
   appearance: none;
-  border: 0.1rem solid var(--color-gray);
+  border: 1px solid $color-gray;
   border-radius: 0;
   box-sizing: border-box;
-  color: var(--color-base);
+  color: $color-base;
   display: block;
-  font-family: var(--font-source-sans);
-  font-size: 1.6rem;
-  height: 4.2rem;
+  font-family: $font-family-sans;
+  font-size: v1_rem_to_px($font-size-base);
+  height: v1_rem_to_px(4.2rem);
   line-height: 1.3;
   margin: 0.2em 0;
-  max-width: 46rem;
-  padding: 1rem 0.7em;
+  max-width: v1_rem_to_px(46rem);
+  padding: v1_rem_to_px(1rem) 0.7em;
   width: 100%;
 }
 
 :host(:not([uswds])) input:not([disabled]):focus {
-  outline: 2px solid var(--color-gold-light);
+  outline: 2px solid $color-gold-light;
   outline-offset: 2px;
 }
 
 :host([success]:not([success='false']):not([uswds])) input {
-  border: 4px solid var(--color-green);
+  border: 4px solid $color-green;
 }

--- a/packages/web-components/src/global/_formation_overrides.scss
+++ b/packages/web-components/src/global/_formation_overrides.scss
@@ -1,12 +1,12 @@
 @import 'functions';
 
 .usa-form {
-  font-size: rem-override(1rem);
+  font-size: v3_rem_to_px(1rem);
 }
 
 @media (min-width: 30em) {
   .usa-form {
-    max-width: rem-override(20rem);
+    max-width: v3_rem_to_px(20rem);
   }
 }
 
@@ -19,98 +19,98 @@
 .usa-textarea,
 .usa-modal,
 .usa-select {
-  font-size: rem-override(1.06rem);
+  font-size: v3_rem_to_px(1.06rem);
 }
 
 .usa-label,
 .usa-legend {
-  margin-top: rem-override(1.5rem);
-  max-width: rem-override(30rem);
+  margin-top: v3_rem_to_px(1.5rem);
+  max-width: v3_rem_to_px(30rem);
 }
 
 .usa-radio__label {
-  margin-top: rem-override(0.75rem);
-  padding-left: rem-override(2rem);
+  margin-top: v3_rem_to_px(0.75rem);
+  padding-left: v3_rem_to_px(2rem);
 
   &::before {
-    height: rem-override(1.25rem);
-    border-radius: rem-override(99rem);
-    width: rem-override(1.25rem);
-    margin-top: rem-override(0.064rem);
+    height: v3_rem_to_px(1.25rem);
+    border-radius: v3_rem_to_px(99rem);
+    width: v3_rem_to_px(1.25rem);
+    margin-top: v3_rem_to_px(0.064rem);
   }
 
   &-description {
-    font-size: rem-override(0.93rem);
-    margin-top: rem-override(0.5rem);
+    font-size: v3_rem_to_px(0.93rem);
+    margin-top: v3_rem_to_px(0.5rem);
   }
 }
 
 .usa-radio__input {
-  font-size: rem-override(1.6rem);
-  border-width: rem-override(0.1rem);
-  height: rem-override(4.2rem);
-  max-width: rem-override(46rem);
-  padding: rem-override(1rem) 0.7em;
+  font-size: v3_rem_to_px(1.6rem);
+  border-width: v3_rem_to_px(0.1rem);
+  height: v3_rem_to_px(4.2rem);
+  max-width: v3_rem_to_px(46rem);
+  padding: v3_rem_to_px(1rem) 0.7em;
 
   &--tile + [class*='__label'] {
-    border-radius: rem-override(0.25rem);
-    margin-top: rem-override(0.5rem);
-    padding: rem-override(0.75rem) rem-override(1rem) rem-override(0.75rem)
-      rem-override(2.5rem);
+    border-radius: v3_rem_to_px(0.25rem);
+    margin-top: v3_rem_to_px(0.5rem);
+    padding: v3_rem_to_px(0.75rem) v3_rem_to_px(1rem) v3_rem_to_px(0.75rem)
+      v3_rem_to_px(2.5rem);
 
     &::before {
-      left: rem-override(0.5rem);
+      left: v3_rem_to_px(0.5rem);
     }
   }
 }
 
 .usa-input, .usa-select, .usa-textarea {
-  height: rem-override(2.5rem);
-  margin-top: rem-override(0.5rem);
-  max-width: rem-override(30rem);
-  padding: rem-override(0.5rem);
+  height: v3_rem_to_px(2.5rem);
+  margin-top: v3_rem_to_px(0.5rem);
+  max-width: v3_rem_to_px(30rem);
+  padding: v3_rem_to_px(0.5rem);
 
   &--success,
   &--error {
-    padding-top: rem-override(0.25rem);
-    padding-bottom: rem-override(0.25rem);
-    border-width: rem-override(0.25rem);
+    padding-top: v3_rem_to_px(0.25rem);
+    padding-bottom: v3_rem_to_px(0.25rem);
+    border-width: v3_rem_to_px(0.25rem);
   }
 }
 
 .usa-checkbox {
   &__label {
-    margin-top: rem-override(0.75rem);
-    padding-left: rem-override(2rem);
-    font-size: rem-override(1.06rem);
+    margin-top: v3_rem_to_px(0.75rem);
+    padding-left: v3_rem_to_px(2rem);
+    font-size: v3_rem_to_px(1.06rem);
 
     &::before {
-      height: rem-override(1.25rem);
-      width: rem-override(1.25rem);
-      margin-top: rem-override(0.064rem);
+      height: v3_rem_to_px(1.25rem);
+      width: v3_rem_to_px(1.25rem);
+      margin-top: v3_rem_to_px(0.064rem);
     }
   }
 
   &__input--tile + [class*='__label'] {
-    border-radius: rem-override(0.25rem);
-    margin-top: rem-override(0.5rem);
-    padding: rem-override(0.75rem) rem-override(1rem) rem-override(0.75rem)
-      rem-override(2.5rem);
+    border-radius: v3_rem_to_px(0.25rem);
+    margin-top: v3_rem_to_px(0.5rem);
+    padding: v3_rem_to_px(0.75rem) v3_rem_to_px(1rem) v3_rem_to_px(0.75rem)
+      v3_rem_to_px(2.5rem);
 
     &::before {
-      left: rem-override(0.5rem);
+      left: v3_rem_to_px(0.5rem);
     }
   }
 
   &__label-description {
-    font-size: rem-override(0.93rem);
-    margin-top: rem-override(0.5rem);
+    font-size: v3_rem_to_px(0.93rem);
+    margin-top: v3_rem_to_px(0.5rem);
   }
 }
 
 .usa-error-message {
-  padding-bottom: rem-override(0.25rem);
-  padding-top: rem-override(0.25rem);
+  padding-bottom: v3_rem_to_px(0.25rem);
+  padding-top: v3_rem_to_px(0.25rem);
 }
 
 .usa-legend {
@@ -118,8 +118,8 @@
 }
 
 .usa-select {
-  background-size: rem-override(1.25rem);
-  background-position: right rem-override(0.5rem) center;
+  background-size: v3_rem_to_px(1.25rem);
+  background-position: right v3_rem_to_px(0.5rem) center;
 }
 
 .usa-memorable-date .usa-form-group {
@@ -127,139 +127,139 @@
 }
 
 .usa-form-group--day, .usa-form-group--month, .usa-form-group--year {
-  margin-right: rem-override(1rem);
+  margin-right: v3_rem_to_px(1rem);
 }
 
 .usa-form-group--day-input, .usa-form-group--month-input {
-  width: rem-override(3rem);
+  width: v3_rem_to_px(3rem);
 }
 
 .usa-form-group--year-input {
-  width: rem-override(4.5rem);
+  width: v3_rem_to_px(4.5rem);
 }
 
 .usa-form-group--month-select {
-  width: rem-override(15rem);
+  width: v3_rem_to_px(15rem);
 }
 
 .usa-textarea {
-  height: rem-override(10rem);
+  height: v3_rem_to_px(10rem);
 }
 
 .usa-button {
-  font-size: rem-override(1.06rem);
-  border-radius: rem-override(0.25rem);
-  margin-right: rem-override(0.5rem);
-  padding: rem-override(0.75rem) rem-override(1.25rem);
+  font-size: v3_rem_to_px(1.06rem);
+  border-radius: v3_rem_to_px(0.25rem);
+  margin-right: v3_rem_to_px(0.5rem);
+  padding: v3_rem_to_px(0.75rem) v3_rem_to_px(1.25rem);
   &--big {
-    border-radius: rem-override(0.25rem);
-    font-size: rem-override(1.46rem);
-    padding: rem-override(1rem) rem-override(1.5rem);
+    border-radius: v3_rem_to_px(0.25rem);
+    font-size: v3_rem_to_px(1.46rem);
+    padding: v3_rem_to_px(1rem) v3_rem_to_px(1.5rem);
   }
 }
 
 .usa-button-group {
   &__item {
-    margin: rem-override(0.25rem);
+    margin: v3_rem_to_px(0.25rem);
   }
-  margin: 0px rem-override(-0.5rem);
+  margin: 0px v3_rem_to_px(-0.5rem);
 }
 
 .usa-modal {
-  border-radius: rem-override(0.5rem);
-  margin: rem-override(1.25rem) auto;
-  max-width: rem-override(30rem);
+  border-radius: v3_rem_to_px(0.5rem);
+  margin: v3_rem_to_px(1.25rem) auto;
+  max-width: v3_rem_to_px(30rem);
 }
 
 .usa-modal__content {
-  padding-top: rem-override(2rem);
+  padding-top: v3_rem_to_px(2rem);
 }
 
 .usa-modal--lg .usa-modal__main {
-  padding-bottom: rem-override(4rem);
-  padding-top: rem-override(1.25rem);
-  max-width: rem-override(40rem);
+  padding-bottom: v3_rem_to_px(4rem);
+  padding-top: v3_rem_to_px(1.25rem);
+  max-width: v3_rem_to_px(40rem);
 }
 
 .usa-modal__main {
-  padding: rem-override(0.5rem) rem-override(2rem) rem-override(2rem);
+  padding: v3_rem_to_px(0.5rem) v3_rem_to_px(2rem) v3_rem_to_px(2rem);
 }
 
 .usa-modal__heading {
-  font-size: rem-override(1.34rem);
+  font-size: v3_rem_to_px(1.34rem);
 }
 
 .usa-modal__footer {
-  margin-top: rem-override(1.5rem);
+  margin-top: v3_rem_to_px(1.5rem);
 }
 
 .usa-modal__close {
-  font-size: rem-override(.93rem);
-  margin: rem-override(-2rem) 0 0 auto;
-  padding: rem-override(0.25rem);
+  font-size: v3_rem_to_px(.93rem);
+  margin: v3_rem_to_px(-2rem) 0 0 auto;
+  padding: v3_rem_to_px(0.25rem);
 }
 
 .usa-modal__close .usa-icon {
-  height: rem-override(2rem);
-  width: rem-override(2rem);
+  height: v3_rem_to_px(2rem);
+  width: v3_rem_to_px(2rem);
 }
 
 .usa-modal--lg {
-  max-width: rem-override(55rem);
+  max-width: v3_rem_to_px(55rem);
 }
 
 .usa-alert {
-  border-left-width: rem-override(0.5rem);
+  border-left-width: v3_rem_to_px(0.5rem);
   .usa-alert__body {
-    font-size: rem-override(1.06rem);
-    max-width: rem-override(64rem);
-    padding: rem-override(1rem);
+    font-size: v3_rem_to_px(1.06rem);
+    max-width: v3_rem_to_px(64rem);
+    padding: v3_rem_to_px(1rem);
   }
 }
 
-.usa-alert--info, 
-.usa-alert--warning, 
-.usa-alert--success, 
+.usa-alert--info,
+.usa-alert--warning,
+.usa-alert--success,
 .usa-alert--error {
   .usa-alert__body {
-    padding-left: rem-override(2.9166666667rem);
+    padding-left: v3_rem_to_px(2.9166666667rem);
     &::before {
-      height: rem-override(2rem);
-      width: rem-override(2rem);
-      top: rem-override(0.75rem);
-      left: rem-override(0.5rem);
+      height: v3_rem_to_px(2rem);
+      width: v3_rem_to_px(2rem);
+      top: v3_rem_to_px(0.75rem);
+      left: v3_rem_to_px(0.5rem);
     }
   }
 }
 
 @media (min-width: 64em) {
-  .usa-alert--info, 
-  .usa-alert--warning, 
-  .usa-alert--success, 
+  .usa-alert--info,
+  .usa-alert--warning,
+  .usa-alert--success,
   .usa-alert--error {
     .usa-alert__body {
-      padding-left: rem-override(4rem);
-      padding-right: rem-override(4rem);
+      padding-left: v3_rem_to_px(4rem);
+      padding-right: v3_rem_to_px(4rem);
       &::before {
-        left: rem-override(1.5rem);
-        top: rem-override(0.75rem);
+        left: v3_rem_to_px(1.5rem);
+        top: v3_rem_to_px(0.75rem);
       }
     }
   }
 }
 
 .usa-alert--slim .usa-alert__body {
-  padding-bottom: rem-override(0.5rem);
-  padding-top: rem-override(0.5rem);
-  padding-left: rem-override(2.4166666667rem);
+  padding-bottom: v3_rem_to_px(0.5rem);
+  padding-top: v3_rem_to_px(0.5rem);
+  padding-left: v3_rem_to_px(2.4166666667rem);
 }
 
 @media (min-width: 64em) {
   .usa-alert--slim .usa-alert__body {
-    padding-left: rem-override(3.5rem);;
+    padding-left: v3_rem_to_px(3.5rem);;
   }
 }
 
 .usa-checkbox__input:checked + [class*="__label"]::before {
-  background-size: rem-override(0.75rem);
+  background-size: v3_rem_to_px(0.75rem);
 }

--- a/packages/web-components/src/global/_functions.scss
+++ b/packages/web-components/src/global/_functions.scss
@@ -1,15 +1,22 @@
 @use 'sass:math';
-
 @import 'variables';
 
 // Uses $v3-font-base-size from _variables.scss
-@function rem-override($original) {
+@function v3_rem_to_px($original) {
   @if unit($original) == 'rem' {
     $rem-to-px: (math.div($original, 1rem)) * $v3-font-base-size;
     @return $rem-to-px;
   }
   @if unit($original) != 'px' {
     @error 'This value must be in either px or rem';
+  }
+  @return $original;
+}
+
+@function v1_rem_to_px($original) {
+  @if unit($original) == 'rem' {
+    $rem-to-px: (math.div($original, 1rem)) * $v1-font-base-size;
+    @return $rem-to-px;
   }
   @return $original;
 }

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -1,5 +1,6 @@
+
 // Do not edit directly
-// Generated on Mon, 27 Feb 2023 21:20:09 GMT
+// Generated on Wed, 26 Apr 2023 16:21:09 GMT
 
 $color-base: #212121;
 $color-white: #ffffff;
@@ -51,6 +52,7 @@ $font-size-h3: 2rem;
 $font-size-h4: 1.7rem;
 $font-size-h5: 1.5rem;
 $font-size-h6: 1.5rem;
+$v1-font-base-size: 10px;
 $v3-font-base-size: 16px;
 $units-0: 0;
 $units-1: 0.8rem;

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 26 Apr 2023 16:21:09 GMT
+// Generated on Fri, 28 Apr 2023 15:05:00 GMT
 
 $color-base: #212121;
 $color-white: #ffffff;
@@ -32,6 +32,13 @@ $color-gray-lightest: #f1f1f1;
 $color-gray-warm-dark: #494440;
 $color-gray-warm-light: #e4e2e0;
 $color-gray-cool-light: #dce4ef;
+$color-gold: #fdb81e;
+$color-gold-light: #f9c642;
+$color-gold-lighter: #fad980;
+$color-gold-lightest: #fff1d2;
+$color-green: #2e8540;
+$color-green-lighter: #94bfa2;
+$color-green-lightest: #e7f4e4;
 $v3-color-error-dark: #b50909;
 $v3-color-base-darkest: #1B1B1B;
 $font-family-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;

--- a/packages/web-components/src/mixins/uswds-error-border.scss
+++ b/packages/web-components/src/mixins/uswds-error-border.scss
@@ -3,7 +3,7 @@
 
 :host([error][uswds]:not([error=''])) {
     border-left: 0.4rem solid $v3-color-error-dark; /* USWDS red-60v, $theme-color-error-dark */
-    padding-left: rem-override(1rem);
+    padding-left: v3_rem_to_px(1rem);
     position: relative;
 }
 

--- a/packages/web-components/src/mixins/uswds-error-border.scss
+++ b/packages/web-components/src/mixins/uswds-error-border.scss
@@ -2,13 +2,13 @@
 @import 'functions';
 
 :host([error][uswds]:not([error=''])) {
-    border-left: 0.4rem solid $v3-color-error-dark; /* USWDS red-60v, $theme-color-error-dark */
-    padding-left: v3_rem_to_px(1rem);
+    border-left: 4px solid $v3-color-error-dark; /* USWDS red-60v, $theme-color-error-dark */
+    padding-left: 16px;
     position: relative;
 }
 
 @media screen and (min-width: 1008px) {
     :host([error][uswds]:not([error=''])) {
-        margin-left: -1.4rem;
+        margin-left: v3_rem_to_px(-1.4rem);
     }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://asteele-uxpin-updates-906--60f9b557105290003b387cd5.chromatic.com

---

## Description
Relates to [#906](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/906).

- Modifying styles on va-button to make better use of style-dictionary-generated SCSS tokens, as well as outputting rem values as px to improve compatibility with UXPin.
- Added v1-font-base-size
- Added v1_rem_to_px function
- Renamed rem_override to v3_rem_to_px function to reduce confusion

## Testing done
Tested in UXPin app and storybook using Brave/Chrome.

## Acceptance criteria
- [X] Still looks the same as it did.
- [X] Renders in UXPin correctly.

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
