### PR TITLE
Introducing a new script to copy USWDS tokens

### DIFF
--- a/packages/css-library/copy-uswds-color-tokens.js
+++ b/packages/css-library/copy-uswds-color-tokens.js
@@ -22,6 +22,7 @@ const tokensToKeep = {
   'blue-cool': {
     file: 'blue-cool.json',
     colors: [
+      'blue-cool-60',
       'blue-cool-vivid-5',
       'blue-cool-vivid-20',
       'blue-cool-vivid-40',
@@ -30,15 +31,26 @@ const tokensToKeep = {
   },
   'blue-warm': {
     file: 'blue-warm.json',
-    colors: ['blue-warm-vivid-60', 'blue-warm-vivid-70', 'blue-warm-vivid-80'],
+    colors: [
+      'blue-warm-10',
+      'blue-warm-vivid-60',
+      'blue-warm-vivid-70',
+      'blue-warm-vivid-80',
+    ],
   },
   'cyan': {
     file: 'cyan.json',
-    colors: ['cyan-vivid-30'],
+    colors: ['cyan-5', 'cyan-20', 'cyan-vivid-30', 'cyan-vivid-40'],
   },
   'gold': {
     file: 'gold.json',
-    colors: ['gold-vivid-5'],
+    colors: [
+      'gold-vivid-5',
+      'gold-vivid-10',
+      'gold-vivid-20',
+      'gold-vivid-30',
+      'gold-vivid-50',
+    ],
   },
   'gray': {
     file: 'gray.json',
@@ -79,9 +91,48 @@ const tokensToKeep = {
       'gray-cool-90',
     ],
   },
+  'gray-warm': {
+    file: 'gray-warm.json',
+    colors: ['gray-warm-10', 'gray-warm-70'],
+  },
+  'green-cool': {
+    file: 'green-cool.json',
+    colors: [
+      'green-cool-5',
+      'green-cool-20',
+      'green-cool-40',
+      'green-cool-vivid-20',
+      'green-cool-vivid-40',
+      'green-cool-vivid-50',
+      'green-cool-vivid-60',
+    ],
+  },
   'orange': {
     file: 'orange.json',
     colors: ['orange-40'],
+  },
+  'red': {
+    file: 'red.json',
+    colors: ['red-30', 'red-50', 'red-70', 'red-vivid-60', 'red-vivid-70'],
+  },
+  'red-cool': {
+    file: 'red-cool.json',
+    colors: [
+      'red-cool-vivid-10',
+      'red-cool-vivid-50',
+      'red-cool-vivid-60',
+      'red-cool-vivid-70',
+    ],
+  },
+  'red-warm': {
+    file: 'red-warm.json',
+    colors: [
+      'red-warm-10',
+      'red-warm-80',
+      'red-warm-vivid-30',
+      'red-warm-vivid-50',
+      'red-warm-vivid-60',
+    ],
   },
   'violet': {
     file: 'violet.json',
@@ -89,7 +140,7 @@ const tokensToKeep = {
   },
   'yellow': {
     file: 'yellow.json',
-    colors: ['yellow-5'],
+    colors: ['yellow-5', 'yellow-vivid-10', 'yellow-vivid-20'],
   },
 };
 // Desired prefix/namespace for colors

--- a/packages/css-library/copy-uswds-color-tokens.js
+++ b/packages/css-library/copy-uswds-color-tokens.js
@@ -1,0 +1,169 @@
+const fs = require('fs');
+
+// List of color tokens to "pass through"
+const tokensToKeep = {
+  'blue': {
+    file: 'blue.json',
+    colors: [
+      'blue-5',
+      'blue-10',
+      'blue-20',
+      'blue-30',
+      'blue-40',
+      'blue-50',
+      'blue-60',
+      'blue-70',
+      'blue-80',
+      'blue-90',
+      'blue-vivid-50',
+      'blue-vivid-60',
+    ],
+  },
+  'blue-cool': {
+    file: 'blue-cool.json',
+    colors: [
+      'blue-cool-vivid-5',
+      'blue-cool-vivid-20',
+      'blue-cool-vivid-40',
+      'blue-cool-vivid-60',
+    ],
+  },
+  'blue-warm': {
+    file: 'blue-warm.json',
+    colors: ['blue-warm-vivid-60', 'blue-warm-vivid-70', 'blue-warm-vivid-80'],
+  },
+  'cyan': {
+    file: 'cyan.json',
+    colors: ['cyan-vivid-30'],
+  },
+  'gold': {
+    file: 'gold.json',
+    colors: ['gold-vivid-5'],
+  },
+  'gray': {
+    file: 'gray.json',
+    colors: [
+      'gray-1',
+      'gray-2',
+      'gray-3',
+      'gray-4',
+      'gray-5',
+      'gray-10',
+      'gray-20',
+      'gray-30',
+      'gray-40',
+      'gray-50',
+      'gray-60',
+      'gray-70',
+      'gray-80',
+      'gray-90',
+      'gray-100',
+    ],
+  },
+  'gray-cool': {
+    file: 'gray-cool.json',
+    colors: [
+      'gray-cool-1',
+      'gray-cool-2',
+      'gray-cool-3',
+      'gray-cool-4',
+      'gray-cool-5',
+      'gray-cool-10',
+      'gray-cool-20',
+      'gray-cool-30',
+      'gray-cool-40',
+      'gray-cool-50',
+      'gray-cool-60',
+      'gray-cool-70',
+      'gray-cool-80',
+      'gray-cool-90',
+    ],
+  },
+  'orange': {
+    file: 'orange.json',
+    colors: ['orange-40'],
+  },
+  'violet': {
+    file: 'violet.json',
+    colors: ['violet-vivid-70'],
+  },
+  'yellow': {
+    file: 'yellow.json',
+    colors: ['yellow-5'],
+  },
+};
+// Desired prefix/namespace for colors
+const prefix = 'uswds-system-color';
+
+/**
+ * @description Looks to see if the color (colorName) is in the list of tokens we want to keep
+ * @param {Array<string>} tokenColorsToKeep
+ * @param {string} colorName
+ */
+function colorsIncludes(tokenColorsToKeep, colorName) {
+  // Using findIndex instead of includes so that we can add the prefix
+  const matched = tokenColorsToKeep.findIndex(color => {
+    return `${prefix}-${color}` === colorName;
+  });
+  return matched > -1;
+}
+
+/**
+ * @description Takes a color's name and it's value, checks if value is array or string, iterates over all values until it knows if they're all keepers or not (recursive)
+ * @param {string} colorName
+ * @param {string | [{name: string; value: string}]} value
+ * @param {string[]} tokenColorsToKeep
+ */
+function iterateValues(colorName, value, tokenColorsToKeep) {
+  if (Array.isArray(value)) {
+    // value is an array, iterate over the values
+    const newPrefix = `${colorName}`;
+    return value
+      .flatMap(val => {
+        return iterateValues(
+          `${newPrefix}-${val.name}`,
+          val.value,
+          tokenColorsToKeep,
+        );
+      })
+      .filter(element => element !== undefined); // Filters out empty entries
+  } else {
+    // value is a singleton or false, keep if needed
+    if (colorsIncludes(tokenColorsToKeep, colorName)) {
+      return { name: colorName, value };
+    }
+  }
+}
+
+// Get desired tokens
+const uswdsTokens = Object.entries(tokensToKeep)
+  .flatMap(([_, tokenProps]) => {
+    // Using 'require' allows us to read and parse JSON files in one command
+    const tokens = require(`./node_modules/@uswds/uswds/packages/uswds-tokens/colors/${tokenProps.file}`);
+    const keptTokens = tokens.props
+      // First, find all of the keepers
+      .reduce((accumulator, prop) => {
+        const retVal = iterateValues(
+          `${prefix}-${prop.name}`,
+          prop.value,
+          tokenProps.colors,
+        );
+        if (retVal) {
+          accumulator.push(retVal);
+        }
+        return accumulator;
+      }, [])
+      .flat();
+    return keptTokens;
+  })
+  // Second, convert the array of names and values into Style Dictionary's format
+  .reduce((accumulator, prop) => {
+    accumulator[prop.name] = { value: prop.value };
+    return accumulator;
+  }, {});
+
+// Last, need to write out uswdsTokens into a tokens/uswds.json file
+let data = JSON.stringify(uswdsTokens, null, 2);
+fs.writeFileSync('./tokens/uswds.json', data);
+
+console.log('USWDS Tokens copied successfully.');

--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 08 Aug 2023 21:11:38 GMT
+ * Generated on Wed, 23 Aug 2023 14:46:33 GMT
  */
 
 :root {
@@ -102,4 +102,57 @@
   --units-neg-9: -7.2rem;
   --units-neg-10: -8rem;
   --units-neg-15: -12rem;
+  --uswds-system-color-blue-5: #eff6fb;
+  --uswds-system-color-blue-10: #d9e8f6;
+  --uswds-system-color-blue-20: #aacdec;
+  --uswds-system-color-blue-30: #73b3e7;
+  --uswds-system-color-blue-40: #4f97d1;
+  --uswds-system-color-blue-50: #2378c3;
+  --uswds-system-color-blue-60: #2c608a;
+  --uswds-system-color-blue-70: #274863;
+  --uswds-system-color-blue-80: #1f303e;
+  --uswds-system-color-blue-90: #11181d;
+  --uswds-system-color-blue-vivid-50: #0076d6;
+  --uswds-system-color-blue-vivid-60: #005ea2;
+  --uswds-system-color-blue-cool-vivid-5: #e1f3f8;
+  --uswds-system-color-blue-cool-vivid-20: #97d4ea;
+  --uswds-system-color-blue-cool-vivid-40: #28a0cb;
+  --uswds-system-color-blue-cool-vivid-60: #07648d;
+  --uswds-system-color-blue-warm-vivid-60: #0050d8;
+  --uswds-system-color-blue-warm-vivid-70: #1a4480;
+  --uswds-system-color-blue-warm-vivid-80: #162e51;
+  --uswds-system-color-cyan-vivid-30: #00bde3;
+  --uswds-system-color-gold-vivid-5: #fef0c8;
+  --uswds-system-color-gray-1: #fcfcfc;
+  --uswds-system-color-gray-2: #f9f9f9;
+  --uswds-system-color-gray-3: #f6f6f6;
+  --uswds-system-color-gray-4: #f3f3f3;
+  --uswds-system-color-gray-5: #f0f0f0;
+  --uswds-system-color-gray-10: #e6e6e6;
+  --uswds-system-color-gray-20: #c9c9c9;
+  --uswds-system-color-gray-30: #adadad;
+  --uswds-system-color-gray-40: #919191;
+  --uswds-system-color-gray-50: #757575;
+  --uswds-system-color-gray-60: #5c5c5c;
+  --uswds-system-color-gray-70: #454545;
+  --uswds-system-color-gray-80: #2e2e2e;
+  --uswds-system-color-gray-90: #1b1b1b;
+  --uswds-system-color-gray-100: #000000;
+  --uswds-system-color-gray-cool-1: #fbfcfd;
+  --uswds-system-color-gray-cool-2: #f7f9fa;
+  --uswds-system-color-gray-cool-3: #f5f6f7;
+  --uswds-system-color-gray-cool-4: #f1f3f6;
+  --uswds-system-color-gray-cool-5: #edeff0;
+  --uswds-system-color-gray-cool-10: #dfe1e2;
+  --uswds-system-color-gray-cool-20: #c6cace;
+  --uswds-system-color-gray-cool-30: #a9aeb1;
+  --uswds-system-color-gray-cool-40: #8d9297;
+  --uswds-system-color-gray-cool-50: #71767a;
+  --uswds-system-color-gray-cool-60: #565c65;
+  --uswds-system-color-gray-cool-70: #3d4551;
+  --uswds-system-color-gray-cool-80: #2d2e2f;
+  --uswds-system-color-gray-cool-90: #1c1d1f;
+  --uswds-system-color-orange-40: #dd7533;
+  --uswds-system-color-violet-vivid-70: #54278f;
+  --uswds-system-color-yellow-5: #faf3d1;
 }

--- a/packages/css-library/dist/tokens/figma/colors/variables.json
+++ b/packages/css-library/dist/tokens/figma/colors/variables.json
@@ -7,7 +7,7 @@
       "value": "#ffffff"
     },
     "black": {
-      "value": "#000000"
+      "value": "{uswds-system-color-gray-100}"
     },
     "orange": {
       "value": "#eb7f29"

--- a/packages/css-library/dist/tokens/json/variables.json
+++ b/packages/css-library/dist/tokens/json/variables.json
@@ -39,7 +39,7 @@
       "filePath": "tokens/color.json",
       "isSource": true,
       "original": {
-        "value": "#000000"
+        "value": "{uswds-system-color-gray-100}"
       },
       "name": "color-black",
       "attributes": {
@@ -1824,5 +1824,800 @@
         "neg-15"
       ]
     }
+  },
+  "uswds-system-color-blue-5": {
+    "value": "#eff6fb",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#eff6fb"
+    },
+    "name": "uswds-system-color-blue-5",
+    "attributes": {
+      "category": "uswds-system-color-blue-5"
+    },
+    "path": [
+      "uswds-system-color-blue-5"
+    ]
+  },
+  "uswds-system-color-blue-10": {
+    "value": "#d9e8f6",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#d9e8f6"
+    },
+    "name": "uswds-system-color-blue-10",
+    "attributes": {
+      "category": "uswds-system-color-blue-10"
+    },
+    "path": [
+      "uswds-system-color-blue-10"
+    ]
+  },
+  "uswds-system-color-blue-20": {
+    "value": "#aacdec",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#aacdec"
+    },
+    "name": "uswds-system-color-blue-20",
+    "attributes": {
+      "category": "uswds-system-color-blue-20"
+    },
+    "path": [
+      "uswds-system-color-blue-20"
+    ]
+  },
+  "uswds-system-color-blue-30": {
+    "value": "#73b3e7",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#73b3e7"
+    },
+    "name": "uswds-system-color-blue-30",
+    "attributes": {
+      "category": "uswds-system-color-blue-30"
+    },
+    "path": [
+      "uswds-system-color-blue-30"
+    ]
+  },
+  "uswds-system-color-blue-40": {
+    "value": "#4f97d1",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#4f97d1"
+    },
+    "name": "uswds-system-color-blue-40",
+    "attributes": {
+      "category": "uswds-system-color-blue-40"
+    },
+    "path": [
+      "uswds-system-color-blue-40"
+    ]
+  },
+  "uswds-system-color-blue-50": {
+    "value": "#2378c3",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#2378c3"
+    },
+    "name": "uswds-system-color-blue-50",
+    "attributes": {
+      "category": "uswds-system-color-blue-50"
+    },
+    "path": [
+      "uswds-system-color-blue-50"
+    ]
+  },
+  "uswds-system-color-blue-60": {
+    "value": "#2c608a",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#2c608a"
+    },
+    "name": "uswds-system-color-blue-60",
+    "attributes": {
+      "category": "uswds-system-color-blue-60"
+    },
+    "path": [
+      "uswds-system-color-blue-60"
+    ]
+  },
+  "uswds-system-color-blue-70": {
+    "value": "#274863",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#274863"
+    },
+    "name": "uswds-system-color-blue-70",
+    "attributes": {
+      "category": "uswds-system-color-blue-70"
+    },
+    "path": [
+      "uswds-system-color-blue-70"
+    ]
+  },
+  "uswds-system-color-blue-80": {
+    "value": "#1f303e",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#1f303e"
+    },
+    "name": "uswds-system-color-blue-80",
+    "attributes": {
+      "category": "uswds-system-color-blue-80"
+    },
+    "path": [
+      "uswds-system-color-blue-80"
+    ]
+  },
+  "uswds-system-color-blue-90": {
+    "value": "#11181d",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#11181d"
+    },
+    "name": "uswds-system-color-blue-90",
+    "attributes": {
+      "category": "uswds-system-color-blue-90"
+    },
+    "path": [
+      "uswds-system-color-blue-90"
+    ]
+  },
+  "uswds-system-color-blue-vivid-50": {
+    "value": "#0076d6",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#0076d6"
+    },
+    "name": "uswds-system-color-blue-vivid-50",
+    "attributes": {
+      "category": "uswds-system-color-blue-vivid-50"
+    },
+    "path": [
+      "uswds-system-color-blue-vivid-50"
+    ]
+  },
+  "uswds-system-color-blue-vivid-60": {
+    "value": "#005ea2",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#005ea2"
+    },
+    "name": "uswds-system-color-blue-vivid-60",
+    "attributes": {
+      "category": "uswds-system-color-blue-vivid-60"
+    },
+    "path": [
+      "uswds-system-color-blue-vivid-60"
+    ]
+  },
+  "uswds-system-color-blue-cool-vivid-5": {
+    "value": "#e1f3f8",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#e1f3f8"
+    },
+    "name": "uswds-system-color-blue-cool-vivid-5",
+    "attributes": {
+      "category": "uswds-system-color-blue-cool-vivid-5"
+    },
+    "path": [
+      "uswds-system-color-blue-cool-vivid-5"
+    ]
+  },
+  "uswds-system-color-blue-cool-vivid-20": {
+    "value": "#97d4ea",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#97d4ea"
+    },
+    "name": "uswds-system-color-blue-cool-vivid-20",
+    "attributes": {
+      "category": "uswds-system-color-blue-cool-vivid-20"
+    },
+    "path": [
+      "uswds-system-color-blue-cool-vivid-20"
+    ]
+  },
+  "uswds-system-color-blue-cool-vivid-40": {
+    "value": "#28a0cb",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#28a0cb"
+    },
+    "name": "uswds-system-color-blue-cool-vivid-40",
+    "attributes": {
+      "category": "uswds-system-color-blue-cool-vivid-40"
+    },
+    "path": [
+      "uswds-system-color-blue-cool-vivid-40"
+    ]
+  },
+  "uswds-system-color-blue-cool-vivid-60": {
+    "value": "#07648d",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#07648d"
+    },
+    "name": "uswds-system-color-blue-cool-vivid-60",
+    "attributes": {
+      "category": "uswds-system-color-blue-cool-vivid-60"
+    },
+    "path": [
+      "uswds-system-color-blue-cool-vivid-60"
+    ]
+  },
+  "uswds-system-color-blue-warm-vivid-60": {
+    "value": "#0050d8",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#0050d8"
+    },
+    "name": "uswds-system-color-blue-warm-vivid-60",
+    "attributes": {
+      "category": "uswds-system-color-blue-warm-vivid-60"
+    },
+    "path": [
+      "uswds-system-color-blue-warm-vivid-60"
+    ]
+  },
+  "uswds-system-color-blue-warm-vivid-70": {
+    "value": "#1a4480",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#1a4480"
+    },
+    "name": "uswds-system-color-blue-warm-vivid-70",
+    "attributes": {
+      "category": "uswds-system-color-blue-warm-vivid-70"
+    },
+    "path": [
+      "uswds-system-color-blue-warm-vivid-70"
+    ]
+  },
+  "uswds-system-color-blue-warm-vivid-80": {
+    "value": "#162e51",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#162e51"
+    },
+    "name": "uswds-system-color-blue-warm-vivid-80",
+    "attributes": {
+      "category": "uswds-system-color-blue-warm-vivid-80"
+    },
+    "path": [
+      "uswds-system-color-blue-warm-vivid-80"
+    ]
+  },
+  "uswds-system-color-cyan-vivid-30": {
+    "value": "#00bde3",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#00bde3"
+    },
+    "name": "uswds-system-color-cyan-vivid-30",
+    "attributes": {
+      "category": "uswds-system-color-cyan-vivid-30"
+    },
+    "path": [
+      "uswds-system-color-cyan-vivid-30"
+    ]
+  },
+  "uswds-system-color-gold-vivid-5": {
+    "value": "#fef0c8",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#fef0c8"
+    },
+    "name": "uswds-system-color-gold-vivid-5",
+    "attributes": {
+      "category": "uswds-system-color-gold-vivid-5"
+    },
+    "path": [
+      "uswds-system-color-gold-vivid-5"
+    ]
+  },
+  "uswds-system-color-gray-1": {
+    "value": "#fcfcfc",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#fcfcfc"
+    },
+    "name": "uswds-system-color-gray-1",
+    "attributes": {
+      "category": "uswds-system-color-gray-1"
+    },
+    "path": [
+      "uswds-system-color-gray-1"
+    ]
+  },
+  "uswds-system-color-gray-2": {
+    "value": "#f9f9f9",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#f9f9f9"
+    },
+    "name": "uswds-system-color-gray-2",
+    "attributes": {
+      "category": "uswds-system-color-gray-2"
+    },
+    "path": [
+      "uswds-system-color-gray-2"
+    ]
+  },
+  "uswds-system-color-gray-3": {
+    "value": "#f6f6f6",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#f6f6f6"
+    },
+    "name": "uswds-system-color-gray-3",
+    "attributes": {
+      "category": "uswds-system-color-gray-3"
+    },
+    "path": [
+      "uswds-system-color-gray-3"
+    ]
+  },
+  "uswds-system-color-gray-4": {
+    "value": "#f3f3f3",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#f3f3f3"
+    },
+    "name": "uswds-system-color-gray-4",
+    "attributes": {
+      "category": "uswds-system-color-gray-4"
+    },
+    "path": [
+      "uswds-system-color-gray-4"
+    ]
+  },
+  "uswds-system-color-gray-5": {
+    "value": "#f0f0f0",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#f0f0f0"
+    },
+    "name": "uswds-system-color-gray-5",
+    "attributes": {
+      "category": "uswds-system-color-gray-5"
+    },
+    "path": [
+      "uswds-system-color-gray-5"
+    ]
+  },
+  "uswds-system-color-gray-10": {
+    "value": "#e6e6e6",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#e6e6e6"
+    },
+    "name": "uswds-system-color-gray-10",
+    "attributes": {
+      "category": "uswds-system-color-gray-10"
+    },
+    "path": [
+      "uswds-system-color-gray-10"
+    ]
+  },
+  "uswds-system-color-gray-20": {
+    "value": "#c9c9c9",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#c9c9c9"
+    },
+    "name": "uswds-system-color-gray-20",
+    "attributes": {
+      "category": "uswds-system-color-gray-20"
+    },
+    "path": [
+      "uswds-system-color-gray-20"
+    ]
+  },
+  "uswds-system-color-gray-30": {
+    "value": "#adadad",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#adadad"
+    },
+    "name": "uswds-system-color-gray-30",
+    "attributes": {
+      "category": "uswds-system-color-gray-30"
+    },
+    "path": [
+      "uswds-system-color-gray-30"
+    ]
+  },
+  "uswds-system-color-gray-40": {
+    "value": "#919191",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#919191"
+    },
+    "name": "uswds-system-color-gray-40",
+    "attributes": {
+      "category": "uswds-system-color-gray-40"
+    },
+    "path": [
+      "uswds-system-color-gray-40"
+    ]
+  },
+  "uswds-system-color-gray-50": {
+    "value": "#757575",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#757575"
+    },
+    "name": "uswds-system-color-gray-50",
+    "attributes": {
+      "category": "uswds-system-color-gray-50"
+    },
+    "path": [
+      "uswds-system-color-gray-50"
+    ]
+  },
+  "uswds-system-color-gray-60": {
+    "value": "#5c5c5c",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#5c5c5c"
+    },
+    "name": "uswds-system-color-gray-60",
+    "attributes": {
+      "category": "uswds-system-color-gray-60"
+    },
+    "path": [
+      "uswds-system-color-gray-60"
+    ]
+  },
+  "uswds-system-color-gray-70": {
+    "value": "#454545",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#454545"
+    },
+    "name": "uswds-system-color-gray-70",
+    "attributes": {
+      "category": "uswds-system-color-gray-70"
+    },
+    "path": [
+      "uswds-system-color-gray-70"
+    ]
+  },
+  "uswds-system-color-gray-80": {
+    "value": "#2e2e2e",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#2e2e2e"
+    },
+    "name": "uswds-system-color-gray-80",
+    "attributes": {
+      "category": "uswds-system-color-gray-80"
+    },
+    "path": [
+      "uswds-system-color-gray-80"
+    ]
+  },
+  "uswds-system-color-gray-90": {
+    "value": "#1b1b1b",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#1b1b1b"
+    },
+    "name": "uswds-system-color-gray-90",
+    "attributes": {
+      "category": "uswds-system-color-gray-90"
+    },
+    "path": [
+      "uswds-system-color-gray-90"
+    ]
+  },
+  "uswds-system-color-gray-100": {
+    "value": "#000000",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#000000"
+    },
+    "name": "uswds-system-color-gray-100",
+    "attributes": {
+      "category": "uswds-system-color-gray-100"
+    },
+    "path": [
+      "uswds-system-color-gray-100"
+    ]
+  },
+  "uswds-system-color-gray-cool-1": {
+    "value": "#fbfcfd",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#fbfcfd"
+    },
+    "name": "uswds-system-color-gray-cool-1",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-1"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-1"
+    ]
+  },
+  "uswds-system-color-gray-cool-2": {
+    "value": "#f7f9fa",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#f7f9fa"
+    },
+    "name": "uswds-system-color-gray-cool-2",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-2"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-2"
+    ]
+  },
+  "uswds-system-color-gray-cool-3": {
+    "value": "#f5f6f7",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#f5f6f7"
+    },
+    "name": "uswds-system-color-gray-cool-3",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-3"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-3"
+    ]
+  },
+  "uswds-system-color-gray-cool-4": {
+    "value": "#f1f3f6",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#f1f3f6"
+    },
+    "name": "uswds-system-color-gray-cool-4",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-4"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-4"
+    ]
+  },
+  "uswds-system-color-gray-cool-5": {
+    "value": "#edeff0",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#edeff0"
+    },
+    "name": "uswds-system-color-gray-cool-5",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-5"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-5"
+    ]
+  },
+  "uswds-system-color-gray-cool-10": {
+    "value": "#dfe1e2",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#dfe1e2"
+    },
+    "name": "uswds-system-color-gray-cool-10",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-10"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-10"
+    ]
+  },
+  "uswds-system-color-gray-cool-20": {
+    "value": "#c6cace",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#c6cace"
+    },
+    "name": "uswds-system-color-gray-cool-20",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-20"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-20"
+    ]
+  },
+  "uswds-system-color-gray-cool-30": {
+    "value": "#a9aeb1",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#a9aeb1"
+    },
+    "name": "uswds-system-color-gray-cool-30",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-30"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-30"
+    ]
+  },
+  "uswds-system-color-gray-cool-40": {
+    "value": "#8d9297",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#8d9297"
+    },
+    "name": "uswds-system-color-gray-cool-40",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-40"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-40"
+    ]
+  },
+  "uswds-system-color-gray-cool-50": {
+    "value": "#71767a",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#71767a"
+    },
+    "name": "uswds-system-color-gray-cool-50",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-50"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-50"
+    ]
+  },
+  "uswds-system-color-gray-cool-60": {
+    "value": "#565c65",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#565c65"
+    },
+    "name": "uswds-system-color-gray-cool-60",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-60"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-60"
+    ]
+  },
+  "uswds-system-color-gray-cool-70": {
+    "value": "#3d4551",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#3d4551"
+    },
+    "name": "uswds-system-color-gray-cool-70",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-70"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-70"
+    ]
+  },
+  "uswds-system-color-gray-cool-80": {
+    "value": "#2d2e2f",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#2d2e2f"
+    },
+    "name": "uswds-system-color-gray-cool-80",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-80"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-80"
+    ]
+  },
+  "uswds-system-color-gray-cool-90": {
+    "value": "#1c1d1f",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#1c1d1f"
+    },
+    "name": "uswds-system-color-gray-cool-90",
+    "attributes": {
+      "category": "uswds-system-color-gray-cool-90"
+    },
+    "path": [
+      "uswds-system-color-gray-cool-90"
+    ]
+  },
+  "uswds-system-color-orange-40": {
+    "value": "#dd7533",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#dd7533"
+    },
+    "name": "uswds-system-color-orange-40",
+    "attributes": {
+      "category": "uswds-system-color-orange-40"
+    },
+    "path": [
+      "uswds-system-color-orange-40"
+    ]
+  },
+  "uswds-system-color-violet-vivid-70": {
+    "value": "#54278f",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#54278f"
+    },
+    "name": "uswds-system-color-violet-vivid-70",
+    "attributes": {
+      "category": "uswds-system-color-violet-vivid-70"
+    },
+    "path": [
+      "uswds-system-color-violet-vivid-70"
+    ]
+  },
+  "uswds-system-color-yellow-5": {
+    "value": "#faf3d1",
+    "filePath": "tokens/uswds.json",
+    "isSource": true,
+    "original": {
+      "value": "#faf3d1"
+    },
+    "name": "uswds-system-color-yellow-5",
+    "attributes": {
+      "category": "uswds-system-color-yellow-5"
+    },
+    "path": [
+      "uswds-system-color-yellow-5"
+    ]
   }
 }

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 08 Aug 2023 21:11:38 GMT
+// Generated on Wed, 23 Aug 2023 14:46:33 GMT
 
 $color-base: #212121;
 $color-white: #ffffff;
