### PR TITLE
va-alert: force status to be defined

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "30.0.0",
+  "version": "30.0.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-alert-uswds.stories.jsx
+++ b/packages/storybook/stories/va-alert-uswds.stories.jsx
@@ -39,6 +39,7 @@ const defaultArgs = {
   'close-btn-aria-label': 'Close notification',
   'closeable': false,
   'full-width': false,
+  'background-only': false,
   'headline': (
     <h2 id="track-your-status-on-mobile" slot="headline">
       Track your claim or appeal on your mobile device
@@ -62,6 +63,7 @@ const Template = ({
   'full-width': fullWidth,
   headline,
   onCloseEvent,
+  'background-only': backgroundOnly,
   children,
 }) => {
   if (onCloseEvent)
@@ -76,6 +78,7 @@ const Template = ({
         closeable={closeable}
         fullWidth={fullWidth}
         onCloseEvent={onCloseEvent}
+        background-only={backgroundOnly}
       >
         {headline}
         {children}
@@ -92,6 +95,7 @@ const Template = ({
       close-btn-aria-label={closeBtnAriaLabel}
       closeable={closeable}
       full-width={fullWidth}
+      background-only={backgroundOnly}
     >
       {headline}
       {children}
@@ -301,6 +305,13 @@ Dismissable.args = {
   closeable: true,
   onCloseEvent: () => console.log('Close event triggered'),
 };
+
+export const BackgroundOnly = Template.bind(null);
+BackgroundOnly.args = {
+  ...defaultArgs,
+  'background-only': true,
+  status: 'fake'
+}
 
 export const Slim = SlimTemplate.bind(null);
 Slim.args = {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.46.3",
+  "version": "4.47.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -94,9 +94,9 @@ export namespace Components {
          */
         "slim"?: boolean;
         /**
-          * Determines the icon and border/background color. One of `info`, `error`, `success`, `warning`, or `continue`
+          * Determines the icon and border/background color.
          */
-        "status"?: string;
+        "status"?: "info" | "warning" | "error" | "success" | "continue";
         /**
           * Whether or not the component will use USWDS v3 styling.
          */
@@ -140,9 +140,9 @@ export namespace Components {
          */
         "showClose"?: boolean;
         /**
-          * The type of the banner. One of 'info', 'error', 'success', 'continue', or 'warning'. This affects both the icon of the AlertBox and the top border color.
+          * The type of the banner. This affects both the icon of the AlertBox and the top border color.
          */
-        "type"?: string;
+        "type"?: "info" | "warning" | "error" | "success" | "continue";
         /**
           * A boolean that when false makes it so that the banner does not render.
          */
@@ -1862,9 +1862,9 @@ declare namespace LocalJSX {
          */
         "slim"?: boolean;
         /**
-          * Determines the icon and border/background color. One of `info`, `error`, `success`, `warning`, or `continue`
+          * Determines the icon and border/background color.
          */
-        "status"?: string;
+        "status"?: "info" | "warning" | "error" | "success" | "continue";
         /**
           * Whether or not the component will use USWDS v3 styling.
          */
@@ -1916,9 +1916,9 @@ declare namespace LocalJSX {
          */
         "showClose"?: boolean;
         /**
-          * The type of the banner. One of 'info', 'error', 'success', 'continue', or 'warning'. This affects both the icon of the AlertBox and the top border color.
+          * The type of the banner. This affects both the icon of the AlertBox and the top border color.
          */
-        "type"?: string;
+        "type"?: "info" | "warning" | "error" | "success" | "continue";
         /**
           * A boolean that when false makes it so that the banner does not render.
          */

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -345,4 +345,49 @@ describe('va-alert', () => {
       'aria-live': 'assertive',
     });
   });
+
+  it('should set status to info if null', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-alert uswds><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
+    );
+
+    const element = await page.find('va-alert >>> .usa-alert');
+
+    expect(element.classList.contains('usa-alert--info')).toBeTruthy();
+  })
+
+  it('should set status to info if it is an empty string', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-alert uswds status=""><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
+    );
+
+    const element = await page.find('va-alert >>> .usa-alert');
+
+    expect(element.classList.contains('usa-alert--info')).toBeTruthy();
+  })
+
+  it('should set status to info if value not in pre-defined list', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-alert uswds status="Fake"><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
+    );
+
+    const element = await page.find('va-alert >>> .usa-alert');
+
+    expect(element.classList.contains('usa-alert--info')).toBeTruthy();
+  })
+
+  it('should not overwrite status if valid', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-alert uswds status="continue"><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
+    );
+
+    const element = await page.find('va-alert >>> .usa-alert');
+
+    expect(element.classList.contains('usa-alert--info')).toBeFalsy();
+    expect(element.classList.contains('usa-alert--continue')).toBeTruthy();
+  })
 });

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -193,6 +193,51 @@ describe('va-alert', () => {
     expect(loadSpy).toHaveReceivedEvent();
   });
 
