### PR TITLE
Add width option to va-text-input

### DIFF
--- a/packages/storybook/stories/va-text-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.jsx
@@ -142,6 +142,72 @@ const I18nTemplate = ({
   );
 };
 
+const WidthsTemplate = ({
+  name,
+  value,
+  uswds,
+}) => {
+  return (
+    <>
+      <va-text-input
+        width="2xs"
+        uswds={uswds}
+        name={name}
+        label='My input - 2xs'
+        value={value}
+      />
+
+      <va-text-input
+        width="xs"
+        uswds={uswds}
+        name={name}
+        label='My input - xs'
+        value={value}
+      />  
+  
+      <va-text-input
+        width="sm"
+        uswds={uswds}
+        name={name}
+        label='My input - sm'
+        value={value}
+      />
+
+      <va-text-input
+        width="md"
+        uswds={uswds}
+        name={name}
+        label='My input - md'
+        value={value}
+      />
+
+      <va-text-input
+        width="lg"
+        uswds={uswds}
+        name={name}
+        label='My input - lg'
+        value={value}
+      />
+
+      <va-text-input
+        width="xl"
+        uswds={uswds}
+        name={name}
+        label='My input - xl'
+        value={value}
+      />
+
+      <va-text-input
+        width="2xl"
+        uswds={uswds}
+        name={name}
+        label='My input - 2xl'
+        value={value}
+      />
+    </>
+  );
+};
+
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(textInputDocs);
@@ -205,7 +271,7 @@ WithHintText.args = { ...defaultArgs, hint: 'This is hint text' };
 const WithInlineHintTextTemplate = ({ name, label }) => {
   return (
     <>
-      <va-text-input name={name} label={label} />
+      <va-text-input name={name} label={label} uswds />
       <p>If your hint is very short it can be included in the label.</p>
     </>
   );
@@ -232,4 +298,9 @@ export const WithAdditionalInfo = WithAdditionalInfoTemplate.bind(null);
 WithAdditionalInfo.args = {
   ...defaultArgs,
   label: 'Veteran’s Social Security number',
+};
+
+export const Widths = WidthsTemplate.bind(null);
+Widths.args = {
+  ...defaultArgs,
 };

--- a/packages/storybook/stories/va-text-input.stories.jsx
+++ b/packages/storybook/stories/va-text-input.stories.jsx
@@ -134,6 +134,65 @@ const I18nTemplate = ({
   );
 };
 
+
+const WidthsTemplate = ({
+  name,
+  value,
+}) => {
+  return (
+    <>
+      <va-text-input
+        width="2xs"
+        name={name}
+        label='My input - 2xs'
+        value={value}
+      />
+
+      <va-text-input
+        width="xs"
+        name={name}
+        label='My input - xs'
+        value={value}
+      />  
+  
+      <va-text-input
+        width="sm"
+        name={name}
+        label='My input - sm'
+        value={value}
+      />
+
+      <va-text-input
+        width="md"
+        name={name}
+        label='My input - md'
+        value={value}
+      />
+
+      <va-text-input
+        width="lg"
+        name={name}
+        label='My input - lg'
+        value={value}
+      />
+
+      <va-text-input
+        width="xl"
+        name={name}
+        label='My input - xl'
+        value={value}
+      />
+
+      <va-text-input
+        width="2xl"
+        name={name}
+        label='My input - 2xl'
+        value={value}
+      />
+    </>
+  );
+};
+
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(textInputDocs);
@@ -224,4 +283,9 @@ export const WithAdditionalInfo = AdditionalInfoTemplate.bind(null);
 WithAdditionalInfo.args = {
   ...defaultArgs,
   label: 'Veteran’s Social Security number',
+};
+
+export const Widths = WidthsTemplate.bind(null);
+Widths.args = {
+  ...defaultArgs,
 };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.40.0",
+  "version": "4.40.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -992,6 +992,10 @@ export namespace Components {
           * The value for the input.
          */
         "value"?: string;
+        /**
+          * Displays the input at a specific width. Accepts 2xs (4ex), xs (7ex), sm or small (10ex), md or medium (20ex), lg (30ex), xl (40ex), and 2xl (50ex).
+         */
+        "width"?: string;
     }
     interface VaTextarea {
         /**
@@ -2635,6 +2639,10 @@ declare namespace LocalJSX {
           * The value for the input.
          */
         "value"?: string;
+        /**
+          * Displays the input at a specific width. Accepts 2xs (4ex), xs (7ex), sm or small (10ex), md or medium (20ex), lg (30ex), xl (40ex), and 2xl (50ex).
+         */
+        "width"?: string;
     }
     interface VaTextarea {
         /**

--- a/packages/web-components/src/components/va-text-input/va-text-input.scss
+++ b/packages/web-components/src/components/va-text-input/va-text-input.scss
@@ -7,6 +7,7 @@
 @use 'usa-hint/src/styles/usa-hint';
 
 @import '../../mixins/uswds-error-border.scss';
+@import '../../mixins/uswds-input-width.scss';
 @import '../../global/formation_overrides';
 
 :host([uswds]) {

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -306,6 +306,9 @@ export class VaTextInput {
         </Host>
       );
     } else {
+      const inputClass = classnames({
+        [`usa-input--${this.width}`]: this.width,
+      });
       return (
         <Host>
           {label && (
@@ -326,6 +329,7 @@ export class VaTextInput {
             )}
           </span>
           <input
+            class={inputClass}
             id="inputField"
             type={type}
             value={value}

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -141,6 +141,11 @@ export class VaTextInput {
   @Prop() success?: boolean = false;
 
   /**
+   * Displays the input at a specific width. Accepts 2xs (4ex), xs (7ex), sm or small (10ex), md or medium (20ex), lg (30ex), xl (40ex), and 2xl (50ex).
+   */
+  @Prop() width?: string;
+
+  /**
    * Whether or not the component will use USWDS v3 styling.
    */
   @Prop({reflect: true}) uswds?: boolean = false;
@@ -245,6 +250,7 @@ export class VaTextInput {
         'usa-input': true,
         'usa-input--success': success,
         'usa-input--error': error || reflectInputError,
+        [`usa-input--${this.width}`]: this.width,
       });
       return (
         <Host>

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -308,7 +308,7 @@ export class VaTextInput {
       );
     } else {
       const inputClass = classnames({
-        [`usa-input--${this.width}`]: this.width,
+        [`usa-input--${width}`]: width,
       });
       return (
         <Host>

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -233,6 +233,7 @@ export class VaTextInput {
       uswds,
       success,
       messageAriaDescribedby,
+      width,
     } = this;
     const type = this.getInputType();
     const maxlength = this.getMaxlength();
@@ -250,7 +251,7 @@ export class VaTextInput {
         'usa-input': true,
         'usa-input--success': success,
         'usa-input--error': error || reflectInputError,
-        [`usa-input--${this.width}`]: this.width,
+        [`usa-input--${width}`]: width,
       });
       return (
         <Host>

--- a/packages/web-components/src/mixins/uswds-input-width.scss
+++ b/packages/web-components/src/mixins/uswds-input-width.scss
@@ -1,0 +1,25 @@
+:host .usa-input {
+  &--2xs {
+    max-width: 5ex;
+  }
+  &--xs {
+    max-width: 9ex;
+  }
+  &--sm,
+  &--small {
+    max-width: 13ex;
+  }
+  &--md,
+  &--medium {
+    max-width: 20ex;
+  }
+  &--lg {
+    max-width: 30ex;
+  }
+  &--xl {
+    max-width: 40ex;
+  }
+  &--2xl {
+    max-width: 50ex;
+  }
+}

--- a/packages/web-components/src/mixins/uswds-input-width.scss
+++ b/packages/web-components/src/mixins/uswds-input-width.scss
@@ -1,3 +1,4 @@
+:host(:not([uswds])) .usa-input, 
 :host .usa-input {
   &--2xs {
     max-width: 5ex;


### PR DESCRIPTION
## Chromatic
<!-- This `1712-va-text-input-width` is a placeholder for a CI job - it will be updated automatically -->
https://1712-va-text-input-width--60f9b557105290003b387cd5.chromatic.com

## Description
This PR adds a `width` prop that sets a corresponding USWDS input width class (for both v1 and v3):

https://designsystem.digital.gov/components/text-input/#component-variants-text-input

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1712

## Testing done
Storybook
Browserstack iOS

## Screenshots

![Screenshot 2023-05-31 at 1 01 06 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/b38f6cdf-2408-4259-bec6-090176908c4c)

![Screenshot 2023-05-31 at 3 31 13 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/4414999d-2155-4c06-9566-01127d8ae95d)


## Acceptance criteria
- [ ] va-text-input component has an option for setting the width.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
