### PR TITLE
sync margin top of checkbox-group with uswds

### DIFF
--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.scss
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.scss
@@ -13,6 +13,10 @@
   padding: 0;
 }
 
+:host([uswds]) {
+  margin-top: 24px;
+}
+
 /* Original Component Style */
 
 @import '../../mixins/accessibility.css';


### PR DESCRIPTION
## Chromatic
<!-- This `1780-update-va-checkbox-group-margin-top` is a placeholder for a CI job - it will be updated automatically -->
https://1780-update-va-checkbox-group-margin-top--60f9b557105290003b387cd5.chromatic.com

---

## Description
Make the margin top of va-checkbox-group component consistent with the corresponding USWDS component
Task: https://app.zenhub.com/workspaces/platform-design-system-5f8de67192551b0012ebb802/issues/gh/department-of-veterans-affairs/vets-design-system-documentation/1780

## Testing done
local testing in chrome

## Screenshots
Before:
<img width="409" alt="Screenshot 2023-07-05 at 12 22 45 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/758c0244-3a62-4611-bc11-6dac8ea421af">

After:
<img width="429" alt="Screenshot 2023-07-05 at 12 23 26 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/4f367686-ddfb-4087-8d5c-b2d0aa7ab918">


## Acceptance criteria
- [ ]

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
