### PR TITLE
update core to 34.1.0 and css-library to 0.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "34.0.0",
+  "version": "34.1.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/css-library",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packageManager": "yarn@3.2.0",
   "files": [
     "dist/**/*.css",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,7 +1920,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@department-of-veterans-affairs/css-library@^0.2.0, @department-of-veterans-affairs/css-library@workspace:packages/css-library":
+"@department-of-veterans-affairs/css-library@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@department-of-veterans-affairs/css-library@npm:0.0.1"
+  dependencies:
+    "@divriots/style-dictionary-to-figma": ^0.4.0
+  checksum: 20ef0f4690babc8da12508d7b66af455bf7545011fca97dce90d2716aa873da4756f1e49951fe7748aea76484f479438db8c7356a6d82336ecb75de00f3be2ba
+  languageName: node
+  linkType: hard
+
+"@department-of-veterans-affairs/css-library@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@department-of-veterans-affairs/css-library@npm:0.2.0"
+  dependencies:
+    "@divriots/style-dictionary-to-figma": ^0.4.0
+  checksum: cd1a106bbf988d447ff20c881ef5be9648bdcad3d67b21eb8debee116d93df795ce99729761748dfc32e021d18d2dd64937e0da4159a8f4790ce224208c7c0b4
+  languageName: node
+  linkType: hard
+
+"@department-of-veterans-affairs/css-library@workspace:packages/css-library":
   version: 0.0.0-use.local
   resolution: "@department-of-veterans-affairs/css-library@workspace:packages/css-library"
   dependencies:
@@ -1930,15 +1948,6 @@ __metadata:
     style-dictionary: ^3.8.0
   languageName: unknown
   linkType: soft
-
-"@department-of-veterans-affairs/css-library@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@department-of-veterans-affairs/css-library@npm:0.0.1"
-  dependencies:
-    "@divriots/style-dictionary-to-figma": ^0.4.0
-  checksum: 20ef0f4690babc8da12508d7b66af455bf7545011fca97dce90d2716aa873da4756f1e49951fe7748aea76484f479438db8c7356a6d82336ecb75de00f3be2ba
-  languageName: node
-  linkType: hard
 
 "@department-of-veterans-affairs/formation@npm:^10.1.0":
   version: 10.1.0


### PR DESCRIPTION
## Description
Updates core to 34.1.0 and css library to 0.3.0

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
