### PR TITLE
va-modal: Fix logic for aria-label, don't set aria-label if title is not provided

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.26",
+  "version": "4.45.27",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -402,7 +402,7 @@ export class VaModal {
 
     if (!visible) return null;
 
-    const ariaLabel = `${modalTitle} modal` || 'Modal';
+    const ariaLabel = modalTitle && modalTitle !== '' ? `${modalTitle} modal` : null;
     /* eslint-enable i18next/no-literal-string */
     const btnAriaLabel = modalTitle
       ? `Close ${modalTitle} modal`


### PR DESCRIPTION
## Chromatic
<!-- This `2087-modal-undefined-label` is a placeholder for a CI job - it will be updated automatically -->
https://2087-modal-undefined-label--60f9b557105290003b387cd5.chromatic.com

## Description
- Don't set aria-label if title is undefined
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2087

## Testing done
- Local testing through storybook
- E2E tests are passing

## Screenshots
- No visual changes

## Acceptance criteria
- [ ] aria-label is not set when title is undefined

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
