### PR TITLE
Allow month to be selected for va-memorable-date using 'month-select'

### DIFF
--- a/packages/storybook/stories/va-memorable-date-uswds.stories.jsx
+++ b/packages/storybook/stories/va-memorable-date-uswds.stories.jsx
@@ -119,8 +119,8 @@ Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(memorableDateInputDocs);
 
 export const Error = Template.bind(null);
-Error.args = {
-  ...defaultArgs,
+Error.args = { 
+  ...defaultArgs, 
   error: 'Error Message Example',
 };
 

--- a/packages/storybook/stories/va-memorable-date-uswds.stories.jsx
+++ b/packages/storybook/stories/va-memorable-date-uswds.stories.jsx
@@ -119,8 +119,8 @@ Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(memorableDateInputDocs);
 
 export const Error = Template.bind(null);
-Error.args = { 
-  ...defaultArgs, 
+Error.args = {
+  ...defaultArgs,
   error: 'Error Message Example',
 };
 
@@ -128,6 +128,7 @@ export const WithMonthSelect = Template.bind(null);
 WithMonthSelect.args = {
   ...defaultArgs,
   monthSelect: true,
+  value: '2022-04-19',
 };
 
 export const ErrorWithMonthSelect = Template.bind(null);

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.41.0",
+  "version": "4.41.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -123,7 +123,7 @@ export class VaMemorableDate {
     /* eslint-disable i18next/no-literal-string */
     this.value = year || month || day ? `${year}-${month ? numFormatter.format(monthNum) : ''}-${
       day ? numFormatter.format(dayNum) : ''
-    }` : '';
+      }` : '';
     /* eslint-enable i18next/no-literal-string */
 
     // Run built-in validation. Any custom validation
@@ -196,7 +196,7 @@ export class VaMemorableDate {
       forceUpdate(this.el);
     });
   }
-  
+
   disconnectedCallback() {
     i18next.off('languageChanged');
   }
@@ -220,7 +220,7 @@ export class VaMemorableDate {
     const describedbyIds = ['dateHint', hint ? 'hint' : '']
       .filter(Boolean)
       .join(' ');
-      
+
     const hintText = monthSelect ? i18next.t('date-hint-with-select') : i18next.t('date-hint');
 
     const errorParameters = (error: string) => {
@@ -233,44 +233,48 @@ export class VaMemorableDate {
     // Fieldset has an implicit aria role of group
     if(uswds) { 
       const monthDisplay = monthSelect
-      ? <div class="usa-form-group usa-form-group--month usa-form-group--select">
-        <va-select
-          uswds
-          label={i18next.t('month')}
-          name={`${name}Month`}
-          aria-describedby={describedbyIds}
-          invalid={this.invalidMonth}
-          onVaSelect={handleDateChange}
-          class='usa-form-group--month-select'
-          reflectInputError={error ? true : false}
-        >
-          {months &&
-          months.map(month => (
-            <option value={month.value}>{month.label}</option>
-          ))}
-        </va-select>
-      </div>
-      : <div class="usa-form-group usa-form-group--month">
-        <va-text-input
-          uswds
-          label={i18next.t('month')}
-          name={`${name}Month`}
-          maxlength={2}
-          minlength={2}
-          pattern="[0-9]*"
-          aria-describedby={describedbyIds}
-          invalid={this.invalidMonth}
-          // Value must be a string
-          // if NaN provide empty string
-          value={month?.toString()}
-          onInput={handleDateChange}
-          onKeyDown={handleDateKey}
-          class="usa-form-group--month-input"
-          reflectInputError={error ? true : false}
-          inputmode="numeric"
-          type="text"
-        />
-      </div>;
+        ? <div class="usa-form-group usa-form-group--month usa-form-group--select">
+          <va-select
+            uswds
+            label={i18next.t('month')}
+            name={`${name}Month`}
+            aria-describedby={describedbyIds}
+            invalid={this.invalidMonth}
+            onVaSelect={handleDateChange}
+            class='usa-form-group--month-select'
+            reflectInputError={error ? true : false}
+            value={String(parseInt(month))}
+          >
+            {months &&
+              months.map(monthOption => (
+                <option value={monthOption.value} selected={monthOption.value === parseInt(month)}>
+                  {monthOption.label}
+                </option>
+              ))
+            }
+          </va-select>
+        </div>
+        : <div class="usa-form-group usa-form-group--month">
+          <va-text-input
+            uswds
+            label={i18next.t('month')}
+            name={`${name}Month`}
+            maxlength={2}
+            minlength={2}
+            pattern="[0-9]*"
+            aria-describedby={describedbyIds}
+            invalid={this.invalidMonth}
+            // Value must be a string
+            // if NaN provide empty string
+            value={month?.toString()}
+            onInput={handleDateChange}
+            onKeyDown={handleDateKey}
+            class="usa-form-group--month-input"
+            reflectInputError={error ? true : false}
+            inputmode="numeric"
+            type="text"
+          />
+        </div>;
       const legendClass = classnames({
         'usa-legend': true,
         'usa-label--error': error
@@ -288,7 +292,7 @@ export class VaMemorableDate {
             <span id="error-message" role="alert">
               {error && (
                 <Fragment>
-                  <span class="usa-sr-only">{i18next.t('error')}</span> 
+                  <span class="usa-sr-only">{i18next.t('error')}</span>
                   <span class="usa-error-message">{i18next.t(error, errorParameters(error))}</span>
                 </Fragment>
               )}
@@ -350,7 +354,7 @@ export class VaMemorableDate {
               {hint && <div id="hint">{hint}</div>}
               <div id="dateHint">{i18next.t('date-hint')}.</div>
             </legend>
-            <slot /> 
+            <slot />
             <span id="error-message" role="alert">
               {error && (
                 <Fragment>
@@ -375,7 +379,7 @@ export class VaMemorableDate {
                 class="input-month"
                 inputmode="numeric"
                 type="text"
-                />
+              />
               <va-text-input
                 label={i18next.t('day')}
                 name={`${name}Day`}
@@ -392,7 +396,7 @@ export class VaMemorableDate {
                 class="input-day"
                 inputmode="numeric"
                 type="text"
-                />
+              />
               <va-text-input
                 label={i18next.t('year')}
                 name={`${name}Year`}
@@ -409,7 +413,7 @@ export class VaMemorableDate {
                 class="input-year"
                 inputmode="numeric"
                 type="text"
-                />
+              />
             </div>
           </fieldset>
         </Host>

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -123,7 +123,7 @@ export class VaMemorableDate {
     /* eslint-disable i18next/no-literal-string */
     this.value = year || month || day ? `${year}-${month ? numFormatter.format(monthNum) : ''}-${
       day ? numFormatter.format(dayNum) : ''
-      }` : '';
+    }` : '';
     /* eslint-enable i18next/no-literal-string */
 
     // Run built-in validation. Any custom validation
@@ -196,7 +196,7 @@ export class VaMemorableDate {
       forceUpdate(this.el);
     });
   }
