### PR TITLE
sync va-radio margin top with uswds

### DIFF
--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -17,6 +17,10 @@
   padding: 0;
 }
 
+:host([uswds]) {
+  margin-top: 24px;
+}
+
 /* Original Component Styles. */
 
 @import '../../mixins/accessibility.css';


### PR DESCRIPTION
## Chromatic
<!-- This `1780-update-va-radio-margin-top` is a placeholder for a CI job - it will be updated automatically -->
https://1780-update-va-radio-margin-top--60f9b557105290003b387cd5.chromatic.com

---
## Description
Make the margin top of va-radio component consistent with the corresponding USWDS component
Task: https://app.zenhub.com/workspaces/platform-design-system-5f8de67192551b0012ebb802/issues/gh/department-of-veterans-affairs/vets-design-system-documentation/1780 

## Testing done
local testing in chrome

## Screenshots
Before:
<img width="390" alt="Screenshot 2023-07-05 at 9 41 17 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/7ef603d2-4b2f-4f21-ab4b-c55e24e06b9e">

After:
<img width="393" alt="Screenshot 2023-07-05 at 9 44 47 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/3d9b8e0a-c2bb-45dd-9e87-f08ca68a6a5f">


## Acceptance criteria
- [ ]

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
