### PR TITLE
[Mobile Design System] Include .json in NPM dist

### DIFF
--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -4,7 +4,8 @@
   "packageManager": "yarn@3.2.0",
   "files": [
     "dist/**/*.css",
-    "dist/**/*.scss"
+    "dist/**/*.scss",
+    "dist/**/*.json"
   ],
   "scripts": {
     "build:tokens": "style-dictionary build",


### PR DESCRIPTION
## Chromatic
<!-- This `narin-mobile-tokens` is a placeholder for a CI job - it will be updated automatically -->
https://narin-mobile-tokens--60f9b557105290003b387cd5.chromatic.com

---
<!-- ## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete -->

## Description


The mobile design system team would like to be able to reference the design tokens that live in `css-library`. Our plan is to add `css-library` as a dependency to our component library and convert the `.json` outputted by `build:tokens` into TypeScript for our needs. 

However `css-library`'s `package.json` is currently configured to only expose `.scss` and `.css` files to NPM. I believe the change in this PR and an additional minor/patch release would be all that is needed for us to begin this process.

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
