### PR TITLE
update search script to support uswds query

### DIFF
--- a/packages/design-system-dashboard-cli/README.md
+++ b/packages/design-system-dashboard-cli/README.md
@@ -75,6 +75,8 @@ If you supply search terms, it'll filter the result.
 
 ![filtered result](./img/filtered-result.png)
 
+If you supply the string `uswds` as a search term, it'll return all web component and react binding usages where the uswds prop is being used.
+
 **Note:** Search terms are case sensitive!
 
 Search terms may be regex.

--- a/packages/design-system-dashboard-cli/src/find-ds-components.js
+++ b/packages/design-system-dashboard-cli/src/find-ds-components.js
@@ -71,7 +71,6 @@ function tallyResults(vwComponents, contentBuildWC) {
   vwComponents.forEach(i => {
     const manifest = getManifest(i.path);
     const app = manifest ? manifest.appName : 'Platform(ish)';
-
     i.matches.forEach(m => {
       const componentName = m[1];
       if (componentName) {
@@ -143,6 +142,9 @@ function findUsedReactComponents(vwModules, regexPattern) {
  * Search vets-website and the content build for design system components.
  *
  * @param searchStrings {string[]} - The components to display usage for
+ *
+ * Passing in the string 'uswds' will output a list of all web components and
+ * web component react bindings where the uswds prop is used
  */
 function findComponents(searchStrings) {
   const vwModules = readAllModules(`${repos['vets-website']}/src`);
@@ -163,18 +165,30 @@ function findComponents(searchStrings) {
   );
 
   const wcTagRegex = /<(va-[^\s>]+)/gms;
-  const vwWebComponents = search(vwModules, wcTagRegex);
-  const contentBuildWC = search(contentTemplates, wcTagRegex);
+  const wcUswds3Regex = /<(Va[^\s]+|va-[^\s]+)(\s|\n)[^>]*?uswds/gms;
 
-  const vwComponents = [
-    ...usedReactComponents,
-    ...vwWebComponents,
-    ...usedReactBindings,
-  ];
+  let vwWebComponents;
+  let contentBuildWC;
+  let vwComponents;
+
+  if (searchStrings?.includes('uswds')) {
+    vwWebComponents = search(vwModules, wcUswds3Regex);
+    contentBuildWC = search(contentTemplates, wcUswds3Regex);
+    vwComponents = [...vwWebComponents];
+  } else {
+    vwWebComponents = search(vwModules, wcTagRegex);
+    contentBuildWC = search(contentTemplates, wcTagRegex);
+    vwComponents = [
+      ...usedReactComponents,
+      ...vwWebComponents,
+      ...usedReactBindings,
+    ];
+  }
 
   const data = tallyResults(vwComponents, contentBuildWC);
-
-  return filterSearchedComponents(data, searchStrings);
+  return searchStrings?.includes('uswds')
+    ? data
+    : filterSearchedComponents(data, searchStrings);
 }
 
 if (require.main === module) {

--- a/packages/design-system-dashboard-cli/src/find-ds-components.js
+++ b/packages/design-system-dashboard-cli/src/find-ds-components.js
@@ -71,6 +71,7 @@ function tallyResults(vwComponents, contentBuildWC) {
   vwComponents.forEach(i => {
     const manifest = getManifest(i.path);
     const app = manifest ? manifest.appName : 'Platform(ish)';
+
     i.matches.forEach(m => {
       const componentName = m[1];
       if (componentName) {

--- a/packages/design-system-dashboard-cli/src/search-files.js
+++ b/packages/design-system-dashboard-cli/src/search-files.js
@@ -26,6 +26,8 @@ function readAllModules(rootDir) {
       `${rootDir}/**/_mock-form/**`,
       `${rootDir}/**/*.unit.@(js|jsx)`,
       `${rootDir}/**/*.spec.@(js|jsx)`,
+      `${rootDir}/**/ds-playground/**`,
+      `${rootDir}/**/ds-v3-playground/**`,
     ],
   });
 


### PR DESCRIPTION
## Chromatic
<!-- This `mc-2517-uswds-components` is a placeholder for a CI job - it will be updated automatically -->
https://mc-2517-uswds-components--60f9b557105290003b387cd5.chromatic.com

---
## Description
This pull request adds support to the design system dashboard cli to search for all components using the `uswds` prop. 
Running `yarn search uswds` will use a regex that matches any web component or web component react binding where the `uswds` prop is being used. 
Related to https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2157

## Testing done
Locally tested the regex in both the cli tool and vets-website to ensure results matched up

## Screenshots
![Screenshot from 2023-10-13 11-43-43](https://github.com/department-of-veterans-affairs/component-library/assets/15097156/f3a48b53-db18-45f8-a54b-dd8fa97b9437)
![Screenshot from 2023-10-13 11-43-56](https://github.com/department-of-veterans-affairs/component-library/assets/15097156/9acd5e0f-8520-41d6-9301-02128e50b55d)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
