### PR TITLE
va-radio: increase legend width to 480px

### DIFF
--- a/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
+++ b/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
@@ -128,7 +128,7 @@ describe('va-radio-option', () => {
     );
 
     const changeSpy = await page.spyOnEvent('radioOptionSelected');
-    const inputEl = await page.find('va-radio-option');
+    const inputEl = await page.find('va-radio-option >>> label');
     await inputEl.click();
 
     expect(changeSpy).toHaveReceivedEvent();

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -5,6 +5,10 @@
 
 @import '../../global/formation_overrides';
 
+:host label {
+  max-width: 320px;
+  box-sizing: border-box;
+}
 
 .usa-radio {
   background: transparent;

--- a/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
+++ b/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
@@ -441,7 +441,10 @@ describe('va-radio', () => {
     expect(await options[0].getProperty('checked')).toBeTruthy();
     expect(await options[1].getProperty('checked')).toBeFalsy();
 
-    await options[1].click();
+    //without specifying center of element with this offset the click has no effect
+    await options[1].click({
+      offset: { x: 0, y: 0 }
+    });
 
     expect(await options[0].getProperty('checked')).toBeFalsy();
     expect(await options[1].getProperty('checked')).toBeTruthy();
@@ -493,7 +496,10 @@ describe('va-radio', () => {
       `);
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
     const inputEl = await page.find('va-radio-option');
-    await inputEl.click();
+    //without specifying center of element with this offset the click has no effect
+    await inputEl.click({
+      offset: { x: 0, y: 0 }
+    });
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'change',
@@ -531,7 +537,10 @@ describe('va-radio', () => {
 
     const changeSpy = await page.spyOnEvent('vaValueChange');
     const inputEl = await page.find('va-radio-option');
-    await inputEl.click();
+    //without specifying center of element with this offset the click has no effect
+    await inputEl.click({
+      offset: { x: 0, y: 0 }
+    });
 
     expect(changeSpy).toHaveReceivedEventDetail({ value: 'one' });
   });

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -232,7 +232,7 @@ export class VaRadio {
       });
       return (
         <Host aria-invalid={error ? 'true' : 'false'} aria-label={ariaLabel}>
-          <fieldset class="usa-form usa-fieldset" role="radiogroup">
+          <fieldset class="usa-fieldset" role="radiogroup">
             <legend class={legendClass} part="legend">
               {HeaderLevel ? (
                 <HeaderLevel part="header">{label}</HeaderLevel>


### PR DESCRIPTION
## Chromatic
<!-- This `2041-radio-options-label-width` is a placeholder for a CI job - it will be updated automatically -->
https://2041-radio-options-label-width--60f9b557105290003b387cd5.chromatic.com

---

## Description
This PR modifies the va-radio component to allow the legend to have more space. 
Note: this is one response to the the ticket below. Another possibility is to increase the size of the radio-option labels to 480px as well as the legend.

Closes [2041](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2041)

## Testing done
local testing in chrome, firefox, safari, edge
## Screenshots
### before

<img width="349" alt="Screenshot 2023-09-05 at 4 48 19 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/0f247125-4034-4f2f-a849-6c78d719b8d5">

### after 
<img width="485" alt="Screenshot 2023-09-05 at 4 47 56 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/d36dcfe0-c85f-4c23-bc47-18cd857c8ed5">

## Acceptance criteria
- [ ] widths of legend / labels are satisfactory

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
