### PR TITLE
va-button - add alternate (green) version to primary button

### DIFF
--- a/packages/css-library/tokens/color.json
+++ b/packages/css-library/tokens/color.json
@@ -5,6 +5,7 @@
     "black": { "value": "#000000"},
     "orange": { "value": "#eb7f29"},
     "link-default": { "value": "#004795"},
+    "link-visited": { "value": "#4c2c92"},
     "warning-message": { "value": "#fac922"},
     "gibill-accent": { "value": "#fff1d2"},
     "primary": {

--- a/packages/css-library/tokens/color.json
+++ b/packages/css-library/tokens/color.json
@@ -41,10 +41,17 @@
     "green": {
       "*": { "value": "#2e8540"},
       "dark": { "value": "#1e5f2f"},
+      "darker": { "value": "#195c27"},
       "darkest": { "value": "#0f3f1f"},
       "light": { "value": "#7dbf7c"},
       "lighter": { "value": "#94bfa2"},
       "lightest": { "value": "#e7f4e4"}
+    },
+    "gold": {
+      "*": { "value": "#fdb81e"},
+      "light": { "value": "#f9c642"},
+      "lighter": { "value": "#fad980"},
+      "lightest": { "value": "#fff1d2"}
     }
   },
   "v3-color": {

--- a/packages/css-library/tokens/color.json
+++ b/packages/css-library/tokens/color.json
@@ -37,6 +37,14 @@
       "warm-dark": { "value": "#494440"},
       "warm-light": { "value": "#e4e2e0"},
       "cool-light": { "value": "#dce4ef"}
+    },
+    "green": {
+      "*": { "value": "#2e8540"},
+      "dark": { "value": "#1e5f2f"},
+      "darkest": { "value": "#0f3f1f"},
+      "light": { "value": "#7dbf7c"},
+      "lighter": { "value": "#94bfa2"},
+      "lightest": { "value": "#e7f4e4"}
     }
   },
   "v3-color": {

--- a/packages/css-library/tokens/fonts.json
+++ b/packages/css-library/tokens/fonts.json
@@ -4,6 +4,10 @@
       "sans": { "value": "'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif" },
       "serif": { "value": "Bitter, Georgia, Cambria, 'Times New Roman', Times, serif" }
     },
