### PR TITLE
Button-Pair: spacing issue

### DIFF
--- a/packages/web-components/src/global/_formation_overrides.scss
+++ b/packages/web-components/src/global/_formation_overrides.scss
@@ -171,7 +171,7 @@
   &__item {
     margin: rem-override(0.25rem);
   }
-  margin: 0px rem-override(-0.5rem);
+  margin: 0;
 }
 
 .usa-modal {


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

---

## Description
This PR addresses the spacing issue in the Button Pair component on https://design.va.gov/components/button/button-pair.
Closes [64453](https://github.com/department-of-veterans-affairs/va.gov-team/issues/64453)

## Testing done
Storybook: Chrome/Edge/Firefox

## Screenshots
![Screenshot 2023-11-28 at 3 10 33 PM](https://github.com/department-of-veterans-affairs/component-library/assets/22892911/584139c3-5438-4dd5-8c4c-cb78eaf81107)
![Screenshot 2023-11-28 at 3 10 54 PM](https://github.com/department-of-veterans-affairs/component-library/assets/22892911/195a5250-2e00-4193-9d5f-6d7c1834dc50)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
