### PR TITLE
update stencil config to copy static assets to dist folder during build

### DIFF
--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -3,6 +3,7 @@ import { postcss } from '@stencil/postcss';
 import { sass } from '@stencil/sass';
 import url from 'postcss-url';
 import { reactOutputTarget } from '@stencil/react-output-target';
+import * as path from 'path';
 
 export const config: Config = {
   namespace: 'component-library',
@@ -40,6 +41,9 @@ export const config: Config = {
     {
       type: 'dist',
       esmLoaderPath: '../loader',
+      copy: [
+        { src: 'assets', dest: path.join(__dirname, 'dist/assets')}
+      ]
     },
     {
       type: 'dist-custom-elements',


### PR DESCRIPTION
## Chromatic
<!-- This `copy-assets-to-dist` is a placeholder for a CI job - it will be updated automatically -->
https://copy-assets-to-dist--60f9b557105290003b387cd5.chromatic.com

## Description
This PR updates the Stencil config so that static assets get copied to the `dist` folder during build. This is necessary because when the `va-icon` component is used in `vets-website` a 404 was thrown when the browser tried to resolve the path on the icon.

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1977

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
