### PR TITLE
Text input label font-size fix for UXPin

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.38.0",
+  "version": "4.38.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.37.1",
+  "version": "4.37.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-text-input/va-text-input.scss
+++ b/packages/web-components/src/components/va-text-input/va-text-input.scss
@@ -45,6 +45,7 @@ input.usa-input {
   display: block;
   max-width: 46rem;
   margin-top: 3rem;
+  font-size: 16px;
 }
 
 span.required {


### PR DESCRIPTION
## Chromatic
<!-- This `asteele-text-input-label-font-size` is a placeholder for a CI job - it will be updated automatically -->
https://asteele-text-input-label-font-size--60f9b557105290003b387cd5.chromatic.com

---

## Description
Relates to [#906](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/906)

## Testing done
- Tested locally using Brave and UXPin

## Acceptance criteria
- [X] Renders correctly
