### PR TITLE
va-memorable-date: Change two and four to 2 and 4

### DIFF
--- a/packages/core/src/i18n/translations/en.js
+++ b/packages/core/src/i18n/translations/en.js
@@ -28,7 +28,7 @@ export default {
   'november': 'November',
   'december': 'December',
   'on-this-page': 'On this page',
-  'date-hint': 'Please enter two digits for the month and day and four digits for the year',
+  'date-hint': 'Please enter 2 digits for the month and day and 4 digits for the year',
   'date-hint-with-select': 'For example: January 19 2000',
   'date-error': 'Please enter a complete date',
   'gov-site-label': 'Official website of the United States government',

--- a/packages/core/src/i18n/translations/es.js
+++ b/packages/core/src/i18n/translations/es.js
@@ -28,7 +28,7 @@ export default {
   'november': 'Noviembre',
   'december': 'Diciembre',
   'on-this-page': 'En esta página',
-  'date-hint': 'Ingrese dos dígitos para el mes y el día y cuatro dígitos para el año',
+  'date-hint': 'Ingrese 2 dígitos para el mes y el día y 4 dígitos para el año',
   'date-hint-with-select': 'Por ejemplo: Enero 19 2000',
   'date-error': 'Ingrese una fecha completa',
   'gov-site-label': 'Un sitio oficial del Gobierno de Estados Unidos',

--- a/packages/core/src/i18n/translations/tl.js
+++ b/packages/core/src/i18n/translations/tl.js
@@ -15,6 +15,6 @@ export default {
   'expand-all-aria-label': 'I-expand ang lahat ng accordion',
   'collapse-all-aria-label': 'I-collapse ang lahat ng accordion',
   'on-this-page': 'Sa pahinang ito',
-  'date-hint': 'Mangyaring maglagay ang dalawang numero para sa buwan at araw at apat na numero para sa taon',
+  'date-hint': 'Mangyaring magpasok ng 2 numero para sa buwan at araw at 4 na numero para sa taon',
   'date-error': 'Mangyaring maglagay ng kumpletong petsa',
 };


### PR DESCRIPTION
## Chromatic
<!-- This `1791-memorable-date-numbers` is a placeholder for a CI job - it will be updated automatically -->
https://1791-memorable-date-numbers--60f9b557105290003b387cd5.chromatic.com

## Description
Replace "two" and "four" in the en.js translation bundle with "2" and "4"

Task: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1791

## Testing done
Local browser testing in chrome

## Screenshots
Before:
![Screenshot 2023-06-28 at 3 40 13 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/302df7d3-f76f-4847-ac06-c49e49f18d4b)

After: 
![Screenshot 2023-06-28 at 3 38 43 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/9a93d6a3-c54a-4441-8c22-d95e671893f2)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
