### PR TITLE
va-modal: button widths, margin bug fix, storybook copy, title font family

### DIFF
--- a/packages/storybook/stories/va-modal-uswds.stories.jsx
+++ b/packages/storybook/stories/va-modal-uswds.stories.jsx
@@ -29,14 +29,14 @@ const defaultArgs = {
   'click-to-close': false,
   'disable-analytics': false,
   'large': undefined,
-  'modal-title': 'Are you sure you want to continue?',
+  'modal-title': 'Title',
   'initial-focus-selector': undefined,
   'status': undefined,
   'visible': false,
   'primaryButtonClick': () => window.alert('Primary button clicked!'),
-  'primary-button-text': 'Continue without saving',
+  'primary-button-text': 'Primary',
   'secondaryButtonClick': () => window.alert('Secondary button clicked!'),
-  'secondary-button-text': 'Go back',
+  'secondary-button-text': 'Secondary',
   'uswds': true,
   'forcedModal': false,
 };
@@ -80,7 +80,7 @@ const Template = ({
         visible={isVisible}
       >
         <p>
-          You have unsaved changes that will be lost.
+          This is a succinct, helful {status} message
         </p>
       </VaModal>
     </div>
@@ -144,15 +144,15 @@ WithForcedAction.args = { ...defaultArgs, forcedModal: true };
 
 // Statuses
 export const Info = Template.bind(null);
-Info.args = { ...defaultArgs, status: 'info' };
+Info.args = { ...defaultArgs, 'modal-title': 'Info status', status: 'info' };
 export const Continue = Template.bind(null);
-Continue.args = { ...defaultArgs, status: 'continue' };
+Continue.args = { ...defaultArgs, 'modal-title': 'Continue status', status: 'continue' };
 export const Success = Template.bind(null);
-Success.args = { ...defaultArgs, status: 'success' };
+Success.args = { ...defaultArgs, 'modal-title': 'Success status', status: 'success' };
 export const Warning = Template.bind(null);
-Warning.args = { ...defaultArgs, status: 'warning' };
+Warning.args = { ...defaultArgs, 'modal-title': 'Warning status', status: 'warning' };
 export const Error = Template.bind(null);
-Error.args = { ...defaultArgs, status: 'error' };
+Error.args = { ...defaultArgs, 'modal-title': 'Error status', status: 'error' };
 
 export const ClickOutsideToClose = Template.bind(null);
 ClickOutsideToClose.args = {

--- a/packages/storybook/stories/va-modal-uswds.stories.jsx
+++ b/packages/storybook/stories/va-modal-uswds.stories.jsx
@@ -80,7 +80,7 @@ const Template = ({
         visible={isVisible}
       >
         <p>
-          This is a succinct, helful {status} message
+          This is a succinct, helpful {status} message
         </p>
       </VaModal>
     </div>

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.21",
+  "version": "4.45.22",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-modal/va-modal.scss
+++ b/packages/web-components/src/components/va-modal/va-modal.scss
@@ -16,6 +16,22 @@
   padding: 0px // => Due to icons
 }
 
+
+.usa-modal__heading {
+  font-family: var(--font-serif);
+}
+
+.usa-modal {
+  &:not(.usa-modal--lg) {
+    width: auto; // USWDS style made it so that the modal was wider than it should be
+  }
+
+  & va-button {
+    width: 100%;
+  }
+}
+
+
 :host([status='info']) .usa-modal {
   border-left-color: var(--color-primary-alt-dark);
   background-color: var(--color-primary-alt-lightest);


### PR DESCRIPTION
## Chromatic
<!-- This `2116-modal-storybook` is a placeholder for a CI job - it will be updated automatically -->
https://2116-modal-storybook--60f9b557105290003b387cd5.chromatic.com

## Description
- Update to make the buttons be full width in mobile
- Make the storybook copy/content match sketch
- Update title font to be bitter
- Fix bug that was making the margins of the modal wider than they should be

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2116

## Testing done
Local testing in Chrome, Safari, Edge, and Firefox

## Screenshots

Before:
![Screenshot 2023-09-28 at 9 41 51 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/dab0e74d-f432-4de7-a9d2-62c2733caf54)

After:

![Screenshot 2023-09-28 at 9 42 26 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/a0b7c864-36d7-46c5-ab44-3aa64ae4b5d9)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
