### PR TITLE
Add label-header-level to checkbox group

### DIFF
--- a/packages/storybook/stories/va-checkbox-group-uswds.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-group-uswds.stories.jsx
@@ -31,6 +31,7 @@ const vaCheckboxGroup = args => {
     label,
     required,
     hint,
+    'label-header-level': labelHeaderLevel,
     uswds,
     ...rest
   } = args;
@@ -41,6 +42,7 @@ const vaCheckboxGroup = args => {
       label={label}
       required={required}
       hint={hint}
+      label-header-level={labelHeaderLevel}
       uswds={uswds}
     >
       <va-checkbox uswds label="Sojourner Truth" name="example" value="1" />
@@ -136,6 +138,7 @@ const defaultArgs = {
   'error': null,
   'hint': null,
   'uswds': true,
+  'label-header-level': '',
 };
 
 export const Default = Template.bind(null);
@@ -143,6 +146,13 @@ Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(checkBoxGroupDocs);
+
+export const LabelHeader = Template.bind(null);
+LabelHeader.args = {
+  ...defaultArgs,
+  label: 'This is a label containing an H3',
+  'label-header-level': '3',
+};
 
 export const WithHintText = Template.bind(null);
 WithHintText.args = {

--- a/packages/storybook/stories/va-checkbox-group.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-group.stories.jsx
@@ -31,6 +31,7 @@ const vaCheckboxGroup = args => {
     label,
     required,
     hint,
+    'label-header-level': labelHeaderLevel,
     ...rest
   } = args;
   return (
@@ -40,6 +41,7 @@ const vaCheckboxGroup = args => {
       label={label}
       required={required}
       hint={hint}
+      label-header-level={labelHeaderLevel}
     >
       <va-checkbox label="Option one" name="example" value="1" />
       <va-checkbox label="Option two" name="example" value="2" />
@@ -73,6 +75,7 @@ const defaultArgs = {
   'required': false,
   'error': null,
   'hint': null,
+  'label-header-level': '',
 };
 
 export const Default = Template.bind(null);
@@ -80,6 +83,13 @@ Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(checkBoxGroupDocs);
+
+export const LabelHeader = Template.bind(null);
+LabelHeader.args = {
+  ...defaultArgs,
+  label: 'This is a label containing an H3',
+  'label-header-level': '3',
+};
 
 export const WithHintText = Template.bind(null);
 WithHintText.args = {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -324,6 +324,10 @@ export namespace Components {
          */
         "label": string;
         /**
+          * Insert a header with defined level inside the label (legend)
+         */
+        "labelHeaderLevel"?: string;
+        /**
           * Whether or not this input field is required.
          */
         "required"?: boolean;
@@ -2046,6 +2050,10 @@ declare namespace LocalJSX {
           * The text label for the checkbox group.
          */
         "label": string;
+        /**
+          * Insert a header with defined level inside the label (legend)
+         */
+        "labelHeaderLevel"?: string;
         /**
           * The event used to track usage of the component. This is emitted when an input value changes and enableAnalytics is true.
          */

--- a/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
@@ -256,4 +256,47 @@ describe('va-checkbox-group', () => {
 
     expect(await options[0].getProperty('checked')).toBeTruthy();
   });
+
+  it('uswds v3 renders H3 header in legend if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-checkbox-group uswds label="Testing H3" label-header-level="3" />');
+
+    const legend = await page.find('va-checkbox-group >>> legend');
+    expect(legend).toEqualHtml(`
+    <legend class="usa-legend">
+      <h3 part="header">Testing H3</h3>
+    </legend>
+  `);
+  });
+
+  it('renders H5 header in legend if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-checkbox-group uswds label="Testing H5" label-header-level="5" required></va-checkbox-group>');
+
+    const legend = await page.find('va-checkbox-group >>> legend');
+    expect(legend).toEqualHtml(`
+      <legend class="usa-legend">
+        <h5 part="header">Testing H5</h5>
+        <span class="usa-label--required">
+          required
+        </span>
+      </legend>
+ `);
+  });
+
+  it('renders legend text and ignores adding a header if an invalid level is included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-checkbox-group uswds label="Testing" label-header-level="7" required></va-checkbox-group>');
+
+    const legend = await page.find('va-checkbox-group >>> legend');
+    expect(legend).toEqualHtml(`
+      <legend class="usa-legend">
+        Testing
+        <span class="usa-label--required">
+          required
+        </span>
+      </legend>
+   `);
+  });
+
 });

--- a/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
@@ -128,6 +128,49 @@ describe('va-checkbox-group', () => {
     expect(await options[0].getProperty('checked')).toBeTruthy();
   });
 
