### PR TITLE
Fix spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ In order to a single file, you can run:
 npx stencil test --e2e -- src/components/[component-name]/[component-name].e2e.ts
 ```
 
-Replace `[component-name]` with the name of the component you want to test. Optionnally, you cad add `--watchAll` after `--e2e` to watch the file for changes. For example:
+Replace `[component-name]` with the name of the component you want to test. Optionally, you can add `--watchAll` after `--e2e` to watch the file for changes. For example:
 
 ```bash
 npx stencil test --e2e --watchAll -- src/components/[component-name]/[component-name].e2e.ts


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

---
## Configuring this pull request
- [x] Link to any related issues in the description so they can be cross-referenced.
- [x] Under **Testing done**, be specific about how this update was tested. 
    - Examples: Storybook, Chrome, Browserstack, Mobile/Responsive, etc.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [x] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [x] Complete all sections below.
- [ ] Delete this section once complete

## Description
- Originated in #679

## Testing done
- n/a


## Screenshots
- ![image](https://github.com/department-of-veterans-affairs/component-library/assets/1915925/030d9c7e-854e-4c9b-8f68-b798f99e031d)


## Acceptance criteria
- [x] README passes spell-check.

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
