### PR TITLE
va-accordion: Load correct font family for expand/collapse

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.12",
+  "version": "4.45.13",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.11",
+  "version": "4.45.12",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion.scss
+++ b/packages/web-components/src/components/va-accordion/va-accordion.scss
@@ -28,6 +28,7 @@ button.va-accordion__button {
   background: transparent;
   padding: 1rem;
   cursor: pointer;
+  font-family: inherit;
   font-weight: bold;
   float: right;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `2033-accordion-font-family` is a placeholder for a CI job - it will be updated automatically -->
https://2033-accordion-font-family--60f9b557105290003b387cd5.chromatic.com

## Description
The expand/collapse all was not displaying the correct font family (Arial). This update allows the element to inherit the correct font-family (Source Sans Pro) 

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2033

## Testing done
Storybook

## Screenshots

**Before**

![Screenshot 2023-08-31 at 9 57 48 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/f892cd39-d548-47cf-b4a3-840536e01e4f)



![Screenshot 2023-08-31 at 9 54 05 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/0a3a3997-3bc6-4a3d-8c32-168137404c9b)

**After**

![Screenshot 2023-08-31 at 9 57 28 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/d2a14037-3404-464b-837f-b5104d005418)


![Screenshot 2023-08-31 at 9 54 24 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/21d58c31-c5e8-4b86-b0b1-b377d85e182f)


## Acceptance criteria
- [ ] The expand/collapse text is display as Source Sans Pro

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
