### PR TITLE
feat: Additional info v3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "16.3.0",
+  "version": "16.2.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "16.2.0",
+  "version": "16.3.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-additional-info-uswds.stories.jsx
+++ b/packages/storybook/stories/va-additional-info-uswds.stories.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
+
+const additionalInfoDocs = getWebComponentDocs('va-additional-info');
+
+export default {
+  title: 'USWDS/Additional info USWDS',
+  id: 'uswds/va-additional-info',
+  parameters: {
+    componentSubtitle: `va-additional-info web component`,
+    docs: {
+      page: () => <StoryDocs data={additionalInfoDocs} />,
+    },
+    actions: {
+      handles: ['component-library-analytics'],
+    },
+  },
+};
+
+const defaultArgs = {
+  'uswds': true,
+  'trigger': 'Additional Information',
+  'disable-border': false,
+  'disable-analytics': false,
+};
+
+const Template = ({
+  uswds,
+  trigger,
+  'disable-border': disableBorder,
+  'disable-analytics': disableAnalytics,
+}) => {
+  return (
+    <>
+      <p>Surrounding content.</p>
+      <va-additional-info
+        uswds={uswds}
+        trigger={trigger}
+        disable-analytics={disableAnalytics}
+        disable-border={disableBorder}
+      >
+        <div>Here are some popular pets to consider</div>
+        <ul>
+          <li>Dogs</li>
+          <li>Cats</li>
+          <li>Fish</li>
+          <li>Birds</li>
+        </ul>
+      </va-additional-info>
+      <p>Surrounding content.</p>
+    </>
+  );
+};
+
+export const Default = Template.bind(null);
+Default.args = { ...defaultArgs };
+Default.argTypes = propStructure(additionalInfoDocs);
+
+export const NoBorder = Template.bind(null);
+NoBorder.args = {
+  ...defaultArgs,
+  'disable-border': true,
+};

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.39.2",
+  "version": "4.40.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -55,6 +55,10 @@ export namespace Components {
           * The text to trigger the expansion
          */
         "trigger": string;
