### PR TITLE
Accessibility fix for radio option width for va-radio-option.scss

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.41.3",
+  "version": "4.41.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -37,7 +37,8 @@
   display: flex;
   align-items: baseline;
   margin: 0;
-  width: 320px;
+  max-width: 320px;
+  width: auto;
   padding-left: 6px;
 }
 


### PR DESCRIPTION
## Chromatic
<!-- This `va-radio-option-max-width-patch` is a placeholder for a CI job - it will be updated automatically -->
https://va-radio-option-max-width-patch--60f9b557105290003b387cd5.chromatic.com

## Description
Change `width` from fixed width to `max-width` and added `width: auto` to address 400% zoom accessibility testing. 

Closes [#1797](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1797)

## Testing done
- Chrome
- Storybook

## Screenshots
<img width="942" alt="Screenshot 2023-06-22 at 4 49 50 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/1631062/27d9494f-71af-4232-9306-f5cfb7251270">
<img width="1037" alt="Screenshot 2023-06-22 at 4 53 33 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/1631062/55e39405-a40f-4163-9c7b-ed69a7a3b452">


## Acceptance criteria
- [x] Content doesn't overflow at 400% anymore and wraps instead. 

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