+  it('should set status to info if null', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-alert><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
+    );
+
+    const element = await page.find('va-alert >>> .alert');
+
+    expect(element.classList.contains('info')).toBeTruthy();
+  })
+
+  it('should set status to info if it is an empty string', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-alert status=""><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
+    );
+
+    const element = await page.find('va-alert >>> .alert');
+
+    expect(element.classList.contains('info')).toBeTruthy();
+  })
+
+  it('should set status to info if value not in pre-defined list', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-alert status="Fake"><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
+    );
+
+    const element = await page.find('va-alert >>> .alert');
+
+    expect(element.classList.contains('info')).toBeTruthy();
+  })
+
+  it('should not overwrite status if valid', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-alert status="continue"><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
+    );
+
+    const element = await page.find('va-alert >>> .alert');
+
+    expect(element.classList.contains('info')).toBeFalsy();
+    expect(element.classList.contains('continue')).toBeTruthy();
+  })
+
 
   /** Begin USWDS v3 Tests */
 
@@ -346,7 +391,7 @@ describe('va-alert', () => {
     });
   });
 
-  it('should set status to info if null', async () => {
+  it('uswds should set status to info if null', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-alert uswds><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
@@ -357,7 +402,7 @@ describe('va-alert', () => {
     expect(element.classList.contains('usa-alert--info')).toBeTruthy();
   })
 
-  it('should set status to info if it is an empty string', async () => {
+  it('uswds should set status to info if it is an empty string', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-alert uswds status=""><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
@@ -368,7 +413,7 @@ describe('va-alert', () => {
     expect(element.classList.contains('usa-alert--info')).toBeTruthy();
   })
 
-  it('should set status to info if value not in pre-defined list', async () => {
+  it('uswds should set status to info if value not in pre-defined list', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-alert uswds status="Fake"><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
@@ -379,7 +424,7 @@ describe('va-alert', () => {
     expect(element.classList.contains('usa-alert--info')).toBeTruthy();
   })
 
-  it('should not overwrite status if valid', async () => {
+  it('uswds should not overwrite status if valid', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-alert uswds status="continue"><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -30,10 +30,9 @@ export class VaAlert {
 
   /**
    * Determines the icon and border/background color.
-   * One of `info`, `error`, `success`, `warning`, or `continue`
    */
   //  Reflect Prop into DOM for va-banner: https://stenciljs.com/docs/properties#prop-options
-  @Prop({ reflect: true }) status?: string = 'info';
+  @Prop({ reflect: true }) status?: "info" | "warning" | "error" | "success" | "continue" = "info";
 
   /**
    * If `true`, renders the alert with only a background color corresponding
@@ -161,13 +160,19 @@ export class VaAlert {
   render() {
     const { 
       backgroundOnly, 
-      status, 
       visible, 
       closeable, 
       uswds, 
       slim,
     } = this;
+    let status = this.status;
     /* eslint-disable i18next/no-literal-string */
+
+    // Enforce pre-defined statuses
+    const definedStatuses = ["info", "warning", "error", "success", "continue"];
+    if (definedStatuses.indexOf(status) === -1) {
+      status = 'info'
+    }
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;
     /* eslint-enable i18next/no-literal-string */

--- a/packages/web-components/src/components/va-banner/va-banner.tsx
+++ b/packages/web-components/src/components/va-banner/va-banner.tsx
@@ -49,9 +49,9 @@ export class VaBanner {
 
   /* eslint-disable i18next/no-literal-string */
   /**
-   * The type of the banner. One of 'info', 'error', 'success', 'continue', or 'warning'. This affects both the icon of the AlertBox and the top border color.
+   * The type of the banner. This affects both the icon of the AlertBox and the top border color.
    * */
-  @Prop() type?: string = 'info';
+  @Prop() type?: "info" | "warning" | "error" | "success" | "continue" = 'info';
   /* eslint-enable i18next/no-literal-string */
 
   /**


### PR DESCRIPTION
## Chromatic
<!-- This `61262-require-alert-icon` is a placeholder for a CI job - it will be updated automatically -->
https://61262-require-alert-icon--60f9b557105290003b387cd5.chromatic.com

## Description
Update to ensure that there is always an icon/status for the alert and prevent the alert from rendering as text on a grey background.

- Update Prop definition to list allowed statuses for alert
- Add code to default to 'info' for status if the value is null or not found in the list of supported statuses
- Add tests for this logic
- Add story for USWDS to show "backgroundOnly" version

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/61262

## Testing done
- E2E tests
- Local testing with Chrome, Firefox, Edge, and Safari

## Screenshots
Before:
![Screenshot 2023-10-30 at 11 18 43 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/60dc5020-c4c2-41ee-bae1-d4760433fa02)

After:
![Screenshot 2023-10-30 at 11 17 39 AM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/a3188832-dbbb-464d-84dc-158ddb0dae71)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
