### PR TITLE
va-segmented-progress-bar: Hiding steps from JAWS

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.49.2",
+  "version": "4.49.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -576,7 +576,7 @@ export namespace Components {
     }
     interface VaModal {
         /**
-          * Additional DOM-nodes that should not be hidden from screen readers.  Useful when an open modal shouldn't hide all content behind the overlay.
+          * Additional DOM-nodes that should not be hidden from screen readers. Useful when an open modal shouldn't hide all content behind the overlay.
          */
         "ariaHiddenNodeExceptions"?: HTMLElement[];
         /**
@@ -2453,7 +2453,7 @@ declare namespace LocalJSX {
     }
     interface VaModal {
         /**
-          * Additional DOM-nodes that should not be hidden from screen readers.  Useful when an open modal shouldn't hide all content behind the overlay.
+          * Additional DOM-nodes that should not be hidden from screen readers. Useful when an open modal shouldn't hide all content behind the overlay.
          */
         "ariaHiddenNodeExceptions"?: HTMLElement[];
         /**

--- a/packages/web-components/src/components/va-segmented-progress-bar/test/va-segmented-progress-bar.e2e.ts
+++ b/packages/web-components/src/components/va-segmented-progress-bar/test/va-segmented-progress-bar.e2e.ts
@@ -27,9 +27,6 @@ describe('v1 va-segmented-progress-bar', () => {
               <div class="progress-segment"></div>
               <div class="progress-segment"></div>
             </div>
-            <span aria-atomic="true" aria-live="polite" class="sr-only">
-              Step 3 of 6
-            </span>
           </div>
         </mock:shadow-root>
       </va-segmented-progress-bar>
@@ -84,15 +81,6 @@ describe('v1 va-segmented-progress-bar', () => {
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
     expect(analyticsSpy).not.toHaveReceivedEvent();
   });
-
-  it("should render correct progress text", async () => {
-    const page = await newE2EPage({
-      html: '<va-segmented-progress-bar current="3" total="6" progress-term="Chapter"></va-segmented-progress-bar>',
-    });
-    const element = await page.find('va-segmented-progress-bar');
-    const counter = element.shadowRoot.querySelector('.sr-only');
-    expect(counter.innerHTML.indexOf('Chapter')).not.toEqual(-1);
-  })
 });
 
 
@@ -174,7 +162,7 @@ describe('v3 va-segmented-progress-bar', () => {
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
     expect(analyticsSpy).not.toHaveReceivedEvent();
   });
-  
+
   it("uswds - should render heading-text when labels are not provided", async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6" uswds heading-text="My Header"></va-segmented-progress-bar>',

--- a/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
+++ b/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
@@ -185,6 +185,7 @@ export class VaSegmentedProgressBar {
               aria-valuemin="0"
               aria-valuemax={total}
               aria-valuetext={label}
+              aria-hidden="true"
             >
               {range.map(step => (
                 <div

--- a/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
+++ b/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
@@ -185,7 +185,6 @@ export class VaSegmentedProgressBar {
               aria-valuemin="0"
               aria-valuemax={total}
               aria-valuetext={label}
-              aria-hidden="true"
             >
               {range.map(step => (
                 <div
@@ -196,9 +195,6 @@ export class VaSegmentedProgressBar {
                 />
               ))}
             </div>
-            <span aria-atomic="true" aria-live="polite" class="sr-only">
-              {progressTerm} {current} of {total}
-            </span>
           </div>
         </Host>
       )


### PR DESCRIPTION
## Chromatic
<!-- This `2209-hide-steppers-aria` is a placeholder for a CI job - it will be updated automatically -->
https://2209-hide-steppers-aria--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes [#2209](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2209)

## Testing done
Tested locally using storybook, brave, and VoiceOver. Did not have JAWS to test with.

## Screenshots
N/A

## Acceptance criteria
- [ ] Does not repeat the step indicator text in JAWS

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
