### PR TITLE
Fix issue with va-on-this-page left margin alignment

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.49.0",
+  "version": "4.49.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
@@ -26,7 +26,7 @@ dd {
 dl {
   margin-top: 0;
   margin-bottom: 0;
-  margin-left: -0.5em;
+  margin-left: 0;
   list-style-type: none;
   padding-left: 0;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `2225-fix-VaOnThisPage-align` is a placeholder for a CI job - it will be updated automatically -->
https://2225-fix-VaOnThisPage-align--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2225

## Testing done
Local testing in browser

## Screenshots
Before:
![image](https://github.com/department-of-veterans-affairs/component-library/assets/15200011/b699a870-87aa-4b24-9d33-35a88befe29f)

After:
<img width="339" alt="image" src="https://github.com/department-of-veterans-affairs/component-library/assets/15200011/6aa93a06-3d8b-4ae7-940e-ee174848dafc">
<img width="845" alt="image" src="https://github.com/department-of-veterans-affairs/component-library/assets/15200011/388be3cf-8fe9-47c9-a316-b95f14976988">


## Acceptance criteria
- [ ] The left margin on the `va-on-this-page` web-component is fixed

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
