### PR TITLE
Removing accordion-item tabindex

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.41.4",
+  "version": "4.41.5",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -21,7 +21,7 @@ describe('va-accordion-item', () => {
           </button>
         </h2>
         <slot name="headline"></slot>
-        <div id="content" tabindex="0">
+        <div id="content">
           <slot></slot>
         </div>
       </mock:shadow-root>
@@ -182,7 +182,7 @@ describe('va-accordion-item', () => {
           </button>
         </h2>
         <slot name="headline"></slot>
-        <div id="content" tabindex="0">
+        <div id="content">
           <slot></slot>
         </div>
       </mock:shadow-root>
@@ -207,7 +207,7 @@ describe('va-accordion-item', () => {
           </button>
         </h2>
         <slot name="headline"></slot>
-        <div id="content" tabindex="0">
+        <div id="content">
           <slot></slot>
         </div>
       </mock:shadow-root>

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -131,10 +131,10 @@ export class VaAccordionItem {
       <Host>
         <Header />
         <slot name="headline" onSlotchange={() => this.populateStateValues()} />
-        <div id="content" tabIndex={0}>
+        <div id="content">
           <slot />
         </div>
-      </Host >
+      </Host>
     );
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `asteele-accordion-tabindex-fix-1875` is a placeholder for a CI job - it will be updated automatically -->
https://asteele-accordion-tabindex-fix-1875--60f9b557105290003b387cd5.chromatic.com

## Description
Closes #[1875](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1875)

## Testing done
No testing done.

## Acceptance criteria
- [ ] Tabindex={0} removed

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
