### PR TITLE
Removing background-only section from V3 Alerts

### DIFF
--- a/packages/storybook/stories/va-alert-uswds.stories.jsx
+++ b/packages/storybook/stories/va-alert-uswds.stories.jsx
@@ -306,13 +306,6 @@ Dismissable.args = {
   onCloseEvent: () => console.log('Close event triggered'),
 };
 
-export const BackgroundOnly = Template.bind(null);
-BackgroundOnly.args = {
-  ...defaultArgs,
-  'background-only': true,
-  status: 'fake'
-}
-
 export const Slim = SlimTemplate.bind(null);
 Slim.args = {
   ...defaultArgs,


### PR DESCRIPTION
## Chromatic
<!-- This `2246-remove-bkg-only-alerts` is a placeholder for a CI job - it will be updated automatically -->
https://2246-remove-bkg-only-alerts--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes [#2246](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2246)

## Testing done
Tested locally in Storybook using Brave.

## Screenshots
N/A

## Acceptance criteria
- [X] Background-only alerts removed from va-alert-uswds.stories.jsx

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
