### PR TITLE
add/convert maintenance banner to a web component

### DIFF
--- a/packages/storybook/stories/MaintenanceBanner.stories.jsx
+++ b/packages/storybook/stories/MaintenanceBanner.stories.jsx
@@ -5,7 +5,7 @@ import MaintenanceBanner from '../../react-components/src/components/Maintenance
 import { StoryDocs } from './wc-helpers';
 
 export default {
-  title: 'Components/Banner - Maintenance',
+  title: 'Components/Banner - Maintenance (React)',
   component: MaintenanceBanner,
   id: 'components/banners-maintenancebanner',
   argTypes: {

--- a/packages/storybook/stories/va-maintenance-banner.stories.jsx
+++ b/packages/storybook/stories/va-maintenance-banner.stories.jsx
@@ -17,7 +17,14 @@ export default {
 const Template = args => (
   <va-maintenance-banner {...args}
     
-  />
+  >
+    <div slot="warn-content">
+      <span>We’ll be doing some work on VA.gov. The&nbsp;<a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-developer-documentation.687931428.html">maintenance</a>&nbsp;will last X hours. During that time, you won’t be able to sign in or use tools.</span>
+    </div>
+    <div slot="maintenance-content">
+      We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.
+    </div>
+  </va-maintenance-banner>
 );
 
 let expiresAt = new Date();
@@ -30,8 +37,6 @@ const defaultArgs = {
   'banner-id': 'maintenance-banner',
   'maintenance-title': 'Site maintenance',
   'warn-title': 'Upcoming site maintenance',
-  'maintenance-content': 'We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.',
-  'warn-content': 'We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools.',
   'starts-at': `${new Date()}`,
   'expires-at': `${expiresAt}`,
   'warn-starts-at': `${warnStartsAt}`

--- a/packages/storybook/stories/va-maintenance-banner.stories.jsx
+++ b/packages/storybook/stories/va-maintenance-banner.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const maintenanceBannerDocs = getWebComponentDocs('va-maintenance-banner');
 
 export default {
-  title: 'Components/Maintenance Banner',
+  title: 'Components/Banner - Maintenance',
   id: 'components/va-maintenance-banner',
   parameters: {
     componentSubtitle: `va-maintenance-banner web component`,

--- a/packages/storybook/stories/va-maintenance-banner.stories.jsx
+++ b/packages/storybook/stories/va-maintenance-banner.stories.jsx
@@ -1,5 +1,4 @@
-import React, { Fragment } from 'react';
-import { VaMaintenanceBanner } from '@department-of-veterans-affairs/web-components/react-bindings';
+import React from 'react';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const maintenanceBannerDocs = getWebComponentDocs('va-maintenance-banner');
@@ -15,8 +14,17 @@ export default {
   },
 };
 
+const Template = args => (
+  <va-maintenance-banner {...args}
+    
+  />
+);
+
 let expiresAt = new Date();
 expiresAt.setHours(expiresAt.getHours() + 4);
+
+let warnStartsAt = new Date();
+warnStartsAt.setDate(warnStartsAt.getDate() - 1);
 
 const defaultArgs = {
   'banner-id': 'maintenance-banner',
@@ -24,18 +32,10 @@ const defaultArgs = {
   'warn-title': 'Upcoming site maintenance',
   'maintenance-content': 'We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.',
   'warn-content': 'We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools.',
-  startsAt: new Date(),
-  expiresAt: expiresAt,
-  warnStartsAt: { control: { type: 'date' } }
+  'starts-at': `${new Date()}`,
+  'expires-at': `${expiresAt}`,
+  'warn-starts-at': `${warnStartsAt}`
 };
-
-const Template = args => (
-  <Fragment>
-    <VaMaintenanceBanner {...args}
-      
-    />
-  </Fragment>
-);
 
 export const Default = Template.bind(null);
 Default.args = {
@@ -49,9 +49,9 @@ expiresAt.setDate(expiresAt.getDate() + 2);
 export const MaintenanceWarning = Template.bind(null);
 MaintenanceWarning.args = {
   ...defaultArgs,
-  startsAt: startsAt,
-  expiresAt: expiresAt,
-  warnStartsAt: new Date() 
+  'starts-at': `${startsAt}`,
+  'expires-at': `${expiresAt}`,
+  'warn-starts-at': `${new Date()}` 
 };
 
 Default.argTypes = propStructure(maintenanceBannerDocs);

--- a/packages/storybook/stories/va-maintenance-banner.stories.jsx
+++ b/packages/storybook/stories/va-maintenance-banner.stories.jsx
@@ -1,0 +1,58 @@
+import React, { Fragment } from 'react';
+import { VaMaintenanceBanner } from '@department-of-veterans-affairs/web-components/react-bindings';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
+
+const maintenanceBannerDocs = getWebComponentDocs('va-maintenance-banner');
+
+export default {
+  title: 'Components/Maintenance Banner',
+  id: 'components/va-maintenance-banner',
+  parameters: {
+    componentSubtitle: `va-maintenance-banner web component`,
+    docs: {
+      page: () => <StoryDocs data={maintenanceBannerDocs} />,
+    },
+  },
+};
+
+let expiresAt = new Date();
+expiresAt.setHours(expiresAt.getHours() + 4);
+
+const defaultArgs = {
+  'banner-id': 'maintenance-banner',
+  'maintenance-title': 'Site maintenance',
+  'warn-title': 'Upcoming site maintenance',
+  'maintenance-content': 'We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.',
+  'warn-content': 'We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools.',
+  startsAt: new Date(),
+  expiresAt: expiresAt,
+  warnStartsAt: { control: { type: 'date' } }
+};
+
+const Template = args => (
+  <Fragment>
+    <VaMaintenanceBanner {...args}
+      
+    />
+  </Fragment>
+);
+
+export const Default = Template.bind(null);
+Default.args = {
+  ...defaultArgs,
+};
+
+let startsAt = new Date();
+startsAt.setDate(startsAt.getDate() + 1);
+expiresAt.setDate(expiresAt.getDate() + 2);
+
+export const MaintenanceWarning = Template.bind(null);
+MaintenanceWarning.args = {
+  ...defaultArgs,
+  startsAt: startsAt,
+  expiresAt: expiresAt,
+  warnStartsAt: new Date() 
+};
+
+Default.argTypes = propStructure(maintenanceBannerDocs);
+

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.40.3",
+  "version": "4.41.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -449,6 +449,44 @@ export namespace Components {
          */
         "setFocus"?: boolean;
     }
+    interface VaMaintenanceBanner {
+        /**
+          * A unique ID that will be used for conditionally rendering the banner based on if the user has dismissed it already.
+         */
+        "bannerId": string;
+        /**
+          * Whether or not an analytics event will be fired.
+         */
+        "enableAnalytics"?: boolean;
+        /**
+          * A Date object used when downtime expires.
+         */
+        "expiresAt": string;
+        /**
+          * The content of the banner for downtime.
+         */
+        "maintenanceContent": string;
+        /**
+          * The title of the banner for downtime.
+         */
+        "maintenanceTitle": string;
+        /**
+          * A Date object used when downtime starts.
+         */
+        "startsAt": string;
+        /**
+          * The content of the banner for pre-downtime.
+         */
+        "warnContent": string;
+        /**
+          * A Date object used when pre-downtime starts.
+         */
+        "warnStartsAt": string;
+        /**
+          * The title of the banner for pre-downtime.
+         */
+        "warnTitle": string;
+    }
     interface VaMemorableDate {
         /**
           * Whether or not an analytics event will be fired.
@@ -1096,6 +1134,10 @@ export interface VaLoadingIndicatorCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLVaLoadingIndicatorElement;
 }
+export interface VaMaintenanceBannerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLVaMaintenanceBannerElement;
+}
 export interface VaMemorableDateCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLVaMemorableDateElement;
@@ -1273,6 +1315,12 @@ declare global {
         prototype: HTMLVaLoadingIndicatorElement;
         new (): HTMLVaLoadingIndicatorElement;
     };
+    interface HTMLVaMaintenanceBannerElement extends Components.VaMaintenanceBanner, HTMLStencilElement {
+    }
+    var HTMLVaMaintenanceBannerElement: {
+        prototype: HTMLVaMaintenanceBannerElement;
+        new (): HTMLVaMaintenanceBannerElement;
+    };
     interface HTMLVaMemorableDateElement extends Components.VaMemorableDate, HTMLStencilElement {
     }
     var HTMLVaMemorableDateElement: {
@@ -1424,6 +1472,7 @@ declare global {
         "va-file-input": HTMLVaFileInputElement;
         "va-link": HTMLVaLinkElement;
         "va-loading-indicator": HTMLVaLoadingIndicatorElement;
+        "va-maintenance-banner": HTMLVaMaintenanceBannerElement;
         "va-memorable-date": HTMLVaMemorableDateElement;
         "va-modal": HTMLVaModalElement;
         "va-need-help": HTMLVaNeedHelpElement;
@@ -1983,6 +2032,48 @@ declare namespace LocalJSX {
           * Set to true if the loading indicator should capture focus
          */
         "setFocus"?: boolean;
+    }
+    interface VaMaintenanceBanner {
+        /**
+          * A unique ID that will be used for conditionally rendering the banner based on if the user has dismissed it already.
+         */
+        "bannerId"?: string;
+        /**
+          * Whether or not an analytics event will be fired.
+         */
+        "enableAnalytics"?: boolean;
+        /**
+          * A Date object used when downtime expires.
+         */
+        "expiresAt"?: string;
+        /**
+          * The content of the banner for downtime.
+         */
+        "maintenanceContent"?: string;
+        /**
+          * The title of the banner for downtime.
+         */
+        "maintenanceTitle"?: string;
+        /**
+          * The event used to track usage of the component. This is emitted when the component renders and enableAnalytics is true.
+         */
+        "onComponent-library-analytics"?: (event: VaMaintenanceBannerCustomEvent<any>) => void;
+        /**
+          * A Date object used when downtime starts.
+         */
+        "startsAt"?: string;
+        /**
+          * The content of the banner for pre-downtime.
+         */
+        "warnContent"?: string;
+        /**
+          * A Date object used when pre-downtime starts.
+         */
+        "warnStartsAt"?: string;
+        /**
+          * The title of the banner for pre-downtime.
+         */
+        "warnTitle"?: string;
     }
     interface VaMemorableDate {
         /**
@@ -2701,6 +2792,7 @@ declare namespace LocalJSX {
         "va-file-input": VaFileInput;
         "va-link": VaLink;
         "va-loading-indicator": VaLoadingIndicator;
+        "va-maintenance-banner": VaMaintenanceBanner;
         "va-memorable-date": VaMemorableDate;
         "va-modal": VaModal;
         "va-need-help": VaNeedHelp;
@@ -2747,6 +2839,7 @@ declare module "@stencil/core" {
             "va-file-input": LocalJSX.VaFileInput & JSXBase.HTMLAttributes<HTMLVaFileInputElement>;
             "va-link": LocalJSX.VaLink & JSXBase.HTMLAttributes<HTMLVaLinkElement>;
             "va-loading-indicator": LocalJSX.VaLoadingIndicator & JSXBase.HTMLAttributes<HTMLVaLoadingIndicatorElement>;
+            "va-maintenance-banner": LocalJSX.VaMaintenanceBanner & JSXBase.HTMLAttributes<HTMLVaMaintenanceBannerElement>;
             "va-memorable-date": LocalJSX.VaMemorableDate & JSXBase.HTMLAttributes<HTMLVaMemorableDateElement>;
             "va-modal": LocalJSX.VaModal & JSXBase.HTMLAttributes<HTMLVaModalElement>;
             "va-need-help": LocalJSX.VaNeedHelp & JSXBase.HTMLAttributes<HTMLVaNeedHelpElement>;

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -457,7 +457,7 @@ export namespace Components {
         /**
           * Whether or not an analytics event will be fired.
          */
-        "enableAnalytics"?: boolean;
+        "disableAnalytics"?: boolean;
         /**
           * A Date object used when downtime expires.
          */
@@ -2041,7 +2041,7 @@ declare namespace LocalJSX {
         /**
           * Whether or not an analytics event will be fired.
          */
-        "enableAnalytics"?: boolean;
+        "disableAnalytics"?: boolean;
         /**
           * A Date object used when downtime expires.
          */
@@ -2054,6 +2054,10 @@ declare namespace LocalJSX {
           * The title of the banner for downtime.
          */
         "maintenanceTitle"?: string;
+        /**
+          * Fires when the component is closed by clicking on the close icon.
+         */
+        "onCloseEvent"?: (event: VaMaintenanceBannerCustomEvent<any>) => void;
         /**
           * The event used to track usage of the component. This is emitted when the component renders and enableAnalytics is true.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -463,10 +463,6 @@ export namespace Components {
          */
         "expiresAt": string;
         /**
-          * The content of the banner for downtime.
-         */
-        "maintenanceContent": string;
-        /**
           * The title of the banner for downtime.
          */
         "maintenanceTitle": string;
@@ -474,10 +470,6 @@ export namespace Components {
           * A Date object used when downtime starts.
          */
         "startsAt": string;
-        /**
-          * The content of the banner for pre-downtime.
-         */
-        "warnContent": string;
         /**
           * A Date object used when pre-downtime starts.
          */
@@ -2047,10 +2039,6 @@ declare namespace LocalJSX {
          */
         "expiresAt"?: string;
         /**
-          * The content of the banner for downtime.
-         */
-        "maintenanceContent"?: string;
-        /**
           * The title of the banner for downtime.
          */
         "maintenanceTitle"?: string;
@@ -2066,10 +2054,6 @@ declare namespace LocalJSX {
           * A Date object used when downtime starts.
          */
         "startsAt"?: string;
-        /**
-          * The content of the banner for pre-downtime.
-         */
-        "warnContent"?: string;
         /**
           * A Date object used when pre-downtime starts.
          */

--- a/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
+++ b/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
@@ -6,7 +6,7 @@ describe('USWDS maintenance-banner', () => {
   it('uswds - renders', async () => {
     let startsAt = new Date(),
         expiresAt = new Date();
-    expiresAt.setHours(expiresAt.getHours() + 4);
+    expiresAt.setHours(expiresAt.getHours(), expiresAt.getMinutes() + 10);
     const page = await newE2EPage({
       html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance" starts-at="${startsAt}" expires-at="${expiresAt}" warn-starts-at="${startsAt}">
               <div slot="maintenance-content">We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.</div>

--- a/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
+++ b/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
@@ -1,0 +1,145 @@
+import { newE2EPage } from '@stencil/core/testing';
+import { axeCheck } from '../../../testing/test-helpers';
+import { formatDate } from '../../../utils/date-utils';
+
+describe('USWDS maintenance-banner', () => {
+  it('uswds - renders', async () => {
+    let startsAt = new Date(),
+        expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + 4);
+    const page = await newE2EPage({
+      html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance" maintenance-content="We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience." warn-content="We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools." starts-at="${startsAt}" expires-at="${expiresAt}" warn-starts-at="${startsAt}"></va-maintenance-banner>`,
+    });
+    const element = await page.find('va-maintenance-banner');
+    expect(element).toEqualHtml(`
+      <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" expires-at="${expiresAt}" maintenance-content="Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience." maintenance-title="Site maintenance" starts-at="${startsAt}" warn-content="Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools." warn-starts-at="${startsAt}" warn-title="Upcoming site maintenance">
+        <mock:shadow-root>
+          <div class="usa-maintenance-banner usa-maintenance-banner--error">
+            <div class="usa-maintenance-banner__body">
+              <h4 class="usa-maintenance-banner__title">
+                Site maintenance
+              </h4>
+              <div class="usa-maintenance-banner__content">
+                Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience.
+              </div>
+              <div class="usa-maintenance-banner__derived-content">
+              <div>
+                <p>
+                  <strong>
+                    Date:
+                  </strong>
+                    ${formatDate(startsAt, {})}
+                  </p>
+                <p>
+                  <strong>
+                    Start/End time:
+                  </strong>
+                    ${formatDate(startsAt, {timeStyle: 'short'})} to ${formatDate(expiresAt, {timeStyle: 'short'})} ET
+                  </p>
+                </div>
+              </div>
+            </div>
+            <button aria-label="Close notification" class="usa-maintenance-banner__close" type="button">
+              <i aria-hidden="true"></i>
+            </button>
+          </div>
+        </mock:shadow-root>
+      </va-maintenance-banner>
+    `);
+  });
+
+
+  it('uswds - Does not render when expiration date is in the past', async () => {
+    let startsAt = new Date(),
+        expiresAt = new Date();
+    startsAt.setDate(startsAt.getDate() - 2);
+    expiresAt.setDate(expiresAt.getDate() - 1);
+    const page = await newE2EPage({
+      html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance" maintenance-content="We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience." warn-content="We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools." starts-at="${startsAt}" expires-at="${expiresAt}" warn-starts-at="${startsAt}"></va-maintenance-banner>`,
+    });
+    const element = await page.find('va-maintenance-banner');
+    expect(element).toEqualHtml(`
+      <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" expires-at="${expiresAt}" maintenance-content="Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience." maintenance-title="Site maintenance" starts-at="${startsAt}" warn-content="Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools." warn-starts-at="${startsAt}" warn-title="Upcoming site maintenance">
+        <mock:shadow-root>
+        </mock:shadow-root>
+      </va-maintenance-banner>
+    `);
+  });
+
+  it('uswds - does not render if before warning start date', async () => {
+    let startsAt = new Date(),
+        expiresAt = new Date(),
+        warnStartsAt = new Date();
+    warnStartsAt.setHours(warnStartsAt.getHours() + 4);
+    startsAt.setDate(startsAt.getDate() + 1);
+    expiresAt.setDate(expiresAt.getDate() + 2);
+    const page = await newE2EPage({
+      html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance" maintenance-content="We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience." warn-content="We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools." starts-at="${startsAt}" expires-at="${expiresAt}" warn-starts-at="${warnStartsAt}"></va-maintenance-banner>`,
+    });
+    const element = await page.find('va-maintenance-banner');
+    expect(element).toEqualHtml(`
+      <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" expires-at="${expiresAt}" maintenance-content="Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience." maintenance-title="Site maintenance" starts-at="${startsAt}" warn-content="Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools." warn-starts-at="${warnStartsAt}" warn-title="Upcoming site maintenance">
+        <mock:shadow-root>
+        </mock:shadow-root>
+      </va-maintenance-banner>
+    `);
+  });
+
+  it('uswds - renders warning if before maintenance', async () => {
+    let startsAt = new Date(),
+        expiresAt = new Date(),
+        warnStartsAt = new Date();
+    startsAt.setDate(startsAt.getDate() + 1);
+    expiresAt.setDate(expiresAt.getDate() + 2);
+    const page = await newE2EPage({
+      html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance" maintenance-content="We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience." warn-content="We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools." starts-at="${startsAt}" expires-at="${expiresAt}" warn-starts-at="${warnStartsAt}"></va-maintenance-banner>`,
+    });
+    const element = await page.find('va-maintenance-banner');
+    expect(element).toEqualHtml(`
+      <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" expires-at="${expiresAt}" maintenance-content="Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience." maintenance-title="Site maintenance" starts-at="${startsAt}" warn-content="Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools." warn-starts-at="${warnStartsAt}" warn-title="Upcoming site maintenance">
+        <mock:shadow-root>
+          <div class="usa-maintenance-banner usa-maintenance-banner--warning">
+            <div class="usa-maintenance-banner__body">
+              <h4 class="usa-maintenance-banner__title">
+                Upcoming site maintenance
+              </h4>
+              <div class="usa-maintenance-banner__content">
+                Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools.
+              </div>
+              <div class="usa-maintenance-banner__derived-content">
+              <div>
+                <p>
+                  <strong>
+                    Start:
+                  </strong>
+                    ${formatDate(startsAt)} ET
+                  </p>
+                <p>
+                  <strong>
+                    End:
+                  </strong>
+                    ${formatDate(expiresAt)} ET
+                  </p>
+                </div>
+              </div>
+            </div>
+            <button aria-label="Close notification" class="usa-maintenance-banner__close" type="button">
+              <i aria-hidden="true"></i>
+            </button>
+          </div>
+        </mock:shadow-root>
+      </va-maintenance-banner>
+    `);
+  });
+
+  it('uswds - passes an axe check', async () => {
+    let currentDate = new Date(),
+        expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + 4);
+    const page = await newE2EPage({
+      html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance" maintenance-content="We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience." warn-content="We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools." starts-at="${currentDate}" expires-at="${expiresAt}" warn-starts-at="${currentDate}"></va-maintenance-banner>`,
+    });
+    await axeCheck(page);
+  });
+});
+

--- a/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
+++ b/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
@@ -41,10 +41,11 @@ describe('USWDS maintenance-banner', () => {
                   </p>
                 </div>
               </div>
+              <button aria-label="Close notification" class="maintenance-banner__close" type="button">
+                <i aria-hidden="true"></i>
+              </button>
             </div>
-            <button aria-label="Close notification" class="maintenance-banner__close" type="button">
-              <i aria-hidden="true"></i>
-            </button>
+            
           </div>
         </mock:shadow-root>
         <div slot="maintenance-content">
@@ -134,10 +135,10 @@ describe('USWDS maintenance-banner', () => {
                   </p>
                 </div>
               </div>
+              <button aria-label="Close notification" class="maintenance-banner__close" type="button">
+                <i aria-hidden="true"></i>
+              </button>
             </div>
-            <button aria-label="Close notification" class="maintenance-banner__close" type="button">
-              <i aria-hidden="true"></i>
-            </button>
           </div>
         </mock:shadow-root>
         <div slot="maintenance-content">

--- a/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
+++ b/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
@@ -8,21 +8,24 @@ describe('USWDS maintenance-banner', () => {
         expiresAt = new Date();
     expiresAt.setHours(expiresAt.getHours() + 4);
     const page = await newE2EPage({
-      html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance" maintenance-content="We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience." warn-content="We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools." starts-at="${startsAt}" expires-at="${expiresAt}" warn-starts-at="${startsAt}"></va-maintenance-banner>`,
+      html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance" starts-at="${startsAt}" expires-at="${expiresAt}" warn-starts-at="${startsAt}">
+              <div slot="maintenance-content">We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.</div>
+              <div slot="warn-content">We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools.</div>
+            </va-maintenance-banner>`,
     });
     const element = await page.find('va-maintenance-banner');
     expect(element).toEqualHtml(`
-      <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" expires-at="${expiresAt}" maintenance-content="Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience." maintenance-title="Site maintenance" starts-at="${startsAt}" warn-content="Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools." warn-starts-at="${startsAt}" warn-title="Upcoming site maintenance">
+      <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" expires-at="${expiresAt}" maintenance-title="Site maintenance" starts-at="${startsAt}" warn-starts-at="${startsAt}" warn-title="Upcoming site maintenance">
         <mock:shadow-root>
-          <div class="usa-maintenance-banner usa-maintenance-banner--error">
-            <div class="usa-maintenance-banner__body">
-              <h4 class="usa-maintenance-banner__title">
+          <div class="maintenance-banner maintenance-banner--error" role="banner">
+            <div class="maintenance-banner__body">
+              <h4 class="maintenance-banner__title">
                 Site maintenance
               </h4>
-              <div class="usa-maintenance-banner__content">
-                Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience.
+              <div class="maintenance-banner__content">
+                <slot name="maintenance-content"></slot>
               </div>
-              <div class="usa-maintenance-banner__derived-content">
+              <div class="maintenance-banner__derived-content">
               <div>
                 <p>
                   <strong>
@@ -39,11 +42,17 @@ describe('USWDS maintenance-banner', () => {
                 </div>
               </div>
             </div>
-            <button aria-label="Close notification" class="usa-maintenance-banner__close" type="button">
+            <button aria-label="Close notification" class="maintenance-banner__close" type="button">
               <i aria-hidden="true"></i>
             </button>
           </div>
         </mock:shadow-root>
+        <div slot="maintenance-content">
+          Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience.
+        </div>
+        <div slot="warn-content">
+          Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools.
+        </div>
       </va-maintenance-banner>
     `);
   });
@@ -92,21 +101,24 @@ describe('USWDS maintenance-banner', () => {
     startsAt.setDate(startsAt.getDate() + 1);
     expiresAt.setDate(expiresAt.getDate() + 2);
     const page = await newE2EPage({
-      html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance" maintenance-content="We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience." warn-content="We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools." starts-at="${startsAt}" expires-at="${expiresAt}" warn-starts-at="${warnStartsAt}"></va-maintenance-banner>`,
+      html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" warn-title="Upcoming site maintenance"  starts-at="${startsAt}" expires-at="${expiresAt}" warn-starts-at="${warnStartsAt}">
+              <div slot="maintenance-content">We’re working on VA.gov right now. If you have trouble signing in or using tools, check back after we’re finished. Thank you for your patience.</div>
+              <div slot="warn-content">We’ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you won’t be able to sign in or use tools.</div>
+            </va-maintenance-banner>`,
     });
     const element = await page.find('va-maintenance-banner');
     expect(element).toEqualHtml(`
-      <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" expires-at="${expiresAt}" maintenance-content="Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience." maintenance-title="Site maintenance" starts-at="${startsAt}" warn-content="Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools." warn-starts-at="${warnStartsAt}" warn-title="Upcoming site maintenance">
+      <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" expires-at="${expiresAt}" maintenance-title="Site maintenance" starts-at="${startsAt}" warn-starts-at="${warnStartsAt}" warn-title="Upcoming site maintenance">
         <mock:shadow-root>
-          <div class="usa-maintenance-banner usa-maintenance-banner--warning">
-            <div class="usa-maintenance-banner__body">
-              <h4 class="usa-maintenance-banner__title">
+          <div class="maintenance-banner maintenance-banner--warning" role="banner">
+            <div class="maintenance-banner__body">
+              <h4 class="maintenance-banner__title">
                 Upcoming site maintenance
               </h4>
-              <div class="usa-maintenance-banner__content">
-                Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools.
+              <div class="maintenance-banner__content">
+              <slot name="warn-content"></slot>
               </div>
-              <div class="usa-maintenance-banner__derived-content">
+              <div class="maintenance-banner__derived-content">
               <div>
                 <p>
                   <strong>
@@ -123,11 +135,17 @@ describe('USWDS maintenance-banner', () => {
                 </div>
               </div>
             </div>
-            <button aria-label="Close notification" class="usa-maintenance-banner__close" type="button">
+            <button aria-label="Close notification" class="maintenance-banner__close" type="button">
               <i aria-hidden="true"></i>
             </button>
           </div>
         </mock:shadow-root>
+        <div slot="maintenance-content">
+          Weâ€™re working on VA.gov right now. If you have trouble signing in or using tools, check back after weâ€™re finished. Thank you for your patience.
+        </div>
+        <div slot="warn-content">
+          Weâ€™ll be doing some work on VA.gov. The maintenance will last X hours. During that time, you wonâ€™t be able to sign in or use tools.
+        </div>
       </va-maintenance-banner>
     `);
   });

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
@@ -6,6 +6,8 @@
   border-top: 8px solid;
   background-color: var(--color-gray-lightest);
   position: relative;
+  max-width: 1000px;
+  margin: 0px auto;
 }
 
 .maintenance-banner--warning {
@@ -19,6 +21,7 @@
 .maintenance-banner__title {
   font-family: var(--font-serif);
   margin: 0 0 8px;
+  font-size: 20px;
 }
 
 .maintenance-banner__body {
@@ -36,7 +39,7 @@
   position: absolute;
   height: 32px;
   width: 32px;
-  top: 12px;
+  top: 18px;
   left: 18px;
 }
 

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
@@ -1,0 +1,86 @@
+@forward 'settings';
+@use 'uswds-helpers/src/styles/usa-sr-only';
+@use 'usa-button/src/styles/usa-button';
+@use 'usa-icon/src/styles/usa-icon';
+
+@import '../../global/formation_overrides';
+@import '../../mixins/buttons.css';
+
+
+
+.usa-maintenance-banner {
+  border-top: 8px solid;
+  background-color: var(--color-gray-lightest);
+  position: relative;
+}
+
+.usa-maintenance-banner--warning {
+  border-color: var(--color-gold);
+}
+
+.usa-maintenance-banner--error {
+  border-color: var(--color-secondary-dark);
+}
+
+.usa-maintenance-banner__title {
+  font-family: var(--font-serif);
+  margin: 0 0 8px;
+}
+
+.usa-maintenance-banner__body {
+  padding: 16px 56px;
+  position: relative;
+
+}
+
+.usa-maintenance-banner__body::before {
+  font-family: "Font Awesome 5 Free";
+  font-size: 26px;
+  font-style: normal;
+  font-weight: 900;
+  line-height: 1;
+  position: absolute;
+  height: 32px;
+  width: 32px;
+  top: 12px;
+  left: 18px;
+}
+
+.usa-maintenance-banner--warning .usa-maintenance-banner__body::before {
+  content: '\F071'; /* fa-exclamation-triangle */
+}
+
+.usa-maintenance-banner--error .usa-maintenance-banner__body::before {
+  content: '\F06A'; /* fa-exclamation-circle */
+  color: var(--color-secondary-dark);
+}
+
+.usa-maintenance-banner__close {
+  background-color: transparent;
+  color: var(--color-gray-dark);
+  font-size: 2.25rem;
+  padding: 0;
+  position: absolute;
+  margin: 16px;
+  right: 0;
+  top: 0;
+  width: auto;
+  z-index: 9;
+  white-space: nowrap;
+}
+
+.usa-maintenance-banner__close:hover {
+  color: var(--color-base);
+}
+
+.usa-maintenance-banner i::before {
+  -webkit-font-smoothing: antialiased;
+  content: '\F057'; /* fa-times-circle*/
+  display: inline-block;
+  font-family: 'Font Awesome 5 Free';
+  font-style: normal;
+  font-variant: normal;
+  font-weight: 900;
+  line-height: 1;
+  text-rendering: auto;
+}

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
@@ -1,39 +1,33 @@
-@forward 'settings';
-@use 'uswds-helpers/src/styles/usa-sr-only';
-@use 'usa-button/src/styles/usa-button';
-@use 'usa-icon/src/styles/usa-icon';
-
-@import '../../global/formation_overrides';
 @import '../../mixins/buttons.css';
 
 
 
-.usa-maintenance-banner {
+.maintenance-banner {
   border-top: 8px solid;
   background-color: var(--color-gray-lightest);
   position: relative;
 }
 
-.usa-maintenance-banner--warning {
+.maintenance-banner--warning {
   border-color: var(--color-gold);
 }
 
-.usa-maintenance-banner--error {
+.maintenance-banner--error {
   border-color: var(--color-secondary-dark);
 }
 
-.usa-maintenance-banner__title {
+.maintenance-banner__title {
   font-family: var(--font-serif);
   margin: 0 0 8px;
 }
 
-.usa-maintenance-banner__body {
+.maintenance-banner__body {
   padding: 16px 56px;
   position: relative;
 
 }
 
-.usa-maintenance-banner__body::before {
+.maintenance-banner__body::before {
   font-family: "Font Awesome 5 Free";
   font-size: 26px;
   font-style: normal;
@@ -46,16 +40,16 @@
   left: 18px;
 }
 
-.usa-maintenance-banner--warning .usa-maintenance-banner__body::before {
+.maintenance-banner--warning .maintenance-banner__body::before {
   content: '\F071'; /* fa-exclamation-triangle */
 }
 
-.usa-maintenance-banner--error .usa-maintenance-banner__body::before {
+.maintenance-banner--error .maintenance-banner__body::before {
   content: '\F06A'; /* fa-exclamation-circle */
   color: var(--color-secondary-dark);
 }
 
-.usa-maintenance-banner__close {
+.maintenance-banner__close {
   background-color: transparent;
   color: var(--color-gray-dark);
   font-size: 2.25rem;
@@ -69,11 +63,11 @@
   white-space: nowrap;
 }
 
-.usa-maintenance-banner__close:hover {
+.maintenance-banner__close:hover {
   color: var(--color-base);
 }
 
-.usa-maintenance-banner i::before {
+.maintenance-banner i::before {
   -webkit-font-smoothing: antialiased;
   content: '\F057'; /* fa-times-circle*/
   display: inline-block;

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
@@ -6,8 +6,6 @@
   border-top: 8px solid;
   background-color: var(--color-gray-lightest);
   position: relative;
-  max-width: 1000px;
-  margin: 0px auto;
 }
 
 .maintenance-banner--warning {
@@ -27,7 +25,8 @@
 .maintenance-banner__body {
   padding: 16px 56px;
   position: relative;
-
+  max-width: 1000px;
+  margin: 0px auto;
 }
 
 .maintenance-banner__body::before {
@@ -55,7 +54,7 @@
 .maintenance-banner__close {
   background-color: transparent;
   color: var(--color-gray-dark);
-  font-size: 2.25rem;
+  font-size: 24px;
   padding: 0;
   position: absolute;
   margin: 16px;

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
@@ -42,10 +42,6 @@ export class VaMaintenanceBanner {
    */
   @Prop() maintenanceTitle: string;
   /**
-   * The content of the banner for downtime.
-   */
-  @Prop() maintenanceContent: string;
-  /**
    * A Date object used when pre-downtime starts.
    */
   @Prop() warnStartsAt: string;
@@ -53,11 +49,6 @@ export class VaMaintenanceBanner {
    * The title of the banner for pre-downtime.
    */
   @Prop() warnTitle: string;
-  /**
-   * The content of the banner for pre-downtime.
-   */
-  @Prop() warnContent: string;
-
   /**
    * Fires when the component is closed by clicking on the close icon.
    */
@@ -136,7 +127,7 @@ export class VaMaintenanceBanner {
       return null;
     }
     if (window.localStorage.getItem('MAINTENANCE_BANNER') !== this.bannerId) {
-      const { warnTitle, warnContent, startsAt, maintenanceTitle, maintenanceContent } = this;
+      const { warnTitle, startsAt, maintenanceTitle} = this;
       const isWarning = isDateBefore(now, new Date(startsAt));
       const maintenanceBannerClass = classNames({
         'maintenance-banner': true,
@@ -149,7 +140,11 @@ export class VaMaintenanceBanner {
             <div class={maintenanceBannerClass} ref={el => (this.maintenanceBannerEl = el as HTMLDivElement)} role="banner">
                 <div class="maintenance-banner__body">
                   <h4 class="maintenance-banner__title">{isWarning ? warnTitle : maintenanceTitle}</h4>
-                  <div class="maintenance-banner__content">{ isWarning ? warnContent : maintenanceContent}</div>
+                  <div class="maintenance-banner__content">{ 
+                    isWarning ? 
+                      <slot name="warn-content"></slot> : 
+                      <slot name="maintenance-content"></slot>
+                  }</div>
                   <div class="maintenance-banner__derived-content">{this.derivePostContent(new Date(startsAt), new Date(expiresAt))}</div>
                 </div>
                 <button

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
@@ -146,15 +146,16 @@ export class VaMaintenanceBanner {
                       <slot name="maintenance-content"></slot>
                   }</div>
                   <div class="maintenance-banner__derived-content">{this.derivePostContent(new Date(startsAt), new Date(expiresAt))}</div>
-                </div>
-                <button
-                  aria-label="Close notification"
-                  class="maintenance-banner__close"
-                  onClick={this.onCloseAlert}
-                  type="button"
-                >
-                  <i aria-hidden="true" />
+                  <button
+                    aria-label="Close notification"
+                    class="maintenance-banner__close"
+                    onClick={this.onCloseAlert}
+                    type="button"
+                  >
+                    <i aria-hidden="true" />
                 </button>
+                </div>
+                
             </div>
         </Host>
       )

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
@@ -1,0 +1,150 @@
+import { Component, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
+import classNames from 'classnames';
+import {
+  formatDate,
+  isDateAfter,
+  isDateBefore,
+  isDateSameDay,
+} from '../../utils/date-utils';
+
+/**
+ * @componentName Maintenance Banner
+ * @maturityCategory use
+ * @maturityLevel deployed
+ * @guidanceHref form/maintenance-banner
+ */
+
+@Component({
+  tag: 'va-maintenance-banner',
+  styleUrl: 'va-maintenance-banner.scss',
+  shadow: true,
+})
+export class VaMaintenanceBanner {
+
+  maintenanceBannerEl: HTMLDivElement;
+  /**
+   * Whether or not an analytics event will be fired.
+   */
+  @Prop() enableAnalytics?: boolean = false;
+  /**
+   * A unique ID that will be used for conditionally rendering the banner based on if the user has dismissed it already.
+   */
+  @Prop() bannerId: string;
+  /**
+   * A Date object used when downtime starts.
+   */
+  @Prop() startsAt: string;
+  /**
+   * A Date object used when downtime expires.
+   */
+  @Prop() expiresAt: string;
+  /**
+   * The title of the banner for downtime.
+   */
+  @Prop() maintenanceTitle: string;
+  /**
+   * The content of the banner for downtime.
+   */
+  @Prop() maintenanceContent: string;
+  /**
+   * A Date object used when pre-downtime starts.
+   */
+  @Prop() warnStartsAt: string;
+  /**
+   * The title of the banner for pre-downtime.
+   */
+  @Prop() warnTitle: string;
+  /**
+   * The content of the banner for pre-downtime.
+   */
+  @Prop() warnContent: string;
+  /**
+   * The event used to track usage of the component. This is emitted when the
+   * component renders and enableAnalytics is true.
+   */
+  @Event({
+    eventName: 'component-library-analytics',
+    composed: true,
+    bubbles: true,
+  })
+  componentLibraryAnalytics: EventEmitter;
+
+  derivePostContent = ( startsAt: Date, expiresAt: Date) => {
+    if (isDateSameDay(startsAt, expiresAt)) {
+      return (
+        <div>
+          <p>
+            <strong>Date:</strong> {formatDate(startsAt, {})}
+          </p>
+          <p>
+            <strong>Start/End time:</strong> {formatDate(startsAt, {timeStyle: 'short'})}{' '}
+            to {formatDate(expiresAt, {timeStyle: 'short'})} ET
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <p>
+          <strong>Start:</strong> {formatDate(startsAt)} ET
+        </p>
+        <p>
+          <strong>End:</strong> {formatDate(expiresAt)} ET
+        </p>
+      </div>
+    );
+  };
+
+  onCloseAlert = () => {
+      window.localStorage.setItem('MAINTENANCE_BANNER', this.bannerId);
+      this.maintenanceBannerEl.remove();
+  };
+
+  render() {
+    const {warnStartsAt, expiresAt} = this,
+      now = new Date();
+
+    // Escape early if it's before when it should show.
+    if (isDateBefore(now, new Date(warnStartsAt))) {
+      return null;
+    }
+
+    // Escape early if it's after when it should show.
+    if (isDateAfter(now, new Date(expiresAt))) {
+      return null;
+    }
+    if (window.localStorage.getItem('MAINTENANCE_BANNER') !== this.bannerId) {
+      const { warnTitle, warnContent, startsAt, maintenanceTitle, maintenanceContent } = this;
+      const isWarning = isDateBefore(now, new Date(startsAt));
+      const maintenanceBannerClass = classNames({
+        'usa-maintenance-banner': true,
+        'usa-maintenance-banner--warning': isWarning,
+        'usa-maintenance-banner--error': !isWarning
+      })
+
+      return (
+        <Host>
+            <div class={maintenanceBannerClass} ref={el => (this.maintenanceBannerEl = el as HTMLDivElement)}>
+                <div class="usa-maintenance-banner__body">
+                  <h4 class="usa-maintenance-banner__title">{isWarning ? warnTitle : maintenanceTitle}</h4>
+                  <div class="usa-maintenance-banner__content">{ isWarning ? warnContent : maintenanceContent}</div>
+                  <div class="usa-maintenance-banner__derived-content">{this.derivePostContent(new Date(startsAt), new Date(expiresAt))}</div>
+                </div>
+                <button
+                  aria-label="Close notification"
+                  class="usa-maintenance-banner__close"
+                  onClick={this.onCloseAlert}
+                  type="button"
+                >
+                  <i aria-hidden="true" />
+                </button>
+            </div>
+        </Host>
+      )
+    } else {
+      return null
+    }
+    
+  }
+}

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
@@ -10,7 +10,7 @@ import {
 /**
  * @componentName Maintenance Banner
  * @maturityCategory caution
- * @maturityLevel proposed
+ * @maturityLevel available
  */
 
 @Component({
@@ -19,8 +19,8 @@ import {
   shadow: true,
 })
 export class VaMaintenanceBanner {
-
   maintenanceBannerEl: HTMLDivElement;
+  maintenanceBannerContent: HTMLDivElement;
   /**
    * Whether or not an analytics event will be fired.
    */
@@ -106,7 +106,11 @@ export class VaMaintenanceBanner {
         componentName: 'va-maintenance-banner',
         action: 'close',
         details: {
-          text: this.maintenanceBannerEl.innerText,
+          header: isDateBefore(new Date(), new Date(this.startsAt)) ? this.warnTitle : this.maintenanceTitle,
+          warnStartsAt: this.warnStartsAt,
+          startsAt: this.startsAt,
+          expiresAt: this.expiresAt,
+          displayedContent: this.maintenanceBannerContent.innerText,
         }
       }
       this.componentLibraryAnalytics.emit(detail);
@@ -137,10 +141,10 @@ export class VaMaintenanceBanner {
 
       return (
         <Host>
-            <div class={maintenanceBannerClass} ref={el => (this.maintenanceBannerEl = el as HTMLDivElement)} role="banner">
+            <div class={maintenanceBannerClass} role="banner" ref={el => (this.maintenanceBannerEl = el as HTMLDivElement)}>
                 <div class="maintenance-banner__body">
                   <h4 class="maintenance-banner__title">{isWarning ? warnTitle : maintenanceTitle}</h4>
-                  <div class="maintenance-banner__content">{ 
+                  <div class="maintenance-banner__content" ref={el => (this.maintenanceBannerContent = el as HTMLDivElement)}>{ 
                     isWarning ? 
                       <slot name="warn-content"></slot> : 
                       <slot name="maintenance-content"></slot>

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -1,5 +1,5 @@
 import { Components } from '../components';
-import { checkLeapYear, validate } from './date-utils';
+import { checkLeapYear, validate, formatDate, isDateAfter, isDateBefore, isDateSameDay } from './date-utils';
 
 describe('checkLeapYear', () => {
   it('determines an input year is a leap year', () => {
@@ -159,3 +159,56 @@ describe('validate', () => {
     expect(memorableDateComponent.invalidDay).toEqual(true);
   });
 });
+
+describe('formatDate', () => {
+  it('should return a formatted date when not options are provided', () => {
+    const result = formatDate(new Date('01/01/1990'));
+    expect(result).toEqual('Monday, January 1, 1990 at 2:00 AM')
+  })
+  it('should return a formatted date when options are provided', () => {
+    const result = formatDate(new Date('01/01/1990'), {dateStyle: 'short', timeStyle: 'long'});
+    expect(result).toEqual('1/1/90, 2:00:00 AM EST')
+  })
+});
+
+describe('isDateAfter', () => {
+  it('returns false if date1 is not after date2', () => {
+    const date1 = new Date(Date.UTC(2021, 11, 17, 8, 24, 0));
+    const date2 = new Date(Date.UTC(2022, 11, 17, 8, 24, 0));
+    expect(isDateAfter(date1, date2)).toEqual(false);
+  });
+
+  it('returns true if date1 is after date2', () => {
+    const date1 = new Date(Date.UTC(2022, 11, 17, 8, 24, 0));
+    const date2 = new Date(Date.UTC(2021, 11, 17, 8, 24, 0));
+    expect(isDateAfter(date1, date2)).toEqual(true);
+  });
+});
+
+describe('isDateBefore', () => {
+  it('returns true if date1 is before date2', () => {
+    const date1 = new Date(Date.UTC(1995, 11, 17, 8, 24, 0));
+    const date2 = new Date(Date.UTC(1996, 11, 17, 8, 24, 0));
+    expect(isDateBefore(date1, date2)).toEqual(true);
+  });
+
+  it('returns false if date1 is not before date2', () => {
+    const date1 = new Date(Date.UTC(1996, 11, 17, 8, 24, 0));
+    const date2 = new Date(Date.UTC(1995, 11, 17, 8, 24, 0));
+    expect(isDateBefore(date1, date2)).toEqual(false);
+  });
+});
+
+describe('isDateSameDay', () => {
+  it('returns true if date1 is on the same day as date2', () => {
+    const date1 = new Date(Date.UTC(2022, 11, 17, 8, 24, 0));
+    const date2 = new Date(Date.UTC(2022, 11, 17, 10, 24, 0));
+    expect(isDateSameDay(date1, date2)).toEqual(true);
+  });
+
+  it('returns false if date1 is not on the same day as date2', () => {
+    const date1 = new Date(Date.UTC(2022, 11, 17, 8, 24, 0));
+    const date2 = new Date(Date.UTC(1995, 11, 17, 8, 24, 0));
+    expect(isDateSameDay(date1, date2)).toEqual(false);
+  });
+})

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -28,7 +28,6 @@ describe('validate', () => {
     const year = 3000;
     const month = 1;
     const day = 1;
-    const currentYear = new Date().getFullYear();
 
     validate(memorableDateComponent, year, month, day);
 
@@ -161,12 +160,12 @@ describe('validate', () => {
 });
 
 describe('formatDate', () => {
-  it('should return a formatted date when not options are provided', () => {
-    const result = formatDate(new Date('01/01/1990'));
+  it('should return a formatted date when no options are provided', () => {
+    const result = formatDate(new Date('Mon Jan 01 1990 02:00:00 GMT-0500'));
     expect(result).toEqual('Monday, January 1, 1990 at 2:00 AM')
   })
   it('should return a formatted date when options are provided', () => {
-    const result = formatDate(new Date('01/01/1990'), {dateStyle: 'short', timeStyle: 'long'});
+    const result = formatDate(new Date('Mon Jan 01 1990 02:00:00 GMT-0500'), {dateStyle: 'short', timeStyle: 'long'});
     expect(result).toEqual('1/1/90, 2:00:00 AM EST')
   })
 });

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -255,4 +255,46 @@ export const validKeys = [
   'Tab',
   'Delete',
 ];
+
+/**
+ * Returns a string with date & time by default.
+ * Ex: Tuesday, June 9, 2020 at 10:00 AM
+ * Accepts an optional `options` object matching `Intl.DateTimeFormat` standards.
+ */
+export const formatDate = (
+  date: Date,
+  options: Intl.DateTimeFormatOptions = { 
+    dateStyle: 'full', 
+    timeStyle: 'short'
+  },
+  timeZone: string = 'America/New_York',
+) => {
+  if (!date || !(date instanceof Date)) return;
+  return date.toLocaleString('en-US', { ...options, timeZone });
+};
+
+export const isDateAfter = (date1: Date, date2: Date) => {
+  if (!date1 || !(date1 instanceof Date) || !date2 || !(date2 instanceof Date))
+    return;
+
+  return date1.getTime() > date2.getTime();
+};
+
+export const isDateBefore = (date1: Date, date2: Date) => {
+  if (!date1 || !(date1 instanceof Date) || !date2 || !(date2 instanceof Date))
+    return;
+
+  return date1.getTime() < date2.getTime();
+};
+
+export const isDateSameDay = (date1: Date, date2: Date) => {
+  if (!date1 || !(date1 instanceof Date) || !date2 || !(date2 instanceof Date))
+    return;
+
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDay() === date2.getDay()
+  );
+};
 /* eslint-enable i18next/no-literal-string */


### PR DESCRIPTION
## Chromatic
<!-- This `1508-maintenance-banner` is a placeholder for a CI job - it will be updated automatically -->
https://1508-maintenance-banner--60f9b557105290003b387cd5.chromatic.com

## Description
Convert "Banner - Maintenance" react component to a web component. 
Sketch Design: https://www.sketch.com/s/2476e4ee-fa82-4a19-bf11-dcb9b790acb7/p/D413251A-9268-4E48-9E4C-8E8A3A6B31F9/canvas

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1508

## Testing done
- Browser testing: Chrome, Firefox, Safari, MS Edge
- Mac Voice Over

## Screenshots
![Screenshot 2023-06-07 at 3 53 30 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/8112681b-119a-439f-a5be-a6a453798c19)
![Screenshot 2023-06-07 at 3 53 52 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/c0927a89-71a0-44c2-9d43-2602f27d8499)


## Acceptance criteria
- [ ] Warning shows if current date is before startsAt and after warnStartsAt
- [ ] Alert shows if current date is after startsAt and before expiresAt
- [ ] Maintenance banner does not show if previous 2 conditions are not met
- [ ] Maintenance banner does not show if the user has dismissed the banner

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
