### PR TITLE
fix scroll bug in va-number-input

### DIFF
--- a/packages/storybook/stories/va-number-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-number-input-uswds.stories.jsx
@@ -11,15 +11,7 @@ export default {
     docs: {
       page: () => <StoryDocs data={numberInputDocs} />,
     },
-  },
-  argTypes: {
-    inputmode: {
-      control: {
-        type: 'select',
-        options: ['decimal', 'numeric'],
-      },
-    },
-  },
+  }
 };
 
 const defaultArgs = {
@@ -29,7 +21,6 @@ const defaultArgs = {
   'required': false,
   'error': undefined,
   'value': 0,
-  'inputmode': 'numeric',
   'min': undefined,
   'max': undefined,
   hint: null,
@@ -44,7 +35,6 @@ const vaNumberInput = args => {
     required,
     error,
     value,
-    inputmode,
     min,
     max,
     hint,
@@ -60,7 +50,6 @@ const vaNumberInput = args => {
       required={required}
       error={error}
       value={value}
-      inputmode={inputmode}
       max={max}
       min={min}
       hint={hint}

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -11,15 +11,7 @@ export default {
     docs: {
       page: () => <StoryDocs data={numberInputDocs} />,
     },
-  },
-  argTypes: {
-    inputmode: {
-      control: {
-        type: 'select',
-        options: ['decimal', 'numeric'],
-      },
-    },
-  },
+  }
 };
 
 const defaultArgs = {
@@ -29,7 +21,6 @@ const defaultArgs = {
   'required': false,
   'error': undefined,
   'value': 0,
-  'inputmode': 'numeric',
   'min': undefined,
   'max': undefined,
   hint: null,
@@ -45,7 +36,6 @@ const vaNumberInput = args => {
     required,
     error,
     value,
-    inputmode,
     min,
     max,
     hint,
@@ -61,7 +51,6 @@ const vaNumberInput = args => {
       required={required}
       error={error}
       value={value}
-      inputmode={inputmode}
       max={max}
       min={min}
       hint={hint}

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -679,10 +679,6 @@ export namespace Components {
          */
         "hint"?: string;
         /**
-          * The inputmode attribute.
-         */
-        "inputmode"?: 'decimal' | 'numeric';
-        /**
           * The label for the text input.
          */
         "label"?: string;
@@ -2461,10 +2457,6 @@ declare namespace LocalJSX {
           * Optional hint text.
          */
         "hint"?: string;
-        /**
-          * The inputmode attribute.
-         */
-        "inputmode"?: 'decimal' | 'numeric';
         /**
           * The label for the text input.
          */

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -47,11 +47,6 @@ export class VaNumberInput {
   @Prop() required?: boolean = false;
 
   /**
-   * The inputmode attribute.
-   */
-  @Prop() inputmode?: 'decimal' | 'numeric';
-
-  /**
    * Emit component-library-analytics events on the blur event.
    */
   @Prop() enableAnalytics?: boolean = false;
@@ -148,7 +143,6 @@ export class VaNumberInput {
       label,
       required,
       error,
-      inputmode,
       name,
       max,
       min,
@@ -202,8 +196,9 @@ export class VaNumberInput {
             aria-describedby={ariaDescribedbyIds}
             aria-invalid={error ? 'true' : 'false'}
             id="inputField"
-            type="number"
-            inputmode={inputmode ? inputmode : null}
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]+(\.[0-9]{1,})?"
             name={name}
             max={max}
             min={min}
@@ -247,8 +242,9 @@ export class VaNumberInput {
               aria-describedby={ariaDescribedbyIds}
               aria-invalid={error ? 'true' : 'false'}
               id="inputField"
-              type="number"
-              inputmode={inputmode ? inputmode : null}
+              type="text"
+              inputmode="numeric"
+              pattern="[0-9]+(\.[0-9]{1,})?"
               name={name}
               max={max}
               min={min}


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

---

## Description
This PR prevents `va-number-input` values from being influenced by scrolling when under focus. The fix implements a change recommended [here](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/).  This is a major release because the inputMode prop is removed as being unnecessary. 

Closes [1989](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1989)

## Testing done
local testing in chrome, firefox, edge, safari

## Screenshots

https://github.com/department-of-veterans-affairs/component-library/assets/8867779/cd7d0333-d69c-4d05-a0ef-8126cc396d60

## Acceptance criteria
- [ ] `va-number-input` scroll value does not increment on scroll when in focus

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
