### PR TITLE
va-radio: Fix alignment & add Datadog privacy class to description

### DIFF
--- a/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
+++ b/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
@@ -18,7 +18,7 @@ describe('va-radio-option', () => {
     <va-radio-option id="yes2" label="Yes - Any Veteran" name="yes" value="2" aria-checked="false" class="hydrated">
       <input id="yes2input" name="yes" type="radio" value="2">
       <label for="yes2input">
-        Yes - Any Veteran
+        <div>Yes - Any Veteran</div>
       </label>
     </va-radio-option>
   `);
@@ -68,6 +68,7 @@ describe('va-radio-option', () => {
 
     const description = await page.find('va-radio-option .description');
     expect(description.textContent).toEqual("Some description text");
+    expect(description.classList.contains('dd-privacy-hidden'))
   });
 
   // Begin USWDS version test
@@ -138,8 +139,9 @@ describe('va-radio-option', () => {
       '<va-radio-option uswds checked aria-describedby="test" label="A label" value="something" description="Example description" />',
     );
 
-    const hint = await page.find('va-radio-option .usa-radio__label-description');
-    expect(hint.textContent).toEqual("Example description");
+    const description = await page.find('va-radio-option .usa-radio__label-description');
+    expect(description.textContent).toEqual("Example description");
+    expect(description.classList.contains('dd-privacy-hidden'))
   });
 
 });

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -107,15 +107,22 @@ export class VaRadioOption {
             />
           <label class="usa-radio__label" htmlFor={id + 'input'}>
             {label}
-            {description && <span class="usa-radio__label-description" aria-describedby="option-label">{description}</span>}
+            {description && (
+              <span
+                class="usa-radio__label-description dd-privacy-hidden"
+                aria-describedby="option-label"
+              >
+                {description}
+              </span>
+            )}
           </label>
         </div>
       )
     } else {
       return (
         <Host aria-checked={checked ? `${checked}` : 'false'}>
-          <input 
-              type='radio' 
+          <input
+              type='radio'
               aria-describedby={(checked && ariaDescribedby) || null}
               checked={checked}
               name={name}
@@ -124,8 +131,17 @@ export class VaRadioOption {
               id={id + 'input'}
             />
           <label htmlFor={id + 'input'}>
-            {label}
-            {description && <span class="description" aria-describedby="option-label">{description}</span>}
+            <div>
+              {label}
+              {description && (
+                <span
+                  class="description dd-privacy-hidden"
+                  aria-describedby="option-label"
+                >
+                  {description}
+                </span>
+              )}
+            </div>
           </label>
         </Host>
       );


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description

Fixes non-USWDS description alignment issue
Added `dd-privacy-hidden` class to USWDS & non-USWDS radio option descriptions to hide potential PII in Datadog

- Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2132
- Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/62612

## Testing done

Updated `va-radio-option` tests for non-USWDS rendering
Added Datadog privacy class check

## Screenshots

### Before

![](https://user-images.githubusercontent.com/872479/270685247-89b9e9c7-47e0-4295-834a-4f43248107c5.png)

### After

<img width="683" alt="Screenshot 2023-10-02 at 1 34 42 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/a8efab26-9c51-462b-b467-d3079bcdfa87">
<img width="715" alt="Screenshot 2023-10-02 at 1 35 11 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/3783b1f3-144c-441d-a252-5b9fb4950694">

## Acceptance criteria
- [x] `va-radio-option` description alignment is fixed
- [x] Added Datadog privacy class to description
- [x] All tests passing

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
