### PR TITLE
va-radio-option: Set tab index to -1 for radio button input

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.3",
+  "version": "4.45.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
+++ b/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
@@ -89,7 +89,7 @@ describe('va-radio-option', () => {
     <va-radio-option uswds="" id="yes2" label="Yes - Any Veteran" name="yes" value="2" class="hydrated">
       <mock:shadow-root>
         <div class="usa-radio">
-          <input class="usa-radio__input" id="yes2" type="radio" name="yes" value="2">
+          <input class="usa-radio__input" id="yes2" type="radio" name="yes" tabindex="-1" value="2">
           <label class="usa-radio__label" for="yes2" id="option-label">
             Yes - Any Veteran
           </label>

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -104,6 +104,7 @@ export class VaRadioOption {
             checked={checked}
             disabled={disabled}
             onClick={() => this.handleChange()}
+            tabIndex={-1}
           />
           <label htmlFor={id} id="option-label" class="usa-radio__label">
             {label}


### PR DESCRIPTION
## Chromatic
<!-- This `1961-multiple-tab-presses` is a placeholder for a CI job - it will be updated automatically -->
https://1961-multiple-tab-presses--60f9b557105290003b387cd5.chromatic.com

## Description
Closes [v3 va-radio button uses more than one tab to get to next focusable item #1961](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1961)

## Testing done
Tested locally in Storybook in Chrome, Firefox, Edge, Safari

## Acceptance criteria
- [ ] Only on tab press to exit focus on radio buttons

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
