### PR TITLE
va-official-gov-banner: Fix for medium screens wrapping wrongly

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.49.3",
+  "version": "4.49.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.scss
+++ b/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.scss
@@ -46,7 +46,7 @@
   padding-right: 0.75rem;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .col {
     flex: unset;
   }
@@ -62,7 +62,7 @@ header.expanded .header-action {
   display: none;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   header {
     min-height: 32px;
   }
@@ -119,7 +119,7 @@ button[aria-expanded=false], button[aria-expanded=true] {
   background-image: none;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   button {
     width: 100%;
   }
@@ -136,7 +136,7 @@ button {
   position: relative;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   button {
     -webkit-font-smoothing: inherit;
     background-color: transparent;
@@ -180,7 +180,7 @@ button:hover {
 }
 
 // Mobile display dropdown/expand more arrow.
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   header .header-action::after, header.expanded .header-action::after {
     background-color: #005ea2;
   }
@@ -230,7 +230,7 @@ button:hover {
 }
 
 // Mobile display close icon.
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   button[aria-expanded=true]:after {
     bottom: 0;
     top: 0;


### PR DESCRIPTION
## Chromatic
<!-- This `2097-gov-banner-wrapping` is a placeholder for a CI job - it will be updated automatically -->
https://2097-gov-banner-wrapping--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes [#2097](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2097)
Fixes overlapping CSS instructions that caused the Medium screen size to be janky.

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (No a11y changes)
- [X] Designer has signed off on changes (No Design changes)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2023-12-04 at 11 28 32 AM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/c42a9d1b-0704-4429-8c09-5fefc3a154d0)

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
