### PR TITLE
(bug): make html header tag lowercase

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.2",
+  "version": "4.45.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-notification/va-notification.tsx
+++ b/packages/web-components/src/components/va-notification/va-notification.tsx
@@ -150,7 +150,7 @@ export class VaNotification {
 
   private getHeadlineLevel() {
     const number = parseInt(this.headlineLevel, 10);
-    return number >= 1 && number <= 6 ? `H${number}` : `H3`;
+    return number >= 1 && number <= 6 ? `h${number}` : `h3`;
   }
 
   render() {

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -195,7 +195,7 @@ export class VaRadio {
 
   private getHeaderLevel() {
     const number = parseInt(this.labelHeaderLevel, 10);
-    return number >= 1 && number <= 6 ? `H${number}` : null;
+    return number >= 1 && number <= 6 ? `h${number}` : null;
   }
 
   componentDidLoad(): void {


### PR DESCRIPTION
## Chromatic
<!-- This `bug-make-header-tag-lowercase` is a placeholder for a CI job - it will be updated automatically -->
https://bug-make-header-tag-lowercase--60f9b557105290003b387cd5.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [x] Under **Testing done**, be specific about how this update was tested. 
    - Examples: Storybook, Chrome, Browserstack, Mobile/Responsive, etc.
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
This PR updates functions for creating dynamic headers (passed on props set by user) for `va-radio` and `va-notification` components.

## Testing done


## Screenshots
| Before | After |
|--|--|
| <img width="584" alt="Screenshot 2023-08-03 at 2 51 25 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8542413/4d17fe34-c39f-481d-a33b-645b71345ef7"> | <img width="583" alt="Screenshot 2023-08-03 at 2 51 42 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8542413/7801fff9-2845-4599-996a-4528ca89148f"> | 

## Acceptance criteria
- [x] Heading on va-notification component is styled correctly
- [x] Heading on va-radio component is styled correctly

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
