### PR TITLE
2076 Fix V3 and non-V3 CSS Selectors (Part 4)

### DIFF
--- a/packages/web-components/src/components/va-text-input/va-text-input.scss
+++ b/packages/web-components/src/components/va-text-input/va-text-input.scss
@@ -11,7 +11,7 @@
 @import '../../mixins/uswds-input-width.scss';
 @import '../../global/formation_overrides';
 
-:host([uswds]) {
+:host([uswds]:not([uswds='false'])) {
   color: var(--v3-color-base-darkest);
 }
 
@@ -24,7 +24,7 @@
   outline: none !important;
 }
 
-:host([uswds]) input:not([disabled]):focus {
+:host([uswds]:not([uswds='false'])) input:not([disabled]):focus {
   outline: 2px solid var(--color-gold-light);
   outline-offset: 2px;
 }
@@ -47,7 +47,7 @@ input.usa-input {
 @import '../../mixins/hint-text.css';
 
 
-:host(:not([uswds])) label {
+:host(:not([uswds="true"],[uswds=""])) label {
   display: block;
   max-width: 46rem;
   margin-top: 3rem;
@@ -58,7 +58,7 @@ span.required {
   color: var(--color-secondary-dark);
 }
 
-:host(:not([uswds])) input {
+:host(:not([uswds="true"],[uswds=""])) input {
   appearance: none;
   border: 0.1rem solid var(--color-gray);
   border-radius: 0;
@@ -75,11 +75,11 @@ span.required {
   width: 100%;
 }
 
-:host(:not([uswds])) input:not([disabled]):focus {
+:host(:not([uswds="true"],[uswds=""])) input:not([disabled]):focus {
   outline: 2px solid var(--color-gold-light);
   outline-offset: 2px;
 }
 
-:host([success]:not([success='false']):not([uswds])) input {
+:host([success]:not([success='false']):not([uswds="true"],[uswds=""])) input {
   border: 4px solid var(--color-green);
 }

--- a/packages/web-components/src/components/va-textarea/va-textarea.scss
+++ b/packages/web-components/src/components/va-textarea/va-textarea.scss
@@ -37,18 +37,18 @@
 @import '../../mixins/form-field-error.css';
 @import '../../mixins/hint-text.css';
 
-:host(:not([uswds])) label {
+:host(:not([uswds="true"],[uswds=""])) label {
   display: block;
   max-width: 46rem;
   margin-top: 3rem;
 }
 
-:host(:not([uswds])) span.required {
+:host(:not([uswds="true"],[uswds=""])) span.required {
   color: var(--color-secondary-dark);
   margin-left: 0.4rem;
 }
 
-:host(:not([uswds])) textarea {
+:host(:not([uswds="true"],[uswds=""])) textarea {
   font-family: var(--font-source-sans);
   font-size: 16px;
   line-height: 1.3;
@@ -62,6 +62,6 @@
   resize: inherit;
 }
 
-:host([error]:not([error='']):host(:not([uswds]))) textarea {
+:host([error]:not([error='']):not([uswds="true"],[uswds=""])) textarea {
   padding-right: 0.7rem;
 }

--- a/packages/web-components/src/mixins/focusable.css
+++ b/packages/web-components/src/mixins/focusable.css
@@ -1,7 +1,7 @@
 /* From the USWDS styles: */
 /*   https://github.com/uswds/uswds/blob/3dc296ec56cd621fe52d918701fd94621d96a198/src/stylesheets/core/mixins/_focus.scss#L12-L13 */
 button:not([disabled]):focus,
-:host(:not([uswds])) button:not([disabled]):active,
+:host(:not([uswds="true"],[uswds=""])) button:not([disabled]):active,
 select:not([disabled]):focus,
 a:not([disabled]):focus,
 h1:focus,

--- a/packages/web-components/src/mixins/form-field-error.css
+++ b/packages/web-components/src/mixins/form-field-error.css
@@ -1,31 +1,34 @@
 #error-message {
-    margin-bottom: 1.2rem;
+  margin-bottom: 1.2rem;
 }
 
-#error-message, #input-error-message {
+#error-message,
+#input-error-message {
   color: var(--color-secondary-dark);
   display: block;
   font-weight: 700;
 }
 
 :host([error]:not([error=''])) {
-    border-left: 0.4rem solid  var(--color-secondary-dark);
-    padding-left: 2rem;
-    position: relative;
+  border-left: 0.4rem solid var(--color-secondary-dark);
+  padding-left: 2rem;
+  position: relative;
 }
 
 @media screen and (min-width: 1008px) {
-    :host([error]:not([error=''])) {
-        margin-left: -2.4rem; /* padding left + border left */
-    }
+  :host([error]:not([error=''])) {
+    margin-left: -2.4rem; /* padding left + border left */
+  }
 }
 
-:host([error]:not([error='']):not([uswds])) label {
+:host([error]:not([error='']):not([uswds="true"],[uswds=""])) {
+  label {
     margin-top: 0;
-}
+  }
 
-:host([error]:not([error='']):not([uswds])) input, 
-:host([error]:not([error='']):not([uswds])) textarea,
-:host([error]:not([error='']):not([uswds])) select {
+  input,
+  textarea,
+  select {
     border: 4px solid var(--color-secondary-dark);
+  }
 }

--- a/packages/web-components/src/mixins/uswds-error-border.scss
+++ b/packages/web-components/src/mixins/uswds-error-border.scss
@@ -1,14 +1,14 @@
 @import 'variables';
 @import 'functions';
 
-:host([error][uswds]:not([error=''])) {
+:host([error]:not([error=''])[uswds]:not([uswds='false'])) {
     border-left: 0.4rem solid $v3-color-error-dark; /* USWDS red-60v, $theme-color-error-dark */
     padding-left: rem-override(1rem);
     position: relative;
 }
 
 @media screen and (min-width: 1008px) {
-    :host([error][uswds]:not([error=''])) {
+    :host([error]:not([error=''])[uswds]:not([uswds='false'])) {
         margin-left: -1.4rem;
     }
 }

--- a/packages/web-components/src/mixins/uswds-input-width.scss
+++ b/packages/web-components/src/mixins/uswds-input-width.scss
@@ -1,4 +1,4 @@
-:host(:not([uswds])) .usa-input, 
+:host(:not([uswds="true"],[uswds=""])) .usa-input,
 :host .usa-input {
   &--2xs {
     max-width: 5ex;


### PR DESCRIPTION
## Chromatic
<!-- This `2076-4-fix-non-v3-styles` is a placeholder for a CI job - it will be updated automatically -->
https://2076-4-fix-non-v3-styles--60f9b557105290003b387cd5.chromatic.com

---

## Description
Relates to #[2076](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2076)

Converts styles for V1 and V3 to make use of more specific selectors. Previously, non-V3 styles were 'selected' in CSS by checking for the presence or absence of the `uswds` attribute, looking like:

```
:host(:not([uswds]))
```

However, this was not specific enough, because if the `uswds` attribute was present but set to `false`, the CSS engine would still ignore the V1 style. This PR replaces the above with this:

```
:host(:not([uswds='true'], [uswds='']))
```

This will check for both the presence of the attribute (`=''`) and/or if it is present and true (`='true'`). In other places, where we *want* the attribute to be true, I've replaced this:

```
:host([uswds])
```

with this:

```
:host([uswds]:not([uswds='false']))
```

which will match if the `uswds` attribute is present but not set to `false`.

This PR covers the second batch of components:
- Text Input
- Textarea
- focusable.css
- form-field-error.css
- uswds-error-border.scss
- uswds-input-width.scss

## Testing done
Tested locally using Storybook

## Screenshots
No screenshots as the before and after are identical.

## Acceptance criteria
- [X] Successfully converts non-V3 styles

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)