### PR TITLE
va-alert Storybook: Remove action link and add button for sign-in prompt

### DIFF
--- a/packages/storybook/stories/va-alert-uswds.stories.jsx
+++ b/packages/storybook/stories/va-alert-uswds.stories.jsx
@@ -46,7 +46,7 @@ const defaultArgs = {
   ),
   'children': (
     <p className="vads-u-margin-y--0">
-      Lorem ipsum dolor sit amet, <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.
+      Lorem ipsum dolor sit amet <a class="usa-link" href="javascript:void(0);">consectetur adipiscing</a> elit sed do eiusmod.
     </p>
   ),
 };
@@ -203,7 +203,7 @@ SignInOrToolPrompt.args = {
   ...defaultArgs,
   children: (
     <>
-      <p className="vads-u-margin-top--0">
+      <p className="vads-u-margin-y--0">
         You can use our new mobile app to check the status of your claims or
         appeals on your mobile device. Download the{' '}
         <strong>VA: Health and Benefits</strong> mobile app to get started.
@@ -264,7 +264,7 @@ Warning.args = {
   ),
   children: (
     <>
-      <p className="vads-u-margin-top--0">
+      <p className="vads-u-margin-y--0">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.
       </p>
     </>
@@ -275,16 +275,12 @@ Warning.args = {
 export const Error = Template.bind(null);
 Error.args = {
   ...defaultArgs,
-  headline: <h2 slot="headline">Please sign in to review your information</h2>,
+  headline: <h2 slot="headline">Sorry, we couldn't find any eligible issues</h2>,
   children: (
     <>
-      <p className="vads-u-margin-top--0">
-        We’re sorry for the interruption, but we’ve found some more information
-        that we need you to review before you can apply for VA health care.
-        Please sign in to VA.gov to review. If you don’t have an account, you
-        can create one now.
+      <p className="vads-u-margin-y--0">
+        If you’d like to add an issue for review, select "Add a new issue" to get started.
       </p>
-      <button class="usa-button-primary" type="button">Sign in to VA.gov</button>
     </>
   ),
   status: 'error',

--- a/packages/storybook/stories/va-alert-uswds.stories.jsx
+++ b/packages/storybook/stories/va-alert-uswds.stories.jsx
@@ -208,10 +208,35 @@ SignInOrToolPrompt.args = {
         appeals on your mobile device. Download the{' '}
         <strong>VA: Health and Benefits</strong> mobile app to get started.
       </p>
-      <a className="vads-c-action-link--green" href="#">Sign in to VA.gov</a>
     </>
   ),
   status: 'continue',
+};
+
+export const SignInToStartYourApplication = Template.bind(null);
+SignInToStartYourApplication.args = {
+  ...defaultArgs,
+  headline: (
+    <h2 slot="headline">
+      Sign in now to save time and save your work in progress
+    </h2>
+  ),
+  children: (
+    <div>
+      <p className="vads-u-margin-top--0">
+        Here's how signing in now helps you:
+      </p>
+      <ul>
+        <li>We can fill in some of your information for you to save you time.</li>
+        <li>You can save your work in progress. You'll have 60 days from when you start or make updates to your application to come back and finish it.</li>
+      </ul>
+      <p><strong>Note:</strong> You can sign in after you start your application. But you'll lose any information you already filled in.</p>
+      <button class="usa-button-primary" type="button">Sign in to start your application</button>
+      <p>
+        <a href="#start">Start your application without signing in</a>
+      </p>
+    </div>
+  )
 };
 
 export const Success = Template.bind(null);
@@ -259,7 +284,7 @@ Error.args = {
         Please sign in to VA.gov to review. If you don’t have an account, you
         can create one now.
       </p>
-      <a className="vads-c-action-link--green" href="#">Sign in to VA.gov</a>
+      <button class="usa-button-primary" type="button">Sign in to VA.gov</button>
     </>
   ),
   status: 'error',

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -134,13 +134,10 @@ const BackgroundOnlyTemplate = ({
         class="vads-u-margin-bottom--1"
       >
         <div>
-          <p className="vads-u-margin-top--0">
-            We’re sorry for the interruption, but we’ve found some more
-            information that we need you to review before you can apply for VA
-            health care. Please sign in to VA.gov to review. If you don’t have
-            an account, you can create one now.
+          <p className="vads-u-margin-y--0">
+          Sorry, we couldn’t find any eligible issues. If you’d like to add an issue for review, select "Add a new issue" to
+          get started.
           </p>
-          <a className="vads-c-action-link--green" href="#">Sign in to VA.gov</a>
         </div>
       </va-alert>
       <va-alert
@@ -192,7 +189,6 @@ const BackgroundOnlyTemplate = ({
             appeals on your mobile device. Download the{' '}
             <strong>VA: Health and Benefits</strong> mobile app to get started.
           </p>
-          <a className="vads-c-action-link--green" href="#">Sign in to VA.gov</a>
         </div>
       </va-alert>
     </>
@@ -215,7 +211,6 @@ SignInOrToolPrompt.args = {
         appeals on your mobile device. Download the{' '}
         <strong>VA: Health and Benefits</strong> mobile app to get started.
       </p>
-      <a className="vads-c-action-link--green" href="#">Sign in to VA.gov</a>
     </div>
   ),
   status: 'continue',
@@ -239,8 +234,8 @@ SignInToStartYourApplication.args = {
         <li>You can save your work in progress. You'll have 60 days from when you start or make updates to your application to come back and finish it.</li>
       </ul>
       <p><strong>Note:</strong> You can sign in after you start your application. But you'll lose any information you already filled in.</p>
-      <a className="vads-c-action-link--green" href="#">Sign in to start your application</a>
-      <p className="vads-u-margin-bottom--1">
+      <button class="usa-button-primary" type="button">Sign in to start your application</button>
+      <p>
         <a href="#start">Start your application without signing in</a>
       </p>
     </div>
@@ -290,16 +285,12 @@ Warning.args = {
 export const Error = Template.bind(null);
 Error.args = {
   ...defaultArgs,
-  headline: <h2 slot="headline">Please sign in to review your information</h2>,
+  headline: (
+    <h2 slot="headline">Sorry, we couldn’t find any eligible issues</h2>
+  ),
   children: (
-    <div>
-      <p className="vads-u-margin-top--0">
-        We’re sorry for the interruption, but we’ve found some more information
-        that we need you to review before you can apply for VA health care.
-        Please sign in to VA.gov to review. If you don’t have an account, you
-        can create one now.
-      </p>
-      <a className="vads-c-action-link--green" href="#">Sign in to VA.gov</a>
+    <div className="vads-u-margin-y--0">
+      <p className="vads-u-margin-bottom--0">If you’d like to add an issue for review, select "Add a new issue" to get started.</p>
     </div>
   ),
   status: 'error',


### PR DESCRIPTION
## Chromatic
<!-- This `update-va-alert-storybook` is a placeholder for a CI job - it will be updated automatically -->
https://update-va-alert-storybook--60f9b557105290003b387cd5.chromatic.com

## Description
This PR adds back the sign-in button (instead of action) to the "Sign in to start your application" example in Storybook as well as adds that example to the USWDS variation. We are changing it back to button because the sign-in is a modal which should be triggered by a [button instead of a link](https://design.va.gov/components/button/#when-to-use-a-button).

Related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/908

## Testing done
Storybook locally

## Screenshots

![Screenshot 2023-07-06 at 12 25 15 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/a63df7fa-386f-486b-a0ab-9c02499bfb01)

![Screenshot 2023-07-06 at 12 25 09 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/1a9b57c2-8918-48cc-a1ee-b09b4f217512)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
