### PR TITLE
va-statement-of-truth: update storybook width display

### DIFF
--- a/packages/storybook/stories/va-statement-of-truth-uswds.stories.jsx
+++ b/packages/storybook/stories/va-statement-of-truth-uswds.stories.jsx
@@ -39,7 +39,7 @@ const Template = ({
   checkboxLabel
  }) => {
   return (
-    <div style={{ width: 600 }}>
+    <div style={{ maxWidth: 600 }}>
       <VaStatementOfTruth
         heading={heading}
         inputValue={inputValue}

--- a/packages/storybook/stories/va-statement-of-truth.stories.jsx
+++ b/packages/storybook/stories/va-statement-of-truth.stories.jsx
@@ -39,7 +39,7 @@ const Template = ({
   checkboxLabel
  }) => {
   return (
-    <div style={{ width: 600 }}>
+    <div style={{ maxWidth: 600 }}>
       <VaStatementOfTruth
         heading={heading}
         inputValue={inputValue}


### PR DESCRIPTION
## Chromatic
<!-- This `2201-statement-of-truth-storybook` is a placeholder for a CI job - it will be updated automatically -->
https://2201-statement-of-truth-storybook--60f9b557105290003b387cd5.chromatic.com

## Description
This adjusts the Storybook example so that it doesn't create a horizontal scroll on small screens.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2201

## Testing done
Storybook

## Screenshots

![Screenshot 2023-11-20 at 1 59 02 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/ffa0b13f-b6c0-42d2-8b19-06db4ef5f7c2)

![Screenshot 2023-11-20 at 1 58 48 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/722a5234-d526-4bef-9ccd-80f03a3a7caf)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
