### PR TITLE
va-breadcrumbs: make uswds version support React Router links

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -166,6 +166,10 @@ export namespace Components {
          */
         "label"?: string;
         /**
+          * Are the hrefs provided in the objects of the breadcrumbList to be used  in an app with a Router, e.g. React Router? Has no effect if uswds is false
+         */
+        "useRouter"?: boolean;
+        /**
           * Whether or not the component will use USWDS v3 styling.
          */
         "uswds"?: boolean;
@@ -1970,6 +1974,10 @@ declare namespace LocalJSX {
           * The event used to track usage of the component. This is emitted when a breadcrumb anchor is clicked and disableAnalytics is not true.
          */
         "onComponent-library-analytics"?: (event: VaBreadcrumbsCustomEvent<any>) => void;
+        /**
+          * Are the hrefs provided in the objects of the breadcrumbList to be used  in an app with a Router, e.g. React Router? Has no effect if uswds is false
+         */
+        "useRouter"?: boolean;
         /**
           * Whether or not the component will use USWDS v3 styling.
          */

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -75,6 +75,13 @@ export class VaBreadcrumbs {
   componentLibraryAnalytics: EventEmitter;
 
   /**
+   * Are the hrefs provided in the objects of the breadcrumbList to be used 
+   * in an app with a Router, e.g. React Router?
+   * Has no effect if uswds is false
+   */
+  @Prop() useRouter?: boolean = false;
+
+  /**
    * This method is used to update the formattedBreadcrumbs state.
    * It is only invoked when the uswds attribute is set to true on the component.
    * It either parses a JSON string into an array of breadcrumb objects or uses the passed array as is.
@@ -239,6 +246,29 @@ export class VaBreadcrumbs {
     });
   }
 
+  /**
+   * Changes the route when uswds and useRoute props are true.
+   * Route will be set to the href value in the breadcrumb.
+   */
+  handleRouteChange(e: MouseEvent, href: string): void {
+    e.preventDefault();
+    window.history.pushState(null, '', href);
+    // create event to notify Router
+    const popStateEvent = new PopStateEvent('popstate');
+    // notify Router
+    window.dispatchEvent(popStateEvent);
+  }
+
+  /**
+   * Handle click event on breadcrumb when uswds is true
+   */
+  uswdsHandler(e: MouseEvent, href: string) {
+    if (this.useRouter) {
+      this.handleRouteChange(e, href);
+    }
+    this.fireAnalyticsEvent(e);
+  }
+
   render() {
     const { label, uswds, wrapping } = this;
     const wrapClass = classnames({
@@ -260,7 +290,7 @@ export class VaBreadcrumbs {
                       <span>{item.label}</span>
                     </a>
                   ) : (
-                    <a class="usa-breadcrumb__link" href={item.href} onClick={e => this.fireAnalyticsEvent(e)}>
+                    <a class="usa-breadcrumb__link" href={item.href} onClick={e => this.uswdsHandler(e, item.href)}>
                       <span>{item.label}</span>
                     </a>
                   )}


### PR DESCRIPTION
## Chromatic
<!-- This `2188-breadcrumb-with-link` is a placeholder for a CI job - it will be updated automatically -->
https://2188-breadcrumb-with-link--60f9b557105290003b387cd5.chromatic.com

---
## Description
This PR makes the uswds version of va-breadcrumbs compatible with React Router. The original issue mentioned the `<Link` component. Making the uswds version play nicely with `<Link>` would require a total rewrite of va-breadcrumbs since currently the uswds version does not use slots. However, this PR makes the uswds version work with React Router (or, most likely, other Routers too) by manipulating the History api. So in this PR the component API for the uswds version does **not** change.

Note: in this PR the component directly manipulates the History API. Another approach is to emit an event and let the VFS team handle the route change programmatically in a handler that makes use of utilities that React Router provides. This approach imposes a small burden on the VFS team but may provide more future proof solution (in case, for example, directly manipulating the History API does not work well with a future version of React Router).

Closes [2188](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2188)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
In `vets-website` I modified [this file ](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/simple-forms/mock-simple-forms-patterns/containers/IntroductionPage.jsx) because it is part of an app that uses React Router. The app runs locally at http://localhost:3001/mock-simple-forms-patterns/introduction:

<img width="516" alt="Screenshot 2023-12-06 at 9 58 13 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/f3b16534-c363-4deb-b9ac-abc352c7c9ed">

The `href` values in the `breadcrumbList` prop correspond to pages in the app.

Here is a video of navigation:

https://github.com/department-of-veterans-affairs/component-library/assets/8867779/f1c41f9a-3998-4a52-92e6-c252bc4a3bfe


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
