### PR TITLE
va-progress-list: Forward the USWDS settings to load Source Sans Pro

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.27",
+  "version": "4.45.28",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-process-list/va-process-list-item.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list-item.scss
@@ -1,3 +1,5 @@
+@forward 'settings';
+
 @use 'uswds-helpers/src/styles/usa-sr-only';
 @use 'usa-process-list/src/styles/usa-process-list';
 @import '../../global/formation_overrides';

--- a/packages/web-components/src/components/va-process-list/va-process-list.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list.scss
@@ -1,3 +1,5 @@
+@forward 'settings';
+
 @use 'uswds-helpers/src/styles/usa-sr-only';
 @use 'usa-process-list/src/styles/usa-process-list';
 @import '../../global/formation_overrides';


### PR DESCRIPTION
## Chromatic
<!-- This `2023-process-list-uswds-font` is a placeholder for a CI job - it will be updated automatically -->
https://2023-process-list-uswds-font--60f9b557105290003b387cd5.chromatic.com

## Description
This update will forward the USWDS font setting to the component so that it loads the font family stack for Source Sans Pro.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2023

## Testing done
Storybook

## Screenshots

![Screenshot 2023-10-09 at 4 01 05 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/4f04dd98-16e3-4ee3-9e74-a1038ffca9b0)

## Acceptance criteria
- [ ] Source Sans Pro is loading in the va-progress-bar component

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
