### PR TITLE
61627 mem date selective errors

### DIFF
--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.scss
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.scss
@@ -58,16 +58,16 @@
   border: 0.1rem solid var(--color-gray);
 }
 
-:host([invalid-month]:not([uswds])) va-select.input-month::part(select),
-:host([invalid-month]:not([uswds])) va-text-input.input-month::part(input) {
+:host([error="month-range"]:not([error='']):not([uswds])) va-select.input-month::part(select),
+:host([error="month-range"]:not([error='']):not([uswds])) va-text-input.input-month::part(input) {
   border: 4px solid var(--color-secondary-dark);
 }
 
-:host([invalid-day]:not([uswds])) va-text-input.input-day::part(input) {
+:host([error="day-range"]:not([error='']):not([uswds])) va-text-input.input-day::part(input) {
   border: 4px solid var(--color-secondary-dark);
 }
 
-:host([invalid-year]:not([uswds])) va-text-input.input-year::part(input) {
+:host([error="year-range"]:not([error='']):not([uswds])) va-text-input.input-year::part(input) {
   border: 4px solid var(--color-secondary-dark);
 }
 

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.scss
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.scss
@@ -53,21 +53,21 @@
 @import '../../mixins/form-field-error.css';
 
 // Resets error border to not show for 'any' error, so we can only show for 'specific' errors
-:host([error]:not([error='']):not([uswds])) va-select::part(select),
-:host([error]:not([error='']):not([uswds])) va-text-input::part(input) {
+:host([error]:not([error='']):not([uswds="true"])) va-select::part(select),
+:host([error]:not([error='']):not([uswds="true"])) va-text-input::part(input) {
   border: 0.1rem solid var(--color-gray);
 }
 
-:host([error="month-range"]:not([error='']):not([uswds])) va-select.input-month::part(select),
-:host([error="month-range"]:not([error='']):not([uswds])) va-text-input.input-month::part(input) {
+:host([error="month-range"]:not([error='']):not([uswds="true"])) va-select.input-month::part(select),
+:host([error="month-range"]:not([error='']):not([uswds="true"])) va-text-input.input-month::part(input) {
   border: 4px solid var(--color-secondary-dark);
 }
 
-:host([error="day-range"]:not([error='']):not([uswds])) va-text-input.input-day::part(input) {
+:host([error="day-range"]:not([error='']):not([uswds="true"])) va-text-input.input-day::part(input) {
   border: 4px solid var(--color-secondary-dark);
 }
 
-:host([error="year-range"]:not([error='']):not([uswds])) va-text-input.input-year::part(input) {
+:host([error="year-range"]:not([error='']):not([uswds="true"])) va-text-input.input-year::part(input) {
   border: 4px solid var(--color-secondary-dark);
 }
 

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.scss
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.scss
@@ -52,6 +52,25 @@
 @import '../va-date/va-date.css';
 @import '../../mixins/form-field-error.css';
 
+// Resets error border to not show for 'any' error, so we can only show for 'specific' errors
+:host([error]:not([error='']):not([uswds])) va-select::part(select),
+:host([error]:not([error='']):not([uswds])) va-text-input::part(input) {
+  border: 0.1rem solid var(--color-gray);
+}
+
+:host([invalid-month]:not([uswds])) va-select.input-month::part(select),
+:host([invalid-month]:not([uswds])) va-text-input.input-month::part(input) {
+  border: 4px solid var(--color-secondary-dark);
+}
+
+:host([invalid-day]:not([uswds])) va-text-input.input-day::part(input) {
+  border: 4px solid var(--color-secondary-dark);
+}
+
+:host([invalid-year]:not([uswds])) va-text-input.input-year::part(input) {
+  border: 4px solid var(--color-secondary-dark);
+}
+
 :host(:not([uswds])) .input-month,
 .input-day,
 .input-year {

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -234,7 +234,7 @@ export class VaMemorableDate {
       uswds,
       monthSelect,
     } = this;
-    
+
     const [year, month, day] = (value || '').split('-');
     const describedbyIds = ['dateHint', hint ? 'hint' : '']
       .filter(Boolean)
@@ -260,7 +260,7 @@ export class VaMemorableDate {
             invalid={this.invalidMonth}
             onVaSelect={handleDateChange}
             class='usa-form-group--month-select'
-            reflectInputError={error ? true : false}
+            reflectInputError={error === 'month-range' ? true : false}
             value={month ? String(parseInt(month)) : month}
             ref={(field) => this.monthfield = field}
           >
@@ -287,7 +287,7 @@ export class VaMemorableDate {
           value={month?.toString()}
           onInput={handleDateChange}
           class="usa-form-group--month-input memorable-date-input"
-          reflectInputError={error ? true : false}
+            reflectInputError={error === 'month-range' ? true : false}
           inputmode="numeric"
           type="text"
           ref={(field) => this.monthfield = field}
@@ -331,7 +331,7 @@ export class VaMemorableDate {
                   value={day?.toString()}
                   onInput={handleDateChange}
                   class="usa-form-group--day-input memorable-date-input"
-                  reflectInputError={error ? true : false}
+                  reflectInputError={error === 'day-range' ? true : false}
                   inputmode="numeric"
                   type="text"
                   ref={(field) => this.dayfield = field}
@@ -351,7 +351,7 @@ export class VaMemorableDate {
                   value={year?.toString()}
                   onInput={handleDateChange}
                   class="usa-form-group--year-input memorable-date-input"
-                  reflectInputError={error ? true : false}
+                  reflectInputError={error === 'year-range' ? true : false}
                   inputmode="numeric"
                   type="text"
                   ref={(field) => this.yearfield = field}


### PR DESCRIPTION
## Chromatic
<!-- This `61627-mem-date-selective-errors` is a placeholder for a CI job - it will be updated automatically -->
https://61627-mem-date-selective-errors--60f9b557105290003b387cd5.chromatic.com

---

## Description

Making mem date only show error borders on certain fields, dependent on the error message.
- Fixing CSS to only show error border for V1 components
- Fixing component to only show error border for V3 components

Closes #[61627](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61627)

## Testing done

Tested locally using Storybook

## Screenshots
<img width="384" alt="Screenshot 2023-09-12 at 10 59 53 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/147893/4be84042-b968-4d77-b936-a1cde900f6d9">


## Acceptance criteria
- [X] Doesn't highlight all of the inputs, but does highlight the specific field with an error associated with it.

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
