### PR TITLE
Check for node, tagName for va-loading-indicator

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.43.0",
+  "version": "4.43.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-loading-indicator/va-loading-indicator.tsx
+++ b/packages/web-components/src/components/va-loading-indicator/va-loading-indicator.tsx
@@ -73,7 +73,7 @@ export class VaLoadingIndicator {
           const loadingIndicatorRemoved =
             Array.from(mutation.removedNodes.values()).filter(
               (node: Element) =>
-                node.tagName.toLowerCase() === 'va-loading-indicator',
+                node?.tagName?.toLowerCase() === 'va-loading-indicator',
             ).length > 0;
 
           if (this.enableAnalytics && loadingIndicatorRemoved) {


### PR DESCRIPTION
## Chromatic
<!-- This `asteele-fix-for-null-loading-nodes-1952` is a placeholder for a CI job - it will be updated automatically -->
https://asteele-fix-for-null-loading-nodes-1952--60f9b557105290003b387cd5.chromatic.com

---

## Description
Prevents an error when nodes are either null or don't have a tagName

Closes [#1952](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1952)

## Testing done

Tested in Brave browser's console REPL.

## Screenshots

N/A

## Acceptance criteria
- [X] Appears to correctly filter out non-nodes while still capturing valid nodes.

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
