### PR TITLE
Bump core to 32.1.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "32.0.0",
+  "version": "32.1.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"


### PR DESCRIPTION
## Chromatic
<!-- This `bump-core-32.1.0` is a placeholder for a CI job - it will be updated automatically -->
https://bump-core-32.1.0--60f9b557105290003b387cd5.chromatic.com

---

## Description
This PR bumps core to 32.1.0 for release

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
