### PR TITLE
va-date & va-memorable-date: Switch to zero pad function

### DIFF
--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -16,6 +16,7 @@ import {
   validate,
   getErrorParameters,
   checkIsNaN,
+  zeroPadStart,
 } from '../../utils/date-utils';
 
 /**
@@ -124,16 +125,12 @@ export class VaDate {
    * date values are all NaNs.
    */
   private setValue(year: number, month: number, day: number): void {
-    // Use a leading zero for numbers < 10
-    const numFormatter = new Intl.NumberFormat('en-US', {
-      minimumIntegerDigits: 2,
-    });
     // Ternary to prevent NaN displaying as value for Year
     // Ternary to prevent Month or Day from displaying as single digit
     /* eslint-disable i18next/no-literal-string */
     const val = `${year ? year : ''}-${
-      month ? numFormatter.format(month) : ''
-    }-${day ? numFormatter.format(day) : ''}`.replace(/-+$/, '');
+      month ? zeroPadStart(month) : ''
+    }-${day ? zeroPadStart(day) : ''}`.replace(/-+$/, '');
     /* eslint-enable i18next/no-literal-string */
 
     this.value = val ? val : null;

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -15,6 +15,7 @@ import {
   months,
   validate,
   checkIsNaN,
+  zeroPadStart,
 } from '../../utils/date-utils';
 
 import i18next from 'i18next';
@@ -116,19 +117,16 @@ export class VaMemorableDate {
     const yearNum = Number(year);
     const monthNum = Number(month);
     const dayNum = Number(day);
-    
+
     if(!checkIsNaN(this, yearNum, monthNum, dayNum)) {
       // if any fields are NaN do not continue validation
       return;
     }
 
-    // Use a leading zero for numbers < 10
-    const numFormatter = new Intl.NumberFormat('en-US', {
-      minimumIntegerDigits: 2,
-    });
     /* eslint-disable i18next/no-literal-string */
-    this.value = year || month || day ? `${year}-${month ? numFormatter.format(monthNum) : ''}-${
-      day ? numFormatter.format(dayNum) : ''
+    this.value = year || month || day ? `${year}-${
+      month ? zeroPadStart(monthNum) : ''}-${
+      day ? zeroPadStart(dayNum) : ''
     }` : '';
     /* eslint-enable i18next/no-literal-string */
 
@@ -195,7 +193,7 @@ export class VaMemorableDate {
       forceUpdate(this.el);
     });
   }
-  
+
   disconnectedCallback() {
     i18next.off('languageChanged');
   }
