### PR TITLE
va-modal: Add button click analytics

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.9",
+  "version": "4.42.10",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.7",
+  "version": "4.42.8",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-modal/test/va-modal.e2e.ts
+++ b/packages/web-components/src/components/va-modal/test/va-modal.e2e.ts
@@ -208,6 +208,70 @@ describe('va-modal', () => {
     );
   });
 
+  it('fires a single analytics event when va-modal displays', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+    `<va-modal modal-title="Example Title" status="info" primary-button-text="Primary button" secondary-button-text="Secondary button">
+      <p>Example modal content</p>
+    </va-modal>`,
+    );
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+    const modal = await page.find("va-modal");
+
+    await modal.setProperty("visible", true);
+    await page.waitForChanges()
+
+    expect(analyticsSpy).toHaveReceivedEventTimes(1);
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      componentName: 'va-modal',
+      action: 'show',
+      details: {
+        status: 'info',
+        title: 'Example Title',
+        primaryButtonText: "Primary button",
+        secondaryButtonText: "Secondary button"
+      },
+    });
+  });
+
+  it('fires a single analytics event for each button clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-modal modal-title="Example Title" visible status="info" primary-button-text="Primary button" secondary-button-text="Secondary button">
+      <p>Example modal content</p>
+    </va-modal>`,
+    );
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+    const primaryButton = await page.find('va-modal >>> #modal-primary-button');
+    const secondaryButton = await page.find('va-modal >>> #modal-secondary-button');
+
+    await primaryButton.click();
+
+    expect(analyticsSpy).toHaveReceivedEventTimes(1);
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      componentName: 'va-modal',
+      action: 'click',
+      details: {
+        status: 'info',
+        title: 'Example Title',
+        clickLabel: "Primary button",
+      },
+    });
+
+    await secondaryButton.click();
+
+    expect(analyticsSpy).toHaveReceivedEventTimes(2);
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      componentName: 'va-modal',
+      action: 'click',
+      details: {
+        status: 'info',
+        title: 'Example Title',
+        clickLabel: "Secondary button",
+      },
+    });
+  });
+
   // Begin USWDS v3 test
   it('uswds v3 renders', async () => {
     const page = await newE2EPage();
@@ -415,5 +479,69 @@ describe('va-modal', () => {
     expect(tab2Element.getAttribute('aria-label')).toEqual(
       'Close Example Title modal',
     );
+  });
+
+  it('uswds v3 fires a single analytics event when va-modal displays', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+    `<va-modal uswds modal-title="Example Title" status="info" primary-button-text="Primary button" secondary-button-text="Secondary button">
+      <p>Example modal content</p>
+    </va-modal>`,
+    );
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+    const modal = await page.find("va-modal");
+
+    await modal.setProperty("visible", true);
+    await page.waitForChanges()
+
+    expect(analyticsSpy).toHaveReceivedEventTimes(1);
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      componentName: 'va-modal',
+      action: 'show',
+      details: {
+        status: 'info',
+        title: 'Example Title',
+        primaryButtonText: "Primary button",
+        secondaryButtonText: "Secondary button"
+      },
+    });
+  });
+
+  it('uswds v3 fires a single analytics event for each button clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-modal uswds modal-title="Example Title" visible status="info" primary-button-text="Primary button" secondary-button-text="Secondary button">
+      <p>Example modal content</p>
+    </va-modal>`,
+    );
+    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
+    const primaryButton = await page.find('va-modal >>> va-button');
+    const secondaryButton = await page.find('va-modal >>> va-button[secondary]');
+
+    await primaryButton.click();
+
+    expect(analyticsSpy).toHaveReceivedEventTimes(1);
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      componentName: 'va-modal',
+      action: 'click',
+      details: {
+        status: 'info',
+        title: 'Example Title',
+        clickLabel: "Primary button",
+      },
+    });
+
+    await secondaryButton.click();
+
+    expect(analyticsSpy).toHaveReceivedEventTimes(2);
+    expect(analyticsSpy).toHaveReceivedEventDetail({
+      componentName: 'va-modal',
+      action: 'click',
+      details: {
+        status: 'info',
+        title: 'Example Title',
+        clickLabel: "Secondary button",
+      },
+    });
   });
 });

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -87,6 +87,21 @@ export class VaModal {
   componentLibraryAnalytics: EventEmitter;
 
   /**
+   * Listen for the va-button GA event and capture it so 
+   * that we can emit a single va-modal GA event that includes
+   * the va-button details in handlePrimaryButtonClick and
+   * handleSecondaryButtonClick.
+   */
+  @Listen('component-library-analytics')
+  handleButtonClickAnalytics(event) {
+    // Prevent va-modal GA event from firing multiple times.
+    if (event.detail.componentName === 'va-modal') return;
+
+    // Prevent va-button GA event from firing.
+    event.stopPropagation();
+  }
+
+  /**
    * Click outside modal will trigger closeEvent
    */
   @Prop() clickToClose?: boolean = false;
@@ -248,10 +263,36 @@ export class VaModal {
 
   private handlePrimaryButtonClick(e: MouseEvent) {
     this.primaryButtonClick.emit(e);
+
+    if (!this.disableAnalytics) {
+      const detail = {
+        componentName: 'va-modal',
+        action: 'click',
+        details: {
+          clickLabel: this.primaryButtonText,
+          status: this.status,
+          title: this.modalTitle,
+        },
+      };
+      this.componentLibraryAnalytics.emit(detail);
+    }
   }
 
   private handleSecondaryButtonClick(e: MouseEvent) {
     this.secondaryButtonClick.emit(e);
+
+    if (!this.disableAnalytics) {
+      const detail = {
+        componentName: 'va-modal',
+        action: 'click',
+        details: {
+          clickLabel: this.secondaryButtonText,
+          status: this.status,
+          title: this.modalTitle,
+        },
+      };
+      this.componentLibraryAnalytics.emit(detail);
+    }
   }
 
   // Pass in an array of focusable elements and return non-hidden and elements

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -371,7 +371,7 @@ export class VaModal {
           status: this.status,
           title: this.modalTitle,
           primaryButtonText: this.primaryButtonText,
-          secondayButtonText: this.secondaryButtonText,
+          secondaryButtonText: this.secondaryButtonText,
         },
       };
       this.componentLibraryAnalytics.emit(detail);
@@ -545,6 +545,7 @@ export class VaModal {
                   >
                   {primaryButtonClick && primaryButtonText && (
                     <button
+                    id="modal-primary-button"
                     onClick={e => this.handlePrimaryButtonClick(e)}
                     type="button"
                     >
@@ -553,6 +554,7 @@ export class VaModal {
                   )}
                   {secondaryButtonClick && secondaryButtonText && (
                     <button
+                    id="modal-secondary-button"
                     class="button-secondary"
                     onClick={e => this.handleSecondaryButtonClick(e)}
                     type="button"


### PR DESCRIPTION
## Chromatic
<!-- This `1892-va-modal-analytics` is a placeholder for a CI job - it will be updated automatically -->
https://1892-va-modal-analytics--60f9b557105290003b387cd5.chromatic.com

## Description
The primary and secondary buttons in va-modal were not firing analytics events so this PR adds that functionality.

Related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1892
Related https://github.com/department-of-veterans-affairs/vets-website/pull/24944

## Testing done
Locally in Storybook
Added tests for analytics event

## Screenshots

![Screenshot 2023-07-20 at 3 58 41 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/788842cb-14e1-42c1-ac99-a9d396e803ad)


## Acceptance criteria
- [ ] The primary and secondary buttons in va-modal will fire analytics events.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
