### PR TITLE
va-radio, va-radio-option: Screen reader and keyboard navigation updates

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
+++ b/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
@@ -15,14 +15,11 @@ describe('va-radio-option', () => {
 
     const element = await page.find('va-radio-option');
     expect(element).toEqualHtml(`
-    <va-radio-option id="yes2" label="Yes - Any Veteran" name="yes" value="2" aria-checked="false" role="radio" class="hydrated">
-      <mock:shadow-root>
-        <label for="yes2" id="option-label">
-          <div>
-            Yes - Any Veteran
-          </div>
-        </label>
-      </mock:shadow-root>
+    <va-radio-option id="yes2" label="Yes - Any Veteran" name="yes" value="2" aria-checked="false" class="hydrated">
+      <input id="yes2input" name="yes" type="radio" value="2">
+      <label for="yes2input">
+        Yes - Any Veteran
+      </label>
     </va-radio-option>
   `);
   });
@@ -33,9 +30,10 @@ describe('va-radio-option', () => {
       '<va-radio-option name="test" label="An option with spaces" value="1"></va-radio-option>',
     );
 
-    const inputEl = await page.find('va-radio-option');
+    const option = await page.find('va-radio-option'),
+          inputEl = await option.find('input');
 
-    expect(await inputEl.getProperty('id')).toEqual('test1');
+    expect(await inputEl.getProperty('id')).toEqual('test1input');
   });
 
   it('sets checked to true based on prop', async () => {
@@ -56,8 +54,10 @@ describe('va-radio-option', () => {
     );
 
     const changeSpy = await page.spyOnEvent('radioOptionSelected');
-    const inputEl = await page.find('va-radio-option');
-    await inputEl.click();
+    await page.evaluate(() => {
+      const radio = document.querySelector('va-radio-option input') as HTMLInputElement;
+      radio.click();
+    })
 
     expect(changeSpy).toHaveReceivedEvent();
   });
@@ -66,7 +66,7 @@ describe('va-radio-option', () => {
     const page = await newE2EPage();
     await page.setContent('<va-radio-option description="Some description text"></va-radio-option>');
 
-    const description = await page.find('va-radio-option >>> .description');
+    const description = await page.find('va-radio-option .description');
     expect(description.textContent).toEqual("Some description text");
   });
 
@@ -87,14 +87,12 @@ describe('va-radio-option', () => {
     const element = await page.find('va-radio-option');
     expect(element).toEqualHtml(`
     <va-radio-option uswds="" id="yes2" label="Yes - Any Veteran" name="yes" value="2" class="hydrated">
-      <mock:shadow-root>
         <div class="usa-radio">
-          <input class="usa-radio__input" id="yes2" type="radio" name="yes" tabindex="-1" value="2">
-          <label class="usa-radio__label" for="yes2" id="option-label">
+          <input class="usa-radio__input" id="yes2input" type="radio" name="yes" value="2">
+          <label class="usa-radio__label" for="yes2input">
             Yes - Any Veteran
           </label>
         </div>
-      </mock:shadow-root>
     </va-radio-option>
     `);
   });
@@ -105,9 +103,9 @@ describe('va-radio-option', () => {
       '<va-radio-option uswds name="test" label="An option with spaces" value="1"></va-radio-option>',
     );
 
-    const inputEl = await page.find('va-radio-option >>> input');
+    const inputEl = await page.find('va-radio-option input');
 
-    expect(await inputEl.getProperty('id')).toEqual('test1');
+    expect(await inputEl.getProperty('id')).toEqual('test1input');
   });
 
   it('uswds v3 sets checked to true based on prop', async () => {
@@ -128,7 +126,7 @@ describe('va-radio-option', () => {
     );
 
     const changeSpy = await page.spyOnEvent('radioOptionSelected');
-    const inputEl = await page.find('va-radio-option >>> label');
+    const inputEl = await page.find('va-radio-option label');
     await inputEl.click();
 
     expect(changeSpy).toHaveReceivedEvent();
@@ -140,7 +138,7 @@ describe('va-radio-option', () => {
       '<va-radio-option uswds checked aria-describedby="test" label="A label" value="something" description="Example description" />',
     );
 
-    const hint = await page.find('va-radio-option >>> .usa-radio__label-description');
+    const hint = await page.find('va-radio-option .usa-radio__label-description');
     expect(hint.textContent).toEqual("Example description");
   });
 

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -32,9 +32,8 @@ va-radio-option label.usa-radio__label::before {
 
 }
 
-va-radio-option input:focus + label.usa-radio__label::before {
+va-radio-option .usa-radio__input:focus+[class*=__label]::before {
   outline: 2px solid var(--color-gold-light);
-  outline-offset: 4px;
 }
 
 va-radio-option input[disabled='true']:focus + label.usa-radio__label::before {

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -5,7 +5,7 @@
 
 @import '../../global/formation_overrides';
 
-:host label {
+va-radio-option label {
   max-width: 320px;
   box-sizing: border-box;
 }
@@ -14,33 +14,35 @@
   background: transparent;
 }
 
-:host {
+va-radio-option {
   display: block;
   margin-top: 12px;
 }
 
-:host(:focus) {
+va-radio-option:focus {
   outline: none !important;
 }
 
-:host(:focus) label.usa-radio__label::before {
+va-radio-option:focus label.usa-radio__label::before {
   outline: 2px solid var(--color-gold-light);
   outline-offset: 4px;
 }
 
-:host([disabled='true']:focus) label.usa-radio__label::before {
+va-radio-option[disabled='true']:focus label.usa-radio__label::before {
   outline: none;
 }
 
 /* Original Components Styles. */
 
-@import '../../mixins/inputs.css';
-
-:host(:not([uswds])) {
+va-radio-option:not([uswds]) {
   margin-top: 1rem;
 }
 
-:host(:not([uswds])) label {
+va-radio-option:not([uswds]) input {
+  appearance: none;
+}
+
+va-radio-option:not([uswds]) label {
   box-sizing: border-box;
   outline: none;
   display: flex;
@@ -51,7 +53,7 @@
   padding-left: 6px;
 }
 
-:host(:not([uswds])) label::before {
+va-radio-option:not([uswds]) label::before {
   box-sizing: border-box;
   border-radius: 100%;
   box-shadow: 0 0 0 2px var(--color-white), 0 0 0 3px var(--color-gray-medium);
@@ -67,28 +69,28 @@
   display: inline-block;
 }
 
-:host(:not([uswds])[aria-checked='true']) label::before {
+va-radio-option:not([uswds])[aria-checked='true'] label::before {
   background-color: var(--color-primary);
   box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-primary);
 }
 
-:host(:not([uswds]):focus) label::before {
+va-radio-option:not([uswds]):focus label::before {
   outline: 2px solid var(--color-gold-light);
   outline-offset: 6px;
 }
 
-:host(:not([uswds])) .description {
+va-radio-option:not([uswds]) .description {
   display: block;
   margin-top: 5px;
 }
 
-:host(:not([uswds])[tile='true']) label {
+va-radio-option:not([uswds])[tile='true'] label {
   padding: 12px 16px 12px 12px;
   border: 2px solid var(--color-gray-light);
   border-radius: 0.25em;
 }
 
-:host(:not([uswds])[tile='true'][aria-checked='true']) label {
+va-radio-option:not([uswds])[tile='true'][aria-checked='true'] label {
   border: 2px solid var(--color-primary-alt-darkest);
   background: var(--color-gray-cool-light);
 }

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -19,16 +19,25 @@ va-radio-option {
   margin-top: 12px;
 }
 
-va-radio-option:focus {
+va-radio-option input:focus {
   outline: none !important;
 }
 
-va-radio-option:focus label.usa-radio__label::before {
+// Formation override
+va-radio-option label.usa-radio__label::before {
+  box-shadow: rgb(27, 27, 27) 0px 0px 0px 2px;
+  height: 20px;
+  width: 20px;
+  margin-left: 2px;
+
+}
+
+va-radio-option input:focus + label.usa-radio__label::before {
   outline: 2px solid var(--color-gold-light);
   outline-offset: 4px;
 }
 
-va-radio-option[disabled='true']:focus label.usa-radio__label::before {
+va-radio-option input[disabled='true']:focus + label.usa-radio__label::before {
   outline: none;
 }
 

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -12,7 +12,7 @@ import classnames from 'classnames';
 @Component({
   tag: 'va-radio-option',
   styleUrl: 'va-radio-option.scss',
-  shadow: true,
+  shadow: false,
 })
 export class VaRadioOption {
   @Element() el: HTMLElement;
@@ -96,17 +96,16 @@ export class VaRadioOption {
       return (
         <div class="usa-radio">
           <input
-            class={inputClass}
-            id={id}
-            type="radio"
-            name={name}
-            value={value}
-            checked={checked}
-            disabled={disabled}
-            onClick={() => this.handleChange()}
-            tabIndex={-1}
-          />
-          <label htmlFor={id} id="option-label" class="usa-radio__label">
+              class={inputClass}
+              type="radio"
+              name={name}
+              value={value}
+              checked={checked}
+              disabled={disabled}
+              onClick={() => this.handleChange()}
+              id={id + 'input'}
+            />
+          <label class="usa-radio__label" htmlFor={id + 'input'}>
             {label}
             {description && <span class="usa-radio__label-description" aria-describedby="option-label">{description}</span>}
           </label>
@@ -114,21 +113,19 @@ export class VaRadioOption {
       )
     } else {
       return (
-        <Host
-          aria-checked={checked ? `${checked}` : 'false'}
-          aria-describedby={(checked && ariaDescribedby) || null}
-          checked={checked}
-          name={name}
-          onClick={() => this.handleChange()}
-          role="radio"
-          value={value}
-          id={id}
-        >
-          <label htmlFor={id} id="option-label">
-            <div>
-              {label}
-              {description && <span class="description" aria-describedby="option-label">{description}</span>}
-            </div>
+        <Host aria-checked={checked ? `${checked}` : 'false'}>
+          <input 
+              type='radio' 
+              aria-describedby={(checked && ariaDescribedby) || null}
+              checked={checked}
+              name={name}
+              onClick={() => this.handleChange()}
+              value={value}
+              id={id + 'input'}
+            />
+          <label htmlFor={id + 'input'}>
+            {label}
+            {description && <span class="description" aria-describedby="option-label">{description}</span>}
           </label>
         </Host>
       );

--- a/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
+++ b/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
@@ -85,8 +85,11 @@ describe('va-radio', () => {
 
     expect(await options[0].getProperty('checked')).toBeTruthy();
     expect(await options[1].getProperty('checked')).toBeFalsy();
-
-    await options[1].click();
+    await page.evaluate(() => {
+      const radios = document.querySelectorAll('va-radio-option input'),
+            radio = radios[1] as HTMLInputElement;
+      radio.click();
+    })
 
     expect(await options[0].getProperty('checked')).toBeFalsy();
     expect(await options[1].getProperty('checked')).toBeTruthy();
@@ -179,8 +182,10 @@ describe('va-radio', () => {
       </va-radio>
       `);
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-    const inputEl = await page.find('va-radio-option');
-    await inputEl.click();
+    await page.evaluate(() => {
+      const radio = document.querySelector('va-radio-option input') as HTMLInputElement;
+      radio.click();
+    })
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'change',
@@ -202,9 +207,10 @@ describe('va-radio', () => {
       `);
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-    const inputEl = await page.find('va-radio-option');
-    await inputEl.click();
-
+    await page.evaluate(() => {
+      const radio = document.querySelector('va-radio-option input') as HTMLInputElement;
+      radio.click();
+    })
     expect(analyticsSpy).not.toHaveReceivedEvent();
   });
 
@@ -217,9 +223,10 @@ describe('va-radio', () => {
       `);
 
     const changeSpy = await page.spyOnEvent('vaValueChange');
-    const inputEl = await page.find('va-radio-option');
-    await inputEl.click();
-
+    await page.evaluate(() => {
+      const radio = document.querySelector('va-radio-option input') as HTMLInputElement;
+      radio.click();
+    })
     expect(changeSpy).toHaveReceivedEventDetail({ value: 'one' });
   });
 
@@ -233,8 +240,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('Space');
+    const input = await options[0].find('input');
+    await input.press('Space');
 
     expect(await options[0].getProperty('checked')).toBeTruthy();
   });
@@ -251,8 +258,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowLeft');
+    const input = await options[0].find('input');
+    await input.press('ArrowLeft');
 
     expect(await options[2].getProperty('checked')).toBeTruthy();
   });
@@ -269,8 +276,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowLeft');
+    const input = await options[0].find('input');
+    await input.press('ArrowLeft');
 
     expect(await options[0].getProperty('checked')).toBeFalsy();
   });
@@ -287,8 +294,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowRight');
+    const input = await options[0].find('input');
+    await input.press('ArrowRight');
 
     expect(await options[1].getProperty('checked')).toBeTruthy();
   });
@@ -305,8 +312,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowRight');
+    const input = await options[0].find('input');
+    await input.press('ArrowRight');
 
     expect(await options[0].getProperty('checked')).toBeFalsy();
   });
@@ -322,8 +329,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowDown');
+    const input = await options[0].find('input');
+    await input.press('ArrowDown');
 
     expect(await options[1].getProperty('checked')).toBeTruthy();
   });
@@ -339,8 +346,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowDown');
+    const input = await options[0].find('input');
+    await input.press('ArrowDown');
 
     expect(await options[0].getProperty('checked')).toBeFalsy();
   });
@@ -356,8 +363,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowUp');
+    const input = await options[0].find('input');
+    await input.press('ArrowUp');
 
     expect(await options[1].getProperty('checked')).toBeTruthy();
   });
@@ -373,8 +380,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[1].press('ArrowUp');
+    const input = await options[1].find('input');
+    await input.press('ArrowUp');
 
     expect(await options[1].getProperty('checked')).toBeFalsy();
   });
@@ -555,8 +562,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('Space');
+    const input = await options[0].find('input');
+    await input.press('Space');
 
     expect(await options[0].getProperty('checked')).toBeTruthy();
   });
@@ -573,8 +580,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowLeft');
+    const input = await options[0].find('input');
+    await input.press('ArrowLeft');
 
     expect(await options[2].getProperty('checked')).toBeTruthy();
   });
@@ -591,8 +598,9 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
+    const input = await options[0].find('input');
 
-    await options[0].press('ArrowLeft');
+    await input.press('ArrowLeft');
 
     expect(await options[0].getProperty('checked')).toBeFalsy();
   });
@@ -609,8 +617,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowRight');
+    const input = await options[0].find('input');
+    await input.press('ArrowRight');
 
     expect(await options[1].getProperty('checked')).toBeTruthy();
   });
@@ -627,8 +635,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowRight');
+    const input = await options[0].find('input');
+    await input.press('ArrowRight');
 
     expect(await options[0].getProperty('checked')).toBeFalsy();
   });
@@ -644,8 +652,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowDown');
+    const input = await options[0].find('input');
+    await input.press('ArrowDown');
 
     expect(await options[1].getProperty('checked')).toBeTruthy();
   });
@@ -661,8 +669,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowDown');
+    const input = await options[0].find('input');
+    await input.press('ArrowDown');
 
     expect(await options[0].getProperty('checked')).toBeFalsy();
   });
@@ -678,8 +686,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[0].press('ArrowUp');
+    const input = await options[0].find('input');
+    await input.press('ArrowUp');
 
     expect(await options[1].getProperty('checked')).toBeTruthy();
   });
@@ -695,8 +703,8 @@ describe('va-radio', () => {
     `,
     );
     const options = await page.findAll('va-radio-option');
-
-    await options[1].press('ArrowUp');
+    const input = await options[1].find('input');
+    await input.press('ArrowUp');
 
     expect(await options[1].getProperty('checked')).toBeFalsy();
   });

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -184,30 +184,16 @@ export class VaRadio {
 
   private deselectCurrentNode(node: HTMLVaRadioOptionElement): void {
     node.removeAttribute('checked');
-    node.setAttribute('tabindex', '-1');
   }
 
   private selectNextNode(node: HTMLVaRadioOptionElement): void {
     node.setAttribute('checked', '');
-    node.setAttribute('tabindex', '0');
     node.focus();
   }
 
   private getHeaderLevel() {
     const number = parseInt(this.labelHeaderLevel, 10);
     return number >= 1 && number <= 6 ? `h${number}` : null;
-  }
-
-  componentDidLoad(): void {
-    getSlottedNodes(this.el, 'va-radio-option').forEach(
-      (node: HTMLVaRadioOptionElement, index: number) => {
-        if (index === 0) {
-          node.setAttribute('tabindex', '0');
-        } else {
-          node.setAttribute('tabindex', '-1');
-        }
-      },
-    );
   }
 
   connectedCallback() {
@@ -232,7 +218,7 @@ export class VaRadio {
       });
       return (
         <Host aria-invalid={error ? 'true' : 'false'} aria-label={ariaLabel}>
-          <fieldset class="usa-fieldset" role="radiogroup">
+          <fieldset class="usa-fieldset">
             <legend class={legendClass} part="legend">
               {HeaderLevel ? (
                 <HeaderLevel part="header">{label}</HeaderLevel>
@@ -261,7 +247,7 @@ export class VaRadio {
     } else {
       return (
         <Host aria-invalid={error ? 'true' : 'false'} aria-label={ariaLabel}>
-          <fieldset role="radiogroup">
+          <fieldset>
             <legend part="legend">
               {HeaderLevel ? (
                 <HeaderLevel part="header">{label}</HeaderLevel>

--- a/packages/web-components/src/global/_formation_overrides.scss
+++ b/packages/web-components/src/global/_formation_overrides.scss
@@ -62,6 +62,9 @@
       left: rem-override(0.5rem);
     }
   }
+  &:focus+[class*=__label]::before {
+    outline-offset: rem-override(0.25rem);
+  }
 }
 
 .usa-input, .usa-select, .usa-textarea {


### PR DESCRIPTION
## Chromatic
<!-- This `2075-radio-group-accessibility` is a placeholder for a CI job - it will be updated automatically -->
https://2075-radio-group-accessibility--60f9b557105290003b387cd5.chromatic.com

## Description
- Remove tabIndex from radio options. They were causing options to be read as a "group"
- Update input Ids so they don't conflict with the web-component element id. This was causing the screen reader to not read the option label
- Change va-radio-option from `shadow: true` to `shadow: false`. This was causing the screen reader to not announce the total number of options and dictate that each option was its own radio group
- Remove label `id` attribute as this is not used and was causing AXE checks to complain about duplicate ids
- Update CSS to work with not having a host/shadow root
- Update tests for changes to HTML and functionality being tied to the input and not the web-component
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2075

## Testing done
- Local testing in Chrome, Safari, Firefox and Edge
- Screen reader testing done with Mac VoiceOver

## Screenshots
v1 Before:
![Screenshot 2023-09-20 at 3 07 36 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/01593d16-aa63-498b-8693-a7df7885e0b3)

v1 After:
![Screenshot 2023-09-20 at 3 08 13 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/28ca56b4-a3bb-4f1f-b606-59f25da1f481)

v3 Before:
![Screenshot 2023-09-20 at 3 08 44 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/c4a89af1-1d5f-4729-a1f7-c8cfee808067)

v3 After:
![Screenshot 2023-09-20 at 3 46 02 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/dd79a845-3f96-41ab-bab2-f72615ed8523)


## Acceptance criteria
- [ ] Component works as before functionally
- [ ] Criteria found in card by @rsmithadhoc are met

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
