### PR TITLE
2248 - Deprecating va-notification in storybook

### DIFF
--- a/packages/storybook/stories/va-notification.stories.jsx
+++ b/packages/storybook/stories/va-notification.stories.jsx
@@ -5,9 +5,9 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const notificationDocs = getWebComponentDocs('va-notification');
 
 export default {
-  title: 'Components/Notification',
+  title: 'Deprecated/Notification',
   id: 'components/va-notification',
-  argTypes: {   
+  argTypes: {
     children: {
       table: {
         disable: true,

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.47.0",
+  "version": "4.47.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-notification/va-notification.tsx
+++ b/packages/web-components/src/components/va-notification/va-notification.tsx
@@ -3,8 +3,8 @@ import {
   Element,
   Event,
   EventEmitter,
-  Host, 
-  Prop, 
+  Host,
+  Prop,
   h,
   Listen,
 } from '@stencil/core';
@@ -12,8 +12,8 @@ import classnames from 'classnames';
 
 /**
  * @componentName Notification
- * @maturityCategory caution
- * @maturityLevel proposed
+ * @maturityCategory dont_use
+ * @maturityLevel deprecated
  */
 
 @Component({
@@ -84,7 +84,7 @@ export class VaNotification {
    * If `true`, the component-library-analytics event is disabled.
    */
   @Prop() disableAnalytics?: boolean = false;
-  
+
   /**
    * Fires when the component is closed by clicking on the close icon. This fires only
    * when closeable is true.
@@ -106,7 +106,7 @@ export class VaNotification {
   componentLibraryAnalytics: EventEmitter;
 
   /**
-   * Listen for the va-link GA event and capture it so 
+   * Listen for the va-link GA event and capture it so
    * that we can emit a single va-notification GA event that includes
    * the va-link details.
    */


### PR DESCRIPTION
## Chromatic
<!-- This `2248-deprecate-notification-component` is a placeholder for a CI job - it will be updated automatically -->
https://2248-deprecate-notification-component--60f9b557105290003b387cd5.chromatic.com

---
## Description
Closes [#2248](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2248)

## Testing done
Tested locally using Storybook and Brave

## Screenshots
![Screenshot 2023-11-09 at 12 21 57 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/7ddc7b6e-ce76-4c5f-a6be-9c57a9549ac5)


## Acceptance criteria
- [X] Component shows as "Deprecated - Do Not Use" in storybook

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
