### PR TITLE
va-checkbox-group: make legend font match design spec

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.49.3",
+  "version": "4.49.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.scss
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.scss
@@ -1,3 +1,5 @@
+@forward 'settings';
+
 @use 'uswds-helpers/src/styles/usa-sr-only';
 @use 'usa-fieldset/src/styles/usa-fieldset';
 @use 'usa-label/src/styles/usa-label';


### PR DESCRIPTION
## Chromatic
<!-- This `2251-font-fix` is a placeholder for a CI job - it will be updated automatically -->
https://2251-font-fix--60f9b557105290003b387cd5.chromatic.com

---
## Description
This PR sets the font of the legend in `va-checkbox-group` to be the same as `va-checkbox`: Source Pro Sans Web

Closes [2251](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2251)

## Testing done
local testing in Chrome, Edge, Safari, Firefox

## Screenshots
**Before**: 
<img width="468" alt="Screenshot 2023-11-30 at 4 12 38 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/9cfd1737-15a5-47ff-8ee0-7278a04fbd1c">

**After**
<img width="305" alt="Screenshot 2023-11-30 at 4 14 30 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/2c660869-a5bf-447b-92e5-612d69844dd7">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
