### PR TITLE
Giithub action to disallow zenhub links in PRs

### DIFF
--- a/.github/workflows/disallow-zenhub-link.yml
+++ b/.github/workflows/disallow-zenhub-link.yml
@@ -1,0 +1,16 @@
+name: "Disallow Zenhub Links"
+on: [pull_request]
+
+jobs:
+  check_pr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Disallow zenhub links
+      uses: JJ/github-pr-contains-action@releases/v2
+      with:
+        github-token: ${{github.token}}
+        bodyDoesNotContain: "zenhub"
+        bodyContains: ''
+        diffContains: ''
+        filesChanged: 1
+        linesChanged: 1


### PR DESCRIPTION
## Chromatic
<!-- This `github-workflow-zenhub-link` is a placeholder for a CI job - it will be updated automatically -->
https://github-workflow-zenhub-link--60f9b557105290003b387cd5.chromatic.com


## Description
Closes http://example.com

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
