### PR TITLE
va-pagination: Add optional chaining to activeElement blur

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.4",
+  "version": "4.45.5",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -74,7 +74,7 @@ export class VaPagination {
     this.pageSelect.emit({ page });
 
     // Reset focus to the active page button.
-    (this.el.shadowRoot.activeElement as HTMLElement).blur();
+    (this.el?.shadowRoot?.activeElement as HTMLElement)?.blur();
 
     if (this.enableAnalytics) {
       const detail = {


### PR DESCRIPTION
## Chromatic
<!-- This `va-pagination-active-blur` is a placeholder for a CI job - it will be updated automatically -->
https://va-pagination-active-blur--60f9b557105290003b387cd5.chromatic.com

## Description
No ticket - This is from a support request in Slack: https://dsva.slack.com/archives/C01DBGX4P45/p1691419861861739

The issue reported was that when using a filtering mechanism with the va-pagination component, an error started to appear in the console:

![image](https://github.com/department-of-veterans-affairs/component-library/assets/872479/9265f98f-2bac-43ea-abc7-bbe5ee069167)

From that Slack message:

> To reproduce nav to https://staging.va.gov/my-health/secure-messages/inbox/, enter `test` in filter box, click Filter button and then use pagination

> vets.gov.user+41@gmail.com
> 109SsNrLgPv5

I was not able to reproduce this locally but I think the problem might be that when we are removing the focus state with `.blur`, there could be scenarios where an `.activeElement` element does not exist yet. So this adds optional chaining to account for that.

## Testing done
vets website staging
Storybook

## Acceptance criteria
- [ ] The issue that reports blur not being able to initiate with a null element has been addressed.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
