### PR TITLE
Add Datadog privacy class to hide screen reader text

### DIFF
--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -230,7 +230,7 @@ export class VaCheckbox {
               {checkboxDescription && <span class="usa-checkbox__label-description" aria-describedby="option-label">{checkboxDescription}</span>}
             </label>
             {messageAriaDescribedby && (
-              <span id='input-message' class="sr-only">
+              <span id='input-message' class="sr-only dd-privacy-hidden">
                 {messageAriaDescribedby}
               </span>
             )}
@@ -271,7 +271,7 @@ export class VaCheckbox {
             </span>
           </label>
           {messageAriaDescribedby && (
-            <span id='input-message' class="sr-only">
+            <span id='input-message' class="sr-only dd-privacy-hidden">
               {messageAriaDescribedby}
             </span>
           )}

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -216,7 +216,7 @@ export class VaNumberInput {
             onBlur={handleBlur}
             />
             {messageAriaDescribedby && (
-              <span id="input-message" class="sr-only">
+              <span id="input-message" class="sr-only dd-privacy-hidden">
                 {messageAriaDescribedby}
               </span>
             )}
@@ -262,7 +262,7 @@ export class VaNumberInput {
               onBlur={handleBlur}
               />
               {messageAriaDescribedby && (
-                <span id="input-message" class="sr-only">
+                <span id="input-message" class="sr-only dd-privacy-hidden">
                   {messageAriaDescribedby}
                 </span>
               )}

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -149,9 +149,9 @@ export class VaTextInput {
    * Whether or not the component will use USWDS v3 styling.
    */
   @Prop({reflect: true}) uswds?: boolean = false;
-  
+
   /**
-   * Whether the component should show a character count message. 
+   * Whether the component should show a character count message.
    * Has no effect without uswds and maxlength being set.
    */
   @Prop() charcount?: boolean = false;
@@ -313,7 +313,7 @@ export class VaTextInput {
             part="input"
           />
           {messageAriaDescribedby && (
-            <span id="input-message" class="sr-only">
+            <span id="input-message" class="sr-only dd-privacy-hidden">
               {messageAriaDescribedby}
             </span>
           )}
@@ -371,7 +371,7 @@ export class VaTextInput {
             part="input"
           />
           {messageAriaDescribedby && (
-            <span id="input-message" class="sr-only">
+            <span id="input-message" class="sr-only dd-privacy-hidden">
               {messageAriaDescribedby}
             </span>
           )}

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -234,7 +234,7 @@ export class VaTextarea {
             </span>
           )}
           {messageAriaDescribedby && (
-            <span id="input-message" class="sr-only">
+            <span id="input-message" class="sr-only dd-privacy-hidden">
               {messageAriaDescribedby}
             </span>
           )}
@@ -271,7 +271,7 @@ export class VaTextarea {
             <small>{i18next.t('max-chars', { length: maxlength })}</small>
           )}
           {messageAriaDescribedby && (
-            <span id="input-message" class="sr-only">
+            <span id="input-message" class="sr-only dd-privacy-hidden">
               {messageAriaDescribedby}
             </span>
           )}


### PR DESCRIPTION
## Chromatic
<!-- This `61817-message-pii` is a placeholder for a CI job - it will be updated automatically -->
https://61817-message-pii--60f9b557105290003b387cd5.chromatic.com

## Description

We're using Datadog RUM session replays which records Veteran's interacting with the page. But when a `message-aria-describedby` is set and contains PII/PHI, it gets displayed in the recording. So we need to add a [`dd-privacy-hidden`](https://docs.datadoghq.com/real_user_monitoring/session_replay/privacy_options/#override-an-html-element) class to this screen reader only content to ensure it isn't visible.

Closes #64871 

## Testing done

No changes

## Screenshots

N/A

## Acceptance criteria
- [x] `dd-privacy-hidden` is added to `va-text-input` and `va-checkbox` to hide screen reader only content
- [x] All tests passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
