### PR TITLE
va-back-to-top: Change button to anchor link

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.3",
+  "version": "4.42.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.4",
+  "version": "4.42.5",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.5",
+  "version": "4.42.6",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
+++ b/packages/web-components/src/components/va-back-to-top/test/va-back-to-top.e2e.ts
@@ -45,7 +45,7 @@ describe('va-back-to-top', () => {
     const wrapper = await page.find('va-back-to-top >>> div');
     const notQuitePastRevealPoint = 199;
 
-    // Button shouldn't be revealed initially
+    // Link shouldn't be revealed initially
     expect(wrapper).not.toHaveClass('reveal');
 
     // Scroll until the `<span class="reveal-point">` is just at
@@ -53,14 +53,14 @@ describe('va-back-to-top', () => {
     await page.mouse.wheel({ deltaY: notQuitePastRevealPoint });
     await page.waitForChanges();
 
-    // Button _still_ shouldn't be revealed after a bit of scrolling
+    // Link _still_ shouldn't be revealed after a bit of scrolling
     expect(wrapper).not.toHaveClass('reveal');
 
     // Scroll a few pixels more to get past the `--reveal-breakpoint`
     await page.mouse.wheel({ deltaY: 10 });
     await page.waitForChanges();
 
-    // Button should be revealed with `.reveal-point` above the viewport
+    // Link should be revealed with `.reveal-point` above the viewport
     expect(wrapper).toHaveClass('reveal');
   });
 
@@ -77,7 +77,7 @@ describe('va-back-to-top', () => {
 
     expect(await wrapper.isIntersectingViewport()).toEqual(true);
 
-    // We've scrolled a lot - button should be docked
+    // We've scrolled a lot - link should be docked
     expect(wrapper).toHaveClass('docked');
   });
 
@@ -104,17 +104,17 @@ describe('va-back-to-top', () => {
 
   it('goes to top on click', async () => {
     const page = await pageSetup();
-    const button = await page.find('va-back-to-top >>> button');
+    const anchor = await page.find('va-back-to-top >>> a');
     const topHeading = await page.find('h1');
     const pastRevealPoint = 300;
 
-    // Scroll far enough to make the button visible
+    // Scroll far enough to make the anchor visible
     await page.mouse.wheel({ deltaY: pastRevealPoint });
     await page.waitForChanges();
 
     expect(await topHeading.isIntersectingViewport()).toEqual(false);
 
-    button.click();
+    anchor.click();
     await page.waitForChanges();
 
     expect(await topHeading.isIntersectingViewport()).toEqual(true);

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
@@ -95,6 +95,10 @@ a span.text {
   font-weight: 700;
 }
 
+a span.sr-only {
+  visibility: visible;
+}
+
 div.docked {
   position: relative;
   display: flex;
@@ -136,6 +140,10 @@ i::before {
     color: var(--color-link-default);
     display: inline-block;
     text-decoration: underline;
+  }
+
+  a span.sr-only {
+    visibility: hidden;
   }
 
   i {

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
@@ -42,8 +42,16 @@ a {
   position: absolute;
   transition: all 0.25s ease-in;
 }
-a:active, a:focus {
+a:not([disabled]):active, a:not([disabled]):focus {
   border-radius: 5px;
+  outline: 2px solid var(--color-gold-light);
+  outline-offset: 2px;
+}
+a:not([disabled]):hover {
+  background-color: var(--color-gray-cool-light);
+  border-radius: 0;
+  color: var(--color-primary-darker);
+  outline: none;
 }
 div.reveal a {
   border-bottom-left-radius: 5px;

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
@@ -1,6 +1,7 @@
 @import '../../../../../node_modules/animate.css/source/sliding_entrances/slideInUp.css';
 @import '../../../../../node_modules/animate.css/source/sliding_exits/slideOutDown.css';
 @import '../../mixins/buttons.css';
+@import '../../mixins/accessibility.css';
 
 #marginWrapper {
   display: block;
@@ -26,14 +27,14 @@ div {
   /* width: 100%;  /1* For debugging in browser *1/ */
 }
 
-button {
-  bottom: 0;
-  right: 0;
-  background-color: var(--color-gray-dark);
+a {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
-  height: 44px;
-  width: 44px;
+  bottom: 0;
+  right: 0;
+  background: rgba(255, 255, 255, 0.9);
+  height: 48px;
+  width: 48px;
   margin-bottom: 0.5rem;
   opacity: 0;
   padding: 0;
@@ -41,32 +42,49 @@ button {
   position: absolute;
   transition: all 0.25s ease-in;
 }
-button:hover {
-  background-color: var(--color-black);
+a:active, a:focus {
+  border-radius: 5px;
 }
-div.reveal button {
+div.reveal a {
+  border-bottom-left-radius: 5px;
+  border-top-left-radius: 5px;
+  text-decoration: none;
   pointer-events: auto;
   opacity: 1;
   animation: slideInUp 0.25s;
 }
-div:not(.reveal) button {
+div.reveal a > span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+div:not(.reveal) a {
   animation: slideOutDown 0.25s;
 }
 
 @media (prefers-reduced-motion) {
-  button {
+  a {
     transition: none;
   }
-  div.reveal button {
+  div.reveal a {
     animation: none;
   }
-  div:not(.reveal) button {
+  div:not(.reveal) a {
     animation: none;
   }
 }
 
-button span {
+a > span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+}
+
+a span.text {
   display: none;
+  font-weight: 700;
 }
 
 div.docked {
@@ -81,37 +99,42 @@ div:not(.docked):not(.reveal) {
   position: relative;
 }
 
-div.docked button {
+div.docked a {
   position: relative;
 }
 
 i {
-  font-size: 2rem;
-}
-i {
+  align-self: flex-start;
   font-family: 'Font Awesome 5 Free';
+  font-size: 2rem;
   font-style: normal;
   font-weight: 900;
+  padding-top: 10px;
 }
 i::before {
   content: '\F062'; /* fa-arrow-up*/
 }
 
 @media (min-width: 768px) {
-  button {
+  a {
+    height: 44px;
+    width: 44px;
     padding: 0 1.6rem;
+    text-decoration: none;
     width: auto;
-    border-bottom-right-radius: 5px;
-    border-top-right-radius: 5px;
   }
 
-  button span {
+  a span.text {
+    color: var(--color-link-default);
     display: inline-block;
+    text-decoration: underline;
   }
 
   i {
-    padding-right: 0.8rem;
-    padding-top: 1.2rem;
+    color: var(--color-link-default);
+    padding-right: 8px;
+    padding-top: 11px;
     font-size: 1em;
+    text-decoration: none;
   }
 }

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
@@ -31,6 +31,7 @@ a {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
   bottom: 0;
+  color: var(--color-link-default);
   right: 0;
   background: rgba(255, 255, 255, 0.9);
   height: 48px;

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
@@ -52,7 +52,8 @@ export class VaBackToTop {
     revealObserver.observe(this.revealPixel);
   }
 
-  navigateToTop() {
+  navigateToTop(event) {
+    event.preventDefault();
     // Focus the h1 tag on the page.
     const el = document.querySelector('h1');
     if (el) {
@@ -86,10 +87,13 @@ export class VaBackToTop {
           <div
             class={classnames({ docked: this.isDocked, reveal: this.revealed })}
           >
-            <button type="button" onClick={this.navigateToTop.bind(this)}>
-              <i aria-hidden="true" role="img"></i>
-              <span>Back to top</span>
-            </button>
+            <a href="#ds-back-to-top" onClick={this.navigateToTop.bind(this)}>
+              <span>
+                <i aria-hidden="true" role="img"></i>
+                <span class="sr-only">Back to top</span> {/* For small screen that only displays the arrow */}
+                <span class="text">Back to top</span>
+              </span>
+            </a>
           </div>
         </span>
       </Host>


### PR DESCRIPTION
## Chromatic
<!-- This `899-back-to-top-a11y` is a placeholder for a CI job - it will be updated automatically -->
https://899-back-to-top-a11y--60f9b557105290003b387cd5.chromatic.com/?path=/docs/components-va-back-to-top--default

## Description

Sketch: https://www.sketch.com/s/73212626-acc4-47e6-acd8-d4e2f5a98372

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/899
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/58413
Related https://github.com/department-of-veterans-affairs/va.gov-team/issues/60812

## Testing done
Storybook
Voiceover
vets website locally

## Screenshots

![Screenshot 2023-07-13 at 1 10 14 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/1c0762ea-418c-4cb7-8665-ceebf7715f06)

![Screenshot 2023-07-13 at 1 10 10 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/e382685c-82b5-4baa-aa6c-c9e66482c60b)

![Screenshot 2023-07-13 at 1 10 05 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/2719c344-88e0-43a6-adbc-ad479428c185)

![Screenshot 2023-07-13 at 1 55 42 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/0958bd54-fcf1-4bb4-8d5f-513668169160)



Vets Website Demo

https://github.com/department-of-veterans-affairs/component-library/assets/872479/f82c896a-6f12-416e-97df-6a8520399024




## Acceptance criteria
- [ ] va-back-to-top has been updated from a button to a link

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
