### PR TITLE
adds util function to  wrap slot assignedElementts

### DIFF
--- a/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
+++ b/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
@@ -1,4 +1,5 @@
 import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { wrapAndAddClass, createNewBlankDiv} from '../../utils/shadow-wrapper';
 
 /**
  * @componentName Featured content
@@ -24,12 +25,18 @@ export class VaFeaturedContent {
     }
     // add uswds classes
     const nodes = this.el.shadowRoot
-      .querySelectorAll('slot')
+      .querySelectorAll('slot');
+    // instead of adding class to the slot
+    // we assign a new blank div element to it, as a placeholder
+    nodes.forEach(slot=>createNewBlankDiv(this, slot.name))
+  
     const headline = nodes[0];
     const content = nodes[1];
-    
-    headline.classList.add('usa-summary-box__heading');
-    content.classList.add('usa-summary-box__text');
+    //here we take the placeholder element,
+    // move the original content inside and apply the class
+    // the styles should now apply from the light dom
+    wrapAndAddClass(headline,'usa-summary-box__heading');
+    wrapAndAddClass(content, 'usa-summary-box__text');
   }
 
   render() {

--- a/packages/web-components/src/utils/shadow-wrapper.ts
+++ b/packages/web-components/src/utils/shadow-wrapper.ts
@@ -1,0 +1,20 @@
+export const wrapAndAddClass = (slot, clss) => {
+  const children = slot.assignedElements();
+  const wrapper = children.at(-1);
+  wrapper.classList.add(clss);
+  wrapper.name = undefined;
+  for (let i = 0, l = children.length - 1; i < l; i++) {
+    wrapper.appendChild(children[i]);
+  }
+};
+
+export const createNewBlankDiv = (el, nme, abortIf = []) => {
+  if (abortIf.includes(nme)) {
+    return;
+  }
+  const divElement = document.createElement('div');
+  if (nme) {
+    divElement.slot = nme;
+  }
+  el.appendChild(divElement);
+};


### PR DESCRIPTION
A test solution to:
When creating v3/USWDS components, we import USWDS styles and apply them by marking up the component with USWDS classes (starting with usa-). However, when we accept slot content it is isolated from outside styles, including USWDS, and so the content remains unstyled.

In this attempt, I assign a new blank div element to assigned content, then attach the classes to it, and NOT the slot.

[https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2298](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2298)