### PR TITLE
Hotfix to loading indicator observer disconnect

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "16.1.0",
+  "version": "16.1.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.38.2",
+  "version": "4.38.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-loading-indicator/va-loading-indicator.tsx
+++ b/packages/web-components/src/components/va-loading-indicator/va-loading-indicator.tsx
@@ -101,12 +101,6 @@ export class VaLoadingIndicator {
     });
   }
 
-  disconnectedCallback() {
-    // Don't disconnect the observer before the callback runs
-    const observer = this.observer;
-    setTimeout(() => observer.disconnect());
-  }
-
   render() {
     const { message, label } = this;
 


### PR DESCRIPTION
## Chromatic
<!-- This `asteele-loading-indicator-hotfix` is a placeholder for a CI job - it will be updated automatically -->
https://asteele-loading-indicator-hotfix--60f9b557105290003b387cd5.chromatic.com

---

## Description
Hotfix to stop Sentry errors related to disconnecting the MutationObserver within the va-loading-indicator. Removing the code to manually disconnect the MutationObserver as the disconnect was sometimes being called after the MO had already been garbage collected, leading to 'undefined' errors.

## Testing done
No testing done, just stopped trying to disconnect the observer after it has already been garbage collected.

## Acceptance criteria
- [X] No reason it shouldn't work