### PR TITLE
va-memorable-date: Fix clearing error message bug

### DIFF
--- a/packages/storybook/stories/va-memorable-date-uswds.stories.jsx
+++ b/packages/storybook/stories/va-memorable-date-uswds.stories.jsx
@@ -66,6 +66,7 @@ const CustomValidationTemplate = ({ label, name, required, error, uswds, value }
         name={name}
         required={required}
         error={errorVal}
+        invalidYear={!!errorVal || null}
         value={dateVal}
         onDateBlur={() => handleDateBlur()}
         onDateChange={e => setDateVal(e.target.value)}
@@ -78,6 +79,20 @@ const CustomValidationTemplate = ({ label, name, required, error, uswds, value }
         error prop to be dynamically set if the parameters are not met.
       </div>
       <div className="vads-u-margin-top--2">
+      <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2"><code>
+const [dateVal, setDateVal] = useState(value);<br/>
+const [errorVal, setErrorVal] = useState(error);<br/>
+const today = new Date();<br/>
+// new Date as YYYY-MM-DD is giving the day prior to the day select<br/>
+// new Date as YYYY MM DD is giving the correct day selected<br/>
+const dateInput = new Date(dateVal.split('-').join(' '));<br/>
+function handleDateBlur() &#x7b;<br/>
+  if (dateInput &lt;= today) &#x7b;<br/>
+    setErrorVal('Date must be in the future');<br/>
+  &#x7d; else &#x7b;<br/>
+    setErrorVal('');<br/>
+  &#x7d;<br/>
+&#x7d;</code></pre>
         <a
           href="https://github.com/department-of-veterans-affairs/component-library/tree/main/packages/storybook/stories"
           target="_blank"
@@ -119,8 +134,8 @@ Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(memorableDateInputDocs);
 
 export const Error = Template.bind(null);
-Error.args = { 
-  ...defaultArgs, 
+Error.args = {
+  ...defaultArgs,
   error: 'Error Message Example',
 };
 

--- a/packages/storybook/stories/va-memorable-date.stories.jsx
+++ b/packages/storybook/stories/va-memorable-date.stories.jsx
@@ -79,6 +79,7 @@ const CustomValidationTemplate = ({ label, name, required, error, value, hint })
         hint={hint}
         required={required}
         error={errorVal}
+        invalidYear={!!errorVal || null}
         value={dateVal}
         onDateBlur={() => handleDateBlur()}
         onDateChange={e => setDateVal(e.target.value)}
@@ -91,6 +92,20 @@ const CustomValidationTemplate = ({ label, name, required, error, value, hint })
         error prop to be dynamically set if the parameters are not met.
       </div>
       <div className="vads-u-margin-top--2">
+        <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2"><code>
+const [dateVal, setDateVal] = useState(value);<br/>
+const [errorVal, setErrorVal] = useState(error);<br/>
+const today = new Date();<br/>
+// new Date as YYYY-MM-DD is giving the day prior to the day select<br/>
+// new Date as YYYY MM DD is giving the correct day selected<br/>
+const dateInput = new Date(dateVal.split('-').join(' '));<br/>
+function handleDateBlur() &#x7b;<br/>
+  if (dateInput &lt;= today) &#x7b;<br/>
+    setErrorVal('Date must be in the future');<br/>
+  &#x7d; else &#x7b;<br/>
+    setErrorVal('');<br/>
+  &#x7d;<br/>
+&#x7d;</code></pre>
         <a
           href="https://github.com/department-of-veterans-affairs/component-library/tree/main/packages/storybook/stories"
           target="_blank"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.4",
+  "version": "4.42.5",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -78,6 +78,24 @@ describe('va-memorable-date', () => {
     expect(error.innerText).toContain('This is a mistake');
   });
 
+  it('maintains custom error message after multiple blurs', async () => {
+    const page = await newE2EPage();
+
+    // await page.addScriptTag({ content: ``);
+    await page.setContent(
+      '<va-memorable-date value="1999-05-03" name="test" error="custom error" />',
+    );
+    const date = await page.find('va-memorable-date');
+
+    const handleYear = await page.$('pierce/[name="testYear"]');
+    // Trigger Blur
+    await handleYear.press('Tab');
+    // Trigger Blur twice
+    await handleYear.press('Tab');
+
+    expect(date.getAttribute('error')).toEqual('custom error');
+  });
+
   it('renders a required span', async () => {
     const page = await newE2EPage();
     await page.setContent(
@@ -697,6 +715,24 @@ describe('va-memorable-date', () => {
     const error = await page.find('va-memorable-date >>> span#error-message');
     // expect(error).toEqualHtml('test');
     expect(error.innerText).toContain('This is a mistake');
+  });
+
+  it('uswds v3 maintains custom error message after multiple blurs', async () => {
+    const page = await newE2EPage();
+
+    // await page.addScriptTag({ content: ``);
+    await page.setContent(
+      '<va-memorable-date value="1999-05-03" name="test" error="custom error" uswds />',
+    );
+    const date = await page.find('va-memorable-date');
+
+    const handleYear = await page.$('pierce/[name="testYear"]');
+    // Trigger Blur
+    await handleYear.press('Tab');
+    // Trigger Blur twice
+    await handleYear.press('Tab');
+
+    expect(date.getAttribute('error')).toEqual('custom error');
   });
 
   it('uswds v3 renders a required span', async () => {

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -130,10 +130,13 @@ export class VaMemorableDate {
     }` : '';
     /* eslint-enable i18next/no-literal-string */
 
-    // Run built-in validation. Any custom validation
-    // will happen afterwards
-    validate(this, yearNum, monthNum, dayNum);
+    // Any custom validation will happen first; otherwise consumer code clearing
+    // errors will also remove internal errors.
     this.dateBlur.emit(event);
+
+    // Built-in validation is run after custom so internal errors override
+    // custom errors, e.g. Show invalid date instead of custom error
+    validate(this, yearNum, monthNum, dayNum);
 
     if (this.enableAnalytics) {
       const detail = {

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -61,8 +61,7 @@ describe('validate', () => {
     expect(memorableDateComponent.error).toEqual('month-range');
     expect(memorableDateComponent.invalidYear).toEqual(false);
     expect(memorableDateComponent.invalidMonth).toEqual(true);
-    // invalid month sets max days to zero
-    expect(memorableDateComponent.invalidDay).toEqual(true);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
   });
 
   it('indicates when the day is above the accepted range', () => {
@@ -145,8 +144,7 @@ describe('validate', () => {
       expect(memorableDateComponent.error).toEqual('date-error');
       expect(memorableDateComponent.invalidYear).toEqual(false);
       expect(memorableDateComponent.invalidMonth).toEqual(true);
-      // invalid month sets max days to zero
-      expect(memorableDateComponent.invalidDay).toEqual(true);
+      expect(memorableDateComponent.invalidDay).toEqual(false);
     });
 
     it('indicates when the day is missing', () => {

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -348,7 +348,21 @@ describe('checkIsNaN', () => {
     expect(memorableDateComponent.invalidMonth).toEqual(false);
     expect(memorableDateComponent.invalidDay).toEqual(false);
   });
-<<<<<<< HEAD
+
+  it('should not remove custom error even if values are valid', () => {
+    const memorableDateComponent = { error: 'Some error'} as Components.VaMemorableDate;
+    const year = Number('1999');
+    const month =  Number('1');
+    const day = Number('1');
+
+    const result = checkIsNaN(memorableDateComponent, year, month, day);
+
+    expect(result).toEqual(true);
+    expect(memorableDateComponent.error).toEqual('Some error');
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
+  });
 });
 
 describe('zeroPadStart', () => {
@@ -371,21 +385,3 @@ describe('zeroPadStart', () => {
     expect(zeroPadStart(9)).toEqual('09');
   });
 });
-=======
-
-  it('should not remove custom error even if values are valid', () => {
-    const memorableDateComponent = { error: 'Some error'} as Components.VaMemorableDate;
-    const year = Number('1999');
-    const month =  Number('1');
-    const day = Number('1');
-
-    const result = checkIsNaN(memorableDateComponent, year, month, day);
-
-    expect(result).toEqual(true);
-    expect(memorableDateComponent.error).toEqual('Some error');
-    expect(memorableDateComponent.invalidYear).toEqual(false);
-    expect(memorableDateComponent.invalidMonth).toEqual(false);
-    expect(memorableDateComponent.invalidDay).toEqual(false);
-  });
-});
->>>>>>> 6b3471f (Update tests)

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -32,6 +32,8 @@ describe('validate', () => {
 
     expect(memorableDateComponent.error).toEqual(`year-range`);
     expect(memorableDateComponent.invalidYear).toEqual(true);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
   });
 
   it('indicates when the year is above the accepted range', () => {
@@ -44,6 +46,8 @@ describe('validate', () => {
 
     expect(memorableDateComponent.error).toEqual(`year-range`);
     expect(memorableDateComponent.invalidYear).toEqual(true);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
   });
 
   it('indicates when the month is above the accepted range', () => {
@@ -55,7 +59,10 @@ describe('validate', () => {
     validate(memorableDateComponent, year, month, day);
 
     expect(memorableDateComponent.error).toEqual('month-range');
+    expect(memorableDateComponent.invalidYear).toEqual(false);
     expect(memorableDateComponent.invalidMonth).toEqual(true);
+    // invalid month sets max days to zero
+    expect(memorableDateComponent.invalidDay).toEqual(true);
   });
 
   it('indicates when the day is above the accepted range', () => {
@@ -67,6 +74,8 @@ describe('validate', () => {
     validate(memorableDateComponent, year, month, day);
 
     expect(memorableDateComponent.error).toEqual('day-range');
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
     expect(memorableDateComponent.invalidDay).toEqual(true);
   });
 
@@ -91,18 +100,23 @@ describe('validate', () => {
     validate(memorableDateComponent, year, month, day);
 
     expect(memorableDateComponent.error).toEqual('day-range');
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
     expect(memorableDateComponent.invalidDay).toEqual(true);
   });
 
   it('does not validate day for the monthYearOnly variant', () => {
-    const dateComponent = {} as Components.VaDate;
+    const memorableDateComponent = {} as Components.VaDate;
     const year = 2000;
     const month = 1;
     const day = null;
 
-    validate(dateComponent, year, month, day, true);
+    validate(memorableDateComponent, year, month, day, true);
 
-    expect(dateComponent.error).toEqual(null);
+    expect(memorableDateComponent.error).toEqual(null);
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
   });
 
   describe('required components', () => {
@@ -116,6 +130,8 @@ describe('validate', () => {
 
       expect(memorableDateComponent.error).toEqual('date-error');
       expect(memorableDateComponent.invalidYear).toEqual(true);
+      expect(memorableDateComponent.invalidMonth).toEqual(false);
+      expect(memorableDateComponent.invalidDay).toEqual(false);
     });
 
     it('indicates when the month is missing', () => {
@@ -127,7 +143,10 @@ describe('validate', () => {
       validate(memorableDateComponent, year, month, day);
 
       expect(memorableDateComponent.error).toEqual('date-error');
+      expect(memorableDateComponent.invalidYear).toEqual(false);
       expect(memorableDateComponent.invalidMonth).toEqual(true);
+      // invalid month sets max days to zero
+      expect(memorableDateComponent.invalidDay).toEqual(true);
     });
 
     it('indicates when the day is missing', () => {
@@ -139,6 +158,8 @@ describe('validate', () => {
       validate(memorableDateComponent, year, month, day);
 
       expect(memorableDateComponent.error).toEqual('date-error');
+      expect(memorableDateComponent.invalidYear).toEqual(false);
+      expect(memorableDateComponent.invalidMonth).toEqual(false);
       expect(memorableDateComponent.invalidDay).toEqual(true);
     });
 
@@ -151,11 +172,14 @@ describe('validate', () => {
       validate(memorableDateComponent, year, month, day, true);
 
       expect(memorableDateComponent.error).toEqual(null);
+      expect(memorableDateComponent.invalidYear).toEqual(false);
+      expect(memorableDateComponent.invalidMonth).toEqual(false);
+      expect(memorableDateComponent.invalidDay).toEqual(false);
     });
   });
 
   it('removes error indicators when the values are valid', () => {
-    const memorableDateComponent = { error: 'Some error'} as Components.VaMemorableDate;
+    const memorableDateComponent = { error: 'date-error'} as Components.VaMemorableDate;
     const year = 2000;
     const month = 1;
     const day = 1;
@@ -163,6 +187,20 @@ describe('validate', () => {
     validate(memorableDateComponent, year, month, day);
 
     expect(memorableDateComponent.error).toEqual(null);
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
+  });
+
+  it('should not remove custom error even if values are valid', () => {
+    const memorableDateComponent = { error: 'Some error'} as Components.VaMemorableDate;
+    const year = 2000;
+    const month = 1;
+    const day = 1;
+
+    validate(memorableDateComponent, year, month, day);
+
+    expect(memorableDateComponent.error).toEqual('Some error');
     expect(memorableDateComponent.invalidYear).toEqual(false);
     expect(memorableDateComponent.invalidMonth).toEqual(false);
     expect(memorableDateComponent.invalidDay).toEqual(false);
@@ -177,7 +215,9 @@ describe('validate', () => {
     validate(memorableDateComponent, year, month, day);
 
     expect(memorableDateComponent.error).toEqual('month-range');
+    expect(memorableDateComponent.invalidYear).toEqual(false);
     expect(memorableDateComponent.invalidMonth).toEqual(true);
+    // invalid month sets max days to zero
     expect(memorableDateComponent.invalidDay).toEqual(true);
   });
 });
@@ -247,6 +287,8 @@ describe('checkIsNaN', () => {
     expect(result).toEqual(false);
     expect(memorableDateComponent.error).toEqual(`year-range`);
     expect(memorableDateComponent.invalidYear).toEqual(true);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
   });
 
   it('indicates when the month is NaN', () => {
@@ -259,7 +301,9 @@ describe('checkIsNaN', () => {
 
     expect(result).toEqual(false);
     expect(memorableDateComponent.error).toEqual(`month-range`);
+    expect(memorableDateComponent.invalidYear).toEqual(false);
     expect(memorableDateComponent.invalidMonth).toEqual(true);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
   });
 
   it('indicates when the day is NaN', () => {
@@ -272,6 +316,8 @@ describe('checkIsNaN', () => {
 
     expect(result).toEqual(false);
     expect(memorableDateComponent.error).toEqual(`day-range`);
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
     expect(memorableDateComponent.invalidDay).toEqual(true);
   });
 
@@ -291,7 +337,7 @@ describe('checkIsNaN', () => {
   });
 
   it('removes error indicators when the values are valid', () => {
-    const memorableDateComponent = { error: 'Some error'} as Components.VaMemorableDate;
+    const memorableDateComponent = { error: 'date-error'} as Components.VaMemorableDate;
     const year = Number('1999');
     const month =  Number('1');
     const day = Number('1');
@@ -300,12 +346,11 @@ describe('checkIsNaN', () => {
 
     expect(result).toEqual(true);
     expect(memorableDateComponent.error).toEqual(null);
-
-    expect(memorableDateComponent.error).toEqual(null);
     expect(memorableDateComponent.invalidYear).toEqual(false);
     expect(memorableDateComponent.invalidMonth).toEqual(false);
     expect(memorableDateComponent.invalidDay).toEqual(false);
   });
+<<<<<<< HEAD
 });
 
 describe('zeroPadStart', () => {
@@ -328,3 +373,21 @@ describe('zeroPadStart', () => {
     expect(zeroPadStart(9)).toEqual('09');
   });
 });
+=======
+
+  it('should not remove custom error even if values are valid', () => {
+    const memorableDateComponent = { error: 'Some error'} as Components.VaMemorableDate;
+    const year = Number('1999');
+    const month =  Number('1');
+    const day = Number('1');
+
+    const result = checkIsNaN(memorableDateComponent, year, month, day);
+
+    expect(result).toEqual(true);
+    expect(memorableDateComponent.error).toEqual('Some error');
+    expect(memorableDateComponent.invalidYear).toEqual(false);
+    expect(memorableDateComponent.invalidMonth).toEqual(false);
+    expect(memorableDateComponent.invalidDay).toEqual(false);
+  });
+});
+>>>>>>> 6b3471f (Update tests)

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -152,18 +152,6 @@ export function checkLeapYear(year: number) {
   return (0 == year % 4 && 0 != year % 100) || 0 == year % 400;
 }
 
-/**
- * Checks for an internal or empty component error, then updates it.
- * We don't mess with the error if it was added externally
- */
-export function addError(
-  component: Components.VaDate | Components.VaMemorableDate,
-  error: string) : void {
-  if (!component.error || internalErrors.includes(component.error)) {
-    component.error = error;
-  }
-}
-
 export const internalErrors = [
   'year-range',
   'day-range',
@@ -185,7 +173,7 @@ export function checkIsNaN(
   // Begin NaN validation.
   if (isNaN(year)) {
     component.invalidYear = true;
-    addError(component, 'year-range');
+    component.error = 'year-range';
   }
   else {
     component.invalidYear = false;
@@ -193,7 +181,7 @@ export function checkIsNaN(
 
   if (!monthYearOnly && isNaN(day)) {
     component.invalidDay = true;
-    addError(component, 'day-range');
+    component.error = 'day-range';
   }
   else {
     component.invalidDay = false;
@@ -201,7 +189,7 @@ export function checkIsNaN(
 
   if (isNaN(month)) {
     component.invalidMonth = true;
-    addError(component, 'month-range');
+    component.error = 'month-range';
   }
   else {
     component.invalidMonth = false;
@@ -211,7 +199,7 @@ export function checkIsNaN(
     component.invalidYear = !year;
     component.invalidMonth = !month;
     component.invalidDay = monthYearOnly ? false : !day;
-    addError(component, 'date-error');
+    component.error = 'date-error';
   }
 
   // Remove any error message if none of the fields are NaN
@@ -248,7 +236,7 @@ export function validate(
     component.invalidYear = (!year || year < minYear || year > maxYear);
     component.invalidMonth = (!month || month < minMonths || month > maxMonths);
     component.invalidDay = monthYearOnly ? false : (!day || day < minMonths || day > maxDay);
-    addError(component, 'date-error');
+    component.error = 'date-error';
     return;
   }
 
@@ -256,7 +244,7 @@ export function validate(
   // Empty fields are acceptable unless the component is marked as required
   if (year && (year < minYear || year > maxYear)) {
     component.invalidYear = true;
-    addError(component, 'year-range');
+    component.error = 'year-range';
   }
   else {
     component.invalidYear = false;
@@ -266,7 +254,7 @@ export function validate(
   // We don't know the upper limit on days until we know the month
   if (!monthYearOnly && (day < minMonths || day > maxDay)) {
     component.invalidDay = true;
-    addError(component, 'day-range');
+    component.error = 'day-range';
   }
   else {
     component.invalidDay = false;
@@ -277,7 +265,7 @@ export function validate(
   if ((month && (month < minMonths || month > maxMonths)) ||
       (!month && component.invalidDay)) {
     component.invalidMonth = true;
-    addError(component, 'month-range');
+    component.error = 'month-range';
   }
   else {
     component.invalidMonth = false;


### PR DESCRIPTION
## Chromatic
<!-- This `1593-mem-date-fixes` is a placeholder for a CI job - it will be updated automatically -->
https://1593-mem-date-fixes--60f9b557105290003b387cd5.chromatic.com

## Description

When custom validation applies a custom error message, and the date within the `va-memorable-date` is valid, blurring any of the inputs a second time would result in the custom error message being removed. This appears to be a race condition of the internal validation code removing the error and the external validation code adding the custom error.

To fix this issue, the emitted blur event (which triggers the custom validation), was moved _before_ the internal validation check and the internal validation only add & remove empty, and internal validation errors. Fixes one portion of issue [#1593](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1593), which is also referenced in [#61363](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61363)

## Testing done

Updated utility & `va-memorable-date` component tests

## Screenshots

| Before | After  |
|--------|--------|
| ![date-error-focus-before](https://github.com/department-of-veterans-affairs/component-library/assets/136959/9c3c2198-19dd-415b-af12-ef22e517aed7) | ![date-error-focus-after](https://github.com/department-of-veterans-affairs/component-library/assets/136959/f89b7323-57a8-4530-85b4-416d4424131c) |

Note that the "isNaN check clearing error" & "validate check clearing error" are removing the custom validation error in the before view, but cannot be seen in the after view.

## Acceptance criteria
- [x] Internal error messages override custom error message
- [x] Custom error messages are not removed when the internal validation deems the date as valid
- [x] Added tests & all passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
