### PR TITLE
feat: added v3 breadcrumb variation

### DIFF
--- a/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
+
+const breadcrumbsDocs = getWebComponentDocs('va-breadcrumbs');
+
+export default {
+  title: 'USWDS/Breadcrumbs USWDS',
+  id: 'uswds/va-breadcrumbs',
+  parameters: {
+    componentSubtitle: 'va-breadcrumbs web component',
+    docs: {
+      page: () => <StoryDocs data={breadcrumbsDocs} />,
+    },
+  },
+};
+
+const Template = ({ label, 'disable-analytics': disableAnalytics, uswds }) => (
+  <va-breadcrumbs uswds label={label} disable-analytics={disableAnalytics}>
+    <a href="#home">Home</a>
+    <a href="#one">Level one</a>
+    <a href="#two">Level two</a>
+  </va-breadcrumbs>
+);
+
+const DynamicCrumbsTemplate = ({
+  label,
+  'disable-analytics': disableAnalytics,
+}) => {
+  const breadcrumbs = [
+    { label: 'Level 1', href: '/#1' },
+    { label: 'Level 2', href: '/#2' },
+    { label: 'Level 3', href: '/#3' },
+  ];
+
+  const breadcrumbs2 = [
+    { label: 'First Link', href: '#example1' },
+    { label: 'Second Link', href: '#example2' },
+    { label: 'Third Link', href: '#example3' },
+    { label: 'Fourth Link', href: '#example4' },
+  ];
+  const [crumbs, setCrumbs] = useState(breadcrumbs);
+  const addCrumb = () =>
+    setCrumbs(arr => [
+      ...arr,
+      { label: `Level ${arr.length + 1}`, href: `/#${arr.length + 1}` },
+    ]);
+  const replaceCrumbs = () => setCrumbs(breadcrumbs2);
+  const resetCrumbs = () => setCrumbs(breadcrumbs);
+  const removeCrumb = () =>
+    setCrumbs(arr => {
+      const newArr = [...arr];
+      newArr.pop();
+      return newArr;
+    });
+
+  return (
+    <div>
+      <button onClick={e => addCrumb()}>Add Crumb</button>
+      <button onClick={e => removeCrumb()}>Remove Crumb</button>
+      <button onClick={e => replaceCrumbs()}>Replace Crumbs</button>
+      <button onClick={e => resetCrumbs()}>Reset Crumbs</button>
+      <br />
+      {crumbs.length > 0 && (
+        <va-breadcrumbs
+          uswds
+          label={label}
+          disable-analytics={disableAnalytics}
+        >
+          {crumbs?.map((crumb, i) => {
+            return (
+              <li key={i}>
+                <a href={crumb.path}>{crumb.label}</a>
+              </li>
+            );
+          })}
+        </va-breadcrumbs>
+      )}
+    </div>
+  );
+};
+
+const WrappingCrumbsTemplate = ({
+  label,
+  'disable-analytics': disableAnalytics,
+  uswds,
+  wrapping,
+}) => {
+  // const breadcrumbs = [
+  //   { label: 'Home', href: '/#1' },
+  //   { label: 'Federal Contracting', href: '/#2' },
+  //   { label: 'Contracting assistance programs', href: '/#3' },
+  //   {
+  //     label: 'Women-owned small business federal contracting program',
+  //     href: '/#4',
+  //   },
+  // ];
+  return (
+    <div>
+      <va-breadcrumbs
+        uswds
+        label={label}
+        disable-analytics={disableAnalytics}
+        wrapping
+      >
+        <li>
+          <a href="#home">Home</a>
+        </li>
+        <li>
+          <a href="#one">Federal Contracting</a>
+        </li>
+        <li>
+          <a href="#two">Contracting assistance programs</a>
+        </li>
+        <li>
+          <a href="#two">
+            Women-owned small business federal contracting program
+          </a>
+        </li>
+      </va-breadcrumbs>
+    </div>
+  );
+};
+
+const defaultArgs = {
+  'uswds': true,
+  'label': 'Breadcrumb',
+  'disable-analytics': false,
+  'wrapping': false,
+};
+
+export const Default = Template.bind(null);
+Default.args = {
+  ...defaultArgs,
+};
+Default.argTypes = propStructure(breadcrumbsDocs);
+
+export const RerenderState = DynamicCrumbsTemplate.bind(null);
+RerenderState.args = { ...defaultArgs };
+
+export const WrappingState = WrappingCrumbsTemplate.bind(null);
+WrappingState.args = { ...defaultArgs, wrapping: true };

