### PR TITLE
va-accordion: use setAttribute instead of calling click on accordion buttons

### DIFF
--- a/packages/storybook/stories/va-accordion-uswds.stories.jsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.jsx
@@ -223,6 +223,76 @@ const I18nTemplate = args => {
   );
 };
 
+const ManyItemsTemplate = args => (
+  <va-accordion {...args}>
+    <va-accordion-item uswds id="first" header="First Amendment">
+        <p>
+          Congress shall make no law respecting an establishment of religion, or
+          prohibiting the free exercise thereof; or abridging the freedom of speech,
+          or of the press; or the right of the people peaceably to assemble, and to
+          petition the Government for a redress of grievances.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item uswds id="second" header="Second Amendment">
+        <p>
+          A well regulated Militia, being necessary to the security of a free State, 
+          the right of the people to keep and bear Arms, shall not be infringed.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item uswds id="third" header="Third Amendment">
+        <p>
+          No Soldier shall, in time of peace be quartered in any house, without the 
+          consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item uswds id="fourth" header="Fourth Amendment">
+        <p>
+        The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, 
+        shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly 
+        describing the place to be searched, and the persons or things to be seized.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item uswds id="fifth" header="Fifth Amendment">
+        <p>
+        No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, 
+        except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; 
+        nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any 
+        criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor
+        shall private property be taken for public use, without just compensation.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item uswds id="sixth" header="Sixth Amendment">
+        <p>
+        In all criminal prosecutions, the accused shall enjoy the right to a speedy and public trial, by an impartial jury of the State 
+        and district wherein the crime shall have been committed, which district shall have been previously ascertained by law, and to 
+        be informed of the nature and cause of the accusation; to be confronted with the witnesses against him; to have compulsory process 
+        for obtaining witnesses in his favor, and to have the Assistance of Counsel for his defence.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item uswds id="seventh" header="Seventh Amendment">
+        <p>
+        In Suits at common law, where the value in controversy shall exceed twenty dollars, the right of trial by jury shall be preserved, 
+        and no fact tried by a jury, shall be otherwise re-examined in any Court of the United States, than according to the rules of the common law.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item uswds id="eighth" header="Eighth Amendment">
+        <p>
+        Excessive bail shall not be required, nor excessive fines imposed, nor cruel and unusual punishments inflicted.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item uswds id="ninth" header="Ninth Amendment">
+        <p>
+        The enumeration in the Constitution, of certain rights, shall not be construed to deny or disparage others retained by the people.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item uswds id="tenth" header="Tenth Amendment">
+        <p>
+        The powers not delegated to the United States by the Constitution, nor prohibited by it to the States, are reserved to the States respectively, or to the people.
+        </p>
+    </va-accordion-item>
+  </va-accordion>
+);
+
 
 const defaultArgs = {
   'bordered': false,
@@ -270,5 +340,10 @@ CustomHeaderLevel.args = {
 
 export const Internationalization = I18nTemplate.bind(null);
 Internationalization.args = {
+  ...defaultArgs,
+};
+
+export const ManyAccordions = ManyItemsTemplate.bind(null);
+ManyAccordions.args = {
   ...defaultArgs,
 };

--- a/packages/storybook/stories/va-accordion.stories.jsx
+++ b/packages/storybook/stories/va-accordion.stories.jsx
@@ -138,6 +138,76 @@ const I18nTemplate = args => {
   );
 };
 
+const ManyItemsTemplate = args => (
+  <va-accordion {...args}>
+    <va-accordion-item id="first" header="First Amendment">
+        <p>
+          Congress shall make no law respecting an establishment of religion, or
+          prohibiting the free exercise thereof; or abridging the freedom of speech,
+          or of the press; or the right of the people peaceably to assemble, and to
+          petition the Government for a redress of grievances.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="second" header="Second Amendment">
+        <p>
+          A well regulated Militia, being necessary to the security of a free State, 
+          the right of the people to keep and bear Arms, shall not be infringed.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="third" header="Third Amendment">
+        <p>
+          No Soldier shall, in time of peace be quartered in any house, without the 
+          consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="fourth" header="Fourth Amendment">
+        <p>
+        The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, 
+        shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly 
+        describing the place to be searched, and the persons or things to be seized.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="fifth" header="Fifth Amendment">
+        <p>
+        No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, 
+        except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; 
+        nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any 
+        criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor
+        shall private property be taken for public use, without just compensation.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="sixth" header="Sixth Amendment">
+        <p>
+        In all criminal prosecutions, the accused shall enjoy the right to a speedy and public trial, by an impartial jury of the State 
+        and district wherein the crime shall have been committed, which district shall have been previously ascertained by law, and to 
+        be informed of the nature and cause of the accusation; to be confronted with the witnesses against him; to have compulsory process 
+        for obtaining witnesses in his favor, and to have the Assistance of Counsel for his defence.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="seventh" header="Seventh Amendment">
+        <p>
+        In Suits at common law, where the value in controversy shall exceed twenty dollars, the right of trial by jury shall be preserved, 
+        and no fact tried by a jury, shall be otherwise re-examined in any Court of the United States, than according to the rules of the common law.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="eighth" header="Eighth Amendment">
+        <p>
+        Excessive bail shall not be required, nor excessive fines imposed, nor cruel and unusual punishments inflicted.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="ninth" header="Ninth Amendment">
+        <p>
+        The enumeration in the Constitution, of certain rights, shall not be construed to deny or disparage others retained by the people.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="tenth" header="Tenth Amendment">
+        <p>
+        The powers not delegated to the United States by the Constitution, nor prohibited by it to the States, are reserved to the States respectively, or to the people.
+        </p>
+    </va-accordion-item>
+  </va-accordion>
+);
+
 
 const defaultArgs = {
   'bordered': false,
@@ -184,3 +254,7 @@ UsingIcons.args = {
   ...defaultArgs,
 };
 
+export const ManyAccordions = ManyItemsTemplate.bind(null);
+ManyAccordions.args = {
+  ...defaultArgs,
+};

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.13",
+  "version": "4.45.14",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1087,7 +1087,7 @@ export namespace Components {
          */
         "autocomplete"?: string;
         /**
-          * Whether the component should show a character count message.  Has no effect without uswds and maxlength being set.
+          * Whether the component should show a character count message. Has no effect without uswds and maxlength being set.
          */
         "charcount"?: boolean;
         /**
@@ -2962,7 +2962,7 @@ declare namespace LocalJSX {
          */
         "autocomplete"?: string;
         /**
-          * Whether the component should show a character count message.  Has no effect without uswds and maxlength being set.
+          * Whether the component should show a character count message. Has no effect without uswds and maxlength being set.
          */
         "charcount"?: boolean;
         /**

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -162,20 +162,8 @@ export class VaAccordion {
   // Expand or Collapse All Function for Button Click
   private expandCollapseAll = (expanded: boolean) => {
     this.expanded = expanded;
-    getSlottedNodes(this.el, 'va-accordion-item').forEach((item) => {
-      if (this.uswds) {
-        let button = (item as Element).shadowRoot.querySelector('button.usa-accordion__button') as HTMLButtonElement,
-            buttonExpanded = button.getAttribute('aria-expanded') === 'true';
-        if (expanded && !buttonExpanded) {
-          button.click();
-        }
-        if (!expanded && buttonExpanded) {
-          button.click();
-        }
-      } else {
-        /* eslint-disable-next-line i18next/no-literal-string */
-        (item as Element).setAttribute('open', `${expanded}`)
-      }
+    getSlottedNodes(this.el, 'va-accordion-item').forEach((item:HTMLElement) => {
+      item.setAttribute('open', `${expanded}`)
     });
   };
 


### PR DESCRIPTION
## Chromatic
<!-- This `2060-accordion-scrolling` is a placeholder for a CI job - it will be updated automatically -->
https://2060-accordion-scrolling--60f9b557105290003b387cd5.chromatic.com

## Description
The page was scrolling because calling `button.click()` scrolls to the clicked element if it is not in view. This change simplifies the logic for expanding/collapsing accordionItems and makes it so that `setAttribute` is used on the USWDS version. The scrolling can only be seen when the number of accordions is greater than height of the viewport, I have added a story with more accordion items to verify.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2060

## Testing done
Local testing in Chrome, Firefox, Safari, and Edge

## Screenshots
No visual changes

## Acceptance criteria
- [ ] Accordion items still expand and collapse as usual
- [ ] The "Expand/Collapse all" buttons are functional
- [ ] The page does not scroll when the "Expand/Collapse all" button is clicked

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
