### PR TITLE
va-minimal-footer: add focus outline to logo

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.49.0",
+  "version": "4.49.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.49.1",
+  "version": "4.49.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-minimal-footer/va-minimal-footer.scss
+++ b/packages/web-components/src/components/va-minimal-footer/va-minimal-footer.scss
@@ -1,3 +1,5 @@
+@import '../../mixins/focusable.css';
+
 :host {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Chromatic
<!-- This `2274-focus-minimal-footer-logo` is a placeholder for a CI job - it will be updated automatically -->
https://2274-focus-minimal-footer-logo--60f9b557105290003b387cd5.chromatic.com

## Description

**Before**

![before](https://github.com/department-of-veterans-affairs/component-library/assets/872479/2194faed-daf7-4f76-b779-9ac7541438a8)

**After**

![after](https://github.com/department-of-veterans-affairs/component-library/assets/872479/58a750a7-b215-4db4-b107-ae34e4125de4)

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2274

## Testing done
Storybook

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
