### PR TITLE
va-icon: Remove assetsDirs setting

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.45.28",
+  "version": "4.45.29",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-icon/va-icon.tsx
+++ b/packages/web-components/src/components/va-icon/va-icon.tsx
@@ -3,7 +3,7 @@ import {
   Host,
   Prop,
   h,
-  // getAssetPath
+  getAssetPath
 } from '@stencil/core';
 import classnames from 'classnames';
 import { consoleDevError } from '../../utils/utils';
@@ -18,7 +18,6 @@ import { consoleDevError } from '../../utils/utils';
   tag: 'va-icon',
   styleUrl: 'va-icon.scss',
   shadow: true,
-  // assetsDirs: ['../../assets']
 })
 export class VaIcon {
   /**
@@ -56,7 +55,7 @@ export class VaIcon {
       'usa-icon': true,
       [`usa-icon--size-${size}`]: !!size,
     });
-    const imageSrc = `/assets/sprite.svg#${icon}`;
+    const imageSrc = `${getAssetPath('/assets/sprite.svg')}#${icon}`;
     return (
       <Host>
         <svg

--- a/packages/web-components/src/components/va-icon/va-icon.tsx
+++ b/packages/web-components/src/components/va-icon/va-icon.tsx
@@ -3,7 +3,7 @@ import {
   Host,
   Prop,
   h,
-  getAssetPath
+  // getAssetPath
 } from '@stencil/core';
 import classnames from 'classnames';
 import { consoleDevError } from '../../utils/utils';
@@ -18,7 +18,7 @@ import { consoleDevError } from '../../utils/utils';
   tag: 'va-icon',
   styleUrl: 'va-icon.scss',
   shadow: true,
-  assetsDirs: ['../../assets']
+  // assetsDirs: ['../../assets']
 })
 export class VaIcon {
   /**
@@ -56,7 +56,7 @@ export class VaIcon {
       'usa-icon': true,
       [`usa-icon--size-${size}`]: !!size,
     });
-    const imageSrc = `${getAssetPath('/assets/sprite.svg')}#${icon}`;
+    const imageSrc = `/assets/sprite.svg#${icon}`;
     return (
       <Host>
         <svg


### PR DESCRIPTION
## Chromatic
<!-- This `va-icons-sprite-path` is a placeholder for a CI job - it will be updated automatically -->
https://va-icons-sprite-path--60f9b557105290003b387cd5.chromatic.com

## Description

I was exploring the reason that we kept getting a new assets folder created locally when running the Stencil build command `yarn watch:stencil` like this:

![Screenshot 2023-10-10 at 9 01 00 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/6b5d6883-8f0e-449f-8834-9bc2aa3d764b)

![Screenshot 2023-10-10 at 11 36 44 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/990331b7-8a14-4f8d-add5-0e50ec492899)


When I remove the `va-icon` component's `assetsDirs` setting, this asset folder generation stops happening. Do we recall why we needed that to begin with? Looking at the [original discovery PR for creating a va-icon component](https://github.com/department-of-veterans-affairs/component-library/pull/540/files#diff-e080bd09d1ef6211d9591a52df12d9b3111d7547c089089f4095118102da4f9a), it looks like this setting was commented out (maybe because it's not needed?).

The sprite path still seems to be loading ok locally and with Chromatic using just the Stencil `getAssetPath` utility. I am not sure how it will behave in production yet though.

https://github.com/department-of-veterans-affairs/component-library/blob/9752f6b5c4976b6d71187d8bdaf6d9d92329eca9/packages/web-components/src/components/va-icon/va-icon.tsx#L6-L7

https://github.com/department-of-veterans-affairs/component-library/blob/9752f6b5c4976b6d71187d8bdaf6d9d92329eca9/packages/web-components/src/components/va-icon/va-icon.tsx#L58

original va-icon PR: https://github.com/department-of-veterans-affairs/component-library/pull/772

## Testing done (for va-icon component)
Storybook locally and via Chromatic
Chrome, Safari, Firefox, Edge

## Acceptance criteria
- [ ] We've determined if the `assetsDirs` setting is needed or have decided what to do about the asset files being generated locally.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