@@ -100,3 +100,56 @@ $units-neg-8: -6.4rem;
 $units-neg-9: -7.2rem;
 $units-neg-10: -8rem;
 $units-neg-15: -12rem;
+$uswds-system-color-blue-5: #eff6fb;
+$uswds-system-color-blue-10: #d9e8f6;
+$uswds-system-color-blue-20: #aacdec;
+$uswds-system-color-blue-30: #73b3e7;
+$uswds-system-color-blue-40: #4f97d1;
+$uswds-system-color-blue-50: #2378c3;
+$uswds-system-color-blue-60: #2c608a;
+$uswds-system-color-blue-70: #274863;
+$uswds-system-color-blue-80: #1f303e;
+$uswds-system-color-blue-90: #11181d;
+$uswds-system-color-blue-vivid-50: #0076d6;
+$uswds-system-color-blue-vivid-60: #005ea2;
+$uswds-system-color-blue-cool-vivid-5: #e1f3f8;
+$uswds-system-color-blue-cool-vivid-20: #97d4ea;
+$uswds-system-color-blue-cool-vivid-40: #28a0cb;
+$uswds-system-color-blue-cool-vivid-60: #07648d;
+$uswds-system-color-blue-warm-vivid-60: #0050d8;
+$uswds-system-color-blue-warm-vivid-70: #1a4480;
+$uswds-system-color-blue-warm-vivid-80: #162e51;
+$uswds-system-color-cyan-vivid-30: #00bde3;
+$uswds-system-color-gold-vivid-5: #fef0c8;
+$uswds-system-color-gray-1: #fcfcfc;
+$uswds-system-color-gray-2: #f9f9f9;
+$uswds-system-color-gray-3: #f6f6f6;
+$uswds-system-color-gray-4: #f3f3f3;
+$uswds-system-color-gray-5: #f0f0f0;
+$uswds-system-color-gray-10: #e6e6e6;
+$uswds-system-color-gray-20: #c9c9c9;
+$uswds-system-color-gray-30: #adadad;
+$uswds-system-color-gray-40: #919191;
+$uswds-system-color-gray-50: #757575;
+$uswds-system-color-gray-60: #5c5c5c;
+$uswds-system-color-gray-70: #454545;
+$uswds-system-color-gray-80: #2e2e2e;
+$uswds-system-color-gray-90: #1b1b1b;
+$uswds-system-color-gray-100: #000000;
+$uswds-system-color-gray-cool-1: #fbfcfd;
+$uswds-system-color-gray-cool-2: #f7f9fa;
+$uswds-system-color-gray-cool-3: #f5f6f7;
+$uswds-system-color-gray-cool-4: #f1f3f6;
+$uswds-system-color-gray-cool-5: #edeff0;
+$uswds-system-color-gray-cool-10: #dfe1e2;
+$uswds-system-color-gray-cool-20: #c6cace;
+$uswds-system-color-gray-cool-30: #a9aeb1;
+$uswds-system-color-gray-cool-40: #8d9297;
+$uswds-system-color-gray-cool-50: #71767a;
+$uswds-system-color-gray-cool-60: #565c65;
+$uswds-system-color-gray-cool-70: #3d4551;
+$uswds-system-color-gray-cool-80: #2d2e2f;
+$uswds-system-color-gray-cool-90: #1c1d1f;
+$uswds-system-color-orange-40: #dd7533;
+$uswds-system-color-violet-vivid-70: #54278f;
+$uswds-system-color-yellow-5: #faf3d1;

