### PR TITLE
va-telephone: Change extension prop from number to string type

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.15",
+  "version": "4.45.16",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1061,9 +1061,9 @@ export namespace Components {
          */
         "contact": string;
         /**
-          * Optional phone number extension
+          * Optional numeric string phone number extension
          */
-        "extension"?: number;
+        "extension"?: string;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */
@@ -2936,9 +2936,9 @@ declare namespace LocalJSX {
          */
         "contact": string;
         /**
-          * Optional phone number extension
+          * Optional numeric string phone number extension
          */
-        "extension"?: number;
+        "extension"?: string;
         /**
           * Indicates if this is a number meant to be called from outside the US. Prepends a "+1" to the formatted number.
          */

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -190,7 +190,7 @@ describe('va-telephone', () => {
       componentName: 'va-telephone',
       details: {
         contact: '8779551234',
-        extension: 123,
+        extension: '123',
       },
     });
   });

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -25,9 +25,9 @@ export class VaTelephone {
   @Prop() contact!: string;
 
   /**
-   * Optional phone number extension
+   * Optional numeric string phone number extension
    */
-  @Prop() extension?: number;
+  @Prop() extension?: string;
 
   /**
    * Indicates if the phone number can be clicked or not
@@ -95,7 +95,7 @@ export class VaTelephone {
    */
   static formatPhoneNumber(
     num: string,
-    extension: number,
+    extension: string,
     international: boolean = false,
     vanity: string,
     tty: boolean = false,
@@ -120,12 +120,12 @@ export class VaTelephone {
   /**
    * Format telephone number for screen readers
    * @param {string} contact - The 10 or 3 digit contact prop
-   * @param {number} ext - The extension number
+   * @param {string} ext - The extension numeric string
    * @param {boolean} tty - Whether or not this is a TTY number
    * @return {string} - Combined phone number parts within the label separated by
    * periods, e.g. "800-555-1212" becomes "8 0 0. 5 5 5. 1 2 1 2"
    */
-  static formatTelLabel(contact: string, ext: number, tty: boolean, international: boolean): string {
+  static formatTelLabel(contact: string, ext: string, tty: boolean, international: boolean): string {
     const spaceCharsOut = chars => chars.split('').join(' ');
     let labelPieces = VaTelephone.splitContact(contact)
       .map(spaceCharsOut);
@@ -142,7 +142,7 @@ export class VaTelephone {
     return labelPieces.join('. ');
   }
 
-  static createHref(contact: string, extension: number, sms: boolean): string {
+  static createHref(contact: string, extension: string, sms: boolean): string {
     const cleanedContact = VaTelephone.cleanContact(contact);
     const isN11 = cleanedContact.length === 3;
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5


### PR DESCRIPTION
## Chromatic
<!-- This `va-telephone-ext-type` is a placeholder for a CI job - it will be updated automatically -->
https://va-telephone-ext-type--60f9b557105290003b387cd5.chromatic.com

## Description
When deprecating the React Telephone component for va-telephone, I was getting a failed test on vets-website because it was checking for an extension of `0000` but the web component was not displaying it.

The `extension` prop was being set correctly but the web component wasn't able to accept the value `0000`. In VS Code, a linting error was showing as:

> Octal literals are not allowed. Use the syntax '0o0'.ts(1121)

<img width="822" alt="Screenshot 2023-09-14 at 4 11 30 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/872479/ff8955ba-7383-4d9a-93ce-0a5648f6dd77">

I was able to verify this issue in Storybook locally.

I tried using `Number` and `parseInt` to make sure it was getting passed as a number type but it still didn't work _specifically_ for the value `0000`. Other numbers and numeric strings worked fine.

What seems to fix this is changing the `extension` prop type from number to string. This is the same as what the `contact` prop is as well.

related PR https://github.com/department-of-veterans-affairs/vets-website/pull/25632

## Testing done
Storybook

## Screenshots

<img width="637" alt="Screenshot 2023-09-14 at 4 49 40 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/872479/b2261505-c992-42ea-a88b-bcd18bdf9818">

## Acceptance criteria
- [ ] The extension prop works when passing it `0000` as well as any other extension variation

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
