### PR TITLE
va-text-input (USWDS) add aria-described-by optional message

### DIFF
--- a/packages/storybook/stories/va-text-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.jsx
@@ -53,6 +53,7 @@ const defaultArgs = {
   'pattern': undefined,
   'uswds': true,
   'hint': null,
+  'message-aria-describedby': 'Optional description text for screen readers',
 };
 
 const Template = ({
@@ -71,6 +72,7 @@ const Template = ({
   pattern,
   uswds,
   hint,
+  'message-aria-describedby': messageAriaDescribedby,
 }) => {
   return (
     <va-text-input
@@ -91,6 +93,7 @@ const Template = ({
       pattern={pattern}
       onBlur={e => console.log('blur event', e)}
       onInput={e => console.log('input event value', e.target.value)}
+      message-aria-describedby={messageAriaDescribedby}
     />
   );
 };
@@ -108,6 +111,7 @@ const I18nTemplate = ({
   inputmode,
   type,
   uswds,
+  'message-aria-describedby': messageAriaDescribedby,
 }) => {
   const [lang, setLang] = useState('en');
   useEffect(() => {
@@ -137,6 +141,7 @@ const I18nTemplate = ({
         value={value}
         inputmode={inputmode}
         type={type}
+        message-aria-describedby={messageAriaDescribedby}
       />
     </>
   );

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.8",
+  "version": "4.42.9",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -294,6 +294,11 @@ export class VaTextInput {
             required={required || null}
             part="input"
           />
+          {messageAriaDescribedby && (
+            <span id="input-message" class="sr-only">
+              {messageAriaDescribedby}
+            </span>
+          )}
           {maxlength && value?.length >= maxlength && (
             <small part="validation">
               {i18next.t('max-chars', { length: maxlength })}


### PR DESCRIPTION
## Chromatic
<!-- This `1893-uswds-described-by` is a placeholder for a CI job - it will be updated automatically -->
https://1893-uswds-described-by--60f9b557105290003b387cd5.chromatic.com

## Description
Add ability to set an additional message for screen readers to the USWDS text input
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1893

## Testing done
- Mac Voice-over
- Local testing in Chrome

## Screenshots
- Non-visual changes

## Acceptance criteria
- [ ] Screen reader reads message when provided

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
