### PR TITLE
Add ARIA label to featured content region

### DIFF
--- a/packages/web-components/src/components/va-featured-content/test/va-featured-content.e2e.ts
+++ b/packages/web-components/src/components/va-featured-content/test/va-featured-content.e2e.ts
@@ -94,7 +94,7 @@ describe('va-featured-content', () => {
     expect(element).toEqualHtml(`
       <va-featured-content class="hydrated" uswds="">
         <mock:shadow-root>
-          <div class="usa-summary-box" role="region">
+          <div class="usa-summary-box" role="region" aria-label="If I'm a Veteran, can I get VR&amp;E benefits and services?">
             <div class="usa-summary-box__body">
               <slot class="usa-summary-box__heading" name="headline"></slot>
               <slot class="usa-summary-box__text"></slot>

--- a/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
+++ b/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
@@ -25,8 +25,11 @@ export class VaFeaturedContent {
   @Element() el: HTMLElement;
 
   componentWillLoad() {
-    let childElements = Array.from(this.el.children);
-    this.headlineText = childElements.find(element => element.slot === "headline").textContent.trim();
+    return new Promise<void>((resolve) => {
+      let childElements = Array.from(this.el.children);
+      this.headlineText = childElements.find(element => element.slot === "headline").textContent.trim();
+      resolve();
+    });
   }
 
   componentDidLoad() {
@@ -41,6 +44,9 @@ export class VaFeaturedContent {
     
     headline.classList.add('usa-summary-box__heading');
     content.classList.add('usa-summary-box__text');
+
+    let childElements = Array.from(this.el.children);
+    this.headlineText = childElements.find(element => element.slot === "headline").textContent.trim();
   }
 
   render() {

--- a/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
+++ b/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Element, State } from '@stencil/core';
 
 /**
  * @componentName Featured content
@@ -20,16 +20,13 @@ export class VaFeaturedContent {
    * Local state for slot=headline's text.
    * Used to place an aria-label for role="region" with the same text as the heading.
    */
-  private headlineText: string = null;
+  @State() headlineText: string = null;
 
   @Element() el: HTMLElement;
 
   componentWillLoad() {
-    return new Promise<void>((resolve) => {
-      let childElements = Array.from(this.el.children);
-      this.headlineText = childElements.find(element => element.slot === "headline").textContent.trim();
-      resolve();
-    });
+    let childElements = Array.from(this.el.children);
+    this.headlineText = childElements.find(element => element.slot === "headline").textContent.trim();
   }
 
   componentDidLoad() {

--- a/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
+++ b/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, State, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Element } from '@stencil/core';
 
 /**
  * @componentName Featured content
@@ -20,7 +20,7 @@ export class VaFeaturedContent {
    * Local state for slot=headline's text.
    * Used to place an aria-label for role="region" with the same text as the heading.
    */
-  @State() headlineText: string = null;
+  private headlineText: string = null;
 
   @Element() el: HTMLElement;
 

--- a/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
+++ b/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
@@ -17,7 +17,7 @@ export class VaFeaturedContent {
   @Prop() uswds?: boolean = false;
 
   /**
-   * Local State for slot=headline's text.
+   * Local state for slot=headline's text.
    * Used to place an aria-label for role="region" with the same text as the heading.
    */
   @State() headlineText: string = null;
@@ -26,7 +26,7 @@ export class VaFeaturedContent {
 
   componentWillLoad() {
     let childElements = Array.from(this.el.children);
-    this.headlineText = childElements.find(element => element.slot === "headline").textContent;
+    this.headlineText = childElements.find(element => element.slot === "headline").textContent.trim();
   }
 
   componentDidLoad() {

--- a/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
+++ b/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { Component, Host, h, Prop, State, Element } from '@stencil/core';
 
 /**
  * @componentName Featured content
@@ -16,7 +16,18 @@ export class VaFeaturedContent {
    */
   @Prop() uswds?: boolean = false;
 
+  /**
+   * Local State for slot=headline's text.
+   * Used to place an aria-label for role="region" with the same text as the heading.
+   */
+  @State() headlineText: string = null;
+
   @Element() el: HTMLElement;
+
+  componentWillLoad() {
+    let childElements = Array.from(this.el.children);
+    this.headlineText = childElements.find(element => element.slot === "headline").textContent;
+  }
 
   componentDidLoad() {
     if (!this.uswds) {
@@ -37,7 +48,7 @@ export class VaFeaturedContent {
     if (uswds) {
       return (
         <Host>
-          <div class="usa-summary-box" role="region">
+          <div class="usa-summary-box" role="region" aria-label={this.headlineText}>
             <div class="usa-summary-box__body">
               <slot name="headline"></slot>
               <slot />


### PR DESCRIPTION
## Chromatic
<!-- This `featured-content-region-label` is a placeholder for a CI job - it will be updated automatically -->
https://featured-content-region-label--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2322

- This adds an `aria-label` for the `role="region"` attribute. This gives the landmark a name, which comes in use when there are multiple regions on one page.
- To test this, certain browser/screen reader combos have to be used per [W3C - See **User Agent and Assistive Technology Support Notes**](https://www.w3.org/WAI/GL/wiki/Using_the_region_role_to_identify_a_region_of_the_page). I did a before and after using Safari and VoiceOver (see screenshots).


## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

**Before**
<img width="1792" alt="image" src="https://github.com/department-of-veterans-affairs/component-library/assets/100248909/7f5e3e2f-b42e-4ceb-ac81-040edaffa9ad">


**After**
<img width="1792" alt="image" src="https://github.com/department-of-veterans-affairs/component-library/assets/100248909/476801c8-e9e8-475c-9d20-98b4afc925c7">


## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens
  - No visual changes

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
