### PR TITLE
Github action to disallow zenhub links in PR descriptions

### DIFF
--- a/.github/workflows/disallow-zenhub-link.yml
+++ b/.github/workflows/disallow-zenhub-link.yml
@@ -12,3 +12,5 @@ jobs:
         bodyDoesNotContain: "zenhub.com"
         bodyContains: ''
         diffContains: ''
+        filesChanged: 1
+        linesChanged: 1

--- a/.github/workflows/disallow-zenhub-link.yml
+++ b/.github/workflows/disallow-zenhub-link.yml
@@ -1,5 +1,7 @@
 name: "Disallow Zenhub Links"
-on: [pull_request]
+on:
+  pull_request:
+    types:  [opened, edited, reopened, ready_for_review]
 
 jobs:
   check_pr:

--- a/.github/workflows/disallow-zenhub-link.yml
+++ b/.github/workflows/disallow-zenhub-link.yml
@@ -14,5 +14,3 @@ jobs:
         bodyDoesNotContain: "zenhub.com"
         bodyContains: ''
         diffContains: ''
-        filesChanged: 1
-        linesChanged: 1

--- a/.github/workflows/disallow-zenhub-link.yml
+++ b/.github/workflows/disallow-zenhub-link.yml
@@ -1,7 +1,7 @@
 name: "Disallow Zenhub Links"
 on:
   pull_request:
-    types:  [opened, edited, reopened, ready_for_review]
+    types:  [opened, edited, reopened, synchronize]
 
 jobs:
   check_pr:

--- a/.github/workflows/disallow-zenhub-link.yml
+++ b/.github/workflows/disallow-zenhub-link.yml
@@ -12,5 +12,3 @@ jobs:
         bodyDoesNotContain: "zenhub.com"
         bodyContains: ''
         diffContains: ''
-        filesChanged: 1
-        linesChanged: 1

--- a/.github/workflows/disallow-zenhub-link.yml
+++ b/.github/workflows/disallow-zenhub-link.yml
@@ -9,7 +9,7 @@ jobs:
       uses: JJ/github-pr-contains-action@releases/v2
       with:
         github-token: ${{github.token}}
-        bodyDoesNotContain: "zenhub"
+        bodyDoesNotContain: "zenhub.com"
         bodyContains: ''
         diffContains: ''
         filesChanged: 1

--- a/.github/workflows/disallow-zenhub-link.yml
+++ b/.github/workflows/disallow-zenhub-link.yml
@@ -1,0 +1,16 @@
+name: "Disallow Zenhub Links"
+on: [pull_request]
+
+jobs:
+  check_pr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Disallow zenhub links
+      uses: JJ/github-pr-contains-action@releases/v2
+      with:
+        github-token: ${{github.token}}
+        bodyDoesNotContain: "zenhub"
+        bodyContains: ''
+        diffContains: ''
+        filesChanged: 1
+        linesChanged: 1


### PR DESCRIPTION
## Chromatic
<!-- This `github-workflow-zh-link` is a placeholder for a CI job - it will be updated automatically -->
https://github-workflow-zh-link--60f9b557105290003b387cd5.chromatic.com

## Description

This workflow uses the [github-pr-contains-action](https://github.com/dataloudercom/github-pr-contains-action). It checks for the presence of a word in the body or diff in a PR.

In this case, we are checking for the value `zenhub.c0m` (using a zero in the string here so the workflow doesn't fail) because we want to be linking to Github issues; not zenhub links of Github issues.

The reason we only want to use Github links is because it provides us with **very low effort documentation** by auto-generating cross-references between issues. This cross-referencing is very important for understanding context of changes and makes reviewing PRs easier.

There can also be access issues with Zenhub where other teams are unable to view the original issue.

Lastly, using the Github issue link also allows us to take advantage of [Github keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) like `close, fixes, resolves`. None of this works if we are linking to zenhub.

## Testing done
Tested in this PR

## Screenshots

**Example of linking to Github in a PR which automatically creates a cross-reference to the issue**

![Screenshot 2023-09-27 at 11 49 59 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/2d4ca708-b91c-498f-91d9-53e6d853a627)

**Zenhub link being used instead of the Github issues**

![Screenshot 2023-09-27 at 10 17 18 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/38e4d019-8377-4a38-a471-4feb869dd69a)

**The workflow will fail**
![Screenshot 2023-09-27 at 10 43 39 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/6993d6b6-9dd2-4961-a050-c27b401fb889)

**Updating the description automatically re-runs the workflow**
![Screenshot 2023-09-27 at 11 47 18 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/88bd4241-36ec-452e-a60c-0f2c78adcd23)

**Where to find the Github link in a Zenhub issue**
![Screenshot 2023-09-27 at 1 23 16 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/ab858767-41ac-491e-b97b-c80ac93a2613)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
