### PR TITLE
Adding aria-label to V3 pagination

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.18",
+  "version": "4.45.19",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
+++ b/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
@@ -257,7 +257,7 @@ describe('uswds - va-pagination', () => {
     expect(element).toEqualHtml(`
       <va-pagination page="1" pages="3" uswds class="hydrated">
         <mock:shadow-root>
-          <nav class="usa-pagination">
+          <nav aria-label="Pagination" class="usa-pagination">
             <ul class="usa-pagination__list">
               <li class="usa-pagination__item usa-pagination__page-no">
                 <a href="javascript:void(0)" class="usa-pagination__button usa-current">1</a>
@@ -321,7 +321,7 @@ describe('uswds - va-pagination', () => {
   it('uswds v3 renders all page numbers if total pages is less than or equal to 7', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-pagination page="3" pages="7" max-page-list-length="7" uswds/>`);
-  
+
     const pageNumbers = [1, 2, 3, 4, 5, 6, 7];
 
     const anchors = await page.findAll('va-pagination >>> a.usa-pagination__button');

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -86,7 +86,7 @@ export class VaPagination {
    * Don't show last page when the page count exceeds
    * `maxPageListLength` (but do show the ellipsis).
    * Only relevant if uswds is true.
-   */ 
+   */
 
   @Prop() unbounded?: boolean = false;
 
@@ -96,7 +96,7 @@ export class VaPagination {
   @Prop() uswds?: boolean = false;
 
   /**
-   * If the page total is less than or equal to this limit, show all pages. 
+   * If the page total is less than or equal to this limit, show all pages.
    * Only relevant for uswds.
    */
   SHOW_ALL_PAGES: number = 7;
@@ -177,7 +177,7 @@ export class VaPagination {
         end = currentPage + (radius - 1 - unboundedChar);
       }
     }
-    
+
     return makeArray(start, end);
   }
 
@@ -229,9 +229,9 @@ export class VaPagination {
   };
 
   /**
-   * Adding SVGs here because if SVGs are included in the render method, 
+   * Adding SVGs here because if SVGs are included in the render method,
    * the result is to render the page in xhtml not html
-   * and errors result. 
+   * and errors result.
    */
   addIcons() {
     function makeSvgString(icon: string) {
@@ -259,7 +259,7 @@ export class VaPagination {
   componentDidRender() {
     this.addIcons();
   }
-  
+
   connectedCallback() {
     i18next.on('languageChanged', () => {
       forceUpdate(this.el);
@@ -297,7 +297,7 @@ export class VaPagination {
       });
 
       const previousButton = page > 1
-        ? 
+        ?
         <Fragment>
           <li class={arrowClasses} aria-label={previousAriaLabel}>
             <a
@@ -307,10 +307,10 @@ export class VaPagination {
               href="javascript:void(0)"
             >
               <div id="previous-arrow-icon"></div>
-              <span class="usa-pagination__link-text">{i18next.t('previous')}</span>  
+              <span class="usa-pagination__link-text">{i18next.t('previous')}</span>
             </a>
           </li>
-          {!pageNumbersToRender.includes(1) && 
+          {!pageNumbersToRender.includes(1) &&
           <Fragment>
             <li class={itemClasses}>
               <a
@@ -321,11 +321,11 @@ export class VaPagination {
             </li>
             <li class={ellipsisClasses} aria-label="ellipsis indicating non-visible pages">
               <span>...</span>
-            </li> 
+            </li>
           </Fragment>}
         </Fragment>
         : null;
-      
+
       const renderPages = pageNumbersToRender.map(pageNumber => {
         const anchorClasses = classnames({
           'usa-pagination__button': true,
@@ -380,7 +380,7 @@ export class VaPagination {
 
       return (
         <Host>
-          <nav class="usa-pagination">
+          <nav class="usa-pagination" aria-label="Pagination">
             <ul class="usa-pagination__list">
               {previousButton}
               {renderPages}


### PR DESCRIPTION
## Chromatic
<!-- This `2114-label-pagination` is a placeholder for a CI job - it will be updated automatically -->
https://2114-label-pagination--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2114

## Testing done
Tested locally using Brave and VoiceOver on Safari.

## Screenshots
N/A

## Acceptance criteria
- [X] <nav> element has an aria-label

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
