### PR TITLE
va-notification: align CLOSE text with card padding

### DIFF
--- a/packages/web-components/src/components/va-notification/va-notification.scss
+++ b/packages/web-components/src/components/va-notification/va-notification.scss
@@ -69,6 +69,11 @@ h6 {
   font-size: 17px;
   font-family: var(--font-serif);
   line-height: 22px;
+  width: 66%;
+
+  @media (min-width: 768px) {
+        width: 100%;
+    }
 }
 
 p {

--- a/packages/web-components/src/components/va-notification/va-notification.scss
+++ b/packages/web-components/src/components/va-notification/va-notification.scss
@@ -107,6 +107,7 @@ p {
 
 .va-notification-close > i {
     margin-right: 8px;
+    vertical-align: middle;
 }
 
 .va-notification-close > span {

--- a/packages/web-components/src/components/va-notification/va-notification.scss
+++ b/packages/web-components/src/components/va-notification/va-notification.scss
@@ -111,4 +111,5 @@ p {
 
 .va-notification-close > span {
     font-weight: 600;
+    margin-right: 5px;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `bug-va-notification-button-padding` is a placeholder for a CI job - it will be updated automatically -->
https://bug-va-notification-button-padding--60f9b557105290003b387cd5.chromatic.com

---
## Configuring this pull request
- [x] Link to any related issues in the description so they can be cross-referenced.
- [x] Under **Testing done**, be specific about how this update was tested. 
    - Examples: Storybook, Chrome, Browserstack, Mobile/Responsive, etc.
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [x] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/60661

## Testing done
- visually on local (Storybook)
- all e2e tests pass

## Screenshots
| Before | After |
| -- | -- |
| ![Screenshot 2023-06-21 at 3 33 56 PM](https://github.com/department-of-veterans-affairs/va.gov-team/assets/45603961/16ce7f97-625e-4d9d-92f1-1fb46971e1d4) |  ![Screenshot 2023-06-22 at 10 33 15 AM](https://github.com/department-of-veterans-affairs/component-library/assets/8542413/281ee0ad-01e5-4fe2-bda9-53cb7d6a54cb) |

## Acceptance criteria
- [x] Close and x icon are aligned properly
- [x] Padding matches all the way around
- [ ] Validation by @aagosto90 (see Chromatic link above)

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
