### PR TITLE
va-notification - add dateTime prop

### DIFF
--- a/packages/storybook/stories/va-notification.stories.jsx
+++ b/packages/storybook/stories/va-notification.stories.jsx
@@ -31,6 +31,7 @@ const defaultArgs = {
   'has-close-text': false,
   'headline': 'Notification heading',
   'headline-level': '3',
+  'date-time': 'Wednesday, May 11 at 1:13pm',
   'children': (
      <p>Notification body</p>
   ),
@@ -45,6 +46,7 @@ const Template = ({
   'headline-level': headlineLevel,
   href,
   text,
+  'date-time': dateTime,
   'close-btn-aria-label': closeBtnAriaLabel,
   closeable,
   'has-border': hasBorder,
@@ -57,6 +59,7 @@ const Template = ({
       symbol={symbol}
       headline={headline}
       headline-level={headlineLevel}
+      date-time={dateTime}
       href={href}
       text={text}
       closeable={closeable}
@@ -73,6 +76,7 @@ const MultipleTemplate = ({
   'close-btn-aria-label': closeBtnAriaLabel,
   closeable,
   'has-border': hasBorder,
+  'date-time': dateTime,
 }) => {
   return (
     <>
@@ -81,19 +85,21 @@ const MultipleTemplate = ({
         symbol="action-required"
         headline="You have a new education debt."
         href="https://www.va.gov/"
+        date-time={dateTime}
         text="Manage your VA debt"
         closeable={closeable}
         has-border={hasBorder}
         closeBtnAriaLabel={closeBtnAriaLabel}
         class="vads-u-margin-bottom--1p5"
       >
-        <time slot="date" dateTime="2023-05-1 13:13:00">Wednesday, May 11 at 1:13pm</time>
+        <time slot="date" dateTime={dateTime}>{dateTime}</time>
       </va-notification>
       <va-notification
         visible="true"
         symbol="update"
         headline="Your claim status has been updated."
         href="https://www.va.gov/"
+        date-time={dateTime}
         text="Manage your claims and appeals"
         closeable={closeable}
         has-border={hasBorder}
@@ -114,12 +120,13 @@ Default.argTypes = propStructure(notificationDocs);
 export const ActionRequired = Template.bind(null);
 ActionRequired.args = {
   ...defaultArgs,
-  children: (
-    <time slot="date" dateTime="2023-05-1 13:13:00">Wednesday, May 11 at 1:13pm</time>
-  ),
+  // children: (
+  //   <time slot="date" dateTime="2023-05-1 13:13:00">Wednesday, May 11 at 1:13pm</time>
+  // ),
   symbol: 'action-required',
   headline: 'You have a new education debt.',
-  text: 'Manage your VA debt'
+  text: 'Manage your VA debt',
+  dateTime: 'Wednesday, May 11 at 1:13pm',
 };
 
 export const Update = Template.bind(null);

--- a/packages/storybook/stories/va-notification.stories.jsx
+++ b/packages/storybook/stories/va-notification.stories.jsx
@@ -92,7 +92,6 @@ const MultipleTemplate = ({
         closeBtnAriaLabel={closeBtnAriaLabel}
         class="vads-u-margin-bottom--1p5"
       >
-        <time slot="date" dateTime={dateTime}>{dateTime}</time>
       </va-notification>
       <va-notification
         visible="true"
@@ -105,7 +104,6 @@ const MultipleTemplate = ({
         has-border={hasBorder}
         closeBtnAriaLabel={closeBtnAriaLabel}
       >
-        <time slot="date" dateTime="2023-05-1 13:13:00">Wednesday, May 11 at 1:13pm</time>
       </va-notification>
     </>
   )
@@ -120,21 +118,14 @@ Default.argTypes = propStructure(notificationDocs);
 export const ActionRequired = Template.bind(null);
 ActionRequired.args = {
   ...defaultArgs,
-  // children: (
-  //   <time slot="date" dateTime="2023-05-1 13:13:00">Wednesday, May 11 at 1:13pm</time>
-  // ),
   symbol: 'action-required',
   headline: 'You have a new education debt.',
   text: 'Manage your VA debt',
-  dateTime: 'Wednesday, May 11 at 1:13pm',
 };
 
 export const Update = Template.bind(null);
 Update.args = {
   ...defaultArgs,
-  children: (
-    <time slot="date" dateTime="2023-05-1 13:13:00">Wednesday, May 11 at 1:13pm</time>
-  ),
   symbol: 'update',
   headline: 'Your claim status has been updated.',
   text: 'Manage your claims and appeals'
@@ -143,9 +134,6 @@ Update.args = {
 export const WithCloseText = Template.bind(null);
 WithCloseText.args = {
   ...defaultArgs,
-  children: (
-    <time slot="date" dateTime="2023-05-1 13:13:00">Wednesday, May 11 at 1:13pm</time>
-  ),
   symbol: 'action-required',
   headline: 'You have a new education debt.',
   text: 'Manage your VA debt',
@@ -164,6 +152,7 @@ HeaderLevelChange.args = {
   headline: 'The heading level of this notification is now an h5.',
   'headline-level': '5',
   text: '',
+  dateTime: '',
 };
 
 export const NotDismissable = Template.bind(null);
@@ -175,9 +164,6 @@ NotDismissable.args = {
 export const NoBorder = Template.bind(null);
 NoBorder.args = {
   ...defaultArgs,
-  children: (
-    <time slot="date" dateTime="2023-05-1 13:13:00">Wednesday, May 11 at 1:13pm</time>
-  ),
   symbol: 'action-required',
   headline: 'You have a new education debt.',
   text: 'Manage your VA debt',

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.6",
+  "version": "4.42.7",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -587,6 +587,10 @@ export namespace Components {
          */
         "closeable"?: boolean;
         /**
+          * Headline for notification
+         */
+        "dateTime"?: string;
+        /**
           * If `true`, the component-library-analytics event is disabled.
          */
         "disableAnalytics"?: boolean;
@@ -611,7 +615,7 @@ export namespace Components {
          */
         "href"?: string;
         /**
-          * Symbol indicates type of notification  Current options are: action-required, update
+          * Symbol indicates type of notification Current options are: action-required, update
          */
         "symbol"?: string;
         /**
@@ -2268,6 +2272,10 @@ declare namespace LocalJSX {
          */
         "closeable"?: boolean;
         /**
+          * Headline for notification
+         */
+        "dateTime"?: string;
+        /**
           * If `true`, the component-library-analytics event is disabled.
          */
         "disableAnalytics"?: boolean;
@@ -2300,7 +2308,7 @@ declare namespace LocalJSX {
          */
         "onComponent-library-analytics"?: (event: VaNotificationCustomEvent<any>) => void;
         /**
-          * Symbol indicates type of notification  Current options are: action-required, update
+          * Symbol indicates type of notification Current options are: action-required, update
          */
         "symbol"?: string;
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -587,7 +587,7 @@ export namespace Components {
          */
         "closeable"?: boolean;
         /**
-          * Headline for notification
+          * Date and time for notification. This will be incorporated into a unique aria-describedby label
          */
         "dateTime"?: string;
         /**
@@ -2272,7 +2272,7 @@ declare namespace LocalJSX {
          */
         "closeable"?: boolean;
         /**
-          * Headline for notification
+          * Date and time for notification. This will be incorporated into a unique aria-describedby label
          */
         "dateTime"?: string;
         /**

--- a/packages/web-components/src/components/va-notification/test/va-notification.e2e.ts
+++ b/packages/web-components/src/components/va-notification/test/va-notification.e2e.ts
@@ -5,18 +5,18 @@ describe('va-notification', () => {
   it('renders', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<va-notification headline="Notification heading"></va-notification>');
+    await page.setContent('<va-notification headline="Notification heading" date-time="Tuesday, July 18"></va-notification>');
     const element = await page.find('va-notification');
 
     expect(element).toEqualHtml(`
-      <va-notification class="hydrated" has-border="" headline="Notification heading">
+      <va-notification class="hydrated" has-border="" headline="Notification heading" date-time="Tuesday, July 18">
         <mock:shadow-root>
           <va-card show-shadow="true" class="hydrated show-shadow va-card">
             <div class="va-notification none has-border">
               <i aria-hidden="true" role="img" class="none"></i>
               <div class="body" role="presentation">
-                <h3 part="headline">Notification heading</h3>
-                <slot name="date"></slot>
+                <h3 part="headline" aria-describedby="Notification heading Tuesday, July 18">Notification heading</h3>
+                <time datetime="Tuesday, July 18">Tuesday, July 18</time>
                 <slot></slot>
               </div>
             </div>

--- a/packages/web-components/src/components/va-notification/va-notification.tsx
+++ b/packages/web-components/src/components/va-notification/va-notification.tsx
@@ -66,7 +66,7 @@ export class VaNotification {
   @Prop() headlineLevel?: string = '3';
 
   /**
-   * Date and time for notification. This will be incorporated into a unique aria-describedby label
+   * Date and time for notification. This will also be incorporated into a unique aria-describedby label.
    */
     @Prop() dateTime?: string;
 

--- a/packages/web-components/src/components/va-notification/va-notification.tsx
+++ b/packages/web-components/src/components/va-notification/va-notification.tsx
@@ -181,7 +181,6 @@ export class VaNotification {
             <div class="body" role="presentation">
               {headline ? <HeadlineLevel part="headline" aria-describedby={ariaDescribedByLabel}>{headline}</HeadlineLevel> : null}
               {dateTime ? <time dateTime={dateTime}>{dateTime}</time> : null}
-              {/* <slot name="date"></slot> */}
               <slot></slot>
               {(href && text) ? (
                 <va-link active href={href} text={text} />

--- a/packages/web-components/src/components/va-notification/va-notification.tsx
+++ b/packages/web-components/src/components/va-notification/va-notification.tsx
@@ -66,6 +66,11 @@ export class VaNotification {
   @Prop() headlineLevel?: string = '3';
 
   /**
+   * Headline for notification
+   */
+    @Prop() dateTime?: string;
+
+  /**
    * Destination URL for link (optional)
    */
   @Prop() href?: string;
@@ -153,6 +158,7 @@ export class VaNotification {
       visible,
       symbol,
       headline,
+      dateTime,
       href,
       text,
       closeable,
@@ -165,14 +171,17 @@ export class VaNotification {
 
     const classes = classnames('va-notification', symbol, { 'has-border': hasBorder })
 
+    const ariaDescribedByLabel = `${headline} ${dateTime}`;
+
     return (
       <Host>
         <va-card show-shadow="true">
           <div class={classes}>
             <i aria-hidden="true" role="img" class={symbol}></i>
             <div class="body" role="presentation">
-              {headline ? <HeadlineLevel part="headline">{headline}</HeadlineLevel> : null}
-              <slot name="date"></slot>
+              {headline ? <HeadlineLevel part="headline" aria-describedby={ariaDescribedByLabel}>{headline}</HeadlineLevel> : null}
+              {dateTime ? <time dateTime={dateTime}>{dateTime}</time> : null}
+              {/* <slot name="date"></slot> */}
               <slot></slot>
               {(href && text) ? (
                 <va-link active href={href} text={text} />

--- a/packages/web-components/src/components/va-notification/va-notification.tsx
+++ b/packages/web-components/src/components/va-notification/va-notification.tsx
@@ -66,7 +66,7 @@ export class VaNotification {
   @Prop() headlineLevel?: string = '3';
 
   /**
-   * Headline for notification
+   * Date and time for notification. This will be incorporated into a unique aria-describedby label
    */
     @Prop() dateTime?: string;
 


### PR DESCRIPTION
## Chromatic
<!-- This `notification-add-datetime-prop` is a placeholder for a CI job - it will be updated automatically -->
https://notification-add-datetime-prop--60f9b557105290003b387cd5.chromatic.com

---
## Configuring this pull request
- [x] Link to any related issues in the description so they can be cross-referenced.
- [x] Under **Testing done**, be specific about how this update was tested. 
    - Examples: Storybook, Chrome, Browserstack, Mobile/Responsive, etc.
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [x] Complete all sections below.
- [ ] Delete this section once complete

## Description
This PR adds a dateTime prop to the `va-notification` web component so that and `aria-describedby` label for the headline can be unique and describe content of the notification more clearly. 

- closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/61399 (Authenticated Experience)
- also closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/61158 (Platform)

- Sketch file with a11y annotations: https://www.sketch.com/s/9b0e6efc-423a-4354-9db3-ab2083d566c9/a/vRE9LdQ

## Testing done
- locally, visually
- all e2e tests pass

## Screenshots
<img width="775" alt="Screenshot of notification component with new date time prop" src="https://github.com/department-of-veterans-affairs/component-library/assets/8542413/92402b44-1374-48e7-867c-4ef48d705261">
<img width="818" alt="Screenshot of date time prop in Storybook" src="https://github.com/department-of-veterans-affairs/component-library/assets/8542413/1555d60a-dadc-4667-aa42-446bc1d00d8b">

## Acceptance criteria
- [ ] `aria-describedby` label contains content from headline and datetime props
- [ ] `aria-describedby` label is dynamic and unique 

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
