### PR TITLE
Add va-breadcrumb USWDS v3 variation

### DIFF
--- a/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
+
+const breadcrumbsDocs = getWebComponentDocs('va-breadcrumbs');
+
+export default {
+  title: 'USWDS/Breadcrumbs USWDS',
+  id: 'uswds/va-breadcrumbs',
+  parameters: {
+    componentSubtitle: 'va-breadcrumbs web component',
+    docs: {
+      page: () => <StoryDocs data={breadcrumbsDocs} />,
+    },
+  },
+};
+
+const Template = ({ label, 'disable-analytics': disableAnalytics }) => (
+  <va-breadcrumbs uswds label={label} disable-analytics={disableAnalytics}>
+    <a href="#home">Home</a>
+    <a href="#one">Level one</a>
+    <a href="#two">Level two</a>
+  </va-breadcrumbs>
+);
+
+const DynamicCrumbsTemplate = ({
+  label,
+  'disable-analytics': disableAnalytics,
+}) => {
+  const breadcrumbs = [
+    { label: 'Level 1', path: '/#1' },
+    { label: 'Level 2', path: '/#2' },
+    { label: 'Level 3', path: '/#3' },
+  ];
+
+  const breadcrumbs2 = [
+    { label: 'First Link', path: '#example1' },
+    { label: 'Second Link', path: '#example2' },
+    { label: 'Third Link', path: '#example3' },
+    { label: 'Fourth Link', path: '#example4' },
+  ];
+  const [crumbs, setCrumbs] = useState(breadcrumbs);
+  const addCrumb = () =>
+    setCrumbs(arr => [
+      ...arr,
+      { label: `Level ${arr.length + 1}`, path: `/#${arr.length + 1}` },
+    ]);
+  const replaceCrumbs = () => setCrumbs(breadcrumbs2);
+  const resetCrumbs = () => setCrumbs(breadcrumbs);
+  const removeCrumb = () =>
+    setCrumbs(arr => {
+      const newArr = [...arr];
+      newArr.pop();
+      return newArr;
+    });
+
+  return (
+    <div>
+      <button onClick={e => addCrumb()}>Add Crumb</button>
+      <button onClick={e => removeCrumb()}>Remove Crumb</button>
+      <button onClick={e => replaceCrumbs()}>Replace Crumbs</button>
+      <button onClick={e => resetCrumbs()}>Reset Crumbs</button>
+      <br />
+      <p>
+        Note: To rerender the breadcrumbs dynamically, the anchor links must be
+        wrapped in list tags.
+      </p>
+      {crumbs.length > 0 && (
+        <va-breadcrumbs
+          label={label}
+          disable-analytics={disableAnalytics}
+          uswds
+        >
+          {crumbs?.map((crumb, i) => {
+            return (
+              <li key={i}>
+                <a href={crumb.path}>{crumb.label}</a>
+              </li>
+            );
+          })}
+        </va-breadcrumbs>
+      )}
+    </div>
+  );
+};
+
+const defaultArgs = {
+  'label': 'Breadcrumb',
+  'disable-analytics': false,
+};
+
+export const Default = Template.bind(null);
+Default.args = {
+  ...defaultArgs,
+};
+Default.argTypes = propStructure(breadcrumbsDocs);
+
+export const RerenderState = DynamicCrumbsTemplate.bind(null);
+RerenderState.args = { ...defaultArgs };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -157,6 +157,10 @@ export namespace Components {
           * Adds an aria-label attribute to the <nav /> element.
          */
         "label"?: string;
+        /**
+          * Whether or not the component will use USWDS v3 styling.
+         */
+        "uswds"?: boolean;
     }
     interface VaButton {
         /**
@@ -1636,6 +1640,10 @@ declare namespace LocalJSX {
           * The event used to track usage of the component. This is emitted when a breadcrumb anchor is clicked and disableAnalytics is not true.
          */
         "onComponent-library-analytics"?: (event: VaBreadcrumbsCustomEvent<any>) => void;
+        /**
+          * Whether or not the component will use USWDS v3 styling.
+         */
+        "uswds"?: boolean;
     }
     interface VaButton {
         /**

--- a/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
+++ b/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
@@ -143,4 +143,148 @@ describe('va-breadcrumbs', () => {
 
     expect(analyticsSpy).toHaveReceivedEventTimes(0);
   });
+
+  /** Begin USWDS v3 Tests */
+
+  it('uswds renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-breadcrumbs uswds></va-breadcrumbs>');
+
+    const element = await page.find('va-breadcrumbs');
+    expect(element).toEqualHtml(`
+      <va-breadcrumbs class="hydrated" uswds="">
+        <mock:shadow-root>
+          <nav aria-label="Breadcrumb" class="usa-breadcrumb">
+            <ol class="usa-breadcrumb__list" role="list">
+              <slot></slot>
+            </ol>
+          </nav>
+        </mock:shadow-root>
+      </va-breadcrumbs>
+    `);
+  });
+
+  it('uswds renders slotted content (anchor tags)', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs uswds="">
+        <a href="#home">Home</a>
+        <a href="#one">Level One</a>
+        <a href="#two">Level Two</a>
+      </va-breadcrumbs>
+    `);
+
+    const element = await page.find('va-breadcrumbs');
+    expect(element).toEqualHtml(`
+      <va-breadcrumbs class="hydrated" uswds="">
+        <mock:shadow-root>
+          <nav aria-label="Breadcrumb" class="usa-breadcrumb">
+            <ol class="usa-breadcrumb__list" role="list">
+              <slot></slot>
+            </ol>
+          </nav>
+        </mock:shadow-root>
+        <li class="va-breadcrumbs-li">
+          <a href="#home">Home</a>
+        </li>
+        <li class="va-breadcrumbs-li">
+          <a href="#one">Level One</a>
+        </li>
+        <li class="va-breadcrumbs-li">
+          <a aria-current="page" href="#two">Level Two</a>
+        </li>
+      </va-breadcrumbs>
+    `);
+  });
+
+  it('uswds renders slotted content (list items)', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs uswds="">
+        <li><a href="#home">Home</a></li>
+        <li><a href="#one">Level One</a></li>
+        <li><a href="#two">Level Two</a></li>
+      </va-breadcrumbs>
+    `);
+
+    const element = await page.find('va-breadcrumbs');
+    expect(element).toEqualHtml(`
+      <va-breadcrumbs class="hydrated" uswds="">
+        <mock:shadow-root>
+          <nav aria-label="Breadcrumb" class="usa-breadcrumb">
+            <ol class="usa-breadcrumb__list" role="list">
+              <slot></slot>
+            </ol>
+          </nav>
+        </mock:shadow-root>
+        <li class="va-breadcrumbs-li">
+          <a href="#home">Home</a>
+        </li>
+        <li class="va-breadcrumbs-li">
+          <a href="#one">Level One</a>
+        </li>
+        <li class="va-breadcrumbs-li">
+          <a aria-current="page" href="#two">Level Two</a>
+        </li>
+      </va-breadcrumbs>
+    `);
+  });
+
+  it('uswds passes an axe check', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs uswds="">
+        <a href="#home">Home</a>
+        <a href="#one">Level One</a>
+        <a href="#two">Level Two</a>
+      </va-breadcrumbs>
+    `);
+
+    await axeCheck(page);
+  });
+
+  it('uswds v3 fires an analytics event when an anchor link is clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs uswds="">
+        <a href="#home">Home</a>
+        <a href="#one">Level One</a>
+        <a href="#two">Level Two</a>
+      </va-breadcrumbs>
+    `);
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const anchorElements = await page.findAll('pierce/a');
+
+    await anchorElements[1].click();
+
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      action: 'linkClick',
+      componentName: 'va-breadcrumbs',
+      details: {
+        clickLabel: 'Level One',
+        clickLevel: 2,
+        totalLevels: 3,
+      },
+    });
+  });
+
+  it(`uswds doesn't fire an analytics event with disable-analytics prop when an anchor link is clicked`, async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs disable-analytics uswds="">
+        <a href="#home">Home</a>
+        <a href="#one">Level One</a>
+        <a href="#two">Level Two</a>
+      </va-breadcrumbs>
+    `);
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const anchorElement = await page.find('pierce/a');
+    await anchorElement.click();
+
+    expect(analyticsSpy).toHaveReceivedEventTimes(0);
+  });
 });

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs-slot.css
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs-slot.css
@@ -48,9 +48,10 @@ va-breadcrumbs li > a {
   transition-timing-function: ease-in-out;
 }
 
-va-breadcrumbs li > a:hover {
+:host(:not([uswds])) va-breadcrumbs li > a:hover {
   background: rgba(0, 0, 0, 0.05);
 }
+
 
 va-breadcrumbs li > a:focus {
   outline: 2px solid var(--color-gold-light);

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
@@ -1,15 +1,17 @@
+@use 'usa-breadcrumb/src/styles/usa-breadcrumb';
+
 :host {
   display: block;
 }
 
-nav {
+:host(:not([uswds])) nav {
   background: var(--color-white);
   color: var(--color-link-default);
   font-size: inherit;
   padding: 1.6rem 0;
 }
 
-ul {
+:host(:not([uswds])) ul {
   box-sizing: border-box;
   list-style: square;
   margin: 0 auto;

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -15,7 +15,7 @@ import {
  */
 @Component({
   tag: 'va-breadcrumbs',
-  styleUrl: 'va-breadcrumbs.css',
+  styleUrl: 'va-breadcrumbs.scss',
   shadow: true,
 })
 export class VaBreadcrumbs {
@@ -25,7 +25,10 @@ export class VaBreadcrumbs {
    * Adds an aria-label attribute to the <nav /> element.
    */
   @Prop() label?: string = 'Breadcrumb';
-
+  /**
+     * Whether or not the component will use USWDS v3 styling.
+     */
+  @Prop() uswds?: boolean = false;
   /**
    * Analytics tracking function(s) will not be called
    */
@@ -144,16 +147,29 @@ export class VaBreadcrumbs {
   }
 
   render() {
-    const { label } = this;
+    const { label, uswds } = this;
 
-    return (
-      <Host>
-        <nav aria-label={label}>
-          <ul role="list" onClick={e => this.fireAnalyticsEvent(e)}>
-            <slot onSlotchange={this.handleSlotChange.bind(this)}></slot>
-          </ul>
-        </nav>
-      </Host>
-    );
+    if (uswds) {
+      return (
+        <Host>
+          <nav aria-label={label} class="usa-breadcrumb">
+            <ol role="list" onClick={e => this.fireAnalyticsEvent(e)} class="usa-breadcrumb__list">
+              <slot onSlotchange={this.handleSlotChange.bind(this)}></slot>
+            </ol>
+          </nav>
+        </Host>
+      );
+    }
+    else {
+      return (
+        <Host>
+          <nav aria-label={label}>
+            <ul role="list" onClick={e => this.fireAnalyticsEvent(e)}>
+              <slot onSlotchange={this.handleSlotChange.bind(this)}></slot>
+            </ul>
+          </nav>
+        </Host>
+      );
+    }
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)


## Description
Closes [1716](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1716)

## Testing done
Tested in Storybook
Chrome/Edge/Mozzila

## Screenshots
![breadcrumb](https://github.com/department-of-veterans-affairs/component-library/assets/22892911/686a7026-f559-4f9b-9286-14bf1590fcbf)


## Acceptance criteria
- [ ] A USWDS v3 variation exists for va-breadcrumb web component

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
