### PR TITLE
va-table: Update MutationObserver for pagination

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.41.4",
+  "version": "4.41.5",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -133,7 +133,7 @@ export class VaTable {
     const slot = this.el.shadowRoot.querySelectorAll('slot')[1].assignedElements()[0] as HTMLSlotElement;
     const callback = mutationList => {
       for (const mutation of mutationList) {
-        if (mutation.type === 'childList') {
+        if (mutation.type === 'childList' || mutation.type === 'characterData') {
           handleCellAdjustments();
         }
       }
@@ -143,6 +143,7 @@ export class VaTable {
     this.observer.observe(slot, {
       childList: true,
       subtree: true,
+      characterData: true,
     });
   }
 


### PR DESCRIPTION
## Chromatic
<!-- This `1821-table-mutation-observer` is a placeholder for a CI job - it will be updated automatically -->
https://1821-table-mutation-observer--60f9b557105290003b387cd5.chromatic.com

## Description
It was [brought to our attention](https://dsva.slack.com/archives/C01DBGX4P45/p1687899378028149) that the pagination update previously made was not fully working with a certain data set. I was able to reproduce this issue locally based on this [codesandbox example](https://codesandbox.io/s/nervous-nightingale-ng7rp7?file=/src/App.js).

The issue seemed to be related to the way the data is provided as an array of objects rather than just arrays. In our original testing, I did not fully check these different data structures with the pagination.

Adding the `characterData` option to the observe() method makes sure that we are monitor subtrees in the slot as well as its descendants. Reference: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe

related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1821

## Testing done
Storybook

## Screenshots
Before

![Screenshot 2023-06-28 at 10 36 55 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/5da9b0d1-43c9-480f-9625-6f824f96707c)

After

![Screenshot 2023-06-28 at 10 39 28 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/730b31f7-abab-443d-aadf-2cb7287f9b16)


## Acceptance criteria
- [ ] Pagination is working with a data set that includes an array of objects.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
