### PR TITLE
Add label-header-level to textarea

### DIFF
--- a/packages/storybook/stories/va-textarea-uswds.stories.jsx
+++ b/packages/storybook/stories/va-textarea-uswds.stories.jsx
@@ -18,6 +18,7 @@ export default {
 const defaultArgs = {
   'name': 'my-input',
   'label': 'Describe your situation',
+  'label-header-level': '',
   'enable-analytics': false,
   'required': false,
   'error': undefined,
@@ -33,6 +34,7 @@ const defaultArgs = {
 const Template = ({
   name,
   label,
+  'label-header-level': labelHeaderLevel,
   'enable-analytics': enableAnalytics,
   required,
   error,
@@ -49,6 +51,7 @@ const Template = ({
       uswds={uswds}
       name={name}
       label={label}
+      label-header-level={labelHeaderLevel}
       enable-analytics={enableAnalytics}
       required={required}
       error={error}
@@ -98,6 +101,13 @@ const ResizableTemplate = ({
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(textareaDocs);
+
+export const WithHeader = Template.bind(null);
+WithHeader.args = {
+  ...defaultArgs,
+  'label-header-level': '3',
+  label: 'My input with H3 header',
+};
 
 export const Error = Template.bind(null);
 Error.args = { ...defaultArgs, error: 'This is an error message' };

--- a/packages/storybook/stories/va-textarea.stories.jsx
+++ b/packages/storybook/stories/va-textarea.stories.jsx
@@ -18,6 +18,7 @@ export default {
 const defaultArgs = {
   'name': 'my-input',
   'label': 'Describe your situation',
+  'label-header-level': '',
   'enable-analytics': false,
   'required': false,
   'error': undefined,
@@ -31,6 +32,7 @@ const defaultArgs = {
 const Template = ({
   name,
   label,
+  'label-header-level': labelHeaderLevel,
   'enable-analytics': enableAnalytics,
   required,
   error,
@@ -44,6 +46,7 @@ const Template = ({
     <va-textarea
       name={name}
       label={label}
+      label-header-level={labelHeaderLevel}
       enable-analytics={enableAnalytics}
       required={required}
       error={error}
@@ -88,6 +91,13 @@ const ResizableTemplate = ({
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(textareaDocs);
+
+export const WithHeader = Template.bind(null);
+WithHeader.args = {
+  ...defaultArgs,
+  'label-header-level': '3',
+  label: 'My input with H3 header',
+};
 
 export const Error = Template.bind(null);
 Error.args = { ...defaultArgs, error: 'This is an error message' };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1195,6 +1195,10 @@ export namespace Components {
          */
         "label"?: string;
         /**
+          * Insert a header with defined level inside the label (legend)
+         */
+        "labelHeaderLevel"?: string;
+        /**
           * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */
         "maxlength"?: number;
@@ -3077,6 +3081,10 @@ declare namespace LocalJSX {
           * The label for the textarea.
          */
         "label"?: string;
+        /**
+          * Insert a header with defined level inside the label (legend)
+         */
+        "labelHeaderLevel"?: string;
         /**
           * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */

--- a/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
+++ b/packages/web-components/src/components/va-textarea/test/va-textarea.e2e.ts
@@ -42,6 +42,48 @@ describe('va-textarea', () => {
     expect(hintTextElement.innerText).toContain('This is hint text');
   });
 
+  it('renders H3 header in label if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-textarea label="Testing H3" label-header-level="3" />');
+
+    const label = await page.find('va-textarea >>> label');
+    expect(label).toEqualHtml(`
+      <label for="textarea">
+        <h3 part="header">Testing H3</h3>
+      </label>
+    `);
+  });
+
+  it('renders H5 header in label if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-textarea label="Testing H5" label-header-level="5" required />');
+
+    const label = await page.find('va-textarea >>> label');
+    expect(label).toEqualHtml(`
+      <label for="textarea">
+        <h5 part="header">Testing H5</h5>
+        <span class="required">
+          required
+        </span>
+      </label>
+ `);
+  });
+
+  it('renders label text and ignores adding a header if an invalid level is included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-textarea label="Testing" label-header-level="7" required />');
+
+    const label = await page.find('va-textarea >>> label');
+    expect(label).toEqualHtml(`
+      <label for="textarea">
+        Testing
+        <span class="required">
+          required
+        </span>
+      </label>
+   `);
+  });
+
   it('adds new aria-describedby for error message', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-textarea error="This is a mistake" />');
@@ -243,6 +285,48 @@ describe('va-textarea', () => {
     // Render the hint text
     const hintTextElement = await page.find('va-textarea >>> span.usa-hint');
     expect(hintTextElement.innerText).toContain('This is hint text');
+  });
+
+  it('uswds v3 renders H3 header in label if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-textarea label="Testing H3" label-header-level="3" uswds />');
+
+    const label = await page.find('va-textarea >>> label');
+    expect(label).toEqualHtml(`
+      <label class="usa-label" for="input-type-textarea" part="label">
+        <h3 part="header">Testing H3</h3>
+      </label>
+    `);
+  });
+
+  it('uswds v3 renders H5 header in label if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-textarea label="Testing H5" label-header-level="5" required uswds />');
+
+    const label = await page.find('va-textarea >>> label');
+    expect(label).toEqualHtml(`
+      <label class="usa-label" for="input-type-textarea" part="label">
+        <h5 part="header">Testing H5</h5>
+        <span class="usa-label--required">
+          required
+        </span>
+      </label>
+ `);
+  });
+
+  it('uswds v3 renders label text and ignores adding a header if an invalid level is included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-textarea label="Testing" label-header-level="7" required uswds />');
+
+    const label = await page.find('va-textarea >>> label');
+    expect(label).toEqualHtml(`
+      <label class="usa-label" for="input-type-textarea" part="label">
+        Testing
+        <span class="usa-label--required">
+          required
+        </span>
+      </label>
+   `);
   });
 
   it('uswds v3 adds new aria-describedby for error message', async () => {

--- a/packages/web-components/src/components/va-textarea/va-textarea.scss
+++ b/packages/web-components/src/components/va-textarea/va-textarea.scss
@@ -36,6 +36,7 @@
 @import '../../mixins/focusable.css';
 @import '../../mixins/form-field-error.css';
 @import '../../mixins/hint-text.css';
+@import '../../mixins/headers.css';
 
 :host(:not([uswds])) label {
   display: block;

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -12,7 +12,11 @@ import {
 } from '@stencil/core';
 import classnames from 'classnames';
 import i18next from 'i18next';
-import { consoleDevError, getCharacterMessage } from '../../utils/utils';
+import {
+  consoleDevError,
+  getCharacterMessage,
+  getHeaderLevel,
+} from '../../utils/utils';
 
 if (Build.isTesting) {
   // Make i18next.t() return the key instead of the value
@@ -42,6 +46,11 @@ export class VaTextarea {
    * The label for the textarea.
    */
   @Prop() label?: string;
+
+  /**
+   * Insert a header with defined level inside the label (legend)
+   */
+  @Prop() labelHeaderLevel?: string;
 
   /**
    * The error message to render.
@@ -167,6 +176,7 @@ export class VaTextarea {
       messageAriaDescribedby
     } = this;
 
+    const HeaderLevel = getHeaderLevel(this.labelHeaderLevel);
     const maxlength = this.getMaxlength();
     const ariaDescribedbyIds = `${error ? 'input-error-message' : ''} ${
       charcount && maxlength ? 'charcount-message' : ''} ${
@@ -191,7 +201,11 @@ export class VaTextarea {
         <Host>
           {label && (
             <label htmlFor="input-type-textarea" class={labelClass} part="label">
-              {label}
+              {HeaderLevel ? (
+                <HeaderLevel part="header">{label}</HeaderLevel>
+              ) : (
+                label
+              )}
               {required && (
                 <span class="usa-label--required">
                   {' '}
@@ -244,7 +258,11 @@ export class VaTextarea {
       return (
         <Host>
           <label htmlFor="textarea">
-            {label}
+            {HeaderLevel ? (
+              <HeaderLevel part="header">{label}</HeaderLevel>
+            ) : (
+              label
+            )}
             {required && <span class="required">{i18next.t('required')}</span>}
             {hint && <span class="hint-text">{hint}</span>}
           </label>

--- a/packages/web-components/src/utils/utils.ts
+++ b/packages/web-components/src/utils/utils.ts
@@ -77,3 +77,13 @@ export function getCharacterMessage(
 export function makeArray(start: number, end: number) {
   return Array.from({ length: end - start + 1 }, (_, i) => start + i);
 }
+
+/**
+ * Takes header level string value, parses and ensures it is a valid heading
+ * level, and returns a `H#` as a string to be rendered inside a label/legend
+ * @returns
+ */
+export function getHeaderLevel(level: string) {
+  const number = parseInt(level, 10);
+  return number >= 1 && number <= 6 ? `h${number}` : null;
+}


### PR DESCRIPTION
## Chromatic
<!-- This `2078-add-header-text-area` is a placeholder for a CI job - it will be updated automatically -->
https://2078-add-header-text-area--60f9b557105290003b387cd5.chromatic.com

## Description

Part of [#2078](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2078)

## Testing done

Added tests for headers

## Screenshots

<img width="637" alt="Screenshot 2023-09-13 at 10 17 37 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/f95d72a2-44ef-4637-b1a8-fe09e9e50d02">

## Acceptance criteria
- [x] Add property to render a header inside the textarea label
- [x] Include `part` to allow header styling
- [x] Add tests

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

