### PR TITLE
Add back the contacts file to the React components package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "24.0.1",
+  "version": "25.0.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/packages/react-components/src/components/Telephone/contacts.js
+++ b/packages/react-components/src/components/Telephone/contacts.js
@@ -1,0 +1,102 @@
+/**
+ * Map of phone numbers to descriptions. This is only intended for documentation
+ * purposes. Use CONTACTS.<key> to get the actual phone number.
+ */
+export const contactsMap = Object.freeze({
+  '222_VETS': { phoneNumber: '8772228387', description: 'VA Help Line' },
+  '4AID_VET': {
+    phoneNumber: '8774243838',
+    description: 'National Call Center for Homeless Veterans',
+  },
+  711: { phoneNumber: '711', description: 'Telecommunications Relay Service' },
+  911: { phoneNumber: '911', description: '911' },
+  CAREGIVER: {
+    phoneNumber: '8552603274',
+    description: 'VA National Caregiver Support Line',
+  },
+  CRISIS_LINE: {
+    phoneNumber: '8002738255',
+    description: 'Veterans Crisis hotline',
+  },
+  CRISIS_TTY: {
+    phoneNumber: '8007994889',
+    description: 'Veterans Crisis hotline TTY',
+  },
+  DMC: { phoneNumber: '8008270648', description: 'Debt Management Center' },
+  DMC_OVERSEAS: {
+    phoneNumber: '6127136415',
+    description: 'Debt Management Center (Overseas)',
+  },
+  DMDC_DEERS: {
+    phoneNumber: '8663632883',
+    description:
+      'Defense Manpower Data Center (DMDC) | Defense Enrollment Eligibility Reporting System (DEERS) Support Office',
+  },
+  DS_LOGON: {
+    phoneNumber: '8005389552',
+    description: 'Defense Manpower Data Center',
+  },
+  DS_LOGON_TTY: {
+    phoneNumber: '8663632883',
+    description: 'Defense Manpower Data Center TTY',
+  },
+  FEDERAL_RELAY_SERVICE: {
+    phoneNumber: '8008778339',
+    description: 'Federal Relay Service',
+  },
+  GI_BILL: {
+    phoneNumber: '8884424551',
+    description: 'Education Call Center (1-888-GI-BILL-1)',
+  },
+  GO_DIRECT: {
+    phoneNumber: '8003331795',
+    description: 'Go Direct/Direct Express (Treasury)',
+  },
+  HELP_DESK: { phoneNumber: '8006982411', description: 'VA Help desk' },
+  HEALTHCARE_ELIGIBILITY_CENTER: {
+    phoneNumber: '8554888440',
+    description: 'VA Healthcare Eligibility Center (Eligibility Division)',
+  },
+  HELP_TTY: { phoneNumber: '8008778339', description: 'VA Help Desk TTY' },
+  MY_HEALTHEVET: {
+    phoneNumber: '8773270022',
+    description: 'My HealtheVet help desk',
+  },
+  NCA: {
+    phoneNumber: '8005351117',
+    description: 'National Cemetery Scheduling Office',
+  },
+  SUICIDE_PREVENTION_LIFELINE: {
+    phoneNumber: '8007994889',
+    description: 'Suicide Prevention Line',
+  },
+  TESC: {
+    phoneNumber: '8882242950',
+    description: 'U.S. Treasury Electronic Payment Solution Center',
+  },
+  TREASURY_DMS: {
+    phoneNumber: '8888263127',
+    description: 'U.S. Department of the Treasury (Debt Management Services)',
+  },
+  // VA_311 used before the number changed to include 411
+  VA_311: { phoneNumber: '8006982411', description: 'VA Help desk (VA411)' },
+  VA_411: { phoneNumber: '8006982411', description: 'VA Help desk (VA411)' },
+  VA_BENEFITS: {
+    phoneNumber: '8008271000',
+    description: 'Veterans Benefits Assistance',
+  },
+});
+
+/**
+ * Map of phone numbers. CONTACTS.GI_BILL, for example, will return the phone
+ * number defined in contactsMap.
+ */
+export const CONTACTS = Object.freeze(
+  Object.entries(contactsMap).reduce(
+    (allContacts, currentContact) => ({
+      ...allContacts,
+      [currentContact[0]]: currentContact[1].phoneNumber,
+    }),
+    {},
+  ),
+);


### PR DESCRIPTION
## Chromatic
<!-- This `revert-contacts-react` is a placeholder for a CI job - it will be updated automatically -->
https://revert-contacts-react--60f9b557105290003b387cd5.chromatic.com

## Description
This PR will revert the removal of the `contacts.js` file from the React package: https://github.com/department-of-veterans-affairs/component-library/pull/873

We discovered that vets-website uses the following import path which broke after this file was removed from the React package:

```
import {
  CONTACTS,
} from '@department-of-veterans-affairs/component-library/contacts';
```

Follow-up ticket for fixing this issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2194

## Testing done
locally with Storybook. I tested that it worked with the [`va-telephone` Storybook file.](https://github.com/department-of-veterans-affairs/component-library/blob/main/packages/storybook/stories/va-telephone.stories.jsx#L2-L5)

## Screenshots

![Screenshot 2023-10-12 at 10 17 17 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/852f85ee-ef9e-4d9a-ba68-7cfe7547ae0a)

## Acceptance criteria
- [ ] The contacts.js file is in the React component package again and the import works.

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
