### PR TITLE
va-checkbox - add message-aria-describedby property for optional additional message for screen readers

### DIFF
--- a/packages/storybook/stories/va-checkbox-uswds.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-uswds.stories.jsx
@@ -26,6 +26,7 @@ const defaultArgs = {
   'hint': null,
   'uswds': true,
   'tile': false,
+  'message-aria-describedby': 'Optional description text for screen readers',
 };
 
 const vaCheckbox = args => {
@@ -40,6 +41,7 @@ const vaCheckbox = args => {
     uswds,
     hint,
     tile,
+    messageAriaDescribedBy,
     ...rest
   } = args;
   return (
@@ -55,6 +57,7 @@ const vaCheckbox = args => {
       required={required}
       tile={tile}
       onBlur={e => console.log(e)}
+      message-aria-describedby={messageAriaDescribedBy}
     />
   )
 }

--- a/packages/storybook/stories/va-checkbox-uswds.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-uswds.stories.jsx
@@ -41,7 +41,7 @@ const vaCheckbox = args => {
     uswds,
     hint,
     tile,
-    messageAriaDescribedBy,
+    'message-aria-describedby': messageAriaDescribedBy,
     ...rest
   } = args;
   return (

--- a/packages/storybook/stories/va-checkbox.stories.jsx
+++ b/packages/storybook/stories/va-checkbox.stories.jsx
@@ -25,6 +25,7 @@ const defaultArgs = {
   'enable-analytics': false,
   'hint': null,
   'tile': false,
+  'message-aria-describedby': 'Optional description text for screen readers',
 };
 
 const vaCheckbox = args => {
@@ -37,6 +38,7 @@ const vaCheckbox = args => {
     required, 
     hint,
     tile,
+    'message-aria-describedby': messageAriaDescribedBy,
     ...rest
   } = args;
   return (
@@ -50,6 +52,7 @@ const vaCheckbox = args => {
       required={required}
       tile={tile}
       onBlur={e => console.log(e)}
+      message-aria-describedby={messageAriaDescribedBy}
     />
   )
 }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.7",
+  "version": "4.42.8",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -274,6 +274,10 @@ export namespace Components {
          */
         "label": string;
         /**
+          * An optional message that will be read by screen readers when the checkbox is focused.
+         */
+        "messageAriaDescribedby"?: string;
+        /**
           * Set the input to required and render the (Required) text.
          */
         "required"?: boolean;
@@ -611,7 +615,7 @@ export namespace Components {
          */
         "href"?: string;
         /**
-          * Symbol indicates type of notification  Current options are: action-required, update
+          * Symbol indicates type of notification Current options are: action-required, update
          */
         "symbol"?: string;
         /**
@@ -1879,6 +1883,10 @@ declare namespace LocalJSX {
          */
         "label": string;
         /**
+          * An optional message that will be read by screen readers when the checkbox is focused.
+         */
+        "messageAriaDescribedby"?: string;
+        /**
           * The event used to track usage of the component. This is emitted when the input value changes and enableAnalytics is true.
          */
         "onComponent-library-analytics"?: (event: VaCheckboxCustomEvent<any>) => void;
@@ -2300,7 +2308,7 @@ declare namespace LocalJSX {
          */
         "onComponent-library-analytics"?: (event: VaNotificationCustomEvent<any>) => void;
         /**
-          * Symbol indicates type of notification  Current options are: action-required, update
+          * Symbol indicates type of notification Current options are: action-required, update
          */
         "symbol"?: string;
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -591,7 +591,7 @@ export namespace Components {
          */
         "closeable"?: boolean;
         /**
-          * Date and time for notification. This will be incorporated into a unique aria-describedby label
+          * Date and time for notification. This will also be incorporated into a unique aria-describedby label.
          */
         "dateTime"?: string;
         /**
@@ -2280,7 +2280,7 @@ declare namespace LocalJSX {
          */
         "closeable"?: boolean;
         /**
-          * Date and time for notification. This will be incorporated into a unique aria-describedby label
+          * Date and time for notification. This will also be incorporated into a unique aria-describedby label.
          */
         "dateTime"?: string;
         /**

--- a/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
@@ -87,11 +87,20 @@ describe('va-checkbox', () => {
 
   it('adds new aria-describedby for error message', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-checkbox error="This is a mistake" />');
+    await page.setContent('<va-checkbox error="This is a mistake" message-aria-describedby="This is a message"/>');
 
     // Render the error message text
     const inputEl = await page.find('va-checkbox >>> input');
     expect(inputEl.getAttribute('aria-describedby')).toContain('error-message');
+  });
+
+  it('adds aria-describedby input-message id', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-checkbox message-aria-describedby="This is a message" />');
+
+    // Render the error message text
+    const inputEl = await page.find('va-checkbox >>> input');
+    expect(inputEl.getAttribute('aria-describedby')).toContain('input-message');
   });
 
   it('passes an aXe check', async () => {

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -102,6 +102,11 @@ export class VaCheckbox {
   @Prop() disabled?: boolean = false;
 
   /**
+   * An optional message that will be read by screen readers when the checkbox is focused.
+   */
+  @Prop() messageAriaDescribedby?: string;
+
+  /**
    * The event used to track usage of the component. This is emitted when the
    * input value changes and enableAnalytics is true.
    */
@@ -170,7 +175,9 @@ export class VaCheckbox {
       tile,
       uswds, 
       checkboxDescription, 
-      disabled, } = this;
+      disabled, 
+      messageAriaDescribedby,
+    } = this;
 
     if (uswds) {
       const inputClass = classnames({
@@ -181,6 +188,8 @@ export class VaCheckbox {
         'usa-legend': true,
         'usa-label--error': error
       });
+      const ariaDescribedbyIds = `${messageAriaDescribedby ? 'input-message' : ''} ${error ? 'checkbox-error-message' : ''}`
+      .trim() || null; // Null so we don't add the attribute if we have an empty string
       return (
         <Host>
           {description ? 
@@ -203,7 +212,7 @@ export class VaCheckbox {
               type="checkbox"
               id="checkbox-element"
               checked={checked}
-              aria-describedby={error ? 'checkbox-error-message' : undefined}
+              aria-describedby={ariaDescribedbyIds}
               aria-invalid={error ? 'true' : 'false'}
               disabled={disabled}
               onChange={this.handleChange}
@@ -213,10 +222,17 @@ export class VaCheckbox {
               {required && <span class="usa-label--required">{i18next.t('required')}</span>}
               {checkboxDescription && <span class="usa-checkbox__label-description" aria-describedby="option-label">{checkboxDescription}</span>}
             </label>
+            {messageAriaDescribedby && (
+              <span id='input-message' class="sr-only">
+                {messageAriaDescribedby}
+              </span>
+            )}
           </div>
         </Host>
       );
     } else {
+      const ariaDescribedbyIds = `${messageAriaDescribedby ? 'input-message' : ''} ${error ? 'error-message' : ''}`
+      .trim() || null; // Null so we don't add the attribute if we have an empty string
       return (
         <Host>
           <div id="description">
@@ -234,7 +250,7 @@ export class VaCheckbox {
             type="checkbox"
             id="checkbox-element"
             checked={checked}
-            aria-describedby={error ? 'error-message' : undefined}
+            aria-describedby={ariaDescribedbyIds}
             aria-invalid={error ? 'true' : 'false'}
             onChange={this.handleChange}
           />
@@ -243,6 +259,11 @@ export class VaCheckbox {
               {label} {required && <span class="required">{i18next.t('required')}</span>}
             </span>
           </label>
+          {messageAriaDescribedby && (
+            <span id='input-message' class="sr-only">
+              {messageAriaDescribedby}
+            </span>
+          )}
         </Host>
       );
     }


### PR DESCRIPTION
## Chromatic
<!-- This `1852-chkbx-msg-aria` is a placeholder for a CI job - it will be updated automatically -->
https://1852-chkbx-msg-aria--60f9b557105290003b387cd5.chromatic.com

## Description
add `message-aria-describedby` property to enable adding an optional message for screen readers.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1852

## Testing done
- Mac Voice-over 
- Local testing done in Chrome

## Screenshots
- No visual changes made

## Acceptance criteria
- [x] Screen reader will read additional message if provided
- [x] Error message takes priority over provided message

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