--- a/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
@@ -69,7 +69,7 @@ const DynamicCrumbsTemplate = ({
           {crumbs?.map((crumb, i) => {
             return (
               <li key={i}>
-                <a href={crumb.path}>{crumb.label}</a>
+                <a href={crumb.href}>{crumb.label}</a>
               </li>
             );
           })}

--- a/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
@@ -85,15 +85,6 @@ const WrappingCrumbsTemplate = ({
   uswds,
   wrapping,
 }) => {
-  // const breadcrumbs = [
-  //   { label: 'Home', href: '/#1' },
-  //   { label: 'Federal Contracting', href: '/#2' },
-  //   { label: 'Contracting assistance programs', href: '/#3' },
-  //   {
-  //     label: 'Women-owned small business federal contracting program',
-  //     href: '/#4',
-  //   },
-  // ];
   return (
     <div>
       <va-breadcrumbs

--- a/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
@@ -16,9 +16,11 @@ export default {
 
 const Template = ({ label, 'disable-analytics': disableAnalytics, uswds }) => (
   <va-breadcrumbs uswds label={label} disable-analytics={disableAnalytics}>
-    <a href="#home">Home</a>
-    <a href="#one">Level one</a>
-    <a href="#two">Level two</a>
+    <span slot="list">
+      <a href="#home">Home</a>
+      <a href="#one">Level one</a>
+      <a href="#two">Level two</a>
+    </span>
   </va-breadcrumbs>
 );
 
@@ -66,13 +68,15 @@ const DynamicCrumbsTemplate = ({
           label={label}
           disable-analytics={disableAnalytics}
         >
-          {crumbs?.map((crumb, i) => {
-            return (
-              <li key={i}>
-                <a href={crumb.href}>{crumb.label}</a>
-              </li>
-            );
-          })}
+          <span slot="list">
+            {crumbs?.map((crumb, i) => {
+              return (
+                <li key={i}>
+                  <a href={crumb.href}>{crumb.label}</a>
+                </li>
+              );
+            })}
+          </span>
         </va-breadcrumbs>
       )}
     </div>
@@ -93,20 +97,22 @@ const WrappingCrumbsTemplate = ({
         disable-analytics={disableAnalytics}
         wrapping
       >
-        <li>
-          <a href="#home">Home</a>
-        </li>
-        <li>
-          <a href="#one">Federal Contracting</a>
-        </li>
-        <li>
-          <a href="#two">Contracting assistance programs</a>
-        </li>
-        <li>
-          <a href="#two">
-            Women-owned small business federal contracting program
-          </a>
-        </li>
+        <span slot="list">
+          <li>
+            <a href="#home">Home</a>
+          </li>
+          <li>
+            <a href="#one">Federal Contracting</a>
+          </li>
+          <li>
+            <a href="#two">Contracting assistance programs</a>
+          </li>
+          <li>
+            <a href="#two">
+              Women-owned small business federal contracting program
+            </a>
+          </li>
+        </span>
       </va-breadcrumbs>
     </div>
   );

--- a/packages/storybook/stories/va-breadcrumbs.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs.stories.jsx
@@ -16,37 +16,44 @@ export default {
 
 const Template = ({ label, 'disable-analytics': disableAnalytics }) => (
   <va-breadcrumbs label={label} disable-analytics={disableAnalytics}>
-    <a href="#home">Home</a>
-    <a href="#one">Level one</a>
-    <a href="#two">Level two</a>
+    <span slot="list">
+      <a href="#home">Home</a>
+      <a href="#one">Level one</a>
+      <a href="#two">Level two</a>
+    </span>
   </va-breadcrumbs>
 );
 
-const DynamicCrumbsTemplate = ({ 
-  label, 
-  'disable-analytics': disableAnalytics 
+const DynamicCrumbsTemplate = ({
+  label,
+  'disable-analytics': disableAnalytics,
 }) => {
   const breadcrumbs = [
-    {label: 'Level 1', path: '/#1'},
-    {label: 'Level 2', path: '/#2'},
-    {label: 'Level 3', path: '/#3'},
+    { label: 'Level 1', path: '/#1' },
+    { label: 'Level 2', path: '/#2' },
+    { label: 'Level 3', path: '/#3' },
   ];
 
   const breadcrumbs2 = [
-    {label: 'First Link', path: '#example1'},
-    {label: 'Second Link', path: '#example2'},
-    {label: 'Third Link', path: '#example3'},
-    {label: 'Fourth Link', path: '#example4'},
+    { label: 'First Link', path: '#example1' },
+    { label: 'Second Link', path: '#example2' },
+    { label: 'Third Link', path: '#example3' },
+    { label: 'Fourth Link', path: '#example4' },
   ];
   const [crumbs, setCrumbs] = useState(breadcrumbs);
-  const addCrumb = () => setCrumbs(arr => [...arr, {label: `Level ${arr.length + 1}`, path: `/#${arr.length + 1}`}]);
+  const addCrumb = () =>
+    setCrumbs(arr => [
+      ...arr,
+      { label: `Level ${arr.length + 1}`, path: `/#${arr.length + 1}` },
+    ]);
   const replaceCrumbs = () => setCrumbs(breadcrumbs2);
   const resetCrumbs = () => setCrumbs(breadcrumbs);
-  const removeCrumb = () => setCrumbs((arr) => {
-    const newArr = [...arr];
-    newArr.pop();
-    return newArr;
-  });
+  const removeCrumb = () =>
+    setCrumbs(arr => {
+      const newArr = [...arr];
+      newArr.pop();
+      return newArr;
+    });
 
   return (
     <div>
@@ -54,24 +61,26 @@ const DynamicCrumbsTemplate = ({
       <button onClick={e => removeCrumb()}>Remove Crumb</button>
       <button onClick={e => replaceCrumbs()}>Replace Crumbs</button>
       <button onClick={e => resetCrumbs()}>Reset Crumbs</button>
-      <br/>
-      <p>Note: To rerender the breadcrumbs dynamically, the anchor links must be wrapped in list tags.</p>
+      <br />
+      <p>
+        Note: To rerender the breadcrumbs dynamically, the anchor links must be
+        wrapped in list tags.
+      </p>
       {crumbs.length > 0 && (
         <va-breadcrumbs label={label} disable-analytics={disableAnalytics}>
-          {crumbs?.map((crumb, i) => {
-            return (
-              <li key={i}>
-                <a href={crumb.path}>
-                  {crumb.label}
-                </a>
-              </li>
-            );
-          })
-        }
+          <span slot="list">
+            {crumbs?.map((crumb, i) => {
+              return (
+                <li key={i}>
+                  <a href={crumb.path}>{crumb.label}</a>
+                </li>
+              );
+            })}
+          </span>
         </va-breadcrumbs>
       )}
     </div>
-  )
+  );
 };
 
 const defaultArgs = {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -161,6 +161,14 @@ export namespace Components {
           * Adds an aria-label attribute to the <nav /> element.
          */
         "label"?: string;
+        /**
+          * USWDS variation
+         */
+        "uswds"?: boolean;
+        /**
+          * Whether or not the component will wrap the breadcrumbs. This prop is available when `uswds` is set to `true`.
+         */
+        "wrapping"?: boolean;
     }
     interface VaButton {
         /**
@@ -1750,6 +1758,14 @@ declare namespace LocalJSX {
           * The event used to track usage of the component. This is emitted when a breadcrumb anchor is clicked and disableAnalytics is not true.
          */
         "onComponent-library-analytics"?: (event: VaBreadcrumbsCustomEvent<any>) => void;
+        /**
+          * USWDS variation
+         */
+        "uswds"?: boolean;
+        /**
+          * Whether or not the component will wrap the breadcrumbs. This prop is available when `uswds` is set to `true`.
+         */
+        "wrapping"?: boolean;
     }
     interface VaButton {
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -595,7 +595,7 @@ export namespace Components {
          */
         "closeable"?: boolean;
         /**
-          * Date and time for notification. This will be incorporated into a unique aria-describedby label
+          * Date and time for notification. This will also be incorporated into a unique aria-describedby label.
          */
         "dateTime"?: string;
         /**
@@ -2288,7 +2288,7 @@ declare namespace LocalJSX {
          */
         "closeable"?: boolean;
         /**
-          * Date and time for notification. This will be incorporated into a unique aria-describedby label
+          * Date and time for notification. This will also be incorporated into a unique aria-describedby label.
          */
         "dateTime"?: string;
         /**

--- a/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
+++ b/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
@@ -9,13 +9,11 @@ describe('va-breadcrumbs', () => {
     const element = await page.find('va-breadcrumbs');
     expect(element).toEqualHtml(`
       <va-breadcrumbs class="hydrated">
-        <mock:shadow-root>
-          <nav aria-label="Breadcrumb">
-            <ul role="list">
-              <slot></slot>
-            </ul>
-          </nav>
-        </mock:shadow-root>
+        <!---->
+        <nav aria-label="Breadcrumb">
+          <ul role="list">
+          </ul>
+        </nav>
       </va-breadcrumbs>
     `);
   });
@@ -33,22 +31,20 @@ describe('va-breadcrumbs', () => {
     const element = await page.find('va-breadcrumbs');
     expect(element).toEqualHtml(`
       <va-breadcrumbs class="hydrated">
-        <mock:shadow-root>
+        <!---->
           <nav aria-label="Breadcrumb">
             <ul role="list">
-              <slot></slot>
+              <li class="va-breadcrumbs-li">
+                <a href="#home">Home</a>
+              </li>
+              <li class="va-breadcrumbs-li">
+                <a href="#one">Level One</a>
+              </li>
+              <li class="va-breadcrumbs-li">
+                <a aria-current="page" href="#two">Level Two</a>
+              </li>
             </ul>
           </nav>
-        </mock:shadow-root>
-        <li class="va-breadcrumbs-li">
-          <a href="#home">Home</a>
-        </li>
-        <li class="va-breadcrumbs-li">
-          <a href="#one">Level One</a>
-        </li>
-        <li class="va-breadcrumbs-li">
-          <a aria-current="page" href="#two">Level Two</a>
-        </li>
       </va-breadcrumbs>
     `);
   });
@@ -66,22 +62,20 @@ describe('va-breadcrumbs', () => {
     const element = await page.find('va-breadcrumbs');
     expect(element).toEqualHtml(`
       <va-breadcrumbs class="hydrated">
-        <mock:shadow-root>
-          <nav aria-label="Breadcrumb">
-            <ul role="list">
-              <slot></slot>
-            </ul>
-          </nav>
-        </mock:shadow-root>
-        <li class="va-breadcrumbs-li">
-          <a href="#home">Home</a>
-        </li>
-        <li class="va-breadcrumbs-li">
-          <a href="#one">Level One</a>
-        </li>
-        <li class="va-breadcrumbs-li">
-          <a aria-current="page" href="#two">Level Two</a>
-        </li>
+        <!---->
+        <nav aria-label="Breadcrumb">
+          <ul role="list">
+            <li class="va-breadcrumbs-li">
+              <a href="#home">Home</a>
+            </li>
+            <li class="va-breadcrumbs-li">
+              <a href="#one">Level One</a>
+            </li>
+            <li class="va-breadcrumbs-li">
+              <a aria-current="page" href="#two">Level Two</a>
+            </li>
+          </ul>
+        </nav>
       </va-breadcrumbs>
     `);
   });
@@ -130,6 +124,170 @@ describe('va-breadcrumbs', () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-breadcrumbs disable-analytics>
+        <a href="#home">Home</a>
+        <a href="#one">Level One</a>
+        <a href="#two">Level Two</a>
+      </va-breadcrumbs>
+    `);
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const anchorElement = await page.find('pierce/a');
+    await anchorElement.click();
+
+    expect(analyticsSpy).toHaveReceivedEventTimes(0);
+  });
+
+  /** Begin USWDS v3 Tests */
+  it('uswds - renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-breadcrumbs uswds></va-breadcrumbs>');
+
+    const element = await page.find('va-breadcrumbs');
+    expect(element).toEqualHtml(`
+      <va-breadcrumbs class="hydrated" uswds>
+        <!---->
+        <nav aria-label="Breadcrumb" class="usa-breadcrumb">
+          <ol class="usa-breadcrumb__list" role="list">
+          </ol>
+        </nav>
+      </va-breadcrumbs>
+    `);
+  });
+
+  it("uswds - should render wrap labels when 'wrapping' is true", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs uswds wrapping>
+        <a href="#home">Home</a>
+        <a href="#one">Level One</a>
+        <a href="#two">Level Two</a>
+      </va-breadcrumbs>
+    `);
+    const element = await page.find('va-breadcrumbs nav');
+    expect(element.classList.contains('usa-breadcrumb--wrap')).toBe(true);
+  })
+
+  it('uswds - renders slotted content (anchor tags)', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs uswds>
+        <a href="#home">Home</a>
+        <a href="#one">Level One</a>
+        <a href="#two">Level Two</a>
+      </va-breadcrumbs>
+    `);
+
+    const element = await page.find('va-breadcrumbs');
+    expect(element).toEqualHtml(`
+      <va-breadcrumbs class="hydrated" uswds>
+        <!---->
+        <nav aria-label="Breadcrumb" class="usa-breadcrumb">
+          <ol role="list" class="usa-breadcrumb__list">
+            <li class="usa-breadcrumb__list-item">
+              <a href="#home" class="usa-breadcrumb__link">
+                <span>
+                  Home
+                </span>
+              </a>
+            </li>
+            <li class="usa-breadcrumb__list-item">
+              <a href="#one" class="usa-breadcrumb__link">
+                <span>
+                  Level One
+                </span>
+              </a>
+            </li>
+            <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
+              <span>
+                Level Two
+              </span>
+            </li>
+          </ol>
+        </nav>
+      </va-breadcrumbs>
+    `);
+  });
+
+  it('uswds - renders slotted content (list items)', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs uswds>
+        <li><a href="#home">Home</a></li>
+        <li><a href="#one">Level One</a></li>
+        <li><a href="#two">Level Two</a></li>
+      </va-breadcrumbs>
+    `);
+
+    const element = await page.find('va-breadcrumbs');
+    expect(element).toEqualHtml(`
+    <va-breadcrumbs class="hydrated" uswds>
+      <!---->
+        <nav aria-label="Breadcrumb" class="usa-breadcrumb">
+          <ol role="list" class="usa-breadcrumb__list">
+            <li class="usa-breadcrumb__list-item">
+              <a href="#home" class="usa-breadcrumb__link">
+                <span>Home</span>
+              </a>
+            </li>
+            <li class="usa-breadcrumb__list-item">
+              <a href="#one" class="usa-breadcrumb__link">
+                <span>Level One</span>
+              </a>
+            </li>
+            <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
+              <span>Level Two</span>
+            </li>
+          </ol>
+        </nav>
+    </va-breadcrumbs>
+    `);
+  });
+
+  it('uswds - passes an axe check', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs uswds>
+        <a href="#home">Home</a>
+        <a href="#one">Level One</a>
+        <a href="#two">Level Two</a>
+      </va-breadcrumbs>
+    `);
+
+    await axeCheck(page);
+  });
+
+  it('uswds - fires an analytics event when an anchor link is clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs uswds>
+        <a href="#home">Home</a>
+        <a href="#one">Level One</a>
+        <a href="#two">Level Two</a>
+      </va-breadcrumbs>
+    `);
+
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+
+    const anchorElements = await page.findAll('pierce/a');
+
+    await anchorElements[1].click();
+
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      action: 'linkClick',
+      componentName: 'va-breadcrumbs',
+      details: {
+        clickLabel: 'Level One',
+        clickLevel: 2,
+        totalLevels: 3,
+      },
+    });
+  });
+
+  it(`uswds - doesn't fire an analytics event with disable-analytics prop when an anchor link is clicked`, async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs disable-analytics uswds>
         <a href="#home">Home</a>
         <a href="#one">Level One</a>
         <a href="#two">Level Two</a>

--- a/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
+++ b/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
@@ -22,9 +22,11 @@ describe('va-breadcrumbs', () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-breadcrumbs>
-        <a href="#home">Home</a>
-        <a href="#one">Level One</a>
-        <a href="#two">Level Two</a>
+        <span slot="list">
+          <a href="#home">Home</a>
+          <a href="#one">Level One</a>
+          <a href="#two">Level Two</a>
+        </span>
       </va-breadcrumbs>
     `);
 
@@ -34,15 +36,17 @@ describe('va-breadcrumbs', () => {
         <!---->
           <nav aria-label="Breadcrumb">
             <ul role="list">
-              <li class="va-breadcrumbs-li">
-                <a href="#home">Home</a>
-              </li>
-              <li class="va-breadcrumbs-li">
-                <a href="#one">Level One</a>
-              </li>
-              <li class="va-breadcrumbs-li">
-                <a aria-current="page" href="#two">Level Two</a>
-              </li>
+              <span slot="list">
+                <li class="va-breadcrumbs-li">
+                  <a href="#home">Home</a>
+                </li>
+                <li class="va-breadcrumbs-li">
+                  <a href="#one">Level One</a>
+                </li>
+                <li class="va-breadcrumbs-li">
+                  <a aria-current="page" href="#two">Level Two</a>
+                </li>
+              </span>
             </ul>
           </nav>
       </va-breadcrumbs>
@@ -53,9 +57,11 @@ describe('va-breadcrumbs', () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-breadcrumbs>
-        <li><a href="#home">Home</a></li>
-        <li><a href="#one">Level One</a></li>
-        <li><a href="#two">Level Two</a></li>
+        <span slot="list">
+          <li><a href="#home">Home</a></li>
+          <li><a href="#one">Level One</a></li>
+          <li><a href="#two">Level Two</a></li>
+        </span>
       </va-breadcrumbs>
     `);
 
@@ -65,15 +71,17 @@ describe('va-breadcrumbs', () => {
         <!---->
         <nav aria-label="Breadcrumb">
           <ul role="list">
-            <li class="va-breadcrumbs-li">
-              <a href="#home">Home</a>
-            </li>
-            <li class="va-breadcrumbs-li">
-              <a href="#one">Level One</a>
-            </li>
-            <li class="va-breadcrumbs-li">
-              <a aria-current="page" href="#two">Level Two</a>
-            </li>
+            <span slot="list">
+              <li class="va-breadcrumbs-li">
+                <a href="#home">Home</a>
+              </li>
+              <li class="va-breadcrumbs-li">
+                <a href="#one">Level One</a>
+              </li>
+              <li class="va-breadcrumbs-li">
+                <a aria-current="page" href="#two">Level Two</a>
+              </li>
+            </span>
           </ul>
         </nav>
       </va-breadcrumbs>
@@ -84,9 +92,11 @@ describe('va-breadcrumbs', () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-breadcrumbs>
-        <a href="#home">Home</a>
-        <a href="#one">Level One</a>
-        <a href="#two">Level Two</a>
+        <span slot="list">
+          <a href="#home">Home</a>
+          <a href="#one">Level One</a>
+          <a href="#two">Level Two</a>
+        </span>
       </va-breadcrumbs>
     `);
 
@@ -172,9 +182,11 @@ describe('va-breadcrumbs', () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-breadcrumbs uswds>
-        <a href="#home">Home</a>
-        <a href="#one">Level One</a>
-        <a href="#two">Level Two</a>
+        <span slot="list">
+          <a href="#home">Home</a>
+          <a href="#one">Level One</a>
+          <a href="#two">Level Two</a>
+        </span>
       </va-breadcrumbs>
     `);
 
@@ -184,25 +196,27 @@ describe('va-breadcrumbs', () => {
         <!---->
         <nav aria-label="Breadcrumb" class="usa-breadcrumb">
           <ol role="list" class="usa-breadcrumb__list">
-            <li class="usa-breadcrumb__list-item">
-              <a href="#home" class="usa-breadcrumb__link">
+            <span slot="list">
+              <li class="usa-breadcrumb__list-item">
+                <a href="#home" class="usa-breadcrumb__link">
+                  <span>
+                    Home
+                  </span>
+                </a>
+              </li>
+              <li class="usa-breadcrumb__list-item">
+                <a href="#one" class="usa-breadcrumb__link">
+                  <span>
+                    Level One
+                  </span>
+                </a>
+              </li>
+              <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
                 <span>
-                  Home
+                  Level Two
                 </span>
-              </a>
-            </li>
-            <li class="usa-breadcrumb__list-item">
-              <a href="#one" class="usa-breadcrumb__link">
-                <span>
-                  Level One
-                </span>
-              </a>
-            </li>
-            <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-              <span>
-                Level Two
-              </span>
-            </li>
+              </li>
+            </span>
           </ol>
         </nav>
       </va-breadcrumbs>
@@ -213,9 +227,11 @@ describe('va-breadcrumbs', () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-breadcrumbs uswds>
-        <li><a href="#home">Home</a></li>
-        <li><a href="#one">Level One</a></li>
-        <li><a href="#two">Level Two</a></li>
+        <span slot="list">
+          <li><a href="#home">Home</a></li>
+          <li><a href="#one">Level One</a></li>
+          <li><a href="#two">Level Two</a></li>
+        </span>
       </va-breadcrumbs>
     `);
 
@@ -225,19 +241,21 @@ describe('va-breadcrumbs', () => {
       <!---->
         <nav aria-label="Breadcrumb" class="usa-breadcrumb">
           <ol role="list" class="usa-breadcrumb__list">
-            <li class="usa-breadcrumb__list-item">
-              <a href="#home" class="usa-breadcrumb__link">
-                <span>Home</span>
-              </a>
-            </li>
-            <li class="usa-breadcrumb__list-item">
-              <a href="#one" class="usa-breadcrumb__link">
-                <span>Level One</span>
-              </a>
-            </li>
-            <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-              <span>Level Two</span>
-            </li>
+            <span slot="list">
+              <li class="usa-breadcrumb__list-item">
+                <a href="#home" class="usa-breadcrumb__link">
+                  <span>Home</span>
+                </a>
+              </li>
+              <li class="usa-breadcrumb__list-item">
+                <a href="#one" class="usa-breadcrumb__link">
+                  <span>Level One</span>
+                </a>
+              </li>
+              <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
+                <span>Level Two</span>
+              </li>
+            </span>
           </ol>
         </nav>
     </va-breadcrumbs>
@@ -248,9 +266,11 @@ describe('va-breadcrumbs', () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-breadcrumbs uswds>
-        <a href="#home">Home</a>
-        <a href="#one">Level One</a>
-        <a href="#two">Level Two</a>
+        <span slot="list">
+          <a href="#home">Home</a>
+          <a href="#one">Level One</a>
+          <a href="#two">Level Two</a>
+        </span>
       </va-breadcrumbs>
     `);
 

--- a/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
+++ b/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
@@ -279,7 +279,7 @@ describe('va-breadcrumbs', () => {
       details: {
         clickLabel: 'Level One',
         clickLevel: 2,
-        totalLevels: 3,
+        totalLevels: 2,
       },
     });
   });

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
@@ -25,3 +25,7 @@ ul {
   position: relative;
   width: 100%;
 }
+
+.usa-breadcrumb__link span {
+  pointer-events: none;
+}

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
@@ -1,3 +1,9 @@
+@forward 'settings';
+@use 'usa-breadcrumb/src/styles/usa-breadcrumb';
+
+
+@import '../../global/formation_overrides';
+
 :host {
   display: block;
 }

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -7,6 +7,7 @@ import {
   h,
   Prop,
 } from '@stencil/core';
+import classnames from 'classnames';
 
 /**
  * @componentName Breadcrumbs
@@ -15,8 +16,8 @@ import {
  */
 @Component({
   tag: 'va-breadcrumbs',
-  styleUrl: 'va-breadcrumbs.css',
-  shadow: true,
+  styleUrl: 'va-breadcrumbs.scss',
+  shadow: false,
 })
 export class VaBreadcrumbs {
   @Element() el: HTMLElement;
@@ -30,7 +31,14 @@ export class VaBreadcrumbs {
    * Analytics tracking function(s) will not be called
    */
   @Prop() disableAnalytics?: boolean = false;
-
+  /**
+     * USWDS variation
+     */
+  @Prop() uswds?: boolean = false;
+  /**
+   *  Whether or not the component will wrap the breadcrumbs. This prop is available when `uswds` is set to `true`.
+   */
+  @Prop() wrapping?: boolean = false;
   /**
    * The event used to track usage of the component. This is emitted when a
    * breadcrumb anchor is clicked and disableAnalytics is not true.
@@ -51,8 +59,11 @@ export class VaBreadcrumbs {
   }
 
   private fireAnalyticsEvent(event: MouseEvent): void {
+    event.preventDefault();
     if (!this.disableAnalytics) {
       const target = event.target as HTMLAnchorElement;
+
+      console.log(target)
       // If it's a link being clicked, dispatch an analytics event
       if (target?.tagName === 'A') {
         const details = {
@@ -61,7 +72,7 @@ export class VaBreadcrumbs {
           details: {
             clickLabel: target.innerText.trim(),
             clickLevel: this.getClickLevel(target),
-            totalLevels: this.el.querySelectorAll('a').length,
+            totalLevels: this.uswds ? this.el.querySelectorAll('a').length - 1 : this.el.querySelectorAll('a').length,
           },
         };
         this.componentLibraryAnalytics.emit(details);
@@ -69,10 +80,10 @@ export class VaBreadcrumbs {
     }
   }
 
-  private handleAnchorNode(node: HTMLSlotElement, index: number, slotNodes: Node[]) {
+  private handleAnchorNode(node, index: number, listItems) {
     const li = document.createElement('li');
     li.classList.add('va-breadcrumbs-li');
-    if (index === slotNodes.length - 1) {
+    if (index === listItems.length - 1) {
       /* eslint-disable-next-line i18next/no-literal-string */
       node.setAttribute('aria-current', 'page');
     }
@@ -80,31 +91,99 @@ export class VaBreadcrumbs {
     li.appendChild(node);
   }
 
-  private handleListNode(node: HTMLSlotElement, index: number, slotNodes: Node[]) {
+  private handleListNode(node, index: number, listItems) {
     node.classList.add('va-breadcrumbs-li');
     const anchor = node.querySelector('a');
-    if (anchor && index === slotNodes.length - 1) {
+    if (anchor && index === listItems.length - 1) {
       /* eslint-disable-next-line i18next/no-literal-string */
       anchor.setAttribute('aria-current', 'page');
     }
   }
 
-  componentDidLoad() {
-    // We are getting the slot nodes so that we can handle either receiving an 
-    // anchor tag or a list item with an anchor tag.
-    const slotNodes = (this.el.shadowRoot.querySelector('slot') as HTMLSlotElement)?.assignedNodes();
-    if (!slotNodes) return;
+  /**
+   * This method takes an anchor element as an argument, creates a new span element,
+   * and moves the contents of the anchor into the span. This is useful for adhering to 
+   * the USWDS breadcrumb format, which expects anchor text to be wrapped in a span.
+   * @param {HTMLElement} anchor - The anchor element to be modified
+   */
+  private wrapAnchorText(anchor) {
+    const spanElement = document.createElement('span');
+    spanElement.innerHTML = anchor.innerHTML;
+    anchor.innerHTML = '';
+    anchor.appendChild(spanElement);
+  }
 
-    // This handles two different slot node scenarios:
-    // 1. <li><a href="...">...</a></li>
-    // 2. <a href="...">...</a>
-    slotNodes.forEach((node: HTMLSlotElement, index: number) => {
-      if (node.nodeName === 'LI') { 
-        this.handleListNode(node, index, slotNodes);
-      } else if (node.nodeName === 'A') {
-        this.handleAnchorNode(node, index, slotNodes);
-      }
+  /**
+   * This method takes an array of anchor elements and for each one, it creates a new 
+   * list item, clones the anchor, and appends the cloned anchor to the list item. The 
+   * original anchor is then replaced in the DOM with the new list item. This is useful 
+   * for transforming a list of anchor elements into a list of list items with anchor children.
+   * @param {Array<HTMLElement>} anchorItems - The anchor elements to be transformed
+   */
+  private wrapAnchorsInList(anchorItems) {
+    anchorItems.forEach((anchor) => {
+        const listItem = document.createElement('li');
+        listItem.appendChild(anchor.cloneNode(true)); // clone the anchor to avoid modifying original anchor
+        anchor.parentNode.replaceChild(listItem, anchor);
     });
+  }
+
+  componentDidLoad() {
+    if (this.uswds) {
+      const listItems = Array.from(this.el.querySelectorAll('li'));
+      const anchorItems = Array.from(this.el.querySelectorAll('a'));
+  
+      // Check if we have list items, if not wrap anchorItems into list items
+      if(listItems.length === 0 && anchorItems.length > 0) {
+          this.wrapAnchorsInList(anchorItems);
+      }
+  
+      const updatedListItems = Array.from(this.el.querySelectorAll('li'));
+      const updatedAnchorItems = Array.from(this.el.querySelectorAll('a'));
+
+        updatedListItems.forEach((item, i) => {
+            item.classList.add('usa-breadcrumb__list-item');
+            if (updatedListItems.length - 1 === i) {
+              item.classList.add('usa-current');
+              // eslint-disable-next-line i18next/no-literal-string
+              item.setAttribute('aria-current', 'page');
+
+              // Find the anchor child and replace it with a span
+              const anchor = item.querySelector('a');
+              if (anchor) {
+                const span = document.createElement('span');
+                span.innerHTML = anchor.innerHTML;
+                item.replaceChild(span, anchor);
+              }
+            }
+        });
+
+        updatedAnchorItems.forEach((item) => {
+            item.classList.add('usa-breadcrumb__link');
+            this.wrapAnchorText(item);
+        });
+    } else {
+      // We are getting the slot nodes so that we can handle either receiving an 
+      // anchor tag or a list item with an anchor tag.
+      const listItems = this.el.querySelectorAll('li');
+      const anchorItems = this.el.querySelectorAll('a');
+      
+      if (listItems.length > 0) {
+          // Scenario: <li><a href="...">...</a></li>
+          listItems.forEach((item, index) => {
+              if (item.nodeName === 'LI') { 
+                  this.handleListNode(item, index, listItems);
+              }
+          });
+      } else if (anchorItems.length > 0) {
+          // Scenario: <a href="...">...</a>
+          anchorItems.forEach((item, index) => {
+              if (item.nodeName === 'A') {
+                  this.handleAnchorNode(item, index, anchorItems);
+              }
+          });
+      }
+    }
   }
 
   /**
@@ -115,7 +194,7 @@ export class VaBreadcrumbs {
    */
   handleSlotChange() {
     // Get all of the slot nodes and filter out only the list items.
-    const slotNodes = (this.el.shadowRoot.querySelector('slot') as HTMLSlotElement)
+    const slotNodes = (this.el.querySelector('slot') as HTMLSlotElement)
       ?.assignedNodes()
       .filter((node: HTMLSlotElement) => node.nodeName === 'LI');
 
@@ -144,16 +223,32 @@ export class VaBreadcrumbs {
   }
 
   render() {
-    const { label } = this;
-
-    return (
-      <Host>
-        <nav aria-label={label}>
-          <ul role="list" onClick={e => this.fireAnalyticsEvent(e)}>
-            <slot onSlotchange={this.handleSlotChange.bind(this)}></slot>
-          </ul>
-        </nav>
-      </Host>
-    );
+    const { label, uswds, wrapping } = this;
+    const wrapClass = classnames({
+      'usa-breadcrumb': true,
+      'usa-breadcrumb--wrap': wrapping
+    });
+    
+    if (uswds) {
+      return (
+        <Host>
+          <nav class={wrapClass} aria-label={label}>
+            <ol class="usa-breadcrumb__list" role="list" onClick={e => this.fireAnalyticsEvent(e)}>
+              <slot onSlotchange={this.handleSlotChange.bind(this)}></slot>
+            </ol>
+          </nav>
+        </Host>
+      );
+    } else {
+      return (
+        <Host>
+          <nav aria-label={label}>
+            <ul role="list" onClick={e => this.fireAnalyticsEvent(e)}>
+              <slot onSlotchange={this.handleSlotChange.bind(this)}></slot>
+            </ul>
+          </nav>
+        </Host>
+      );
+    }
   }
 }

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -63,7 +63,6 @@ export class VaBreadcrumbs {
     if (!this.disableAnalytics) {
       const target = event.target as HTMLAnchorElement;
 
-      console.log(target)
       // If it's a link being clicked, dispatch an analytics event
       if (target?.tagName === 'A') {
         const details = {
@@ -72,7 +71,7 @@ export class VaBreadcrumbs {
           details: {
             clickLabel: target.innerText.trim(),
             clickLevel: this.getClickLevel(target),
-            totalLevels: this.uswds ? this.el.querySelectorAll('a').length - 1 : this.el.querySelectorAll('a').length,
+            totalLevels: this.el.querySelectorAll('a').length,
           },
         };
         this.componentLibraryAnalytics.emit(details);
@@ -135,33 +134,33 @@ export class VaBreadcrumbs {
   
       // Check if we have list items, if not wrap anchorItems into list items
       if(listItems.length === 0 && anchorItems.length > 0) {
-          this.wrapAnchorsInList(anchorItems);
+        this.wrapAnchorsInList(anchorItems);
       }
   
       const updatedListItems = Array.from(this.el.querySelectorAll('li'));
       const updatedAnchorItems = Array.from(this.el.querySelectorAll('a'));
 
-        updatedListItems.forEach((item, i) => {
-            item.classList.add('usa-breadcrumb__list-item');
-            if (updatedListItems.length - 1 === i) {
-              item.classList.add('usa-current');
-              // eslint-disable-next-line i18next/no-literal-string
-              item.setAttribute('aria-current', 'page');
+      updatedListItems.forEach((item, i) => {
+        item.classList.add('usa-breadcrumb__list-item');
+        if (updatedListItems.length - 1 === i) {
+          item.classList.add('usa-current');
+          // eslint-disable-next-line i18next/no-literal-string
+          item.setAttribute('aria-current', 'page');
 
-              // Find the anchor child and replace it with a span
-              const anchor = item.querySelector('a');
-              if (anchor) {
-                const span = document.createElement('span');
-                span.innerHTML = anchor.innerHTML;
-                item.replaceChild(span, anchor);
-              }
-            }
-        });
+          // Find the anchor child and replace it with a span
+          const anchor = item.querySelector('a');
+          if (anchor) {
+            const span = document.createElement('span');
+            span.innerHTML = anchor.innerHTML;
+            item.replaceChild(span, anchor);
+          }
+        }
+      });
 
-        updatedAnchorItems.forEach((item) => {
-            item.classList.add('usa-breadcrumb__link');
-            this.wrapAnchorText(item);
-        });
+      updatedAnchorItems.forEach((item) => {
+        item.classList.add('usa-breadcrumb__link');
+        this.wrapAnchorText(item);
+      });
     } else {
       // We are getting the slot nodes so that we can handle either receiving an 
       // anchor tag or a list item with an anchor tag.
@@ -169,19 +168,19 @@ export class VaBreadcrumbs {
       const anchorItems = this.el.querySelectorAll('a');
       
       if (listItems.length > 0) {
-          // Scenario: <li><a href="...">...</a></li>
-          listItems.forEach((item, index) => {
-              if (item.nodeName === 'LI') { 
-                  this.handleListNode(item, index, listItems);
-              }
-          });
+        // Scenario: <li><a href="...">...</a></li>
+        listItems.forEach((item, index) => {
+          if (item.nodeName === 'LI') { 
+              this.handleListNode(item, index, listItems);
+          }
+        });
       } else if (anchorItems.length > 0) {
-          // Scenario: <a href="...">...</a>
-          anchorItems.forEach((item, index) => {
-              if (item.nodeName === 'A') {
-                  this.handleAnchorNode(item, index, anchorItems);
-              }
-          });
+        // Scenario: <a href="...">...</a>
+        anchorItems.forEach((item, index) => {
+          if (item.nodeName === 'A') {
+            this.handleAnchorNode(item, index, anchorItems);
+          }
+        });
       }
     }
   }

--- a/packages/web-components/src/global/_formation_overrides.scss
+++ b/packages/web-components/src/global/_formation_overrides.scss
@@ -387,3 +387,14 @@
   border-right: rem-override(0.25rem) solid rgb(240, 240, 240);
   padding-bottom: rem-override(1rem);
 }
+
+.usa-breadcrumb {
+  padding-bottom: rem-override(1rem);
+  padding-top: rem-override(1rem);
+  font-size: rem-override(1.06rem);
+}
+
+.usa-breadcrumb__list {
+  margin: 0 rem-override(-0.25rem);
+  padding: rem-override(0.25rem);
+}


### PR DESCRIPTION
## Chromatic
<!-- This `1716-new-v3-breadcrumb` is a placeholder for a CI job - it will be updated automatically -->
https://1716-new-v3-breadcrumb--60f9b557105290003b387cd5.chromatic.com

## Description
This pull request adds a new breadcrumb component.
Changes:
- A new prop `wrapping`
- Conversion of rem to px
Closes [1716](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1716)

## Testing done
Tested in Storybook
Chrome/Edge/Mozzila

## Screenshots
<img width="287" alt="Screenshot 2023-07-10 at 3 18 35 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/22892911/5675cfde-55c4-4422-8465-3cc024069617">
<br>
<img width="510" alt="Screenshot 2023-07-10 at 3 19 32 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/22892911/200cd97d-64c3-47f9-ad96-a1a40572eb0f">


## Acceptance criteria
- [ ] A USWDS v3 variation exists for va-breadcrumb web component

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
