### PR TITLE
Fix va-banner displaying left border

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "16.0.1",
+  "version": "16.1.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.37.1",
+  "version": "4.37.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.38.1",
+  "version": "4.38.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-alert/va-alert.scss
+++ b/packages/web-components/src/components/va-alert/va-alert.scss
@@ -170,8 +170,8 @@ i.fa-times-circle::before {
   border-color: var(--color-green);
 }
 
-:host(:not([uswds])[full-width='']) div.alert,
-:host(:not([uswds])[full-width='true']) div.alert {
+:host(:not([uswds])[full-width=''][data-role="banner"]) div.alert,
+:host(:not([uswds])[full-width='true'][data-role="banner"]) div.alert {
   border-left: none;
   max-width: 1000px;
 }

--- a/packages/web-components/src/components/va-alert/va-alert.scss
+++ b/packages/web-components/src/components/va-alert/va-alert.scss
@@ -170,6 +170,8 @@ i.fa-times-circle::before {
   border-color: var(--color-green);
 }
 
+:host(:not([uswds])[full-width='']) div.alert,
+:host(:not([uswds])[full-width='true']) div.alert,
 :host(:not([uswds])[full-width=''][data-role="banner"]) div.alert,
 :host(:not([uswds])[full-width='true'][data-role="banner"]) div.alert {
   border-left: none;

--- a/packages/web-components/src/global/_formation_overrides.scss
+++ b/packages/web-components/src/global/_formation_overrides.scss
@@ -294,7 +294,6 @@
   }
 }
 
-
 .usa-alert {
   border-left-width: rem-override(0.5rem);
   .usa-alert__body {
@@ -309,7 +308,7 @@
 .usa-alert--success, 
 .usa-alert--error {
   .usa-alert__body {
-    padding-left: rem-override(2.9166666667rem);
+    padding-left: rem-override(2.91667rem);
     &::before {
       height: rem-override(2rem);
       width: rem-override(2rem);


### PR DESCRIPTION
## Chromatic
<!-- This `1741-baner-alert-border` is a placeholder for a CI job - it will be updated automatically -->
https://1741-baner-alert-border--60f9b557105290003b387cd5.chromatic.com

## Description

A bug was introduced when we added the v3 variation to `va-alert`. This component is used in `va-banner` and it was displaying a left border when before there wasn't one.

<img width="1153" alt="Screenshot 2023-05-08 at 2 18 04 PM" src="https://user-images.githubusercontent.com/872479/236920974-4f27eee0-a1e1-4248-83b9-94d2ed1e46a9.png">

This update makes sure that the left border is not displayed when the `va-banner` component is being used:

<img width="851" alt="Screenshot 2023-05-08 at 2 56 21 PM" src="https://user-images.githubusercontent.com/872479/236921098-e2eb4584-1743-4d61-89b1-4c16cb0363f8.png">

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1728
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1741

## Testing done
Storybook (checked both va-banner, va-alert (v1), and va-alert (v3)

## Acceptance criteria
- [ ] The va-banner component no longer displays a left border.
- [ ] Any of the other `va-banner` and `va-alert` styles have not changed.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
