### PR TITLE
Update for Chromatic Publish Action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@department-of-veterans-affairs/component-library-monorepo",
   "description": "The monorepo containing the component library packages.",
-  "scripts": {},
+  "scripts": {
+    "chromatic-test": "echo \"Nothing to see here\""
+  },
   "private": true,
   "version": "1.0.0",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library-monorepo",
   "description": "The monorepo containing the component library packages.",
-  "scripts": {
-    "test": "stencil test --spec --e2e"
-  },
+  "scripts": {},
   "private": true,
   "version": "1.0.0",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@department-of-veterans-affairs/component-library-monorepo",
   "description": "The monorepo containing the component library packages.",
+  "scripts": {
+    "test": "stencil test --spec --e2e"
+  },
   "private": true,
   "version": "1.0.0",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@department-of-veterans-affairs/component-library-monorepo",
   "description": "The monorepo containing the component library packages.",
   "scripts": {
-    "chromatic-test": "echo \"Nothing to see here\""
+    "chromatic-bridge": "echo \"Nothing to see here\""
   },
   "private": true,
   "version": "1.0.0",


### PR DESCRIPTION
## Chromatic
<!-- This `chromatic-publish-error` is a placeholder for a CI job - it will be updated automatically -->
https://chromatic-publish-error--60f9b557105290003b387cd5.chromatic.com

## Description
Our Chromatic github workflow for publishing Storybook previews stopped working a few days ago. There is [an issue reported to the chromatic-cli](https://github.com/chromaui/chromatic-cli/issues/766) that is similar to what we are experiencing:

![Screenshot 2023-06-14 at 4 31 06 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/7ff350c2-cbe2-41fc-a9ac-689355e93595)

The resolution mentioned in that issue is to add an empty `"scripts": {},` tag to the root package.json file but this did not work in our case (see the failure below in commit [ffb57dc](https://github.com/department-of-veterans-affairs/component-library/pull/721/commits/ffb57dcdb7ee5db43f783a1bdd565b02ca01b8ee)). 

Adding a "fake script" _does_ work though (which is how this PR is passing at the moment):

```
  "scripts": {
    "chromatic-bridge": "echo \"Nothing to see here\""
  },
```

In an [older issue](https://github.com/chromaui/chromatic-cli/issues/686#issuecomment-1338300001), the following was suggested to avoid having to add an unnecessary script tag to the root package.json:

> Can you try adding the --storybook-build-dir REPLACE_ME_WITH_DIR here? The CLI currently infers how to build your storybook from the package.json file. If you build your storybook using the NX command and then point the CLI at the output directory using the flag above, you should get the desired outcome. Docs: https://www.chromatic.com/docs/cli#storybook-options

But it seems like we already have the `--storybook-build-dir` option set in our Github workflow so I'm not sure if it needs to be added somewhere else too?

https://github.com/department-of-veterans-affairs/component-library/blob/main/.github/workflows/chromatic.yml#L40

```
        uses: chromaui/action@v1
        with:
          token: $
          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
          projectToken: $
         storybookBuildDir: packages/storybook/storybook-static
```

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
