### PR TITLE
VaMinimalHeader: add alt attribute to img

### DIFF
--- a/packages/web-components/src/components/va-minimal-header/test/va-minimal-header.spec.tsx
+++ b/packages/web-components/src/components/va-minimal-header/test/va-minimal-header.spec.tsx
@@ -14,7 +14,7 @@ describe('va-minimal-header', () => {
           <va-crisis-line-modal></va-crisis-line-modal>
           <div class="va-header">
             <a href="/">
-              <img aria-hidden="true" class="va-logo" src="[object Object]">
+              <img alt="VA.gov home" class="va-logo" src="[object Object]">
             </a>
             <div class="header-container">
               <h1>Header</h1>
@@ -37,7 +37,7 @@ describe('va-minimal-header', () => {
           <va-crisis-line-modal></va-crisis-line-modal>
           <div class="va-header">
             <a href="/">
-              <img aria-hidden="true" class="va-logo" src="[object Object]">
+              <img alt="VA.gov home" class="va-logo" src="[object Object]">
             </a>
             <div class="header-container">
               <h1>Header</h1>

--- a/packages/web-components/src/components/va-minimal-header/test/va-minimal-header.spec.tsx
+++ b/packages/web-components/src/components/va-minimal-header/test/va-minimal-header.spec.tsx
@@ -13,8 +13,8 @@ describe('va-minimal-header', () => {
           <va-official-gov-banner></va-official-gov-banner>
           <va-crisis-line-modal></va-crisis-line-modal>
           <div class="va-header">
-            <a href="/">
-              <img alt="VA.gov home" class="va-logo" src="[object Object]">
+            <a href="/" title="Go to VA.gov">
+              <img alt="VA logo and Seal, U.S. Department of Veterans Affairs" class="va-logo" src="[object Object]">
             </a>
             <div class="header-container">
               <h1>Header</h1>
@@ -36,8 +36,8 @@ describe('va-minimal-header', () => {
           <va-official-gov-banner></va-official-gov-banner>
           <va-crisis-line-modal></va-crisis-line-modal>
           <div class="va-header">
-            <a href="/">
-              <img alt="VA.gov home" class="va-logo" src="[object Object]">
+            <a href="/" title="Go to VA.gov">
+              <img alt="VA logo and Seal, U.S. Department of Veterans Affairs" class="va-logo" src="[object Object]">
             </a>
             <div class="header-container">
               <h1>Header</h1>

--- a/packages/web-components/src/components/va-minimal-header/va-minimal-header.tsx
+++ b/packages/web-components/src/components/va-minimal-header/va-minimal-header.tsx
@@ -26,8 +26,8 @@ export class VaMinimalHeader {
         <va-crisis-line-modal/>
         <div class="va-header">
 
-          <a href="/" >
-            <img class="va-logo" src={vaSeal} alt="VA.gov home"/>
+          <a href="/" title="Go to VA.gov">
+            <img class="va-logo" src={vaSeal} alt="VA logo and Seal, U.S. Department of Veterans Affairs"/>
           </a>
           <div class='header-container'>
             <h1>{header}</h1>

--- a/packages/web-components/src/components/va-minimal-header/va-minimal-header.tsx
+++ b/packages/web-components/src/components/va-minimal-header/va-minimal-header.tsx
@@ -27,7 +27,7 @@ export class VaMinimalHeader {
         <div class="va-header">
 
           <a href="/" >
-            <img class="va-logo" src={vaSeal} aria-hidden="true"/>
+            <img class="va-logo" src={vaSeal} alt="VA.gov home"/>
           </a>
           <div class='header-container'>
             <h1>{header}</h1>


### PR DESCRIPTION
## Chromatic
<!-- This `add-alt-minimal-header` is a placeholder for a CI job - it will be updated automatically -->
https://add-alt-minimal-header--60f9b557105290003b387cd5.chromatic.com

---

## Description
This PR adds an "alt" attr to the img for a11y reasons.

## Testing done
local testing in chrome, firefox, safari, edge

## Screenshots

<img width="798" alt="Screenshot 2023-11-07 at 10 33 05 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/1d947ff6-f8f2-4db8-9384-c962bf4af9ff">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
