### PR TITLE
Button icon font size override

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.39.0",
+  "version": "4.39.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/global/_formation_overrides.scss
+++ b/packages/web-components/src/global/_formation_overrides.scss
@@ -151,10 +151,15 @@
   border-radius: rem-override(0.25rem);
   margin-right: rem-override(0.5rem);
   padding: rem-override(0.75rem) rem-override(1.25rem);
+
   &--big {
     border-radius: rem-override(0.25rem);
     font-size: rem-override(1.46rem);
     padding: rem-override(1rem) rem-override(1.5rem);
+  }
+
+  i {
+    font-size: rem-override(1rem);
   }
 }
 
@@ -303,9 +308,9 @@
   }
 }
 
-.usa-alert--info, 
-.usa-alert--warning, 
-.usa-alert--success, 
+.usa-alert--info,
+.usa-alert--warning,
+.usa-alert--success,
 .usa-alert--error {
   .usa-alert__body {
     padding-left: rem-override(2.91667rem);
@@ -319,9 +324,9 @@
 }
 
 @media (min-width: 64em) {
-  .usa-alert--info, 
-  .usa-alert--warning, 
-  .usa-alert--success, 
+  .usa-alert--info,
+  .usa-alert--warning,
+  .usa-alert--success,
   .usa-alert--error {
     .usa-alert__body {
       padding-left: rem-override(4rem);


### PR DESCRIPTION
## Chromatic
<!-- This `asteele-uxpin-override-906` is a placeholder for a CI job - it will be updated automatically -->
https://asteele-uxpin-override-906--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes [#906](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/906)

## Testing done
Works in Brave and Storybook

## Screenshots

<img width="672" alt="Screenshot 2023-05-19 at 12 00 01 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/147893/fa65b075-06e2-4a45-a14d-ccd1fca5f48b">


## Acceptance criteria
- [X] Icons match text font-size

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
