### PR TITLE
1713 vacheckbox issue

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.40.1",
+  "version": "4.40.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.40.0",
+  "version": "4.40.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.scss
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.scss
@@ -82,6 +82,7 @@
   height: var(--visible-checkbox-size);
   max-width: var(--visible-checkbox-size);
   width: 100%;
+  background-color: var(--color-white);
 }
 
 :host(:not([uswds])) input:checked+label::before {

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.scss
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.scss
@@ -20,7 +20,7 @@
 }
 
 .usa-checkbox__input:focus + [class*="__label"]::before {
-  outline: 2px solid var(--color-gold-light);	
+  outline: 2px solid var(--color-gold-light);
   outline-offset: 4px;
 }
 
@@ -49,11 +49,7 @@
 }
 
 :host(:not([uswds])) input {
-  /* Make the clickable element the same size and position as the box */
-  height: var(--visible-checkbox-size);
-  width: var(--visible-checkbox-size);
-  margin-top: var(--visible-checkbox-top-margin);
-
+  margin: 0;
   padding: 0;
   opacity: 0;
   position: absolute;


### PR DESCRIPTION
## Chromatic
<!-- This `1713-vacheckbox-issue` is a placeholder for a CI job - it will be updated automatically -->
https://1713-vacheckbox-issue--60f9b557105290003b387cd5.chromatic.com


## Description
This PR fixes two issues with the VaCheckbox web-component:
1. Fix issue where cursor showed as pointer on bottom half of checkbox and default cursor on top half of checkbox. Now it shows as a pointer
2. Update checkbox to have a white background so it looks the same on darker backgrounds

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1713

## Testing done
Storybook
Chrome

## Screenshots
<img width="1009" alt="image" src="https://github.com/department-of-veterans-affairs/component-library/assets/15200011/6c0e9b93-2c0b-4283-aeaf-737fdaaf5432">
<img width="397" alt="image" src="https://github.com/department-of-veterans-affairs/component-library/assets/15200011/8ad64f73-c0ac-4199-afb2-fa7621f361a5">


## Acceptance criteria
- [ ] va-checkbox now has a pointer for the cursor 
- [ ] va-checkbox has a white background against any color background behind it

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
