### PR TITLE
va-memorable-date: Fix days of month calculation

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -611,7 +611,7 @@ export namespace Components {
          */
         "href"?: string;
         /**
-          * Symbol indicates type of notification  Current options are: action-required, update
+          * Symbol indicates type of notification Current options are: action-required, update
          */
         "symbol"?: string;
         /**
@@ -2300,7 +2300,7 @@ declare namespace LocalJSX {
          */
         "onComponent-library-analytics"?: (event: VaNotificationCustomEvent<any>) => void;
         /**
-          * Symbol indicates type of notification  Current options are: action-required, update
+          * Symbol indicates type of notification Current options are: action-required, update
          */
         "symbol"?: string;
         /**

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -276,8 +276,7 @@ describe('va-memorable-date', () => {
 
         expect(invalidYear).toEqual('false');
         expect(invalidMonth).toEqual('true');
-        // Day is invalid because we don't know the upper limit based on a valid month
-        expect(invalidDay).toEqual('true');
+        expect(invalidDay).toEqual('false');
 
         await handleMonth.press('Backspace');
         await handleMonth.press('Backspace');
@@ -898,8 +897,7 @@ describe('va-memorable-date', () => {
 
         expect(invalidYear).toEqual('false');
         expect(invalidMonth).toEqual('true');
-        // Day is invalid because we don't know the upper limit based on a valid month
-        expect(invalidDay).toEqual('true');
+        expect(invalidDay).toEqual('false');
 
         await handleMonth.press('Backspace');
         await handleMonth.press('Backspace');

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -59,6 +59,18 @@ describe('validate', () => {
     expect(memorableDateComponent.invalidDay).toEqual(true);
   });
 
+  it('indicates when the day is above range for non-leap years', () => {
+    const memorableDateComponent = { required: true} as Components.VaMemorableDate;
+    const year = 2023;
+    const month = 2;
+    const day = 29;
+
+    validate(memorableDateComponent, year, month, day);
+
+    expect(memorableDateComponent.error).toEqual('day-range');
+    expect(memorableDateComponent.invalidDay).toEqual(true);
+  });
+
   it('indicates when the day is below the accepted range', () => {
     const memorableDateComponent = {} as Components.VaMemorableDate;
     const year = 2000;

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -217,8 +217,7 @@ export function validate(
   day: number,
   monthYearOnly : boolean = false) : void {
 
-  const leapYear = checkLeapYear(year);
-  const maxDay = daysForSelectedMonth(leapYear, month);
+  const maxDay = daysForSelectedMonth(year, month);
 
   // Begin built-in validation.
   // Empty fields are acceptable unless the component is marked as required
@@ -269,8 +268,7 @@ export function getErrorParameters(
   year: number,
   month: number) {
 
-  const leapYear = checkLeapYear(year);
-  const maxDay = daysForSelectedMonth(leapYear, month);
+  const maxDay = daysForSelectedMonth(year, month);
 
   switch(error) {
     case 'month-range':
@@ -284,9 +282,12 @@ export function getErrorParameters(
   }
 }
 
-const daysForSelectedMonth = (leapYear: boolean, month: number): number => {
-  return leapYear && month == 2 ? 29 : days[month]?.length || 0;
-}
+// Get last day of the month (month is zero based, so we're +1 month, day 0);
+// new Date() will recalculate and go back to last day of the previous month.
+// Return 31 for undefined month or year to not invalidate the day with
+// partial data (this used to be set to zero by default)
+export const daysForSelectedMonth = (year: number, month: number): number =>
+  year && month ? new Date(year, month, 0).getDate() : 31;
 
 // Allow 0-9, Backspace, Delete, Left and Right Arrow, and Tab to clear data or move to next field
 export const validKeys = [
@@ -314,8 +315,8 @@ export const validKeys = [
  */
 export const formatDate = (
   date: Date,
-  options: Intl.DateTimeFormatOptions = { 
-    dateStyle: 'full', 
+  options: Intl.DateTimeFormatOptions = {
+    dateStyle: 'full',
     timeStyle: 'short'
   },
   timeZone: string = 'America/New_York',


### PR DESCRIPTION
## Chromatic
<!-- This `1593-mem-date-feb` is a placeholder for a CI job - it will be updated automatically -->
https://1593-mem-date-feb--60f9b557105290003b387cd5.chromatic.com

## Description

The max number of days for the month of February is hard-coded to be the length of the `twentyNineDays` array for non-leap years (which is 29). There isn't a 28 days array, so I opted for a simpler method by calculating the days. If the month or year are undefined, it returns 31 as the max - which seems like a reasonable fallback (instead of zero). This PR fixes one portion of issue [#1593](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1593), which is also referenced in [#61363](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61363)

## Testing done

Updated utility tests

## Screenshots

| Before | After |
|--------|-------|
| ![date-error-feb-before](https://github.com/department-of-veterans-affairs/component-library/assets/136959/2bcebc33-743a-489e-8451-a7f74b42aa73) | ![date-error-feb-after](https://github.com/department-of-veterans-affairs/component-library/assets/136959/31d60e6c-aab4-486f-afc5-ad7f9653a67d) |

## Acceptance criteria
- [x] Entering `2` (Feb) for a month will set the appropriate number of days based on the year
- [x] Added tests & all passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