-
+  
   disconnectedCallback() {
     i18next.off('languageChanged');
   }
@@ -220,7 +220,7 @@ export class VaMemorableDate {
     const describedbyIds = ['dateHint', hint ? 'hint' : '']
       .filter(Boolean)
       .join(' ');
-
+      
     const hintText = monthSelect ? i18next.t('date-hint-with-select') : i18next.t('date-hint');
 
     const errorParameters = (error: string) => {
@@ -233,48 +233,48 @@ export class VaMemorableDate {
     // Fieldset has an implicit aria role of group
     if(uswds) { 
       const monthDisplay = monthSelect
-        ? <div class="usa-form-group usa-form-group--month usa-form-group--select">
-          <va-select
-            uswds
-            label={i18next.t('month')}
-            name={`${name}Month`}
-            aria-describedby={describedbyIds}
-            invalid={this.invalidMonth}
-            onVaSelect={handleDateChange}
-            class='usa-form-group--month-select'
-            reflectInputError={error ? true : false}
-            value={String(parseInt(month))}
-          >
-            {months &&
-              months.map(monthOption => (
-                <option value={monthOption.value} selected={monthOption.value === parseInt(month)}>
-                  {monthOption.label}
-                </option>
-              ))
-            }
-          </va-select>
-        </div>
-        : <div class="usa-form-group usa-form-group--month">
-          <va-text-input
-            uswds
-            label={i18next.t('month')}
-            name={`${name}Month`}
-            maxlength={2}
-            minlength={2}
-            pattern="[0-9]*"
-            aria-describedby={describedbyIds}
-            invalid={this.invalidMonth}
-            // Value must be a string
-            // if NaN provide empty string
-            value={month?.toString()}
-            onInput={handleDateChange}
-            onKeyDown={handleDateKey}
-            class="usa-form-group--month-input"
-            reflectInputError={error ? true : false}
-            inputmode="numeric"
-            type="text"
-          />
-        </div>;
+      ? <div class="usa-form-group usa-form-group--month usa-form-group--select">
+        <va-select
+          uswds
+          label={i18next.t('month')}
+          name={`${name}Month`}
+          aria-describedby={describedbyIds}
+          invalid={this.invalidMonth}
+          onVaSelect={handleDateChange}
+          class='usa-form-group--month-select'
+          reflectInputError={error ? true : false}
+          value={String(parseInt(month))}
+        >
+          {months &&
+            months.map(monthOption => (
+              <option value={monthOption.value} selected={monthOption.value === parseInt(month)}>
+                {monthOption.label}
+              </option>
+            ))
+          }
+        </va-select>
+      </div>
+      : <div class="usa-form-group usa-form-group--month">
+        <va-text-input
+          uswds
+          label={i18next.t('month')}
+          name={`${name}Month`}
+          maxlength={2}
+          minlength={2}
+          pattern="[0-9]*"
+          aria-describedby={describedbyIds}
+          invalid={this.invalidMonth}
+          // Value must be a string
+          // if NaN provide empty string
+          value={month?.toString()}
+          onInput={handleDateChange}
+          onKeyDown={handleDateKey}
+          class="usa-form-group--month-input"
+          reflectInputError={error ? true : false}
+          inputmode="numeric"
+          type="text"
+        />
+      </div>;
       const legendClass = classnames({
         'usa-legend': true,
         'usa-label--error': error
@@ -292,7 +292,7 @@ export class VaMemorableDate {
             <span id="error-message" role="alert">
               {error && (
                 <Fragment>
-                  <span class="usa-sr-only">{i18next.t('error')}</span>
+                  <span class="usa-sr-only">{i18next.t('error')}</span> 
                   <span class="usa-error-message">{i18next.t(error, errorParameters(error))}</span>
                 </Fragment>
               )}
@@ -354,7 +354,7 @@ export class VaMemorableDate {
               {hint && <div id="hint">{hint}</div>}
               <div id="dateHint">{i18next.t('date-hint')}.</div>
             </legend>
-            <slot />
+            <slot /> 
             <span id="error-message" role="alert">
               {error && (
                 <Fragment>
@@ -379,7 +379,7 @@ export class VaMemorableDate {
                 class="input-month"
                 inputmode="numeric"
                 type="text"
-              />
+                />
               <va-text-input
                 label={i18next.t('day')}
                 name={`${name}Day`}
@@ -396,7 +396,7 @@ export class VaMemorableDate {
                 class="input-day"
                 inputmode="numeric"
                 type="text"
-              />
+                />
               <va-text-input
                 label={i18next.t('year')}
                 name={`${name}Year`}
@@ -413,7 +413,7 @@ export class VaMemorableDate {
                 class="input-year"
                 inputmode="numeric"
                 type="text"
-              />
+                />
             </div>
           </fieldset>
         </Host>

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -231,29 +231,29 @@ export class VaMemorableDate {
 
     // Error attribute should be leveraged for custom error messaging
     // Fieldset has an implicit aria role of group
-    if(uswds) { 
+    if (uswds) {
       const monthDisplay = monthSelect
-      ? <div class="usa-form-group usa-form-group--month usa-form-group--select">
-        <va-select
-          uswds
-          label={i18next.t('month')}
-          name={`${name}Month`}
-          aria-describedby={describedbyIds}
-          invalid={this.invalidMonth}
-          onVaSelect={handleDateChange}
-          class='usa-form-group--month-select'
-          reflectInputError={error ? true : false}
-          value={String(parseInt(month))}
-        >
-          {months &&
-            months.map(monthOption => (
-              <option value={monthOption.value} selected={monthOption.value === parseInt(month)}>
-                {monthOption.label}
-              </option>
-            ))
-          }
-        </va-select>
-      </div>
+        ? <div class="usa-form-group usa-form-group--month usa-form-group--select">
+          <va-select
+            uswds
+            label={i18next.t('month')}
+            name={`${name}Month`}
+            aria-describedby={describedbyIds}
+            invalid={this.invalidMonth}
+            onVaSelect={handleDateChange}
+            class='usa-form-group--month-select'
+            reflectInputError={error ? true : false}
+            value={month ? String(parseInt(month)) : month}
+          >
+            {months &&
+              months.map(monthOption => (
+                <option value={monthOption.value} selected={monthOption.value === parseInt(month)}>
+                  {monthOption.label}
+                </option>
+              ))
+            }
+          </va-select>
+        </div>
       : <div class="usa-form-group usa-form-group--month">
         <va-text-input
           uswds


### PR DESCRIPTION
## Chromatic
<!-- This `1845-va-memorable-date-month-select-fix` is a placeholder for a CI job - it will be updated automatically -->
https://1845-va-memorable-date-month-select-fix--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1845
Related to https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/60060

## Testing done
Tested in storybook using Chrome with with setting values:  '2022-04-19', '2022-4-19', '2022-12-19', '2022-08-19', '2022-1-19' and all values work.

## Screenshots
![image](https://github.com/department-of-veterans-affairs/component-library/assets/123402053/4065bd0c-f1bb-4b90-896d-38d6a5ca1d78)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
