### PR TITLE
va-modal - 2219 font, icon, and responsiveness fix for v3

### DIFF
--- a/packages/web-components/src/components/va-modal/va-modal.scss
+++ b/packages/web-components/src/components/va-modal/va-modal.scss
@@ -342,6 +342,11 @@ i::before {
   .va-modal-alert .alert-actions button + button {
     margin: 1.6rem 0 0 0;
   }
+
+  .usa-modal--lg .usa-modal__main {
+    max-width: -webkit-fill-available;
+    max-width: -moz-fit-content;
+  }
 }
 
 :host([large]:not([large='false'])) .va-modal-inner {

--- a/packages/web-components/src/components/va-modal/va-modal.scss
+++ b/packages/web-components/src/components/va-modal/va-modal.scss
@@ -16,8 +16,8 @@
   padding: 0px // => Due to icons
 }
 
-
-.usa-modal__heading {
+.usa-modal__heading,
+.usa-modal--lg .usa-modal__heading {
   font-family: var(--font-serif);
 }
 

--- a/packages/web-components/src/components/va-modal/va-modal.scss
+++ b/packages/web-components/src/components/va-modal/va-modal.scss
@@ -62,6 +62,15 @@
   content: '\F00C'; /* fa-check */
 }
 
+.usa-modal::before {
+  padding-top: 0;
+
+  :host([large='true']) &,
+  :host([large]:not([large='false'])) & {
+    padding-top: 20px;
+  }
+}
+
 :host([status='warning']) .usa-modal {
   border-left-color: var(--color-gold);
   background-color: var(--color-gold-lightest);


### PR DESCRIPTION
## Chromatic
<!-- This `2219-modal-font-icon-fix` is a placeholder for a CI job - it will be updated automatically -->
https://2219-modal-font-icon-fix--60f9b557105290003b387cd5.chromatic.com

---
## Description
This PR fixes responsiveness, icon padding, and title font for large modal.

Closes [2219](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2219)

## Testing done
Storybook in Chrome/Safari/Firefox

## Screenshots
**Large Modal title font:**
<img width="1792" alt="Font fix" src="https://github.com/department-of-veterans-affairs/component-library/assets/22892911/2c51296d-3f00-4eea-b430-0c24d7af9b6d">

**Large Modal icon spacing:**
<img width="919" alt="Screenshot 2023-11-09 at 6 35 58 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/22892911/4a0e9a34-b758-4a85-9795-35b659f37414">

**Large Modal width on mobile view:
Firefox:**
<img width="900" alt="Firefox dialog width" src="https://github.com/department-of-veterans-affairs/component-library/assets/22892911/304f5c41-8dc6-44e7-b637-e4b49b38847d">

**Chrome:**
<img width="1109" alt="Chrome dialog width" src="https://github.com/department-of-veterans-affairs/component-library/assets/22892911/0cde0eb5-6a28-4d44-a522-c0468fcb1ec2">

**Safari:**
![Safari dialog width](https://github.com/department-of-veterans-affairs/component-library/assets/22892911/32945265-0003-473e-a15a-0e38b3efbb74)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
