### PR TITLE
va-button-pair: remove css that changes the order of the buttons in mobile

### DIFF
--- a/packages/web-components/src/components/va-button-pair/va-button-pair.scss
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.scss
@@ -21,10 +21,6 @@
     margin: 0 auto;
     width: 100%;
   }
-
-  :host([uswds]:not([uswds='false']):not([continue])) .usa-button-group {
-    flex-direction: column-reverse;
-  }
 }
 
 /* Original Component Styles. */


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
This change removes the css that changed the order of the buttons in mobile. The change is to address accessibility concerns.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2086

## Testing done
Local testing in Storybook
- Chrome
- Firefox
- Safari
- Edge

## Screenshots
Before:
![Screenshot 2023-10-09 at 10 14 16 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/7614d533-2485-40ec-b9c8-fa770b2eccde)

After:
![Screenshot 2023-10-09 at 10 14 55 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/eed9fdd3-9072-4778-869a-fafea2548f5f)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
