### PR TITLE
va-accordion: change line-height to 1.15

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.9",
+  "version": "4.45.10",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.scss
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.scss
@@ -83,7 +83,7 @@ button {
   font-family: var(--font-source-sans);
   font-size: 1.6rem;
   font-weight: 700;
-  line-height: 1;
+  line-height: 1.15;
   padding: 1.5rem 5.5rem 1.5rem 2rem;
   background-color: var(--color-gray-lightest);
   background-image: url('../../assets/minus.svg');


### PR DESCRIPTION
## Chromatic
<!-- This `2000-accordion-line-height` is a placeholder for a CI job - it will be updated automatically -->
https://2000-accordion-line-height--60f9b557105290003b387cd5.chromatic.com

## Description
Change accordion item line-height from 1 to 1.15 per the USWDS design
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2000

## Testing done
Local testing in Chrome

## Screenshots
before:
![Screenshot 2023-08-25 at 10 43 13 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/d6909734-627a-4573-8e8c-bc934f3ab0be)

After:
![Screenshot 2023-08-25 at 10 42 35 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/7d635d5e-6908-4d41-abfa-801ab9736963)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
