### PR TITLE
2076 Fix V3 and non-V3 CSS Selectors (Part 3)

### DIFF
--- a/packages/web-components/src/components/va-privacy-agreement/va-privacy-agreement.scss
+++ b/packages/web-components/src/components/va-privacy-agreement/va-privacy-agreement.scss
@@ -12,7 +12,7 @@ va-checkbox::part(checkbox) {
 }
 
 // Using Source Sans Pro normalization for v3. The base font size for v3 is 16px, which has been normalized to 16.96px
-:host([uswds]) .description {
+:host([uswds]:not([uswds='false'])) .description {
   font-size: 1.06 * $v3-font-base-size;
 }
 

--- a/packages/web-components/src/components/va-process-list/va-process-list.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list.scss
@@ -3,14 +3,14 @@
 @import '../../global/formation_overrides';
 
 
-:host([uswds]) {
+:host([uswds]:not([uswds='false'])) {
   counter-reset: usa-numbered-list;
 }
 
 ::slotted(va-process-list-item[checked='true']):before {
   color: var(--color-green) !important;
   border-color: var(--color-green) !important;
-  content: url(../../assets/green-check.svg) !important;  
+  content: url(../../assets/green-check.svg) !important;
 }
 
 ::slotted(va-process-list-item[active='true']):before {

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -29,10 +29,9 @@ va-radio-option label.usa-radio__label::before {
   height: 20px;
   width: 20px;
   margin-left: 2px;
-
 }
 
-va-radio-option .usa-radio__input:focus+[class*=__label]::before {
+va-radio-option .usa-radio__input:focus + [class*='__label']::before {
   outline: 2px solid var(--color-gold-light);
 }
 
@@ -42,63 +41,62 @@ va-radio-option input[disabled='true']:focus + label.usa-radio__label::before {
 
 /* Original Components Styles. */
 
-va-radio-option:not([uswds]) {
+va-radio-option:not([uswds='true'], [uswds='']) {
   margin-top: 1rem;
+  input {
+    appearance: none;
+  }
+
+  label {
+    box-sizing: border-box;
+    outline: none;
+    display: flex;
+    align-items: baseline;
+    margin: 0;
+    max-width: 320px;
+    width: auto;
+    padding-left: 6px;
+  }
+
+  label::before {
+    box-sizing: border-box;
+    border-radius: 100%;
+    box-shadow: 0 0 0 2px var(--color-white), 0 0 0 3px var(--color-gray-medium);
+    height: 1.4rem;
+    line-height: 1.4rem;
+    margin-right: 1rem;
+    width: 1.4rem;
+    min-width: 1.4rem;
+    max-width: 1.4rem;
+    background: var(--color-white);
+    background-color: var(--color-white);
+    content: '\A0';
+    display: inline-block;
+  }
 }
 
-va-radio-option:not([uswds]) input {
-  appearance: none;
-}
-
-va-radio-option:not([uswds]) label {
-  box-sizing: border-box;
-  outline: none;
-  display: flex;
-  align-items: baseline;
-  margin: 0;
-  max-width: 320px;
-  width: auto;
-  padding-left: 6px;
-}
-
-va-radio-option:not([uswds]) label::before {
-  box-sizing: border-box;
-  border-radius: 100%;
-  box-shadow: 0 0 0 2px var(--color-white), 0 0 0 3px var(--color-gray-medium);
-  height: 1.4rem;
-  line-height: 1.4rem;
-  margin-right: 1rem;
-  width: 1.4rem;
-  min-width: 1.4rem;
-  max-width: 1.4rem;
-  background: var(--color-white);
-  background-color: var(--color-white);
-  content: '\A0';
-  display: inline-block;
-}
-
-va-radio-option:not([uswds])[aria-checked='true'] label::before {
+va-radio-option:not([uswds="true"],[uswds=""])[aria-checked='true'] label::before {
   background-color: var(--color-primary);
   box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-primary);
 }
 
-va-radio-option:not([uswds]):focus label::before {
+va-radio-option:not([uswds="true"],[uswds=""]):focus label::before {
   outline: 2px solid var(--color-gold-light);
   outline-offset: 6px;
 }
 
-va-radio-option:not([uswds]) .description {
+va-radio-option:not([uswds="true"],[uswds=""]) .description {
   display: block;
   margin-top: 5px;
 }
 
-va-radio-option:not([uswds])[tile='true'] label {
+va-radio-option:not([uswds="true"],[uswds=""])[tile='true'] label {
   padding: 12px 16px 12px 12px;
   border: 2px solid var(--color-gray-light);
   border-radius: 0.25em;
 }
 
-va-radio-option:not([uswds])[tile='true'][aria-checked='true'] label {
+va-radio-option:not([uswds="true"],[uswds=""])[tile='true'][aria-checked='true'] label {
   border: 2px solid var(--color-primary-alt-darkest);
   background: var(--color-gray-cool-light);
 }

--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -17,7 +17,7 @@
   padding: 0;
 }
 
-:host([uswds]) {
+:host([uswds]:not([uswds='false'])) {
   margin-top: 24px;
 }
 
@@ -33,13 +33,13 @@
   margin: 0 0.35rem;
 }
 
-:host(:not([uswds])) fieldset {
+:host(:not([uswds="true"],[uswds=""])) fieldset {
   border: none;
   margin: 0;
   padding: 0;
 }
 
-:host(:not([uswds])) legend {
+:host(:not([uswds="true"],[uswds=""])) legend {
   display: block;
   max-width: 46rem;
   font-weight: inherit;

--- a/packages/web-components/src/components/va-select/va-select.scss
+++ b/packages/web-components/src/components/va-select/va-select.scss
@@ -11,7 +11,7 @@
 @import '../../mixins/uswds-error-border.scss';
 @import '../../global/formation_overrides';
 
-:host([uswds]) {
+:host([uswds]:not([uswds='false'])) {
   color: var(--v3-color-base-darkest);
 }
 
@@ -20,7 +20,7 @@
   font-family: var(--font-source-sans);
 }
 
-:host([uswds][inert]) select {
+:host([uswds]:not([uswds='false'])[inert]) select {
   border: 0;
   background: none;
 }
@@ -41,13 +41,13 @@ span.required {
   margin: 0 0.35em;
 }
 
-:host([error]:not([error='']):not([uswds])) label,
-:host([error]:not([error='']):not([uswds])) > span {
+:host([error]:not([error='']):not([uswds="true"],[uswds=""])) label,
+:host([error]:not([error='']):not([uswds="true"],[uswds=""])) > span {
   display: block;
   font-size: 1.6rem;
 }
 
-:host([error]:not([error='']):not([uswds])) > span {
+:host([error]:not([error='']):not([uswds="true"],[uswds=""])) > span {
   color: var(--color-secondary-dark);
 }
 
@@ -55,13 +55,13 @@ span.required {
   display: none;
 }
 
-:host(:not([uswds])) label {
+:host(:not([uswds="true"],[uswds=""])) label {
   margin-top: 3rem;
   max-width: 46rem;
   display: block;
 }
 
-:host(:not([uswds])) select {
+:host(:not([uswds="true"],[uswds=""])) select {
   background-color: var(--color-white);
   background-image: url('../../assets/arrow-both.svg');
   background-position: right 1.3rem center;


### PR DESCRIPTION
## Chromatic
<!-- This `2076-3-fix-non-v3-styles` is a placeholder for a CI job - it will be updated automatically -->
https://2076-3-fix-non-v3-styles--60f9b557105290003b387cd5.chromatic.com

---

## Description
Relates to #[2076](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2076)

Converts styles for V1 and V3 to make use of more specific selectors. Previously, non-V3 styles were 'selected' in CSS by checking for the presence or absence of the `uswds` attribute, looking like:

```
:host(:not([uswds]))
```

However, this was not specific enough, because if the `uswds` attribute was present but set to `false`, the CSS engine would still ignore the V1 style. This PR replaces the above with this:

```
:host(:not([uswds='true'], [uswds='']))
```

This will check for both the presence of the attribute (`=''`) and/or if it is present and true (`='true'`). In other places, where we *want* the attribute to be true, I've replaced this:

```
:host([uswds])
```

with this:

```
:host([uswds]:not([uswds='false']))
```

which will match if the `uswds` attribute is present but not set to `false`.

This PR covers the second batch of components:
- Privacy Agreement
- Process List
- Radio
- Radio Option
- Select

## Testing done
Tested locally using Storybook

## Screenshots
No screenshots as the before and after are identical.

## Acceptance criteria
- [X] Successfully converts non-V3 styles

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)