### PR TITLE
fix: only add margin for when additional info is open

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.3",
+  "version": "4.45.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.css
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.css
@@ -42,9 +42,6 @@ a {
   opacity: 1;
   transition: max-height 700ms 0ms, opacity 500ms 200ms, visibility 500ms 200ms;
   max-height: var(--calc-max-height);
-}
-
-#info {
   margin-bottom: 16px;
   margin-top: 16px;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `fix-additional-info-margin-whitlock` is a placeholder for a CI job - it will be updated automatically -->
https://fix-additional-info-margin-whitlock--60f9b557105290003b387cd5.chromatic.com


## Description
Adjusts the margin on the additional info component to only be present when the component is in it's 'open' state.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1203

## Testing done
Visually tested in storybook. All tests pass for Additional Info component.

## Screenshots

BEFORE
![Screenshot 2023-08-07 at 12 15 37 PM](https://github.com/department-of-veterans-affairs/component-library/assets/8332986/d79909b0-858e-4ce9-bfd7-c71d0d1f501e)


AFTER
![Screenshot 2023-08-07 at 12 15 09 PM](https://github.com/department-of-veterans-affairs/component-library/assets/8332986/d33251d3-bb75-4c78-872a-0b7bfb4516d6)


## Acceptance criteria
- [x] Top and bottom margin not present when component is closed

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
