### PR TITLE
Va-pagination: add aria-labels to page numbers (uswds) for screen readers

### DIFF
--- a/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
+++ b/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
@@ -260,13 +260,13 @@ describe('uswds - va-pagination', () => {
           <nav aria-label="Pagination" class="usa-pagination">
             <ul class="usa-pagination__list">
               <li class="usa-pagination__item usa-pagination__page-no">
-                <a href="javascript:void(0)" class="usa-pagination__button usa-current">1</a>
+                <a aria-label="page 1" href="javascript:void(0)" class="usa-pagination__button usa-current">1</a>
               </li>
               <li class="usa-pagination__item usa-pagination__page-no">
-                <a href="javascript:void(0)" class="usa-pagination__button">2</a>
+                <a aria-label="page 2" href="javascript:void(0)" class="usa-pagination__button">2</a>
               </li>
               <li class="usa-pagination__item usa-pagination__page-no">
-                <a href="javascript:void(0)" class="usa-pagination__button">3</a>
+                <a aria-label="page 3" href="javascript:void(0)" class="usa-pagination__button">3</a>
               </li>
               <li class="usa-pagination__item usa-pagination__arrow" aria-label="Next page">
                 <a href="javascript:void(0)" class="usa-pagination__link usa-pagination__next-page">

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -317,7 +317,9 @@ export class VaPagination {
                 onClick={() => this.handlePageSelect(1, 'nav-paginate-number')}
                 onKeyDown={e => this.handleKeyDown(e, 1)}
                 href="javascript:void(0)"
-                class="usa-pagination__button">1</a>
+                class="usa-pagination__button"
+                aria-label="page 1, first page"
+                >1</a>
             </li>
             <li class={ellipsisClasses} aria-label="ellipsis indicating non-visible pages">
               <span>...</span>
@@ -332,6 +334,8 @@ export class VaPagination {
           'usa-current': page === pageNumber
         })
 
+        let pageAriaLabel = ariaLabelSuffix ? `page ${pageNumber} ${ariaLabelSuffix}` : `page ${pageNumber}`;
+        
         return (
           <li class={itemClasses}>
             <a
@@ -339,6 +343,7 @@ export class VaPagination {
               onKeyDown={e => this.handleKeyDown(e, pageNumber)}
               href="javascript:void(0)"
               class={anchorClasses}
+              aria-label={pageAriaLabel}
             >
               {pageNumber}
             </a>
@@ -360,6 +365,7 @@ export class VaPagination {
                 onKeyDown={e => this.handleKeyDown(e, pages)}
                 href="javascript:void(0)"
                 class="usa-pagination__button"
+                aria-label={`page ${pages}, last page`}
               >
                 {pages}
               </a>


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes [2115](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2115)

## Testing done
local

## Screenshots
n/a

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
