### PR TITLE
va-pagination: add box-sizing to pagination items and overflow

### DIFF
--- a/packages/web-components/src/components/va-pagination/va-pagination.scss
+++ b/packages/web-components/src/components/va-pagination/va-pagination.scss
@@ -5,6 +5,11 @@
 @import '../../mixins/focusable.css';
 @import '../../global/formation_overrides';
 
+// Formation does not specify box-sizing on li elements, this is needed for pagination to fit on 320px size screens
+.va-pagination__item {
+  box-sizing: border-box;
+}
+
 :host([uswds]:not([uswds='false'])) {
   a.usa-pagination__next-page > div,
   a.usa-pagination__previous-page > div {

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -285,15 +285,18 @@ export class VaPagination {
       const pageNumbersToRender = this.pageNumbersUswds();
       const itemClasses = classnames({
         'usa-pagination__item': true,
-        'usa-pagination__page-no': true
+        'usa-pagination__page-no': true,
+        'va-pagination__item': true
       });
       const ellipsisClasses = classnames({
         'usa-pagination__item': true,
-        'usa-pagination__overflow': true
+        'usa-pagination__overflow': true,
+        'va-pagination__item': true
       });
       const arrowClasses = classnames({
         'usa-pagination__item': true,
-        'usa-pagination__arrow': true
+        'usa-pagination__arrow': true,
+
       });
 
       const previousButton = page > 1


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

## Description
Make sure that the component and USWDS design are congruent. The only difference found is that the component overflowed the screen at the 320px screen size. This was fixed by setting `box-sizing: border-box` on the pagination items and overflow items. USWDS does this for all `li` elements.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/66068

## Testing done
- Local testing in Firefox, Chrome, Safari, and Edge

## Screenshots
Before: 
![Screenshot 2023-10-17 at 8 45 45 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/717d5544-73e9-4789-9138-ccc695434f63)

After:
![Screenshot 2023-10-17 at 8 44 50 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/7ec5fd23-2cf7-456b-a349-3236a5f4a995)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
