### PR TITLE
va-memorable-date, va-select - Accessibility updates from staging review

### DIFF
--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -16,9 +16,9 @@ describe('va-memorable-date', () => {
         <fieldset>
           <legend>
             <div id='dateHint'>date-hint.</div>
+            <span id="error-message" role="alert"></span>
           </legend>
           <slot></slot>
-          <span id="error-message" role="alert"></span>
           <div class='date-container'>
             <va-text-input aria-describedby='dateHint' class='hydrated input-month memorable-date-input'></va-text-input>
             <va-text-input aria-describedby='dateHint' class='hydrated input-day memorable-date-input'></va-text-input>
@@ -55,9 +55,9 @@ describe('va-memorable-date', () => {
             <span class="required">required</span>
             <div id="hint">hint text</div>
             <div id='dateHint'>date-hint.</div>
+            <span id="error-message" role="alert"></span>
           </legend>
           <slot></slot>
-          <span id="error-message" role="alert"></span>
           <div class='date-container'>
             <va-text-input aria-describedby='dateHint hint' class='hydrated input-month memorable-date-input'></va-text-input>
             <va-text-input aria-describedby='dateHint hint' class='hydrated input-day memorable-date-input'></va-text-input>
@@ -637,9 +637,9 @@ describe('va-memorable-date', () => {
           <span class="usa-hint" id="dateHint">
             date-hint
           </span>
+          <span id="error-message" role="alert"></span>
           </legend>
           <slot></slot>
-          <span id="error-message" role="alert"></span>
           <div class="usa-memorable-date">
             <div class="usa-form-group usa-form-group--month">
               <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--month-input" uswds=""></va-text-input>
@@ -688,9 +688,9 @@ describe('va-memorable-date', () => {
             <span class="usa-hint" id="dateHint">
               date-hint
             </span>
+            <span id="error-message" role="alert"></span>
           </legend>
           <slot></slot>
-          <span id="error-message" role="alert"></span>
           <div class="usa-memorable-date">
             <div class="usa-form-group usa-form-group--month">
               <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--month-input" uswds=""></va-text-input>
@@ -1277,9 +1277,9 @@ describe('va-memorable-date', () => {
           <span class="usa-hint" id="dateHint">
           date-hint-with-select
           </span>
+          <span id="error-message" role="alert"></span>
           </legend>
           <slot></slot>
-          <span id="error-message" role="alert"></span>
           <div class="usa-memorable-date">
             <div class="usa-form-group usa-form-group--select usa-form-group--month">
               <va-select aria-describedby="dateHint" class="hydrated usa-form-group--month-select" uswds="">
@@ -1365,9 +1365,9 @@ describe('va-memorable-date', () => {
             <span class="usa-hint" id="dateHint">
               date-hint-with-select
             </span>
+            <span id="error-message" role="alert"></span>
           </legend>
           <slot></slot>
-          <span id="error-message" role="alert"></span>
           <div class="usa-memorable-date">
             <div class="usa-form-group usa-form-group--select usa-form-group--month">
               <va-select aria-describedby="dateHint hint" class="hydrated usa-form-group--month-select" uswds="">

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -284,16 +284,17 @@ export class VaMemorableDate {
               {required && <span class="usa-label--required"> {i18next.t('required')}</span>}
               {hint && <div class="usa-hint" id="hint">{hint}</div>}
               <span class="usa-hint" id="dateHint">{hintText}</span>
+              <span id="error-message" role="alert">
+                {error && (
+                  <Fragment>
+                    <span class="usa-sr-only">{i18next.t('error')}</span>
+                    <span class="usa-error-message">{i18next.t(error, errorParameters(error))}</span>
+                  </Fragment>
+                )}
+              </span>
             </legend>
             <slot />
-            <span id="error-message" role="alert">
-              {error && (
-                <Fragment>
-                  <span class="usa-sr-only">{i18next.t('error')}</span>
-                  <span class="usa-error-message">{i18next.t(error, errorParameters(error))}</span>
-                </Fragment>
-              )}
-            </span>
+            
             <div class="usa-memorable-date">
               {monthDisplay}
               <div class="usa-form-group usa-form-group--day">
@@ -346,15 +347,16 @@ export class VaMemorableDate {
               {label} {required && <span class="required">{i18next.t('required')}</span>}
               {hint && <div id="hint">{hint}</div>}
               <div id="dateHint">{i18next.t('date-hint')}.</div>
+              <span id="error-message" role="alert">
+                {error && (
+                  <Fragment>
+                    <span class="sr-only">{i18next.t('error')}</span> {i18next.t(error, errorParameters(error))}
+                  </Fragment>
+                )}
+              </span>
             </legend>
             <slot />
-            <span id="error-message" role="alert">
-              {error && (
-                <Fragment>
-                  <span class="sr-only">{i18next.t('error')}</span> {i18next.t(error, errorParameters(error))}
-                </Fragment>
-              )}
-            </span>
+            
             <div class="date-container">
               <va-text-input
                 label={i18next.t('month')}

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -184,7 +184,7 @@ export class VaSelect {
               {required && <span class="usa-label--required"> {i18next.t('required')}</span>}
             </label>
           )}
-          {hint && <span class="usa-hint">{hint}</span>}
+          {hint && <span class="usa-hint" id="input-hint">{hint}</span>}
           <span id="input-error-message" role="alert">
             {error && (
               <Fragment>
@@ -196,7 +196,7 @@ export class VaSelect {
           <slot onSlotchange={() => this.populateOptions()}></slot>
           <select
             class={selectClass}
-            aria-describedby={error ? 'error-message' : undefined}
+            aria-describedby={error ? 'input-error-message' : hint ? 'input-hint' : undefined}
             aria-invalid={invalid || error ? 'true' : 'false'}
             id="options"
             name={name}
@@ -217,7 +217,7 @@ export class VaSelect {
             {label}
             {required && <span class="required">{i18next.t('required')}</span>}
           </label>
-          {hint && <span class="hint-text">{hint}</span>}
+          {hint && <span class="hint-text" id="input-hint">{hint}</span>}
           <span id="error-message" role="alert">
             {error && (
               <Fragment>
@@ -227,7 +227,7 @@ export class VaSelect {
           </span>
           <slot onSlotchange={() => this.populateOptions()}></slot>
           <select
-            aria-describedby={error ? 'error-message' : undefined}
+            aria-describedby={error ? 'error-message' : hint ? 'input-hint' : undefined}
             aria-invalid={invalid || error ? 'true' : 'false'}
             id="select"
             name={name}


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
- va-memorable-date: move error text inside of legend to ensure that it is read by screen readers
- va-select: Fix bug with aria-describedby where the element id was incorrect for the USWDS version, added a fallback to the help text if it is defined

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/64284

## Testing done
- Local testing via chrome and Mac VoiceOver

## Screenshots
- No visual changes

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
