### PR TITLE
va-textinput add inline hint to storybook

### DIFF
--- a/packages/storybook/stories/va-text-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.jsx
@@ -202,6 +202,18 @@ WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
 export const WithHintText = Template.bind(null);
 WithHintText.args = { ...defaultArgs, hint: 'This is hint text' };
 
+const WithInlineHintTextTemplate = ({ name, label }) => {
+  return (
+    <>
+      <va-text-input name={name} label={label} />
+      <p>If your hint is very short it can be included in the label.</p>
+    </>
+  );
+};
+
+export const WithInlineHintText = WithInlineHintTextTemplate.bind(null);
+WithInlineHintText.args = { ...defaultArgs, label: "My input (with hint)" };
+
 const WithAdditionalInfoTemplate = ({ name, label }) => {
   return (
     <va-text-input name={name} label={label} uswds>

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -191,6 +191,21 @@ Autocomplete.args = {
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
 
+export const WithHintText = Template.bind(null);
+WithHintText.args = { ...defaultArgs, hint: "This is example hint text" };
+
+const WithInlineHintTextTemplate = ({ name, label }) => {
+  return (
+    <>
+      <va-text-input name={name} label={label} />
+      <p>If your hint is very short it can be included in the label.</p>
+    </>
+  );
+};
+
+export const WithInlineHintText = WithInlineHintTextTemplate.bind(null);
+WithInlineHintText.args = { ...defaultArgs, label: "My input (with hint)" };
+
 const AdditionalInfoTemplate = ({ name, label }) => {
   return (
     <va-text-input name={name} label={label}>
@@ -204,9 +219,6 @@ const AdditionalInfoTemplate = ({ name, label }) => {
     </va-text-input>
   );
 };
-
-export const WithHintText = Template.bind(null);
-WithHintText.args = { ...defaultArgs, hint: "This is example hint text" };
 
 export const WithAdditionalInfo = AdditionalInfoTemplate.bind(null);
 WithAdditionalInfo.args = {


### PR DESCRIPTION
## Chromatic
<!-- This `update-va-textinput-1334` is a placeholder for a CI job - it will be updated automatically -->
https://update-va-textinput-1334--60f9b557105290003b387cd5.chromatic.com/?path=/docs/components-va-text-input--with-hint-text
https://update-va-textinput-1334--60f9b557105290003b387cd5.chromatic.com/?path=/docs/uswds-va-text-input--with-hint-text

## Description
Closes [Update va-textinput web component #1334](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1334)

## Testing done
Tested in Storybook in Safari, Edge, Firefox and Chrome

## Screenshots
![Screenshot 2023-05-04 at 2 21 32 PM](https://user-images.githubusercontent.com/1413938/236294322-f482c9b1-1f52-4492-8717-9efccac3379d.png)

## Acceptance criteria
- [ ] va-textinput accepts hint prop
- [ ] Storybook has with hint and inline hint examples

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
