### PR TITLE
Add datadog action name to radio description

### DIFF
--- a/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
+++ b/packages/web-components/src/components/va-radio-option/test/va-radio-option.e2e.ts
@@ -68,7 +68,8 @@ describe('va-radio-option', () => {
 
     const description = await page.find('va-radio-option .description');
     expect(description.textContent).toEqual("Some description text");
-    expect(description.classList.contains('dd-privacy-hidden'))
+    expect(description.classList.contains('dd-privacy-hidden'));
+    expect(description.getAttribute('data-dd-action-name')).toEqual('description');
   });
 
   // Begin USWDS version test
@@ -141,7 +142,8 @@ describe('va-radio-option', () => {
 
     const description = await page.find('va-radio-option .usa-radio__label-description');
     expect(description.textContent).toEqual("Example description");
-    expect(description.classList.contains('dd-privacy-hidden'))
+    expect(description.classList.contains('dd-privacy-hidden'));
+    expect(description.getAttribute('data-dd-action-name')).toEqual('description');
   });
 
 });

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -110,6 +110,7 @@ export class VaRadioOption {
             {description && (
               <span
                 class="usa-radio__label-description dd-privacy-hidden"
+                data-dd-action-name="description"
                 aria-describedby="option-label"
               >
                 {description}
@@ -136,6 +137,7 @@ export class VaRadioOption {
               {description && (
                 <span
                   class="description dd-privacy-hidden"
+                  data-dd-action-name="description"
                   aria-describedby="option-label"
                 >
                   {description}


### PR DESCRIPTION
## Chromatic
<!-- This `62612-dd-radio` is a placeholder for a CI job - it will be updated automatically -->
https://62612-dd-radio--60f9b557105290003b387cd5.chromatic.com

## Description

Added `data-datadog-action-name` to `va-radio-option` description because clicking on the description would reveal the content in Datadog's event pane.

See [#62612](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62612)

## Testing done

Added `data-datadog-action-name` attribute check

## Screenshots

Description showing (mock) PII
<img width="1125" alt="Screenshot 2023-11-03 at 11 01 48 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/244d2db0-ad7a-4b8f-849a-d54a8d4aec05">

Datadog event showing click on description
<img width="956" alt="Screenshot 2023-11-03 at 10 34 25 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/9a6be176-c377-46a5-88b8-7fed3a223af2">

## Acceptance criteria
- [x] Add Datadog action name to radio option description to prevent exposing PII
- [x] Add tests

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