+        /**
+          * Whether or not the component will use USWDS v3 styling.
+         */
+        "uswds"?: boolean;
     }
     interface VaAlert {
         /**
@@ -1493,6 +1497,10 @@ declare namespace LocalJSX {
           * The text to trigger the expansion
          */
         "trigger": string;
+        /**
+          * Whether or not the component will use USWDS v3 styling.
+         */
+        "uswds"?: boolean;
     }
     interface VaAlert {
         /**

--- a/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
+++ b/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
@@ -227,4 +227,231 @@ describe('va-additional-info', () => {
     // margin-bottom and margin-top is set to 0 for first slotted child
     expect(calcMaxHeight).toEqual('calc(70px + 2rem)');
   });
+
+  // Begin USWDS v3 test
+  it('uswds v3 renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-additional-info trigger="More info" uswds></va-additional-info>',
+    );
+
+    const element = await page.find('va-additional-info');
+
+    expect(element).toEqualHtml(`
+      <va-additional-info trigger="More info" class="hydrated" uswds="">
+        <mock:shadow-root>
+          <a aria-controls="info" aria-expanded="false" role="button" tabindex="0">
+            <div>
+              <span class="additional-info-title">
+                More info
+              </span>
+              <i class="fa-angle-down" role="presentation"></i>
+            </div>
+          </a>
+          <div class="closed" id="info" style="--calc-max-height:calc(0px + 2rem);">
+            <slot></slot>
+          </div>
+        </mock:shadow-root>
+      </va-additional-info>
+    `);
+  });
+
+  it('uswds v3 passes an axe check', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-additional-info trigger="Additional information" uswds>
+        <div>
+          Additional content
+        </div>
+      </va-additional-info>`,
+    );
+
+    await axeCheck(page);
+  });
+
+  it('uswds v3 passes an axe check when opened', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-additional-info trigger="Additional information" uswds>
+        <div>
+          Additional content
+        </div>
+      </va-additional-info>`,
+    );
+
+    const anchorEl = await page.find('va-additional-info >>> a');
+    await anchorEl.click();
+
+    await axeCheck(page);
+  });
+
+  it('uswds v3 expands when clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-additional-info trigger="Additional information" uswds>
+        <div id="content">
+          Additional content
+        </div>
+      </va-additional-info>`,
+    );
+    const handle = await page.waitForSelector('pierce/#info');
+
+    const preOpacity = await handle.evaluate(
+      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
+    );
+
+    // Use click to expand
+    const anchorEl = await page.find('va-additional-info >>> a');
+    expect(anchorEl.getAttribute('aria-expanded')).toEqual('false');
+
+    await anchorEl.click();
+    // Allow the transition to complete
+    await page.waitForTimeout(600);
+    expect(anchorEl.getAttribute('aria-expanded')).toEqual('true');
+
+    const postOpacity = await handle.evaluate(
+      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
+    );
+
+    expect(preOpacity).toEqual('0');
+    expect(postOpacity).toEqual('1');
+  });
+
+  it('uswds v3 has keyboard control for expanding & collapsing on spacebar', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-additional-info trigger="Additional information" uswds>
+        <div id="content">
+          Additional content
+        </div>
+      </va-additional-info>`,
+    );
+    const handle = await page.waitForSelector('pierce/#info');
+
+    const preOpacity = await handle.evaluate(
+      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
+    );
+
+    // Use keyboard to expand
+    const anchorEl = await page.find('va-additional-info >>> a');
+    await anchorEl.press(' ');
+    // Allow the transition to complete
+    await page.waitForTimeout(600);
+
+    const postOpacity = await handle.evaluate(
+      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
+    );
+
+    expect(preOpacity).toEqual('0');
+    expect(postOpacity).toEqual('1');
+  });
+
+  it('uswds v3 has keyboard control for expanding & collapsing on enter', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-additional-info trigger="Additional information" uswds>
+        <div id="content">
+          Additional content
+        </div>
+      </va-additional-info>`,
+    );
+    const handle = await page.waitForSelector('pierce/#info');
+
+    const preOpacity = await handle.evaluate(
+      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
+    );
+
+    // Use keyboard to expand
+    const anchorEl = await page.find('va-additional-info >>> a');
+    await anchorEl.press('Enter');
+    // Allow the transition to complete
+    await page.waitForTimeout(600);
+
+    const postOpacity = await handle.evaluate(
+      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
+    );
+
+    expect(preOpacity).toEqual('0');
+    expect(postOpacity).toEqual('1');
+  });
+
+  it('uswds v3 fires an analytics event by default', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <va-additional-info trigger="Whatever" uswds>
+        <div>More content</div>
+      </va-additional-info>
+    `);
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const anchorEl = await page.find('va-additional-info >>> a');
+    await anchorEl.click();
+
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      action: 'expand',
+      componentName: 'va-additional-info',
+      details: {
+        triggerText: 'Whatever',
+      },
+    });
+  });
+
+  it('uswds v3 has the collapse action in analytics event', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <va-additional-info trigger="Whatever" uswds>
+        <div>More content</div>
+      </va-additional-info>
+    `);
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const anchorEl = await page.find('va-additional-info >>> a');
+
+    // Click once to expand, again to collapse
+    await anchorEl.click();
+    await anchorEl.click();
+
+    const secondEvent = analyticsSpy.events[1];
+    expect(secondEvent.detail.action).toEqual('collapse');
+  });
+
+  it('uswds v3 does not fire an analytics event when disableAnalytics is set', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <va-additional-info trigger="Whatever" uswds disable-analytics>
+        <div>More content</div>
+      </va-additional-info>
+    `);
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const anchorEl = await page.find('va-additional-info >>> a');
+    await anchorEl.click();
+
+    expect(analyticsSpy).toHaveReceivedEventTimes(0);
+  });
+
+  it('uswds v3 sets the correct max-height value for the content given', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-additional-info trigger="Click here for a treat!" uswds disable-analytics>
+        <div style="height:50px;padding:10px 0;margin:5px 0;">We're out of treats! Try again later.</div>
+      </va-additional-info>
+    `);
+    const handle = await page.waitForSelector('pierce/#info');
+    const anchorEl = await page.find('va-additional-info >>> a');
+    await anchorEl.click();
+    await page.waitForSelector('pierce/#info.open');
+    const calcMaxHeight = await handle.evaluate((domElement: HTMLElement) =>
+      domElement.style.getPropertyValue('--calc-max-height'),
+    );
+    // 50px from height + 20px from padding
+    // margin-bottom and margin-top is set to 0 for first slotted child
+    expect(calcMaxHeight).toEqual('calc(70px + 2rem)');
+  });
 });

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.css
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.css
@@ -6,7 +6,7 @@
 /* Add left side blue border if disable border prop disabled or not present */
 :host(:not([disable-border])) a[aria-expanded='true'] ~ #info,
 :host([disable-border='false']) a[aria-expanded='true'] ~ #info {
-  padding-left: calc(2rem - 7px);
+  padding-left: calc(20px - 7px);
   border-left: 7px solid transparent;
   border-left-color: var(--color-primary-alt-darkest);
 }
