### PR TITLE
61157 - Remove role="alert" from va-notification. Update package.json versions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "17.0.1",
+  "version": "17.0.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.1",
+  "version": "4.42.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-notification/test/va-notification.e2e.ts
+++ b/packages/web-components/src/components/va-notification/test/va-notification.e2e.ts
@@ -12,7 +12,7 @@ describe('va-notification', () => {
       <va-notification class="hydrated" has-border="" headline="Notification heading">
         <mock:shadow-root>
           <va-card show-shadow="true" class="hydrated show-shadow va-card">
-            <div class="va-notification none has-border" role="alert">
+            <div class="va-notification none has-border">
               <i aria-hidden="true" role="img" class="none"></i>
               <div class="body" role="presentation">
                 <h3 part="headline">Notification heading</h3>

--- a/packages/web-components/src/components/va-notification/va-notification.tsx
+++ b/packages/web-components/src/components/va-notification/va-notification.tsx
@@ -1,11 +1,11 @@
-import { 
-  Component, 
+import {
+  Component,
   Element,
   Event,
   EventEmitter,
-  Host, 
-  Prop, 
-  h 
+  Host,
+  Prop,
+  h
 } from '@stencil/core';
 import classnames from 'classnames';
 
@@ -29,7 +29,7 @@ export class VaNotification {
   @Prop() visible?: boolean = true;
 
   /**
-   * Symbol indicates type of notification 
+   * Symbol indicates type of notification
    * Current options are: action-required, update
    */
   @Prop() symbol?: string = 'none';
@@ -73,7 +73,7 @@ export class VaNotification {
    * Text for destination link. Set to empty string if you don't want a link.
    */
   @Prop() text?: string;
-  
+
   /**
    * Fires when the component is closed by clicking on the close icon. This fires only
    * when closeable is true.
@@ -113,7 +113,7 @@ export class VaNotification {
     return (
       <Host>
         <va-card show-shadow="true">
-          <div class={classes} role="alert">
+          <div class={classes}>
             <i aria-hidden="true" role="img" class={symbol}></i>
             <div class="body" role="presentation">
               {headline ? <HeadlineLevel part="headline">{headline}</HeadlineLevel> : null}


### PR DESCRIPTION
## Chromatic
<!-- This `61157-va-notification-role` is a placeholder for a CI job - it will be updated automatically -->
https://61157-va-notification-role--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/61157
- On the `<va-notification>` web-component, remove the `role="alert"` attribute so it does not read every `va-notification` immediately on page load

## Testing done
- Manual testing on chrome/safari with VoiceOver utility on Mac

## Screenshots
Before (with all notifications):

https://github.com/department-of-veterans-affairs/component-library/assets/15200011/84c572c0-ded2-4d86-8db9-2bdacd6443f7


After removing role="alert":

https://github.com/department-of-veterans-affairs/component-library/assets/15200011/e2cf44c0-6e22-4b46-89e1-d160aae39907


## Acceptance criteria
- [ ] The `<va-notification>` component no longer has `role="alert"`, so it does not announce every alert notification when the page loads

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
