### PR TITLE
va-checkbox: Add error message styling

### DIFF
--- a/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
@@ -35,6 +35,7 @@ describe('va-checkbox', () => {
     expect(input.getAttribute('aria-invalid')).toEqual('true');
     expect(input.getAttribute('aria-describedby')).toEqual('checkbox-error-message');
     expect(element.textContent).toContain('Something went horribly wrong');
+    expect(element.className).toContain('usa-error-message');
   });
 
   it('renders hint text', async () => {

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -257,7 +257,7 @@ export class VaCheckbox {
             {description ? <p>{description}</p> : <slot name="description" />}
           </div>
           {hint && <span class="hint-text">{hint}</span>}
-          <span id="checkbox-error-message" role="alert">
+          <span id="checkbox-error-message" class="usa-error-message" role="alert">
             {error && (
               <Fragment>
                 <span class="sr-only">{i18next.t('error')}</span> {error}


### PR DESCRIPTION
## Chromatic
<!-- This `2355-checkbox-error-style` is a placeholder for a CI job - it will be updated automatically -->
https://2355-checkbox-error-style--60f9b557105290003b387cd5.chromatic.com

## Description

Added `usa-error-message` class to `va-checkbox` error message to match expected error message styling. Also added a test to check for the class name

- Closes [#2355](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2355)
- Related [#71502](https://github.com/department-of-veterans-affairs/va.gov-team/issues/71502)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

| Before | After |
|--------|------|
| <img width="503" alt="before: va checkbox error message with black, non-bold test" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/d1a38e02-1eb6-44e1-9f64-fd22be10690c"> | <img width="502" alt="after: va checkbox error message with bold, red text" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/f006d49e-6046-409e-b948-37d2bd7f80aa"> |

## Acceptance criteria
- [ ] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
