### PR TITLE
add space back to number input

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "22.0.0",
+  "version": "22.0.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.17",
+  "version": "4.45.18",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -254,7 +254,7 @@ export class VaNumberInput {
           <span id="error-message" role="alert">
             {error && (
               <Fragment>
-                <span class="sr-only">{i18next.t('error')}</span>{error}
+                <span class="sr-only">{i18next.t('error')}</span>{' '}{error}
               </Fragment>
             )}
           </span>


### PR DESCRIPTION
## Chromatic
<!-- This `mc-number-input-fix` is a placeholder for a CI job - it will be updated automatically -->
https://mc-number-input-fix--60f9b557105290003b387cd5.chromatic.com

---

## Description
Re-adds a space to the va-number-input whose removal has introduced a regression into vets-website. 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
