### PR TITLE
va-modal: fix for screen readers when using Storybook

### DIFF
--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -108,9 +108,37 @@ export const decorators = [
   ),
 ];
 
+// Sets up a mutation observer to ensure that the storybook docs-root container doesn't get hidden by modals
+const observeDocsRoot = () => {
+  // The target for the observer
+  const targetNode = document.getElementById('docs-root');
+
+  // Configuration options for the observer
+  const config = {attributes: true, childList: false, subtree: false}
+
+  // Callback function that 'resets' the aria-hidden attribute to false
+  const callback = (
+    /** @type {MutationRecord[]} */ mutationList
+  ) => {
+    for (const mutation of mutationList) {
+      if (mutation.attributeName === 'aria-hidden' && targetNode?.getAttribute('aria-hidden') !== 'false') {
+        targetNode?.setAttribute('aria-hidden', 'false');
+      }
+    }
+  };
+
+  // Create an observer instance
+  const observer = new MutationObserver(callback);
+
+  // Start observing
+  if (targetNode) observer.observe(targetNode, config);
+}
+
 document.body.onload = function () {
   // Fix for React 17/NVDA bug where React root is read as "clickable"
   // https://github.com/nvaccess/nvda/issues/13262
   // https://github.com/facebook/react/issues/20895
   document.querySelector('#root').setAttribute('role', 'presentation');
+
+  observeDocsRoot();
 };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.49.4",
+  "version": "4.49.5",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
+++ b/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
@@ -1,12 +1,12 @@
-import { 
-  Component, 
-  Host, 
-  h, 
-  EventEmitter, 
-  Event, 
-  Prop, 
-  Element, 
-  forceUpdate 
+import {
+  Component,
+  Host,
+  h,
+  EventEmitter,
+  Event,
+  Prop,
+  Element,
+  forceUpdate
 } from '@stencil/core';
 import i18next from 'i18next';
 import { Build } from '@stencil/core';
@@ -75,9 +75,9 @@ export class VaOfficialGovBanner {
     const header = this.el.shadowRoot?.querySelector('header') as HTMLElement;
 
     button.setAttribute(
-      'aria-expanded', 
-      button.getAttribute('aria-expanded') === 'true' 
-        ? 'false' 
+      'aria-expanded',
+      button.getAttribute('aria-expanded') === 'true'
+        ? 'false'
         : 'true'
     );
 
@@ -96,7 +96,7 @@ export class VaOfficialGovBanner {
   };
 
   /**
-   * This  will add <strong> tags around the 
+   * This will add <strong> tags around the
    * matching TLD value (.gov or .mil) in the text that is provided
    * and the innerHTML of the element will be updated.
    */
@@ -104,7 +104,9 @@ export class VaOfficialGovBanner {
     const el = this.el.shadowRoot?.querySelector('.gov-site-explanation-text') as HTMLElement;
     if (el) {
       const text = i18next.t('gov-site-explanation', { tld: this.tld });
-      el.innerHTML = text.replace(`.${this.tld}`, `<strong>.${this.tld}</strong>`);
+      if (text) {
+        el.innerHTML = text.replace(`.${this.tld}`, `<strong>.${this.tld}</strong>`);
+      }
     }
   }
 
@@ -121,7 +123,7 @@ export class VaOfficialGovBanner {
     <desc id="banner-lock-description">Locked padlock icon</desc>
     <path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path>
     </svg></span>&nbsp;)`
-  
+
     let html = i18next.t('gov-site-lock', { image: 'SVG', tld: this.tld });
 
     html = html.replace('SVG', lockSvg);
@@ -147,9 +149,9 @@ export class VaOfficialGovBanner {
               <header >
                 <div class="inner">
                   <div class="grid-col-auto">
-                    <img 
-                      role="presentation" 
-                      class="header-flag" 
+                    <img
+                      role="presentation"
+                      class="header-flag"
                       src="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/tiny-usa-flag.png"
                       alt="" />
                   </div>
@@ -157,22 +159,22 @@ export class VaOfficialGovBanner {
                     <p class="header-text">{i18next.t('gov-site-label')}</p>
                     <p class="header-action">{i18next.t('gov-site-button')}</p>
                   </div>
-                  <button 
+                  <button
                     onClick={this.handleClick}
-                    type="button" 
-                    aria-expanded="false" 
+                    type="button"
+                    aria-expanded="false"
                     aria-controls="official-gov-banner">
                     <span class="button-text">{i18next.t('gov-site-button')}</span>
                   </button>
                 </div>
               </header>
-  
+
               <div class="content" id="official-gov-banner" hidden>
                 <div class="grid-row">
                   <div class="col">
-                    <img 
-                      src={iconHttpsSvg} 
-                      role="presentation" 
+                    <img
+                      src={iconHttpsSvg}
+                      role="presentation"
                       alt="" />
                     <div class="media-block">
                       <p>
@@ -184,9 +186,9 @@ export class VaOfficialGovBanner {
                     </div>
                   </div>
                   <div class="col">
-                    <img 
-                      src={iconDotGovSvg} 
-                      role="presentation" 
+                    <img
+                      src={iconDotGovSvg}
+                      role="presentation"
                       alt="" />
                     <div class="media-block">
                       <p>
@@ -199,7 +201,7 @@ export class VaOfficialGovBanner {
                   </div>
                 </div>
               </div>
-  
+
             </div>
           </section>
         </Host>


### PR DESCRIPTION
## Chromatic
<!-- This `2255-modal-screen-reading` is a placeholder for a CI job - it will be updated automatically -->
https://2255-modal-screen-reading--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes [#2255](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2255)

Introduces a MutationObserver that is scoped to only the `#docs-root` element of storybook and is needed because the `hideOthers` function that we call as part of `setupModal` was hiding the docs-root from screen readers, which effectively meant that inside of storybook modals became 'invisible' to screen readers.

## Testing done
Tested locally using storybook and Brave

## Screenshots
N/A

## Acceptance criteria
- [X] Screen readers can see and read out the contents of all modals when viewing them in storybook

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