+  it('renders H3 header in legend if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-checkbox-group label="Testing H3" label-header-level="3" />');
+
+    const legend = await page.find('va-checkbox-group >>> legend');
+    expect(legend).toEqualHtml(`
+    <legend>
+      <h3 part="header">Testing H3</h3>
+    </legend>
+  `);
+  });
+
+  it('renders H5 header in legend if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-checkbox-group label="Testing H5" label-header-level="5" required></va-checkbox-group>');
+
+    const legend = await page.find('va-checkbox-group >>> legend');
+    expect(legend).toEqualHtml(`
+      <legend>
+        <h5 part="header">Testing H5</h5>
+        <span class="required">
+          required
+        </span>
+      </legend>
+ `);
+  });
+
+  it('renders legend text and ignores adding a header if an invalid level is included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-checkbox-group label="Testing" label-header-level="7" required></va-checkbox-group>');
+
+    const legend = await page.find('va-checkbox-group >>> legend');
+    expect(legend).toEqualHtml(`
+      <legend>
+        Testing
+        <span class="required">
+          required
+        </span>
+      </legend>
+   `);
+  });
+
+
   // Begin USWDS v3 variation tests
 
   it('uswds v3 renders', async () => {

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.scss
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.scss
@@ -22,6 +22,7 @@
 @import '../../mixins/accessibility.css';
 @import '../../mixins/form-field-error.css';
 @import '../../mixins/hint-text.css';
+@import '../../mixins/headers.css';
 
 :host(:not([uswds])) #error-message {
   font-size: 1.6rem;

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
@@ -68,6 +68,11 @@ export class VaCheckboxGroup {
   @Prop() uswds?: boolean = false;
 
   /**
+   * Insert a header with defined level inside the label (legend)
+   */
+  @Prop() labelHeaderLevel?: string;
+
+  /**
    * The event used to track usage of the component. This is emitted when an
    * input value changes and enableAnalytics is true.
    */
@@ -96,6 +101,11 @@ export class VaCheckboxGroup {
     });
   }
 
+  private getHeaderLevel() {
+    const number = parseInt(this.labelHeaderLevel, 10);
+    return number >= 1 && number <= 6 ? `h${number}` : null;
+  }
+
   connectedCallback() {
     i18next.on('languageChanged', () => {
       forceUpdate(this.el);
@@ -108,6 +118,7 @@ export class VaCheckboxGroup {
 
   render() {
     const { label, required, error, hint, uswds } = this;
+    const HeaderLevel = this.getHeaderLevel();
 
     if (uswds) {
       const legendClass = classnames({
@@ -118,7 +129,11 @@ export class VaCheckboxGroup {
         <Host role="group">
           <fieldset class="usa-fieldset">
             <legend class={legendClass}>
-              {label}&nbsp;
+              {HeaderLevel ? (
+                <HeaderLevel part="header">{label}</HeaderLevel>
+              ) : (
+                label
+              )}&nbsp;
               {required && <span class="usa-label--required">{i18next.t('required')}</span>}
             </legend>
             {hint && <span class="usa-hint">{hint}</span>}
@@ -139,7 +154,11 @@ export class VaCheckboxGroup {
         <Host role="group">
           <fieldset>
             <legend>
-              {label}
+              {HeaderLevel ? (
+                <HeaderLevel part="header">{label}</HeaderLevel>
+              ) : (
+                label
+              )}
               {required && (
                 <span class="required">{i18next.t('required')}</span>
               )}

--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -26,6 +26,7 @@
 @import '../../mixins/accessibility.css';
 @import '../../mixins/form-field-error.css';
 @import '../../mixins/hint-text.css';
+@import '../../mixins/headers.css';
 
 .required {
   color: var(--color-secondary-dark);
@@ -46,14 +47,4 @@
   color: inherit;
   line-height: inherit;
   padding-inline: 0;
-}
-
-:host legend :is(h1, h2, h3, h4, h5, h6) {
-  display: inline;
-  margin: 0px;
-}
-
-/* h6 remains as Source Sans Pro, everything else uses Bitter */
-:host legend :is(h1, h2, h3, h4, h5) {
-  font-family: var(--font-serif);
 }

--- a/packages/web-components/src/mixins/headers.css
+++ b/packages/web-components/src/mixins/headers.css
@@ -1,0 +1,11 @@
+:host legend :is(h1, h2, h3, h4, h5, h6),
+:host label :is(h1, h2, h3, h4, h5, h6) {
+  display: inline;
+  margin: 0px;
+}
+
+/* h6 remains as Source Sans Pro, everything else uses Bitter */
+:host legend :is(h1, h2, h3, h4, h5),
+:host label :is(h1, h2, h3, h4, h5)  {
+  font-family: var(--font-serif);
+}


### PR DESCRIPTION
## Chromatic
<!-- This `2078-add-header-checkbox-group` is a placeholder for a CI job - it will be updated automatically -->
https://2078-add-header-checkbox-group--60f9b557105290003b387cd5.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Under **Testing done**, be specific about how this update was tested. 
    - Examples: Storybook, Chrome, Browserstack, Mobile/Responsive, etc.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description

Part of [#2078](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2078)

## Testing done

Added tests for headers

## Screenshots

<img width="417" alt="checkbox group with heading level 3, with hint and error message" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/13ddcfd1-926a-444a-bf74-d3be76a16392">

## Acceptance criteria
- [x] Add property to render a header inside the checkbox group legend
- [x] Include `part` to allow header styling
- [x] Add tests

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