--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -9,7 +9,8 @@
     "build:tokens": "style-dictionary build",
     "build:stylesheets": "sass --load-path=../../node_modules/@uswds/uswds/packages/ src/stylesheets:dist/",
     "build:minify": "yarn build:stylesheets --style compressed --no-source-map",
-    "build": "yarn build:tokens && yarn build:stylesheets"
+    "build": "yarn run copy && yarn build:tokens && yarn build:stylesheets",
+    "copy": "node ./copy-uswds-color-tokens.js"
   },
   "devDependencies": {
     "@uswds/uswds": "^3.5.0",

--- a/packages/css-library/tokens/color.json
+++ b/packages/css-library/tokens/color.json
@@ -2,7 +2,7 @@
   "color": {
     "base": { "value": "#212121"},
     "white": { "value": "#ffffff"},
-    "black": { "value": "#000000"},
+    "black": { "value": "{uswds-system-color-gray-100}"},
     "orange": { "value": "#eb7f29"},
     "link-default": { "value": "#004795"},
     "link-visited": { "value": "#4c2c92"},

--- a/packages/css-library/tokens/uswds.json
+++ b/packages/css-library/tokens/uswds.json
@@ -1,0 +1,161 @@
+{
+  "uswds-system-color-blue-5": {
+    "value": "#eff6fb"
+  },
+  "uswds-system-color-blue-10": {
+    "value": "#d9e8f6"
+  },
+  "uswds-system-color-blue-20": {
+    "value": "#aacdec"
+  },
+  "uswds-system-color-blue-30": {
+    "value": "#73b3e7"
+  },
+  "uswds-system-color-blue-40": {
+    "value": "#4f97d1"
+  },
+  "uswds-system-color-blue-50": {
+    "value": "#2378c3"
+  },
+  "uswds-system-color-blue-60": {
+    "value": "#2c608a"
+  },
+  "uswds-system-color-blue-70": {
+    "value": "#274863"
+  },
+  "uswds-system-color-blue-80": {
+    "value": "#1f303e"
+  },
+  "uswds-system-color-blue-90": {
+    "value": "#11181d"
+  },
+  "uswds-system-color-blue-vivid-50": {
+    "value": "#0076d6"
+  },
+  "uswds-system-color-blue-vivid-60": {
+    "value": "#005ea2"
+  },
+  "uswds-system-color-blue-cool-vivid-5": {
+    "value": "#e1f3f8"
+  },
+  "uswds-system-color-blue-cool-vivid-20": {
+    "value": "#97d4ea"
+  },
+  "uswds-system-color-blue-cool-vivid-40": {
+    "value": "#28a0cb"
+  },
+  "uswds-system-color-blue-cool-vivid-60": {
+    "value": "#07648d"
+  },
+  "uswds-system-color-blue-warm-vivid-60": {
+    "value": "#0050d8"
+  },
+  "uswds-system-color-blue-warm-vivid-70": {
+    "value": "#1a4480"
+  },
+  "uswds-system-color-blue-warm-vivid-80": {
+    "value": "#162e51"
+  },
+  "uswds-system-color-cyan-vivid-30": {
+    "value": "#00bde3"
+  },
+  "uswds-system-color-gold-vivid-5": {
+    "value": "#fef0c8"
+  },
+  "uswds-system-color-gray-1": {
+    "value": "#fcfcfc"
+  },
+  "uswds-system-color-gray-2": {
+    "value": "#f9f9f9"
+  },
+  "uswds-system-color-gray-3": {
+    "value": "#f6f6f6"
+  },
+  "uswds-system-color-gray-4": {
+    "value": "#f3f3f3"
+  },
+  "uswds-system-color-gray-5": {
+    "value": "#f0f0f0"
+  },
+  "uswds-system-color-gray-10": {
+    "value": "#e6e6e6"
+  },
+  "uswds-system-color-gray-20": {
+    "value": "#c9c9c9"
+  },
+  "uswds-system-color-gray-30": {
+    "value": "#adadad"
+  },
+  "uswds-system-color-gray-40": {
+    "value": "#919191"
+  },
+  "uswds-system-color-gray-50": {
+    "value": "#757575"
+  },
+  "uswds-system-color-gray-60": {
+    "value": "#5c5c5c"
+  },
+  "uswds-system-color-gray-70": {
+    "value": "#454545"
+  },
+  "uswds-system-color-gray-80": {
+    "value": "#2e2e2e"
+  },
+  "uswds-system-color-gray-90": {
+    "value": "#1b1b1b"
+  },
+  "uswds-system-color-gray-100": {
+    "value": "#000000"
+  },
+  "uswds-system-color-gray-cool-1": {
+    "value": "#fbfcfd"
+  },
+  "uswds-system-color-gray-cool-2": {
+    "value": "#f7f9fa"
+  },
+  "uswds-system-color-gray-cool-3": {
+    "value": "#f5f6f7"
+  },
+  "uswds-system-color-gray-cool-4": {
+    "value": "#f1f3f6"
+  },
+  "uswds-system-color-gray-cool-5": {
+    "value": "#edeff0"
+  },
+  "uswds-system-color-gray-cool-10": {
+    "value": "#dfe1e2"
+  },
+  "uswds-system-color-gray-cool-20": {
+    "value": "#c6cace"
+  },
+  "uswds-system-color-gray-cool-30": {
+    "value": "#a9aeb1"
+  },
+  "uswds-system-color-gray-cool-40": {
+    "value": "#8d9297"
+  },
+  "uswds-system-color-gray-cool-50": {
+    "value": "#71767a"
+  },
+  "uswds-system-color-gray-cool-60": {
+    "value": "#565c65"
+  },
+  "uswds-system-color-gray-cool-70": {
+    "value": "#3d4551"
+  },
+  "uswds-system-color-gray-cool-80": {
+    "value": "#2d2e2f"
+  },
+  "uswds-system-color-gray-cool-90": {
+    "value": "#1c1d1f"
+  },
+  "uswds-system-color-orange-40": {
+    "value": "#dd7533"
+  },
+  "uswds-system-color-violet-vivid-70": {
+    "value": "#54278f"
+  },
+  "uswds-system-color-yellow-5": {
+    "value": "#faf3d1"
+  }
+}

--- a/packages/css-library/tokens/uswds.json
+++ b/packages/css-library/tokens/uswds.json
@@ -35,6 +35,9 @@
   "uswds-system-color-blue-vivid-60": {
     "value": "#005ea2"
   },
+  "uswds-system-color-blue-cool-60": {
+    "value": "#2e6276"
+  },
   "uswds-system-color-blue-cool-vivid-5": {
     "value": "#e1f3f8"
   },
@@ -47,6 +50,9 @@
   "uswds-system-color-blue-cool-vivid-60": {
     "value": "#07648d"
   },
+  "uswds-system-color-blue-warm-10": {
+    "value": "#e1e7f1"
+  },
   "uswds-system-color-blue-warm-vivid-60": {
     "value": "#0050d8"
   },
@@ -56,11 +62,32 @@
   "uswds-system-color-blue-warm-vivid-80": {
     "value": "#162e51"
   },
+  "uswds-system-color-cyan-5": {
+    "value": "#e7f6f8"
+  },
+  "uswds-system-color-cyan-20": {
+    "value": "#99deea"
+  },
   "uswds-system-color-cyan-vivid-30": {
     "value": "#00bde3"
   },
+  "uswds-system-color-cyan-vivid-40": {
+    "value": "#009ec1"
+  },
   "uswds-system-color-gold-vivid-5": {
     "value": "#fef0c8"
+  },
+  "uswds-system-color-gold-vivid-10": {
+    "value": "#ffe396"
+  },
+  "uswds-system-color-gold-vivid-20": {
+    "value": "#ffbe2e"
+  },
+  "uswds-system-color-gold-vivid-30": {
+    "value": "#e5a000"
+  },
+  "uswds-system-color-gold-vivid-50": {
+    "value": "#936f38"
   },
   "uswds-system-color-gray-1": {
     "value": "#fcfcfc"
@@ -149,13 +176,88 @@
   "uswds-system-color-gray-cool-90": {
     "value": "#1c1d1f"
   },
+  "uswds-system-color-gray-warm-10": {
+    "value": "#e6e6e2"
+  },
+  "uswds-system-color-gray-warm-70": {
+    "value": "#454540"
+  },
+  "uswds-system-color-green-cool-5": {
+    "value": "#ecf3ec"
+  },
+  "uswds-system-color-green-cool-20": {
+    "value": "#b4d0b9"
+  },
+  "uswds-system-color-green-cool-40": {
+    "value": "#5e9f69"
+  },
+  "uswds-system-color-green-cool-vivid-20": {
+    "value": "#70e17b"
+  },
+  "uswds-system-color-green-cool-vivid-40": {
+    "value": "#00a91c"
+  },
+  "uswds-system-color-green-cool-vivid-50": {
+    "value": "#008817"
+  },
+  "uswds-system-color-green-cool-vivid-60": {
+    "value": "#216e1f"
+  },
   "uswds-system-color-orange-40": {
     "value": "#dd7533"
+  },
+  "uswds-system-color-red-30": {
+    "value": "#f2938c"
+  },
+  "uswds-system-color-red-50": {
+    "value": "#d83933"
+  },
+  "uswds-system-color-red-70": {
+    "value": "#6f3331"
+  },
+  "uswds-system-color-red-vivid-60": {
+    "value": "#b50909"
+  },
+  "uswds-system-color-red-vivid-70": {
+    "value": "#8b0a03"
+  },
+  "uswds-system-color-red-cool-vivid-10": {
+    "value": "#f8dfe2"
+  },
+  "uswds-system-color-red-cool-vivid-50": {
+    "value": "#e41d3d"
+  },
+  "uswds-system-color-red-cool-vivid-60": {
+    "value": "#b21d38"
+  },
+  "uswds-system-color-red-cool-vivid-70": {
+    "value": "#822133"
+  },
+  "uswds-system-color-red-warm-10": {
+    "value": "#f4e3db"
+  },
+  "uswds-system-color-red-warm-80": {
+    "value": "#332d29"
+  },
+  "uswds-system-color-red-warm-vivid-30": {
+    "value": "#f39268"
+  },
+  "uswds-system-color-red-warm-vivid-50": {
+    "value": "#d54309"
+  },
+  "uswds-system-color-red-warm-vivid-60": {
+    "value": "#9c3d10"
   },
   "uswds-system-color-violet-vivid-70": {
     "value": "#54278f"
   },
   "uswds-system-color-yellow-5": {
     "value": "#faf3d1"
+  },
+  "uswds-system-color-yellow-vivid-10": {
+    "value": "#fee685"
+  },
+  "uswds-system-color-yellow-vivid-20": {
+    "value": "#face00"
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `asteele-passthrough-tokens-1967` is a placeholder for a CI job - it will be updated automatically -->
https://asteele-passthrough-tokens-1967--60f9b557105290003b387cd5.chromatic.com

---

## Description
Adds a script for copying over desired USWDS tokens into the CSS Library package. The list of desired tokens is taken from this [VA Design System Airtable](https://airtable.com/appF4FJKBeNVNGrlm/tblaTo3cDAURdk22q/viwkqvCZIOuv2RT6P?blocks=hide).

Closes #[1967](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1967)

## Testing done
Locally tested.

## Screenshots
Example of changing `color-black` to look to the USWDS color:
<img width="535" alt="Screenshot 2023-08-23 at 11 09 32 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/147893/02bca56c-dd1b-45ee-ab78-3a24cfd16d4d">
<img width="257" alt="Screenshot 2023-08-23 at 11 08 30 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/147893/37c6a4c3-ee05-43c3-960c-1e243034518b">

## Acceptance criteria
- [X] Tokens import and can be used as variables.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
