### PR TITLE
Update styles to fix buttons from overflowing on modals (non-uswds)

### DIFF
--- a/packages/storybook/stories/va-modal.stories.jsx
+++ b/packages/storybook/stories/va-modal.stories.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { VaModal } from '@department-of-veterans-affairs/web-components/react-bindings';
+import { VaModal, VaButtonPair } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 VaModal.displayName = 'VaModal';
@@ -271,3 +271,63 @@ CrisisLineModal.args = {
 
 export const Large = Template.bind(null);
 Large.args = { ...defaultArgs, large: true };
+
+const ButtonPairTemplate = ({
+  'click-to-close': clickToClose,
+  'disable-analytics': disableAnalytics,
+  large,
+  'modal-title': modalTitle,
+  'initial-focus-selector': initialFocusSelector,
+  primaryButtonClick,
+  'primary-button-text': primaryButtonText,
+  secondaryButtonClick,
+  'secondary-button-text': secondaryButtonText,
+  status,
+  visible,
+  uswds,
+  forcedModal,
+}) => {
+  const [isVisible, setIsVisible] = useState(visible);
+  const onCloseEvent = () => setIsVisible(!isVisible);
+  const openModal = () => setIsVisible(true);
+  return (
+    <div>
+      <h1>Testing h1 heading</h1>
+      <button onClick={openModal}>Click here to open modal</button>
+      <VaModal
+        forcedModal={forcedModal}
+        clickToClose={clickToClose}
+        disableAnalytics={disableAnalytics}
+        large={large}
+        modalTitle={modalTitle}
+        initialFocusSelector={initialFocusSelector}
+        onCloseEvent={onCloseEvent}
+        onPrimaryButtonClick={primaryButtonClick}
+        primaryButtonText={primaryButtonText}
+        onSecondaryButtonClick={secondaryButtonClick}
+        secondaryButtonText={secondaryButtonText}
+        status={status}
+        visible={isVisible}
+      >
+        <p>
+          You have unsaved changes that will be lost.
+        </p>
+        <VaButtonPair
+          onPrimaryClick={() => {}}
+          onSecondaryClick={function noRefCheck() {}}
+        />
+      </VaModal>
+    </div>
+  );
+};
+
+
+
+export const WithButtonPair = ButtonPairTemplate.bind(null);
+WithButtonPair.args = {
+  ...defaultArgs,
+  'primaryButtonClick': undefined,
+  'primary-button-text': undefined,
+  'secondaryButtonClick': undefined,
+  'secondary-button-text': undefined,
+};

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.3",
+  "version": "4.42.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -607,7 +607,7 @@ export namespace Components {
          */
         "href"?: string;
         /**
-          * Symbol indicates type of notification  Current options are: action-required, update
+          * Symbol indicates type of notification Current options are: action-required, update
          */
         "symbol"?: string;
         /**
@@ -2288,7 +2288,7 @@ declare namespace LocalJSX {
          */
         "onCloseEvent"?: (event: VaNotificationCustomEvent<any>) => void;
         /**
-          * Symbol indicates type of notification  Current options are: action-required, update
+          * Symbol indicates type of notification Current options are: action-required, update
          */
         "symbol"?: string;
         /**

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.scss
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.scss
@@ -31,7 +31,7 @@
 }
 
 :host(:not([uswds])) {
-  width: 560px;
+  max-width: 560px;
 }
 
 :host(:not([uswds])) va-button::part(button) {
@@ -82,7 +82,7 @@
 @media (max-width: 320px) {
   :host(:not([uswds])) {
     margin: 0 auto;
-    width: 280px;
+    max-width: 280px;
   }
 
   :host([continue]:not([continue='false']):not([uswds])) va-button::part(button) {

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.scss
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.scss
@@ -31,7 +31,7 @@
 }
 
 :host(:not([uswds])) {
-  max-width: 560px;
+  width: 560px;
 }
 
 :host(:not([uswds])) va-button::part(button) {
@@ -82,7 +82,7 @@
 @media (max-width: 320px) {
   :host(:not([uswds])) {
     margin: 0 auto;
-    max-width: 280px;
+    width: 280px;
   }
 
   :host([continue]:not([continue='false']):not([uswds])) va-button::part(button) {

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.scss
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.scss
@@ -68,7 +68,7 @@
 
 @media (max-width: 481px) {
   :host(:not([uswds])) {
-    width: 441px;
+    width: 100%;
   }
 
   :host([continue]:not([continue='false']):not([uswds])) va-button::part(button) {

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.scss
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.scss
@@ -26,8 +26,17 @@
 
 /* Original Component Styles. */
 
+:host(:not([uswds])) va-button {
+  flex: 1 1 auto;
+}
+
+:host(:not([uswds])) {
+  max-width: 560px;
+}
+
 :host(:not([uswds])) va-button::part(button) {
-  width: 280px;
+  max-width: 280px;
+  width: 100%;
 }
 
 @media (min-width: 481px) {
@@ -44,6 +53,7 @@
 @media (min-width: 481px) {
   :host(:not([uswds])) {
     flex-direction: row;
+    max-width: 420px;
   }
 
   :host(:not([uswds])) va-button + va-button::part(button) {
@@ -52,7 +62,7 @@
   }
 
   :host(:not([uswds])) va-button::part(button) {
-    width: 210px;
+    max-width: 210px;
   }
 }
 
@@ -62,7 +72,7 @@
   }
 
   :host([continue]:not([continue='false']):not([uswds])) va-button::part(button) {
-    width: 280px;
+    max-width: 280px;
   }
   :host([continue]:not([continue='false'])) {
     flex-direction: column-reverse;
@@ -72,10 +82,10 @@
 @media (max-width: 320px) {
   :host(:not([uswds])) {
     margin: 0 auto;
-    width: 280px;
+    max-width: 280px;
   }
 
   :host([continue]:not([continue='false']):not([uswds])) va-button::part(button) {
-    width: 280px;
+    max-width: 280px;
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `59774-cut-off-buttons` is a placeholder for a CI job - it will be updated automatically -->
https://59774-cut-off-buttons--60f9b557105290003b387cd5.chromatic.com

## Description
- Change button widths to max-widths to make them flexible and able to fit inside modals
- Give buttons a flex: 1 1 auto so they will fill the space available
- Define a width on the button pair to constrain the width when not inside a modal
- Added a story on the va-modal to test with and verify changes

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/59774

## Testing done
- Local testing in Chrome, Firefox, Safari, and Edge (Both Modal and ButtonPair)

## Screenshots

Button Pair: 
![Screenshot 2023-07-07 at 3 32 11 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/5e5df7f4-1cbd-411b-8751-dfa9162f2e23)

Button Pair inside modal:
![Screenshot 2023-07-07 at 3 34 27 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/538a8b9c-0ee3-406d-920c-52f1b32ea94d)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
