### PR TITLE
va-notification: Add analytics for link and close

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -587,6 +587,10 @@ export namespace Components {
          */
         "closeable"?: boolean;
         /**
+          * If `true`, the component-library-analytics event is disabled.
+         */
+        "disableAnalytics"?: boolean;
+        /**
           * If `false`, card will not have border
          */
         "hasBorder"?: boolean;
@@ -2264,6 +2268,10 @@ declare namespace LocalJSX {
          */
         "closeable"?: boolean;
         /**
+          * If `true`, the component-library-analytics event is disabled.
+         */
+        "disableAnalytics"?: boolean;
+        /**
           * If `false`, card will not have border
          */
         "hasBorder"?: boolean;
@@ -2287,6 +2295,10 @@ declare namespace LocalJSX {
           * Fires when the component is closed by clicking on the close icon. This fires only when closeable is true.
          */
         "onCloseEvent"?: (event: VaNotificationCustomEvent<any>) => void;
+        /**
+          * The event used to track usage of the component.
+         */
+        "onComponent-library-analytics"?: (event: VaNotificationCustomEvent<any>) => void;
         /**
           * Symbol indicates type of notification  Current options are: action-required, update
          */


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1803

## Testing done
Storybook

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
