### PR TITLE
va-memorable-date: Conditionally display name prop value

### DIFF
--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -600,7 +600,7 @@ describe('va-memorable-date', () => {
     });
   });
 
-  it('Applies a unique name name attribute for each input', async () => {
+  it('Applies a unique name attribute for each input', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-memorable-date name="test" />');
 
@@ -612,7 +612,7 @@ describe('va-memorable-date', () => {
     expect(dayInput).not.toBeNull();
   });
 
-  it('When the name prop is not set, the name attribute defaults to input type name', async () => {
+  it('When the name prop is not set, the input name attributes default to input type name', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-memorable-date />');
 
@@ -1819,7 +1819,7 @@ describe('va-memorable-date', () => {
     });
   });
 
-  it('uswds v3 Applies a unique name name attribute for each input', async () => {
+  it('uswds v3 Applies a unique name attribute for each input', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-memorable-date name="test" uswds />');
 
@@ -1831,7 +1831,7 @@ describe('va-memorable-date', () => {
     expect(dayInput).not.toBeNull();
   });
 
-  it('uswds v3 When the name prop is not set, the name attribute defaults to input type name', async () => {
+  it('uswds v3 When the name prop is not set, input name attributes default to input type name', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-memorable-date uswds />');
 

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -600,6 +600,30 @@ describe('va-memorable-date', () => {
     });
   });
 
+  it('Applies a unique name name attribute for each input', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-memorable-date name="test" />');
+
+    const yearInput = await page.$('pierce/[name="testYear"]');
+    const monthInput = await page.$('pierce/[name="testMonth"]');
+    const dayInput = await page.$('pierce/[name="testDay"]');
+    expect(yearInput).not.toBeNull();
+    expect(monthInput).not.toBeNull();
+    expect(dayInput).not.toBeNull();
+  });
+
+  it('When the name prop is not set, the name attribute defaults to input type name', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-memorable-date />');
+
+    const yearInput = await page.$('pierce/[name="Year"]');
+    const monthInput = await page.$('pierce/[name="Month"]');
+    const dayInput = await page.$('pierce/[name="Day"]');
+    expect(yearInput).not.toBeNull();
+    expect(monthInput).not.toBeNull();
+    expect(dayInput).not.toBeNull();
+  });
+
   // Begin USWDS v3 test
   it('uswds v3 renders', async () => {
     const page = await newE2EPage();
@@ -1793,5 +1817,29 @@ describe('va-memorable-date', () => {
         day: 2,
       },
     });
+  });
+
+  it('uswds v3 Applies a unique name name attribute for each input', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-memorable-date name="test" uswds />');
+
+    const yearInput = await page.$('pierce/[name="testYear"]');
+    const monthInput = await page.$('pierce/[name="testMonth"]');
+    const dayInput = await page.$('pierce/[name="testDay"]');
+    expect(yearInput).not.toBeNull();
+    expect(monthInput).not.toBeNull();
+    expect(dayInput).not.toBeNull();
+  });
+
+  it('uswds v3 When the name prop is not set, the name attribute defaults to input type name', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-memorable-date uswds />');
+
+    const yearInput = await page.$('pierce/[name="Year"]');
+    const monthInput = await page.$('pierce/[name="Month"]');
+    const dayInput = await page.$('pierce/[name="Day"]');
+    expect(yearInput).not.toBeNull();
+    expect(monthInput).not.toBeNull();
+    expect(dayInput).not.toBeNull();
   });
 });

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -245,7 +245,7 @@ export class VaMemorableDate {
           <va-select
             uswds
             label={i18next.t('month')}
-            name={`${name}Month`}
+            name={name ? `${name}Month` : 'Month'}
             aria-describedby={describedbyIds}
             invalid={this.invalidMonth}
             onVaSelect={handleDateChange}
@@ -266,7 +266,7 @@ export class VaMemorableDate {
         <va-text-input
           uswds
           label={i18next.t('month')}
-          name={`${name}Month`}
+          name={name ? `${name}Month` : 'Month'}
           maxlength={2}
           pattern="[0-9]*"
           aria-describedby={describedbyIds}
@@ -309,7 +309,7 @@ export class VaMemorableDate {
                 <va-text-input
                   uswds
                   label={i18next.t('day')}
-                  name={`${name}Day`}
+                  name={name ? `${name}Day` : 'Day'}
                   maxlength={2}
                   pattern="[0-9]*"
                   aria-describedby={describedbyIds}
@@ -328,7 +328,7 @@ export class VaMemorableDate {
                 <va-text-input
                   uswds
                   label={i18next.t('year')}
-                  name={`${name}Year`}
+                  name={name ? `${name}Year` : 'Year'}
                   maxlength={4}
                   pattern="[0-9]*"
                   aria-describedby={describedbyIds}
@@ -367,7 +367,7 @@ export class VaMemorableDate {
             <div class="date-container">
               <va-text-input
                 label={i18next.t('month')}
-                name={`${name}Month`}
+                name={name ? `${name}Month` : 'Month'}
                 maxlength={2}
                 minlength={2}
                 pattern="[0-9]*"
@@ -383,7 +383,7 @@ export class VaMemorableDate {
                 />
               <va-text-input
                 label={i18next.t('day')}
-                name={`${name}Day`}
+                name={name ? `${name}Day` : 'Day'}
                 maxlength={2}
                 minlength={2}
                 pattern="[0-9]*"
@@ -399,7 +399,7 @@ export class VaMemorableDate {
                 />
               <va-text-input
                 label={i18next.t('year')}
-                name={`${name}Year`}
+                name={name ? `${name}Year` : 'Year'}
                 maxlength={4}
                 minlength={4}
                 pattern="[0-9]*"


### PR DESCRIPTION
## Chromatic
<!-- This `2077-mem-date-name` is a placeholder for a CI job - it will be updated automatically -->
https://2077-mem-date-name--60f9b557105290003b387cd5.chromatic.com

## Description

The PR updates the way the `name` prop was being applied to the `name` attribute on the input fields. Previously, when the prop wasn't set, it would show up in the DOM as "undefined". This update adds a display condition to avoid that (v1 and v3):

<img width="1086" alt="267144784-c3ce1b71-3a48-49e8-a171-eb7f01cb9c1a" src="https://github.com/department-of-veterans-affairs/component-library/assets/872479/e73f55bd-a16b-496a-b104-115c3939f056">

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2077

## Testing done
Storybook

## Screenshots

**`name` prop not set**

![Screenshot 2023-10-09 at 10 20 09 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/0270a0f0-36b7-48b3-9ea4-9aeb69aff1ae)

**`name` prop set**

![Screenshot 2023-10-09 at 10 54 18 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/98cc1d1d-b759-4d16-af0b-56df229c8876)

## Acceptance criteria
- [ ] The `name` prop does not display as "undefined" when it is not set.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
