### PR TITLE
va-process-list: accessibility updates (staging review)

### DIFF
--- a/packages/storybook/stories/va-process-list-uswds.stories.jsx
+++ b/packages/storybook/stories/va-process-list-uswds.stories.jsx
@@ -70,14 +70,14 @@ const Template = ({uswds}) => {
 const StatusTemplate = ({uswds}) => {
   return (
     <va-process-list uswds={uswds}>
-      <va-process-list-item checked header='Checkmark Icon'>  
-        <p>Add the prop <code>checked</code> to the list icon a checkmark.</p>
+      <va-process-list-item checkmark header='Checkmark Icon'>  
+        <p>Add the prop <code>checkmark</code> to make the list icon a checkmark.</p>
       </va-process-list-item>
       <va-process-list-item active header='Active Icon'>
         <p>Add the prop <code>active</code> to make the list icon and header blue.</p>
       </va-process-list-item>
       <va-process-list-item pending header='Pending Icon'>
-        <p>Add the prop <code>pending</code> list item and icon grayed out.</p>
+        <p>Add the prop <code>pending</code> to make the list item and icon grayed out.</p>
       </va-process-list-item>
       <va-process-list-item header='Default Icon' />
     </va-process-list>

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.46.2",
+  "version": "4.46.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.46.1",
+  "version": "4.46.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-process-list/test/va-process-list-item.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list-item.e2e.ts
@@ -65,5 +65,41 @@ describe('va-process-list-item', () => {
 
     await axeCheck(page);
   });
+  it('includes sr-only span for checkmark status', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ol>
+        <va-process-list-item header="Heading" checkmark>
+          <p>Some content</p>
+        </va-process-list>
+      </ol>
+    `);
+    const element = await page.find('va-process-list-item .sr-only');
+    expect(element.innerText).toEqual('Completed:');
+  })
+  it('includes sr-only span for pending status', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ol>
+        <va-process-list-item header="Heading" pending>
+          <p>Some content</p>
+        </va-process-list>
+      </ol>
+    `);
+    const element = await page.find('va-process-list-item .sr-only');
+    expect(element.innerText).toEqual('Pending:');
+  })
+  it('includes sr-only span for active status', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ol>
+        <va-process-list-item header="Heading" active>
+          <p>Some content</p>
+        </va-process-list>
+      </ol>
+    `);
+    const element = await page.find('va-process-list-item .sr-only');
+    expect(element.innerText).toEqual('Current Step:');
+  })
 })
 

--- a/packages/web-components/src/components/va-process-list/va-process-list-item.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list-item.scss
@@ -8,7 +8,7 @@
   display: list-item;
 }
 va-process-list-item[pending='true'] .usa-process-list__heading {
-  color: var(--color-gray-light);
+  color: var(--color-gray-medium);
 }
 va-process-list-item[active='true'] .usa-process-list__heading {
   color: var(--color-primary);

--- a/packages/web-components/src/components/va-process-list/va-process-list-item.tsx
+++ b/packages/web-components/src/components/va-process-list/va-process-list-item.tsx
@@ -39,12 +39,17 @@ export class VaProcessListItem {
   @Prop() checkmark?: boolean = false;
 
   render() { 
-    const {header, level} = this;
+    const {header, level, checkmark, active, pending} = this;
     // eslint-disable-next-line i18next/no-literal-string
     const HeaderTag = `h${level}`;
     
     return (
       <Host role="listitem" class='usa-process-list__item'>
+        {
+          checkmark || active || pending ? 
+            <span class='sr-only'>{checkmark ? 'Completed:' : active ? 'Current Step:' : pending ? 'Pending:' : null}</span>
+          : null
+        }
         {header ? <HeaderTag class='usa-process-list__heading'>{header}</HeaderTag> : null}
         <slot/>
       </Host>

--- a/packages/web-components/src/components/va-process-list/va-process-list.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list.scss
@@ -12,6 +12,7 @@
 ::slotted(va-process-list-item[checkmark='true']):before {
   color: var(--color-green) !important;
   border-color: var(--color-green) !important;
+  content: url(../../assets/green-check.svg) !important; // Alt text is currently not supported in FF and Safari, This is a fallback declaration (10/27/2023)
   content: url(../../assets/green-check.svg) / "Completed" !important;
 }
 

--- a/packages/web-components/src/components/va-process-list/va-process-list.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list.scss
@@ -9,10 +9,10 @@
   counter-reset: usa-numbered-list;
 }
 
-::slotted(va-process-list-item[checked='true']):before {
+::slotted(va-process-list-item[checkmark='true']):before {
   color: var(--color-green) !important;
   border-color: var(--color-green) !important;
-  content: url(../../assets/green-check.svg) !important;
+  content: url(../../assets/green-check.svg) / "Completed" !important;
 }
 
 ::slotted(va-process-list-item[active='true']):before {
@@ -21,12 +21,12 @@
 }
 
 ::slotted(va-process-list-item[pending='true']):before {
-  color: var(--color-gray-light) !important;
-  border-color: var(--color-gray-light) !important;
+  color: var(--color-gray-medium) !important;
+  border-color: var(--color-gray-medium) !important;
 }
 
 ::slotted(va-process-list-item[pending='true']) {
-  color: var(--color-gray-light) !important;
+  color: var(--color-gray-medium) !important;
 }
 
 ::slotted(va-process-list-item) {


### PR DESCRIPTION
## Chromatic
<!-- This `65235-process-list-accessibility` is a placeholder for a CI job - it will be updated automatically -->
https://65235-process-list-accessibility--60f9b557105290003b387cd5.chromatic.com

## Description
- add sr-only text for statuses (pending, active, and complete)
- choose darker color for pending status that meets accessibility requirements
- add alt text to checkbox image in css

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/65235

## Testing done
Local testing with Chrome and Mac VoiceOver

## Screenshots
Only visual change is to the color on pending.

Before:
![Screenshot 2023-10-25 at 9 57 17 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/e6298d4c-e85f-48c8-9ad6-a4da5989bfad)

After:
![Screenshot 2023-10-25 at 9 57 45 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/89e3e5bf-a791-4037-a056-ed9c671817da)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