+    "serif": { "value": "Bitter, Georgia, Cambria, 'Times New Roman', Times, serif" },
+    "source": {
+      "sans": { "value": "'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif"}
+    },
     "weight": {
       "normal": { "value": "400"},
       "bold": { "value": "700"}

--- a/packages/storybook/stories/va-alert-uswds.stories.jsx
+++ b/packages/storybook/stories/va-alert-uswds.stories.jsx
@@ -208,6 +208,7 @@ SignInOrToolPrompt.args = {
         appeals on your mobile device. Download the{' '}
         <strong>VA: Health and Benefits</strong> mobile app to get started.
       </p>
+      <va-button primary-alternate text="Sign-in to VA.gov"></va-button>
     </>
   ),
   status: 'continue',

--- a/packages/storybook/stories/va-alert.stories.jsx
+++ b/packages/storybook/stories/va-alert.stories.jsx
@@ -211,6 +211,7 @@ SignInOrToolPrompt.args = {
         appeals on your mobile device. Download the{' '}
         <strong>VA: Health and Benefits</strong> mobile app to get started.
       </p>
+      <va-button primary-alternate text="Sign-in to VA.gov"></va-button>
     </div>
   ),
   status: 'continue',

--- a/packages/storybook/stories/va-button-uswds.stories.jsx
+++ b/packages/storybook/stories/va-button-uswds.stories.jsx
@@ -22,6 +22,7 @@ const defaultArgs = {
   'disabled': undefined,
   'label': undefined,
   'secondary': undefined,
+  'primaryAlternate': undefined,
   'submit': undefined,
   'text': 'Default',
   'uswds': true,
@@ -35,6 +36,7 @@ const Template = ({
   disabled,
   label,
   secondary,
+  primaryAlternate,
   submit,
   text,
   uswds
@@ -49,6 +51,7 @@ const Template = ({
       disabled={disabled}
       label={label}
       secondary={secondary}
+      primary-alternate={primaryAlternate}
       submit={submit}
       text={text}
       onClick={e => console.log(e)}
@@ -61,6 +64,13 @@ Primary.args = {
   ...defaultArgs,
 };
 Primary.argTypes = propStructure(buttonDocs);
+
+export const PrimaryAlternate = Template.bind(null);
+PrimaryAlternate.args = {
+  ...defaultArgs,
+  primaryAlternate: true,
+  text: "Primary Alternate"
+};
 
 export const Secondary = Template.bind(null);
 Secondary.args = {

--- a/packages/storybook/stories/va-button.stories.jsx
+++ b/packages/storybook/stories/va-button.stories.jsx
@@ -24,6 +24,7 @@ const defaultArgs = {
   'secondary': undefined,
   'submit': undefined,
   'text': 'Edit',
+  'primary-alternate': undefined
 };
 
 const Template = ({
@@ -36,6 +37,7 @@ const Template = ({
   secondary,
   submit,
   text,
+  primaryAlternate
 }) => {
   return (
     <va-button
@@ -49,6 +51,7 @@ const Template = ({
       submit={submit}
       text={text}
       onClick={e => console.log(e)}
+      primary-alternate = {primaryAlternate}
     />
   );
 };
@@ -58,6 +61,13 @@ Primary.args = {
   ...defaultArgs,
 };
 Primary.argTypes = propStructure(buttonDocs);
+
+export const PrimaryAlternate = Template.bind(null);
+PrimaryAlternate.args = {
+  ...defaultArgs,
+  primaryAlternate: true,
+  text: "Primary Alternate"
+};
 
 export const Secondary = Template.bind(null);
 Secondary.args = {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.42.11",
+  "version": "4.43.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -188,6 +188,10 @@ export namespace Components {
          */
         "label"?: string;
         /**
+          * If `true`, the button will use the primary alternate variant.
+         */
+        "primaryAlternate"?: boolean;
+        /**
           * If `true`, the button will use the secondary variant.
          */
         "secondary"?: boolean;
@@ -1788,6 +1792,10 @@ declare namespace LocalJSX {
           * The event used to track usage of the component.
          */
         "onComponent-library-analytics"?: (event: VaButtonCustomEvent<any>) => void;
+        /**
+          * If `true`, the button will use the primary alternate variant.
+         */
+        "primaryAlternate"?: boolean;
         /**
           * If `true`, the button will use the secondary variant.
          */

--- a/packages/web-components/src/components/va-button/va-button.scss
+++ b/packages/web-components/src/components/va-button/va-button.scss
@@ -25,7 +25,7 @@
 
   &:hover,
   &:focus {
-    background-color: var(--color-green-dark);
+    background-color: var(--color-green-darker);
     text-decoration: none;
   }
 }
@@ -59,7 +59,7 @@
 
   &:hover,
   &:focus {
-    background-color: var(--color-green-dark);
+    background-color: var(--color-green-darker);
     text-decoration: none;
   }
 }

--- a/packages/web-components/src/components/va-button/va-button.scss
+++ b/packages/web-components/src/components/va-button/va-button.scss
@@ -20,6 +20,16 @@
   background-color: var(--color-white);
 }
 
+.va-button-primary--alternate {
+  background: var(--color-green);
+
+  &:hover,
+  &:focus {
+    background-color: var(--color-green-dark);
+    text-decoration: none;
+  }
+}
+
 /* Original Component Styles. */
 
 @import '../../mixins/buttons.css';
@@ -42,6 +52,16 @@
 
 :host(:not([uswds])) button:active {
   background-color: var(--color-primary-darkest);
+}
+
+:host(:not([uswds])) button.va-button-primary--alternate {
+  background: var(--color-green);
+
+  &:hover,
+  &:focus {
+    background-color: var(--color-green-dark);
+    text-decoration: none;
+  }
 }
 
 :host(:not([uswds])[back]:not([back='false'])) button,
@@ -96,3 +116,4 @@ i.fa-angles-right::before {
   box-shadow: none;
   color: var(--color-white);
 }
+

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -55,7 +55,7 @@ export class VaButton {
   /**
    * If `true`, the button will use the primary alternate variant.
    */
-  @Prop({ reflect: true }) primaryAlternate?: boolean = false;
+  @Prop() primaryAlternate?: boolean = false;
 
   /**
    * If `true`, the button will use the secondary variant.

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -53,6 +53,11 @@ export class VaButton {
   @Prop() label?: string; // could use this.el.getAttribute('aria-label') but this is more explicit
 
   /**
+   * If `true`, the button will use the primary alternate variant.
+   */
+  @Prop({ reflect: true }) primaryAlternate?: boolean = false;
+
+  /**
    * If `true`, the button will use the secondary variant.
    */
   @Prop({ reflect: true }) secondary?: boolean = false;
@@ -128,6 +133,7 @@ export class VaButton {
       label,
       submit,
       secondary,
+      primaryAlternate,
       big,
       uswds
     } = this;
@@ -141,8 +147,8 @@ export class VaButton {
         'usa-button': true,
         'usa-button--big': big,
         'usa-button--outline': back || secondary,
+        'va-button-primary--alternate': primaryAlternate
       });
-
       return (
         <Host>
           <button 
@@ -162,9 +168,13 @@ export class VaButton {
         </Host>
       )
     } else {
+      const buttonClass = classnames({
+        'va-button-primary--alternate': primaryAlternate
+      });
       return (
         <Host>
           <button
+            class={buttonClass}
             aria-disabled={ariaDisabled}
             aria-label={label}
             type={type}

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -1,5 +1,6 @@
+
 // Do not edit directly
-// Generated on Mon, 27 Feb 2023 21:20:09 GMT
+// Generated on Wed, 26 Jul 2023 15:27:47 GMT
 
 $color-base: #212121;
 $color-white: #ffffff;
@@ -31,6 +32,12 @@ $color-gray-lightest: #f1f1f1;
 $color-gray-warm-dark: #494440;
 $color-gray-warm-light: #e4e2e0;
 $color-gray-cool-light: #dce4ef;
+$color-green: #2e8540;
+$color-green-dark: #1e5f2f;
+$color-green-darkest: #0f3f1f;
+$color-green-light: #7dbf7c;
+$color-green-lighter: #94bfa2;
+$color-green-lightest: #e7f4e4;
 $v3-color-error-dark: #b50909;
 $v3-color-base-darkest: #1B1B1B;
 $font-family-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -1,12 +1,13 @@
 
 // Do not edit directly
-// Generated on Wed, 26 Jul 2023 21:34:13 GMT
+// Generated on Thu, 27 Jul 2023 19:41:26 GMT
 
 $color-base: #212121;
 $color-white: #ffffff;
 $color-black: #000000;
 $color-orange: #eb7f29;
 $color-link-default: #004795;
+$color-link-visited: #4c2c92;
 $color-warning-message: #fac922;
 $color-gibill-accent: #fff1d2;
 $color-primary: #0071bb;
@@ -47,6 +48,8 @@ $v3-color-error-dark: #b50909;
 $v3-color-base-darkest: #1B1B1B;
 $font-family-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
 $font-family-serif: Bitter, Georgia, Cambria, 'Times New Roman', Times, serif;
+$font-serif: Bitter, Georgia, Cambria, 'Times New Roman', Times, serif;
+$font-source-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
 $font-weight-normal: 400;
 $font-weight-bold: 700;
 $font-style-normal: normal;

--- a/packages/web-components/src/global/_variables.scss
+++ b/packages/web-components/src/global/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 26 Jul 2023 15:27:47 GMT
+// Generated on Wed, 26 Jul 2023 21:34:13 GMT
 
 $color-base: #212121;
 $color-white: #ffffff;
@@ -34,10 +34,15 @@ $color-gray-warm-light: #e4e2e0;
 $color-gray-cool-light: #dce4ef;
 $color-green: #2e8540;
 $color-green-dark: #1e5f2f;
+$color-green-darker: #195c27;
 $color-green-darkest: #0f3f1f;
 $color-green-light: #7dbf7c;
 $color-green-lighter: #94bfa2;
 $color-green-lightest: #e7f4e4;
+$color-gold: #fdb81e;
+$color-gold-light: #f9c642;
+$color-gold-lighter: #fad980;
+$color-gold-lightest: #fff1d2;
 $v3-color-error-dark: #b50909;
 $v3-color-base-darkest: #1B1B1B;
 $font-family-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -1,40 +1,97 @@
-/* Colors from: */
-/*   https://design.va.gov/design/color-palette */
-/* Fonts from: */
-/*   https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/8d39616e957cb44b6664a658b2c51dca8076fe7e/packages/formation/sass/base/_b-variables.scss#L16-L17 */
+/**
+ * Do not edit directly
+ * Generated on Wed, 26 Jul 2023 15:27:47 GMT
+ */
+
 :root {
   --color-base: #212121;
-  --color-black: #000000;
   --color-white: #ffffff;
-  --color-gray: #5b616b;
-  --color-gray-medium: #757575;
-  --color-gray-dark: #323a45;
-  --color-gray-light: #aeb0b5;
-  --color-gray-lighter: #d6d7d9;
-  --color-gray-lightest: #f1f1f1;
-  --color-gray-cool-light: #dce4ef;
-  --color-green: #2e8540;
-  --color-green-lighter: #94bfa2;
-  --color-green-lightest: #e7f4e4;
-  --color-gold: #fdb81e;
-  --color-gold-light: #f9c642;
-  --color-gold-lighter: #fad980;
-  --color-gold-lightest: #fff1d2;
+  --color-black: #000000;
+  --color-orange: #eb7f29;
   --color-link-default: #004795;
-  --color-link-visited: #4c2c92;
+  --color-warning-message: #fac922;
+  --color-gibill-accent: #fff1d2;
   --color-primary: #0071bb;
   --color-primary-darker: #003e73;
-  --color-primary-darkest: #112E51;
+  --color-primary-darkest: #112e51;
+  --color-primary-alt: #02bfe7;
   --color-primary-alt-dark: #00a6d2;
   --color-primary-alt-darkest: #046b99;
   --color-primary-alt-light: #9bdaf1;
   --color-primary-alt-lightest: #e1f3f8;
+  --color-secondary: #e31c3d;
   --color-secondary-dark: #cd2026;
+  --color-secondary-darkest: #981b1e;
   --color-secondary-light: #e59393;
   --color-secondary-lightest: #f9dede;
+  --color-gray: #5b616b;
+  --color-gray-dark: #323a45;
+  --color-gray-medium: #757575;
+  --color-gray-light: #aeb0b5;
+  --color-gray-light-alt: #eeeeee;
+  --color-gray-lighter: #d6d7d9;
+  --color-gray-lightest: #f1f1f1;
+  --color-gray-warm-dark: #494440;
+  --color-gray-warm-light: #e4e2e0;
+  --color-gray-cool-light: #dce4ef;
+  --color-green: #2e8540;
+  --color-green-dark: #1e5f2f;
+  --color-green-darkest: #0f3f1f;
+  --color-green-light: #7dbf7c;
+  --color-green-lighter: #94bfa2;
+  --color-green-lightest: #e7f4e4;
   --v3-color-error-dark: #b50909;
   --v3-color-base-darkest: #1B1B1B;
-  --font-source-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto,
-    Arial, sans-serif;
-  --font-serif: Bitter, Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-family-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
+  --font-family-serif: Bitter, Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-weight-normal: 400;
+  --font-weight-bold: 700;
+  --font-style-normal: normal;
+  --font-style-italic: italic;
+  --font-size-sm: 1.5rem;
+  --font-size-base: 1.6rem;
+  --font-size-md: 1.7rem;
+  --font-size-lg: 2rem;
+  --font-size-xl: 3rem;
+  --font-size-2xl: 4rem;
+  --font-size-h1: 4rem;
+  --font-size-h2: 3rem;
+  --font-size-h3: 2rem;
+  --font-size-h4: 1.7rem;
+  --font-size-h5: 1.5rem;
+  --font-size-h6: 1.5rem;
+  --v3-font-base-size: 16px;
+  --units-0: 0;
+  --units-1: 0.8rem;
+  --units-2: 1.6rem;
+  --units-3: 2.4rem;
+  --units-4: 3.2rem;
+  --units-5: 4rem;
+  --units-6: 4.8rem;
+  --units-7: 5.6rem;
+  --units-8: 6.4rem;
+  --units-9: 7.2rem;
+  --units-10: 8rem;
+  --units-15: 12rem;
+  --units-1px: 1px;
+  --units-0p25: 2px;
+  --units-0p5: 0.4rem;
+  --units-1p5: 1.2rem;
+  --units-2p5: 2rem;
+  --units-neg-1px: -1px;
+  --units-neg-0p25: -2px;
+  --units-neg-0p5: -0.4rem;
+  --units-neg-1: -0.8rem;
+  --units-neg-1p5: -1.2rem;
+  --units-neg-2: -1.6rem;
+  --units-neg-2p5: -2rem;
+  --units-neg-3: -2.4rem;
+  --units-neg-4: -3.2rem;
+  --units-neg-5: -4rem;
+  --units-neg-6: -4.8rem;
+  --units-neg-7: -5.6rem;
+  --units-neg-8: -6.4rem;
+  --units-neg-9: -7.2rem;
+  --units-neg-10: -8rem;
+  --units-neg-15: -12rem;
 }

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -1,9 +1,9 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Jul 2023 15:27:47 GMT
+ * Generated on Wed, 26 Jul 2023 21:34:13 GMT
  */
 
-:root {
+ :root {
   --color-base: #212121;
   --color-white: #ffffff;
   --color-black: #000000;
@@ -36,10 +36,15 @@
   --color-gray-cool-light: #dce4ef;
   --color-green: #2e8540;
   --color-green-dark: #1e5f2f;
+  --color-green-darker: #195c27;
   --color-green-darkest: #0f3f1f;
   --color-green-light: #7dbf7c;
   --color-green-lighter: #94bfa2;
   --color-green-lightest: #e7f4e4;
+  --color-gold: #fdb81e;
+  --color-gold-light: #f9c642;
+  --color-gold-lighter: #fad980;
+  --color-gold-lightest: #fff1d2;
   --v3-color-error-dark: #b50909;
   --v3-color-base-darkest: #1B1B1B;
   --font-family-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 26 Jul 2023 21:34:13 GMT
+ * Generated on Thu, 27 Jul 2023 19:41:26 GMT
  */
 
  :root {
@@ -9,6 +9,7 @@
   --color-black: #000000;
   --color-orange: #eb7f29;
   --color-link-default: #004795;
+  --color-link-visited: #4c2c92;
   --color-warning-message: #fac922;
   --color-gibill-accent: #fff1d2;
   --color-primary: #0071bb;
@@ -49,6 +50,8 @@
   --v3-color-base-darkest: #1B1B1B;
   --font-family-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
   --font-family-serif: Bitter, Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-serif: Bitter, Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-source-sans: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;
   --font-weight-normal: 400;
   --font-weight-bold: 700;
   --font-style-normal: normal;


### PR DESCRIPTION
## Chromatic
<!-- This `1789-primary-alt-btn` is a placeholder for a CI job - it will be updated automatically -->
https://1789-primary-alt-btn--60f9b557105290003b387cd5.chromatic.com

## Description
Add an alternate primary button variation with a green background, update va-button stories and include an example on the va-alert stories using the variation. Update the core colors to include the required greens.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1789

## Testing done
- Local browser testing in Chrome, Firefox, Edge, and Safari

## Screenshots

![Screenshot 2023-07-26 at 1 52 54 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/57c15169-8088-4f20-a961-2b61d108005e)

![Screenshot 2023-07-26 at 1 53 14 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/0ca81125-d9f4-458b-935a-935d0cbf39b8)


## Acceptance criteria
- [x] Green variation added to va-button
- [x] Storybook stories have been updated to include the button
- [x] Design approval

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