@@ -45,8 +45,8 @@ a {
 }
 
 #info {
-  margin-bottom: 1.6rem;
-  margin-top: 1.6rem;
+  margin-bottom: 16px;
+  margin-top: 16px;
 }
 
 i {
@@ -59,8 +59,8 @@ i {
 i.fa-angle-down {
   display: inline-block;
   color: var(--color-primary-alt-darkest);
-  font-size: 1.6rem;
-  margin: 0.5rem;
+  font-size: 16px;
+  margin: 5px;
   transform: rotate(0deg);
   transition: transform 0.15s linear;
 }

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
@@ -9,6 +9,7 @@ import {
   State,
   h,
 } from '@stencil/core';
+import classnames from 'classnames';
 
 /**
  * @componentName Additional info
@@ -29,7 +30,10 @@ export class VaAdditionalInfo {
    * The text to trigger the expansion
    */
   @Prop() trigger!: string;
-
+  /**
+   * Whether or not the component will use USWDS v3 styling.
+   */
+  @Prop() uswds?: boolean = false;
   /**
    * If `true`, doesn't fire the CustomEvent which can be used for analytics tracking.
    */
@@ -96,25 +100,52 @@ export class VaAdditionalInfo {
   }
 
   render() {
-    return (
-      <Host>
-        <a
-          role="button"
-          aria-controls="info"
-          aria-expanded={this.open ? 'true' : 'false'}
-          tabIndex={0}
-          onClick={this.toggleOpen.bind(this)}
-          onKeyDown={this.handleKeydown.bind(this)}
-        >
-          <div>
-            <span class="additional-info-title">{this.trigger}</span>
-            <i class="fa-angle-down" role="presentation" />
+    if (this.uswds) {
+      const infoClass = classnames({
+        'open': this.open,
+        'closed': !this.open
+      });
+      return (
+        <Host>
+          <a
+            role="button"
+            aria-controls="info"
+            aria-expanded={this.open ? 'true' : 'false'}
+            tabIndex={0}
+            onClick={this.toggleOpen.bind(this)}
+            onKeyDown={this.handleKeydown.bind(this)}
+          >
+            <div>
+              <span class="additional-info-title">{this.trigger}</span>
+              <i class="fa-angle-down" role="presentation" />
+            </div>
+          </a>
+          <div id="info" class={`${infoClass}`}>
+            <slot></slot>
           </div>
-        </a>
-        <div id="info" class={this.open ? 'open' : 'closed'}>
-          <slot></slot>
-        </div>
-      </Host>
-    );
+        </Host>
+      );
+    } else {
+      return (
+        <Host>
+          <a
+            role="button"
+            aria-controls="info"
+            aria-expanded={this.open ? 'true' : 'false'}
+            tabIndex={0}
+            onClick={this.toggleOpen.bind(this)}
+            onKeyDown={this.handleKeydown.bind(this)}
+          >
+            <div>
+              <span class="additional-info-title">{this.trigger}</span>
+              <i class="fa-angle-down" role="presentation" />
+            </div>
+          </a>
+          <div id="info" class={this.open ? 'open' : 'closed'}>
+            <slot></slot>
+          </div>
+        </Host>
+      );
+    }
   }
 }

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
@@ -120,7 +120,7 @@ export class VaAdditionalInfo {
               <i class="fa-angle-down" role="presentation" />
             </div>
           </a>
-          <div id="info" class={`${infoClass}`}>
+          <div id="info" class={infoClass}>
             <slot></slot>
           </div>
         </Host>


### PR DESCRIPTION
## Chromatic
<!-- This `1695-additional-info-v3` is a placeholder for a CI job - it will be updated automatically -->
https://1695-additional-info-v3--60f9b557105290003b387cd5.chromatic.com

## Description
This pull request adds a new additional info component. CSS sizes defined in rem units to px units
Sketch: https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/symbols?g=Additional%2520info%252Fuswds-DO%2520NOT%2520USE%252FMVP#Version
Closes [1695](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1695)

## Testing done
Storybook
Chrome/Edge/Mozilla

## Screenshots
<img width="974" alt="additional info" src="https://github.com/department-of-veterans-affairs/component-library/assets/22892911/aaa18691-68ad-4435-8793-e0fe52f4622f">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