@@ -218,7 +216,7 @@ export class VaMemorableDate {
     const describedbyIds = ['dateHint', hint ? 'hint' : '']
       .filter(Boolean)
       .join(' ');
-      
+
     const hintText = monthSelect ? i18next.t('date-hint-with-select') : i18next.t('date-hint');
 
     const errorParameters = (error: string) => {
@@ -289,7 +287,7 @@ export class VaMemorableDate {
             <span id="error-message" role="alert">
               {error && (
                 <Fragment>
-                  <span class="usa-sr-only">{i18next.t('error')}</span> 
+                  <span class="usa-sr-only">{i18next.t('error')}</span>
                   <span class="usa-error-message">{i18next.t(error, errorParameters(error))}</span>
                 </Fragment>
               )}
@@ -349,7 +347,7 @@ export class VaMemorableDate {
               {hint && <div id="hint">{hint}</div>}
               <div id="dateHint">{i18next.t('date-hint')}.</div>
             </legend>
-            <slot /> 
+            <slot />
             <span id="error-message" role="alert">
               {error && (
                 <Fragment>

--- a/packages/web-components/src/utils/date-utils.spec.ts
+++ b/packages/web-components/src/utils/date-utils.spec.ts
@@ -1,8 +1,19 @@
 import { Components } from '../components';
-import { checkLeapYear, validate, formatDate, isDateAfter, isDateBefore, isDateSameDay, checkIsNaN } from './date-utils';
+import {
+  checkLeapYear,
+  validate,
+  formatDate,
+  isDateAfter,
+  isDateBefore,
+  isDateSameDay,
+  checkIsNaN,
+  zeroPadStart,
+} from './date-utils';
 
-describe('checkLeapYear', () => {
-  it('determines an input year is a leap year', () => {
+describe('checkLeapYear',
+() => {
+  it('determines an input year is a leap year',
+  () => {
     expect(checkLeapYear(1996)).toBeTruthy();
     expect(checkLeapYear(1995)).toBeFalsy();
     expect(checkLeapYear(199)).toBeFalsy();
@@ -283,4 +294,25 @@ describe('checkIsNaN', () => {
     expect(memorableDateComponent.invalidMonth).toEqual(false);
     expect(memorableDateComponent.invalidDay).toEqual(false);
   });
-})
+});
+
+describe('zeroPadStart', () => {
+  it('should return "00"', () => {
+    expect(zeroPadStart()).toEqual('00');
+    expect(zeroPadStart(null)).toEqual('00');
+    expect(zeroPadStart('')).toEqual('00');
+    expect(zeroPadStart(0)).toEqual('00');
+  });
+  it('should return numbers > 9 and < 100', () => {
+    expect(zeroPadStart(10)).toEqual('10');
+    expect(zeroPadStart('10')).toEqual('10');
+    expect(zeroPadStart(99)).toEqual('99');
+    expect(zeroPadStart('55')).toEqual('55');
+  });
+  it('should add leading zero to numbers < 10', () => {
+    expect(zeroPadStart(1)).toEqual('01');
+    expect(zeroPadStart(3)).toEqual('03');
+    expect(zeroPadStart('5')).toEqual('05');
+    expect(zeroPadStart(9)).toEqual('09');
+  });
+});

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -314,8 +314,8 @@ export const validKeys = [
  */
 export const formatDate = (
   date: Date,
-  options: Intl.DateTimeFormatOptions = { 
-    dateStyle: 'full', 
+  options: Intl.DateTimeFormatOptions = {
+    dateStyle: 'full',
     timeStyle: 'short',
     hour: 'numeric',
     minute: 'numeric',
@@ -351,4 +351,15 @@ export const isDateSameDay = (date1: Date, date2: Date) => {
     date1.getDay() === date2.getDay()
   );
 };
-/* eslint-enable i18next/no-literal-string */
+
+/**
+ * Returns a zero padded number
+ * Ex: '1' becomes '01'
+ * We could use Intl.NumberFormat('en-US', { minimumIntegerDigits: 2 }) or
+ * padStart(2, '0'), but we have Veterans that are still using Safari v9
+ * See https://caniuse.com/?search=Intl.NumberFormat
+ */
+export const zeroPadStart = (number: number | string) =>
+  `00${(number || '').toString()}`.slice(-2);
+
+  /* eslint-enable i18next/no-literal-string */


### PR DESCRIPTION
## Chromatic
<!-- This `1834-zero-pad` is a placeholder for a CI job - it will be updated automatically -->
https://1834-zero-pad--60f9b557105290003b387cd5.chromatic.com

## Description

While monitoring Sentry errors, we noticed quite a large number of [`undefined is not a constructor (evaluating 'new Intl.NumberFormat(j,p)')` errors](http://sentry.vfs.va.gov/organizations/vsp/issues/?project=4&query=is%3Aunresolved+Intl.NumberFormat&statsPeriod=90d) (~3k events in the past 90 days). See [#1834](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1834).

This happens because the [`Intl.NumberFormat` requires modern up-to-date browsers](https://caniuse.com/?search=Intl.NumberFormat), and we have Veterans still using Safari v9. We can't use [`padStart` since it also requires Safari v10+](https://caniuse.com/?search=padStart)

This PR switches from using `intl.NumberFormat` to `slice` - since it works in legacy browsers

## Testing done

Added tests for new `zeroPadStart` date utility function

## Screenshots

N/A

## Acceptance criteria
- [ ] Numbers < 10 will get zero-padded
- [ ] Use method that will work in Safari v9

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
