### PR TITLE
Add width option to va-number-input

### DIFF
--- a/packages/storybook/stories/va-number-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-number-input-uswds.stories.jsx
@@ -90,6 +90,72 @@ const I18nTemplate = args => {
     </div>
 )};
 
+const WidthsTemplate = ({
+  name,
+  value,
+  uswds,
+}) => {
+  return (
+    <>
+      <va-number-input
+        width="2xs"
+        uswds={uswds}
+        name={name}
+        label='My input - 2xs'
+        value={value}
+      />
+
+      <va-number-input
+        width="xs"
+        uswds={uswds}
+        name={name}
+        label='My input - xs'
+        value={value}
+      />  
+  
+      <va-number-input
+        width="sm"
+        uswds={uswds}
+        name={name}
+        label='My input - sm'
+        value={value}
+      />
+
+      <va-number-input
+        width="md"
+        uswds={uswds}
+        name={name}
+        label='My input - md'
+        value={value}
+      />
+
+      <va-number-input
+        width="lg"
+        uswds={uswds}
+        name={name}
+        label='My input - lg'
+        value={value}
+      />
+
+      <va-number-input
+        width="xl"
+        uswds={uswds}
+        name={name}
+        label='My input - xl'
+        value={value}
+      />
+
+      <va-number-input
+        width="2xl"
+        uswds={uswds}
+        name={name}
+        label='My input - 2xl'
+        value={value}
+      />
+    </>
+  );
+};
+
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(numberInputDocs);
@@ -120,3 +186,7 @@ Internationalization.args = {
   required: true,
 };
 
+export const Widths = WidthsTemplate.bind(null);
+Widths.args = {
+  ...defaultArgs,
+};

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -90,6 +90,64 @@ const I18nTemplate = args => {
     </div>
 )};
 
+const WidthsTemplate = ({
+  name,
+  value,
+}) => {
+  return (
+    <>
+      <va-number-input
+        width="2xs"
+        name={name}
+        label='My input - 2xs'
+        value={value}
+      />
+
+      <va-number-input
+        width="xs"
+        name={name}
+        label='My input - xs'
+        value={value}
+      />  
+  
+      <va-number-input
+        width="sm"
+        name={name}
+        label='My input - sm'
+        value={value}
+      />
+
+      <va-number-input
+        width="md"
+        name={name}
+        label='My input - md'
+        value={value}
+      />
+
+      <va-number-input
+        width="lg"
+        name={name}
+        label='My input - lg'
+        value={value}
+      />
+
+      <va-number-input
+        width="xl"
+        name={name}
+        label='My input - xl'
+        value={value}
+      />
+
+      <va-number-input
+        width="2xl"
+        name={name}
+        label='My input - 2xl'
+        value={value}
+      />
+    </>
+  );
+};
+
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(numberInputDocs);
@@ -125,3 +183,8 @@ WithCurrency.args = {
   ...defaultArgs,
   currency: true
 }
+
+export const Widths = WidthsTemplate.bind(null);
+Widths.args = {
+  ...defaultArgs,
+};

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.40.1",
+  "version": "4.40.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -592,6 +592,10 @@ export namespace Components {
           * The value for the input.
          */
         "value"?: string;
+        /**
+          * Displays the input at a specific width. Accepts 2xs (4ex), xs (7ex), sm or small (10ex), md or medium (20ex), lg (30ex), xl (40ex), and 2xl (50ex).
+         */
+        "width"?: string;
     }
     interface VaOfficialGovBanner {
         /**
@@ -2163,6 +2167,10 @@ declare namespace LocalJSX {
           * The value for the input.
          */
         "value"?: string;
+        /**
+          * Displays the input at a specific width. Accepts 2xs (4ex), xs (7ex), sm or small (10ex), md or medium (20ex), lg (30ex), xl (40ex), and 2xl (50ex).
+         */
+        "width"?: string;
     }
     interface VaOfficialGovBanner {
         /**

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -89,6 +89,11 @@ export class VaNumberInput {
   @Prop() currency?: boolean = false;
 
   /**
+   * Displays the input at a specific width. Accepts 2xs (4ex), xs (7ex), sm or small (10ex), md or medium (20ex), lg (30ex), xl (40ex), and 2xl (50ex).
+   */
+  @Prop() width?: string;
+
+  /**
    * Whether or not the component will use USWDS v3 styling.
    */
   @Prop() uswds?: boolean = false;
@@ -148,6 +153,7 @@ export class VaNumberInput {
       uswds,
       handleBlur,
       handleInput,
+      width,
     } = this;
 
     if (uswds) {
@@ -158,6 +164,7 @@ export class VaNumberInput {
       const inputClasses = classnames({
         'usa-input': true,
         'usa-input--error': error,
+        [`usa-input--${width}`]: width,
       });
       return (
         <Host>
@@ -199,6 +206,10 @@ export class VaNumberInput {
         </Host>
       );
     } else {
+      const inputClass = classnames({
+        [`usa-input--${width}`]: width,
+        'currency-input': currency,
+      });
       return (
         <Host>
           <label htmlFor="inputField">
@@ -217,7 +228,7 @@ export class VaNumberInput {
             {/* eslint-disable-next-line i18next/no-literal-string */}
             {currency && <span id="symbol">$</span>}
             <input
-              class={currency ? 'currency-input' : ''}
+              class={inputClass}
               aria-labelledby={currency ? 'inputField symbol' : undefined}
               aria-describedby={error ? 'error-message' : undefined}
               aria-invalid={error ? 'true' : 'false'}


### PR DESCRIPTION
## Chromatic
<!-- This `1771-va-num-input-width` is a placeholder for a CI job - it will be updated automatically -->
https://1771-va-num-input-width--60f9b557105290003b387cd5.chromatic.com

This PR adds a `width` prop that sets a corresponding USWDS input width class (for both v1 and v3). It mimics the same approach that was taken for va-text-input: https://github.com/department-of-veterans-affairs/component-library/pull/707

https://designsystem.digital.gov/components/text-input/#component-variants-text-input

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1771

## Testing done
Storybook
Browserstack iOS

## Screenshots
![Screenshot 2023-06-01 at 12 11 36 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/5d81f0cc-fca1-4a25-ad4a-c7e74cea7ee5)

![Screenshot 2023-06-01 at 12 25 28 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/ed6ab932-3dc7-4343-8aa8-39c004549c8b)


## Acceptance criteria
- [ ] va-number-input component has an option for setting the width.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
