### PR TITLE
va-checkbox, va-radio - override .usa white background color to be transparent

### DIFF
--- a/packages/storybook/stories/va-checkbox-uswds.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-uswds.stories.jsx
@@ -118,6 +118,14 @@ export const WithDescriptionJSX = props => (
 );
 WithDescriptionJSX.args = { ...defaultArgs };
 
+export const OnBackground = props => (
+  <div style={{background: '#f1f1f1', padding: '30px 5px'}}>
+    <va-checkbox {...props} onBlur={e => console.log(e)}>
+    </va-checkbox>
+  </div>
+);
+OnBackground.args = { ...defaultArgs };
+
 export const Error = Template.bind(null);
 Error.args = {
   ...defaultArgs,

--- a/packages/storybook/stories/va-radio-uswds.stories.jsx
+++ b/packages/storybook/stories/va-radio-uswds.stories.jsx
@@ -315,6 +315,25 @@ LabelHeader.args = {
   'label-header-level': '3',
 };
 
+export const OnBackground = props => (
+  <div style={{background: '#f1f1f1', padding: '30px 5px'}}>
+    <va-radio
+        label="This is a label"
+        uswds
+      >
+        <va-radio-option id="no1" label="No" name="group1" value="1" uswds />
+        <va-radio-option
+          id="yes1"
+          label="Yes - Any Veteran"
+          name="group1"
+          value="2"
+          uswds
+        />
+      </va-radio>
+  </div>
+);
+OnBackground.args = { ...defaultArgs };
+
 export const ReactWithCustomEvent = ReactBindingExample.bind(null);
 ReactWithCustomEvent.args = {
   ...defaultArgs,

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.10",
+  "version": "4.42.11",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.scss
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.scss
@@ -17,6 +17,7 @@
 
 .usa-checkbox {
   max-width: 320px;
+  background: transparent;
 }
 
 .usa-checkbox__input:focus + [class*="__label"]::before {

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -5,6 +5,11 @@
 
 @import '../../global/formation_overrides';
 
+
+.usa-radio {
+  background: transparent;
+}
+
 :host {
   display: block;
   margin-top: 12px;


### PR DESCRIPTION
## Chromatic
<!-- This `1902-chkbox-radio-bg` is a placeholder for a CI job - it will be updated automatically -->
https://1902-chkbox-radio-bg--60f9b557105290003b387cd5.chromatic.com

## Description
override the white background color on .usa-checkbox and .usa-radio to be transparent.
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1902

## Testing done
- local testing in Chrome, Safari, Firefox, and Edge


## Screenshots

Before:
![Screenshot 2023-07-24 at 3 28 42 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/bc759920-239c-4627-a515-7aaa65b2408b)

![Screenshot 2023-07-24 at 3 29 15 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/3e56da57-53e9-4f51-9bd3-cb1b3805d6d2)

After:
![Screenshot 2023-07-24 at 3 29 59 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/eb45ff6b-694e-4fee-a501-82213ad031a4)

![Screenshot 2023-07-24 at 3 30 43 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/846b3eca-7790-4735-9872-a38b6af43199)

## Acceptance criteria
- [ ] Background is transparent

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
