### PR TITLE
va-modal: require modalTitle

### DIFF
--- a/packages/storybook/stories/va-modal-uswds.stories.jsx
+++ b/packages/storybook/stories/va-modal-uswds.stories.jsx
@@ -169,9 +169,6 @@ WithoutButtons.args = {
   'secondary-button-text': undefined,
 };
 
-export const WithoutTitle = Template.bind(null);
-WithoutTitle.args = { ...defaultArgs, 'modal-title': undefined };
-
 export const WithNestedWebComponents = ({
   'click-to-close': clickToClose,
   'disable-analytics': disableAnalytics,

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -594,7 +594,7 @@ export namespace Components {
         /**
           * Title/header text for the modal
          */
-        "modalTitle"?: string;
+        "modalTitle": string;
         /**
           * Primary button text
          */
@@ -2430,7 +2430,7 @@ declare namespace LocalJSX {
         /**
           * Title/header text for the modal
          */
-        "modalTitle"?: string;
+        "modalTitle": string;
         /**
           * Fires when modal is closed.
          */

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -119,7 +119,7 @@ export class VaModal {
   /**
    * Title/header text for the modal
    */
-  @Prop() modalTitle?: string;
+  @Prop() modalTitle!: string;
 
   /**
    * Whether or not the component will use USWDS v3 styling.


### PR DESCRIPTION
## Chromatic
<!-- This `2087-require-modal-title` is a placeholder for a CI job - it will be updated automatically -->
https://2087-require-modal-title--60f9b557105290003b387cd5.chromatic.com

## Description
This change is to make the modal title required. Not having a title was causing the word 'undefined' used as part of ids, and was causing issues with accessibility

- Require modalTitle
- Update storybook to remove example of modal without a title
- 
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2087

## Testing done
Local testing in storybook

## Screenshots
Prop updated to be required:

![Screenshot 2023-09-29 at 2 03 34 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/ef85b329-2f01-4d8e-82c5-97de47a61f06)

No other visual changes

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
