### PR TITLE
Allow date field copy/paste with keyboard shortcut

### DIFF
--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -476,7 +476,12 @@ describe('va-date', () => {
 
       const date = await page.find('va-date');
       const handleYear = await page.$('pierce/[name="testYear"]');
+      const handleMonth = await page.$('pierce/[name="testMonth"]');
 
+      // Month
+      await handleMonth.select('3');
+      await page.waitForChanges();
+      
       // Year
       await handleYear.press('3');
       await handleYear.press('0');

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -14,8 +14,8 @@ import {
   months,
   days,
   validate,
-  validKeys,
   getErrorParameters,
+  checkIsNaN,
 } from '../../utils/date-utils';
 
 /**
@@ -142,7 +142,12 @@ export class VaDate {
   private handleDateBlur = (event: FocusEvent) => {
     const [year, month, day] = (this.value || '')
       .split('-')
-      .map(val => parseInt(val));
+      .map(val => Number(val));
+
+    if(!checkIsNaN(this, year, month, day, this.monthYearOnly)) {
+      // if any fields are NaN do not continue validation
+      return;
+    }
 
     this.setValue(year, month, day);
     // Run built-in validation. Any custom validation
@@ -189,13 +194,6 @@ export class VaDate {
     this.dateChange.emit(event);
   };
 
-  private handleDateKey = (event: KeyboardEvent) => {
-    if (validKeys.indexOf(event.key) < 0) {
-      event.preventDefault();
-      return false;
-    }
-  };
-
   render() {
     const {
       required,
@@ -204,7 +202,6 @@ export class VaDate {
       error,
       handleDateBlur,
       handleDateChange,
-      handleDateKey,
       monthYearOnly,
       value,
       hint,
@@ -285,7 +282,6 @@ export class VaDate {
               value={year ? year.toString() : ''}
               invalid={this.invalidYear}
               onInput={handleDateChange}
-              onKeyDown={handleDateKey}
               class="input-year"
               inputmode="numeric"
               type="text"

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -567,31 +567,6 @@ describe('va-memorable-date', () => {
     expect(date.getAttribute('value')).toBe('2022-01-02');
   });
 
-  it('only allows specific keys to be used inside input fields', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<va-memorable-date name="test"/>');
-    const date = await page.find('va-memorable-date');
-    const handleMonth = await page.$('pierce/[name="testMonth"]');
-    const handleDay = await page.$('pierce/[name="testDay"]');
-    const handleYear = await page.$('pierce/[name="testYear"]');
-    // Month
-    await handleMonth.press('a');
-    await handleMonth.press('Tab');
-    // Day
-    await handleDay.press('b');
-    await handleDay.press('Tab');
-    // Year
-    await handleYear.press('`');
-    await handleYear.press(']');
-    await handleYear.press('/');
-    await handleYear.press(',');
-    // Trigger Blur
-    await handleYear.press('Tab');
-    await page.waitForChanges();
-    expect(date.getAttribute('value')).toBe('');
-  });
-
   it('fires an analytics event when enableAnalytics is true', async () => {
     const page = await newE2EPage();
     await page.setContent(
@@ -1214,31 +1189,6 @@ describe('va-memorable-date', () => {
     expect(date.getAttribute('value')).toBe('2022-01-02');
   });
 
-  it('uswds v3 only allows specific keys to be used inside input fields', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<va-memorable-date name="test" uswds />');
-    const date = await page.find('va-memorable-date');
-    const handleMonth = await page.$('pierce/[name="testMonth"]');
-    const handleDay = await page.$('pierce/[name="testDay"]');
-    const handleYear = await page.$('pierce/[name="testYear"]');
-    // Month
-    await handleMonth.press('a');
-    await handleMonth.press('Tab');
-    // Day
-    await handleDay.press('b');
-    await handleDay.press('Tab');
-    // Year
-    await handleYear.press('`');
-    await handleYear.press(']');
-    await handleYear.press('/');
-    await handleYear.press(',');
-    // Trigger Blur
-    await handleYear.press('Tab');
-    await page.waitForChanges();
-    expect(date.getAttribute('value')).toBe('');
-  });
-
   it('uswds v3 fires an analytics event when enableAnalytics is true', async () => {
     const page = await newE2EPage();
     await page.setContent(
@@ -1752,30 +1702,6 @@ describe('va-memorable-date', () => {
     expect(date.getAttribute('value')).toBe('2022-01-02');
   });
 
-  it('uswds v3 only allows specific keys to be used inside input fields with monthSelect', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<va-memorable-date name="test" uswds month-select />');
-    const date = await page.find('va-memorable-date');
-    const handleMonth = await page.$('pierce/[name="testMonth"]');
-    const handleDay = await page.$('pierce/[name="testDay"]');
-    const handleYear = await page.$('pierce/[name="testYear"]');
-    // Month
-    await handleMonth.select('a');
-    await handleMonth.press('Tab');
-    // Day
-    await handleDay.press('b');
-    await handleDay.press('Tab');
-    // Year
-    await handleYear.press('`');
-    await handleYear.press(']');
-    await handleYear.press('/');
-    await handleYear.press(',');
-    // Trigger Blur
-    await handleYear.press('Tab');
-    await page.waitForChanges();
-    expect(date.getAttribute('value')).toBe('');
-  });
 
   it('uswds v3 fires an analytics event when enableAnalytics is true with monthSelect', async () => {
     const page = await newE2EPage();

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -14,7 +14,6 @@ import {
   getErrorParameters,
   months,
   validate,
-  validKeys,
   checkIsNaN,
 } from '../../utils/date-utils';
 
@@ -114,9 +113,9 @@ export class VaMemorableDate {
 
   private handleDateBlur = (event: FocusEvent) => {
     const [year, month, day] = (this.value || '').split('-');
-    const yearNum = parseInt(year);
-    const monthNum = parseInt(month);
-    const dayNum = parseInt(day);
+    const yearNum = Number(year);
+    const monthNum = Number(month);
+    const dayNum = Number(day);
     
     if(!checkIsNaN(this, yearNum, monthNum, dayNum)) {
       // if any fields are NaN do not continue validation
@@ -175,13 +174,6 @@ export class VaMemorableDate {
     this.dateChange.emit(event);
   };
 
-  private handleDateKey = (event: KeyboardEvent) => {
-    if (validKeys.indexOf(event.key) < 0) {
-      //event.preventDefault();
-      //return false;
-    }
-  };
-
   /**
    * Whether or not an analytics event will be fired.
    */
@@ -217,7 +209,6 @@ export class VaMemorableDate {
       error,
       handleDateBlur,
       handleDateChange,
-      handleDateKey,
       value,
       uswds,
       monthSelect,
@@ -271,7 +262,6 @@ export class VaMemorableDate {
           // if NaN provide empty string
           value={month?.toString()}
           onInput={handleDateChange}
-          onKeyDown={handleDateKey}
           class="usa-form-group--month-input"
           reflectInputError={error ? true : false}
           inputmode="numeric"
@@ -316,7 +306,6 @@ export class VaMemorableDate {
                   // if NaN provide empty string
                   value={day?.toString()}
                   onInput={handleDateChange}
-                  onKeyDown={handleDateKey}
                   class="usa-form-group--day-input"
                   reflectInputError={error ? true : false}
                   inputmode="numeric"
@@ -337,7 +326,6 @@ export class VaMemorableDate {
                   // if NaN provide empty string
                   value={year?.toString()}
                   onInput={handleDateChange}
-                  onKeyDown={handleDateKey}
                   class="usa-form-group--year-input"
                   reflectInputError={error ? true : false}
                   inputmode="numeric"
@@ -378,7 +366,6 @@ export class VaMemorableDate {
                 // if NaN provide empty string
                 value={month?.toString()}
                 onInput={handleDateChange}
-                onKeyDown={handleDateKey}
                 class="input-month"
                 inputmode="numeric"
                 type="text"
@@ -395,7 +382,6 @@ export class VaMemorableDate {
                 // if NaN provide empty string
                 value={day?.toString()}
                 onInput={handleDateChange}
-                onKeyDown={handleDateKey}
                 class="input-day"
                 inputmode="numeric"
                 type="text"
@@ -412,7 +398,6 @@ export class VaMemorableDate {
                 // if NaN provide empty string
                 value={year?.toString()}
                 onInput={handleDateChange}
-                onKeyDown={handleDateKey}
                 class="input-year"
                 inputmode="numeric"
                 type="text"

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -15,6 +15,7 @@ import {
   months,
   validate,
   validKeys,
+  checkIsNaN,
 } from '../../utils/date-utils';
 
 import i18next from 'i18next';
@@ -116,6 +117,12 @@ export class VaMemorableDate {
     const yearNum = parseInt(year);
     const monthNum = parseInt(month);
     const dayNum = parseInt(day);
+    
+    if(!checkIsNaN(this, yearNum, monthNum, dayNum)) {
+      // if any fields are NaN do not continue validation
+      return;
+    }
+
     // Use a leading zero for numbers < 10
     const numFormatter = new Intl.NumberFormat('en-US', {
       minimumIntegerDigits: 2,
@@ -170,8 +177,8 @@ export class VaMemorableDate {
 
   private handleDateKey = (event: KeyboardEvent) => {
     if (validKeys.indexOf(event.key) < 0) {
-      event.preventDefault();
-      return false;
+      //event.preventDefault();
+      //return false;
     }
   };
 

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -1,5 +1,5 @@
 import { Components } from '../components';
-import { checkLeapYear, validate, formatDate, isDateAfter, isDateBefore, isDateSameDay } from './date-utils';
+import { checkLeapYear, validate, formatDate, isDateAfter, isDateBefore, isDateSameDay, checkIsNaN } from './date-utils';
 
 describe('checkLeapYear', () => {
   it('determines an input year is a leap year', () => {
@@ -209,5 +209,78 @@ describe('isDateSameDay', () => {
     const date1 = new Date(Date.UTC(2022, 11, 17, 8, 24, 0));
     const date2 = new Date(Date.UTC(1995, 11, 17, 8, 24, 0));
     expect(isDateSameDay(date1, date2)).toEqual(false);
+  });
+})
+
+describe('checkIsNaN', () => {
+  it('indicates when the year is NaN', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = Number('1999n');
+    const month =  Number('1');
+    const day = Number('1');
+
+    const result = checkIsNaN(memorableDateComponent, year, month, day);
+
+    expect(result).toEqual(false);
+    expect(memorableDateComponent.error).toEqual(`year-range`);
+    expect(memorableDateComponent.invalidYear).toEqual(true);
+  });
+
+  it('indicates when the month is NaN', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = Number('1999');
+    const month =  Number('1n');
+    const day = Number('1');
+
+    const result = checkIsNaN(memorableDateComponent, year, month, day);
+
+    expect(result).toEqual(false);
+    expect(memorableDateComponent.error).toEqual(`month-range`);
+    expect(memorableDateComponent.invalidMonth).toEqual(true);
+  });
+
+  it('indicates when the day is NaN', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = Number('1999');
+    const month =  Number('1');
+    const day = Number('1n');
+
+    const result = checkIsNaN(memorableDateComponent, year, month, day);
+
+    expect(result).toEqual(false);
+    expect(memorableDateComponent.error).toEqual(`day-range`);
+    expect(memorableDateComponent.invalidDay).toEqual(true);
+  });
+
+  it('passes when the all inputs are number', () => {
+    const memorableDateComponent = {} as Components.VaMemorableDate;
+    const year = Number('1999');
+    const month =  Number('1');
+    const day = Number('1');
+
+    const result = checkIsNaN(memorableDateComponent, year, month, day);
+
+    expect(result).toEqual(true);
+    expect(memorableDateComponent.error).toEqual(null);
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
+  });
+
+  it('removes error indicators when the values are valid', () => {
+    const memorableDateComponent = { error: 'Some error'} as Components.VaMemorableDate;
+    const year = Number('1999');
+    const month =  Number('1');
+    const day = Number('1');
+
+    const result = checkIsNaN(memorableDateComponent, year, month, day);
+
+    expect(result).toEqual(true);
+    expect(memorableDateComponent.error).toEqual(null);
+
+    expect(memorableDateComponent.error).toEqual(null);
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
   });
 })

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -152,7 +152,10 @@ export function checkLeapYear(year: number) {
   return (0 == year % 4 && 0 != year % 100) || 0 == year % 400;
 }
 
-
+/**
+ * Checks if any of the of inputs provided resolve to NaN
+ * Returns false if any are NaN and highlights component as error
+ */
 export function checkIsNaN(
   component: Components.VaDate | Components.VaMemorableDate,
   year: number,
@@ -192,7 +195,7 @@ export function checkIsNaN(
     component.error = 'date-error';
   }
 
-  // Remove any error message if none of the fields are marked as invalid
+  // Remove any error message if none of the fields are NaN
   if (!component.invalidYear && !component.invalidMonth && !component.invalidDay) {
     component.error = null;
     return true;

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -152,6 +152,54 @@ export function checkLeapYear(year: number) {
   return (0 == year % 4 && 0 != year % 100) || 0 == year % 400;
 }
 
+
+export function checkIsNaN(
+  component: Components.VaDate | Components.VaMemorableDate,
+  year: number,
+  month: number,
+  day: number,
+  monthYearOnly : boolean = false) : boolean {
+
+  // Begin NaN validation.
+  if (isNaN(year)) {
+    component.invalidYear = true;
+    component.error = 'year-range';
+  }
+  else {
+    component.invalidYear = false;
+  }
+
+  if (!monthYearOnly && isNaN(day)) {
+    component.invalidDay = true;
+    component.error = 'day-range';
+  }
+  else {
+    component.invalidDay = false;
+  }
+
+  if (isNaN(month)) {
+    component.invalidMonth = true;
+    component.error = 'month-range';
+  }
+  else {
+    component.invalidMonth = false;
+  }
+
+  if (component.required && (!year || !month || (!monthYearOnly && !day))) {
+    component.invalidYear = !year;
+    component.invalidMonth = !month;
+    component.invalidDay = monthYearOnly ? false : !day;
+    component.error = 'date-error';
+  }
+
+  // Remove any error message if none of the fields are marked as invalid
+  if (!component.invalidYear && !component.invalidMonth && !component.invalidDay) {
+    component.error = null;
+    return true;
+  }
+  return false;
+}
+
 /**
  * This is used to validate date components and:
  * 1. Indicate which field fails the built-in validation


### PR DESCRIPTION
## Chromatic
<!-- This `allow-paste-in-date-component` is a placeholder for a CI job - it will be updated automatically -->
https://allow-paste-in-date-component--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [va-memorable-date doesn't allow for copy/paste/cut keyboard actions #1775](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1775)

Previously the date inputs restricted what key presses would be registered in order to disallow any non-numeric input. This PR removes that restriction and adds new validation to prevent incorrect inputs.

## Testing done
Tested in Chrome and Safari on Mac

## Screenshots
<img width="362" alt="Screenshot 2023-06-15 at 10 11 49 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/1413938/018d9e71-8c1d-44f5-93ec-08aee98a10bf">
<img width="526" alt="Screenshot 2023-06-15 at 10 11 27 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/1413938/1beadf8b-2fac-41e4-be50-25ec86c4a3d4">


## Acceptance criteria
- [ ] Able to cut/copy/paste into fields
- [ ] If invalid characters are in the date fields, show error

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
