### PR TITLE
Add label-header-level to number input

### DIFF
--- a/packages/storybook/stories/va-number-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-number-input-uswds.stories.jsx
@@ -25,6 +25,7 @@ export default {
 const defaultArgs = {
   'name': 'my-input',
   'label': 'My input',
+  'label-header-level': '',
   'enable-analytics': false,
   'required': false,
   'error': undefined,
@@ -37,9 +38,10 @@ const defaultArgs = {
 };
 
 const vaNumberInput = args => {
-  const {   
+  const {
     name,
     label,
+    'label-header-level': labelHeaderLevel,
     'enable-analytics': enableAnalytics,
     required,
     error,
@@ -56,6 +58,7 @@ const vaNumberInput = args => {
       uswds={uswds}
       name={name}
       label={label}
+      label-header-level={labelHeaderLevel}
       enable-analytics={enableAnalytics}
       required={required}
       error={error}
@@ -111,8 +114,8 @@ const WidthsTemplate = ({
         name={name}
         label='My input - xs'
         value={value}
-      />  
-  
+      />
+
       <va-number-input
         width="sm"
         uswds={uswds}
@@ -159,6 +162,13 @@ const WidthsTemplate = ({
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(numberInputDocs);
+
+export const WithHeader = Template.bind(null);
+WithHeader.args = {
+  ...defaultArgs,
+  label: 'Lable with H3 inside',
+  'label-header-level': '3',
+};
 
 export const Error = Template.bind(null);
 Error.args = { ...defaultArgs, error: 'This is an error message' };

--- a/packages/storybook/stories/va-number-input.stories.jsx
+++ b/packages/storybook/stories/va-number-input.stories.jsx
@@ -25,6 +25,7 @@ export default {
 const defaultArgs = {
   'name': 'my-input',
   'label': 'My input',
+  // 'label-header-level': '',
   'enable-analytics': false,
   'required': false,
   'error': undefined,
@@ -38,9 +39,10 @@ const defaultArgs = {
 };
 
 const vaNumberInput = args => {
-  const {   
+  const {
     name,
     label,
+    'label-header-level': labelHeaderLevel,
     'enable-analytics': enableAnalytics,
     required,
     error,
@@ -52,11 +54,12 @@ const vaNumberInput = args => {
     currency,
     'message-aria-describedby': messageAriaDescribedby,
     ...rest
-  } = args;
+  } = args; console.log(args)
   return (
     <va-number-input
       name={name}
       label={label}
+      label-header-level={labelHeaderLevel}
       enable-analytics={enableAnalytics}
       required={required}
       error={error}
@@ -111,8 +114,8 @@ const WidthsTemplate = ({
         name={name}
         label='My input - xs'
         value={value}
-      />  
-  
+      />
+
       <va-number-input
         width="sm"
         name={name}
@@ -154,6 +157,13 @@ const WidthsTemplate = ({
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(numberInputDocs);
+
+export const WithHeader = Template.bind(null);
+WithHeader.args = {
+  ...defaultArgs,
+  label: 'My input inside H3',
+  'label-header-level': '3',
+};
 
 export const Error = Template.bind(null);
 Error.args = { ...defaultArgs, error: 'This is an error message' };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -691,6 +691,10 @@ export namespace Components {
          */
         "label"?: string;
         /**
+          * Insert a header with defined level inside the label (legend)
+         */
+        "labelHeaderLevel"?: string;
+        /**
           * Maximum number value The max attribute specifies the maximum value for an input element.
          */
         "max": number | string;
@@ -2493,6 +2497,10 @@ declare namespace LocalJSX {
           * The label for the text input.
          */
         "label"?: string;
+        /**
+          * Insert a header with defined level inside the label (legend)
+         */
+        "labelHeaderLevel"?: string;
         /**
           * Maximum number value The max attribute specifies the maximum value for an input element.
          */

--- a/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
+++ b/packages/web-components/src/components/va-number-input/test/va-number-input.e2e.ts
@@ -23,6 +23,39 @@ describe('va-number-input', () => {
     `);
   });
 
+  it('renders H3 header in label if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input label="Testing H3" label-header-level="3" />');
+    const label = await page.find('va-number-input >>> label');
+    expect(label).toEqualHtml(`
+      <label for="inputField">
+        <h3 part="header">Testing H3</h3>
+      </label>
+    `);
+  });
+  it('renders H5 header in label if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input label="Testing H5" label-header-level="5" required />');
+    const label = await page.find('va-number-input >>> label');
+    expect(label).toEqualHtml(`
+      <label for="inputField">
+        <h5 part="header">Testing H5</h5>
+        <span class="required"></span>
+      </label>
+ `);
+  });
+  it('renders label text and ignores adding a header if an invalid level is included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input label="Testing" label-header-level="7" required />');
+    const label = await page.find('va-number-input >>> label');
+    expect(label).toEqualHtml(`
+      <label for="inputField">
+        Testing
+        <span class="required"></span>
+      </label>
+   `);
+  });
+
   it('renders an error message', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-number-input error="This is a mistake" />');
@@ -213,6 +246,39 @@ describe('va-number-input', () => {
         </mock:shadow-root>
       </va-number-input>
     `);
+  });
+
+  it('uswds renders H3 header in label if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input label="Testing H3" label-header-level="3" uswds />');
+    const label = await page.find('va-number-input >>> label');
+    expect(label).toEqualHtml(`
+      <label class="usa-label" for="inputField">
+        <h3 part="header">Testing H3</h3>
+      </label>
+    `);
+  });
+  it('uswds renders H5 header in label if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input label="Testing H5" label-header-level="5" required uswds />');
+    const label = await page.find('va-number-input >>> label');
+    expect(label).toEqualHtml(`
+      <label class="usa-label" for="inputField">
+        <h5 part="header">Testing H5</h5>
+        <span class="usa-label--required"></span>
+      </label>
+ `);
+  });
+  it('uswds renders label text and ignores adding a header if an invalid level is included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-number-input label="Testing" label-header-level="7" required uswds />');
+    const label = await page.find('va-number-input >>> label');
+    expect(label).toEqualHtml(`
+      <label class="usa-label" for="inputField">
+        Testing
+        <span class="usa-label--required"></span>
+      </label>
+   `);
   });
 
   it('uswds renders an error message', async () => {

--- a/packages/web-components/src/components/va-number-input/va-number-input.scss
+++ b/packages/web-components/src/components/va-number-input/va-number-input.scss
@@ -8,6 +8,7 @@
 
 @import '../../mixins/form-field-error.css';
 @import '../../mixins/hint-text.css';
+@import '../../mixins/headers.css';
 
 :host(:not([uswds])) input[type='number'] {
   -moz-appearance: textfield;

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -11,6 +11,7 @@ import {
 } from '@stencil/core';
 import classnames from 'classnames';
 import i18next from 'i18next';
+import { getHeaderLevel } from '../../utils/utils';
 
 /**
  * @nativeHandler onInput
@@ -35,6 +36,11 @@ export class VaNumberInput {
    * The label for the text input.
    */
   @Prop() label?: string;
+
+  /**
+   * Insert a header with defined level inside the label (legend)
+   */
+  @Prop() labelHeaderLevel?: string;
 
   /**
    * The error message to render.
@@ -163,6 +169,7 @@ export class VaNumberInput {
       messageAriaDescribedby,
     } = this;
 
+    const HeaderLevel = getHeaderLevel(this.labelHeaderLevel);
     const ariaDescribedbyIds = `${messageAriaDescribedby ? 'input-message' : ''} ${error ? 'input-error-message' : ''}`
     .trim() || null; // Null so we don't add the attribute if we have an empty string
     const inputMode = inputmode ? inputmode : 'numeric';
@@ -181,7 +188,11 @@ export class VaNumberInput {
         <Host>
           {label && (
             <label htmlFor="inputField" class={labelClasses}>
-              {label}
+              {HeaderLevel ? (
+                <HeaderLevel part="header">{label}</HeaderLevel>
+              ) : (
+                label
+              )}
               {required && (
                 <span class="usa-label--required">
                   {' '}
@@ -230,7 +241,11 @@ export class VaNumberInput {
       return (
         <Host>
           <label htmlFor="inputField">
-            {label}{' '}
+            {HeaderLevel ? (
+              <HeaderLevel part="header">{label}</HeaderLevel>
+            ) : (
+              label
+            )}{' '}
             {required && <span class="required">{i18next.t('required')}</span>}
             {hint && <span class="hint-text">{hint}</span>}
           </label>

--- a/packages/web-components/src/utils/utils.ts
+++ b/packages/web-components/src/utils/utils.ts
@@ -77,3 +77,13 @@ export function getCharacterMessage(
 export function makeArray(start: number, end: number) {
   return Array.from({ length: end - start + 1 }, (_, i) => start + i);
 }
+
+/**
+ * Takes header level string value, parses and ensures it is a valid heading
+ * level, and returns a `H#` as a string to be rendered inside a label/legend
+ * @returns
+ */
+export function getHeaderLevel(level: string) {
+  const number = parseInt(level, 10);
+  return number >= 1 && number <= 6 ? `h${number}` : null;
+}


### PR DESCRIPTION
## Chromatic
<!-- This `2078-add-header-number-input` is a placeholder for a CI job - it will be updated automatically -->
https://2078-add-header-number-input--60f9b557105290003b387cd5.chromatic.com

## Description

Part of [#2078](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2078)

## Testing done

Added tests for headers

## Screenshots

<img width="555" alt="Screenshot 2023-09-13 at 2 53 46 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/17738b43-7002-4e2c-bffe-4408e9826b72">

## Acceptance criteria
- [x] Add property to render a header inside the text input label
- [x] Include `part` to allow header styling
- [x] Add tests

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
