### PR TITLE
Add banner role to minimal header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+*.code-workspace
 *.log
 tmp/
 

--- a/packages/web-components/src/components/va-minimal-header/test/va-minimal-header.spec.tsx
+++ b/packages/web-components/src/components/va-minimal-header/test/va-minimal-header.spec.tsx
@@ -8,7 +8,7 @@ describe('va-minimal-header', () => {
       html: `<va-minimal-header header='Header'></va-minimal-header>`,
     });
     expect(page.root).toEqualHtml(`
-      <va-minimal-header header='Header'>
+      <va-minimal-header header='Header' role="banner">
         <mock:shadow-root>
           <va-official-gov-banner></va-official-gov-banner>
           <va-crisis-line-modal></va-crisis-line-modal>
@@ -31,7 +31,7 @@ describe('va-minimal-header', () => {
       html: `<va-minimal-header header='Header' subheader='Subheader'></va-minimal-header>`,
     });
     expect(page.root).toEqualHtml(`
-      <va-minimal-header header='Header' subheader='Subheader'>
+      <va-minimal-header header='Header' role="banner" subheader='Subheader'>
         <mock:shadow-root>
           <va-official-gov-banner></va-official-gov-banner>
           <va-crisis-line-modal></va-crisis-line-modal>

--- a/packages/web-components/src/components/va-minimal-header/va-minimal-header.tsx
+++ b/packages/web-components/src/components/va-minimal-header/va-minimal-header.tsx
@@ -21,7 +21,7 @@ export class VaMinimalHeader {
     const {header, subheader} = this;
 
     return (
-      <Host>
+      <Host role="banner">
         <va-official-gov-banner/>
         <va-crisis-line-modal/>
         <div class="va-header">


### PR DESCRIPTION
## Chromatic
<!-- This `minimal-header-role` is a placeholder for a CI job - it will be updated automatically -->
https://minimal-header-role--60f9b557105290003b387cd5.chromatic.com

---

## Description

Matt let me know that the check-in team had an a11y consideration for their version of the minimal header, which was to identify this as a banner landmark. I agree, so I added that to our component.

## Testing done

- Used VoiceOver landmarks menu to ensure it shows up there.

## Screenshots

**Before:**

<img width="1726" alt="banner-1" src="https://github.com/department-of-veterans-affairs/component-library/assets/100248909/8591ba2d-073d-4c51-8d27-d7f935569bee">


**After:**

<img width="1726" alt="banner-2" src="https://github.com/department-of-veterans-affairs/component-library/assets/100248909/a99d2394-897d-4a4b-a556-126d518af5e8">





## Acceptance criteria
- [x] Banner landmark shows in assistive technology.

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
