### PR TITLE
moves contents of slot elements into shadow DOM

### DIFF
--- a/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
+++ b/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
@@ -14,6 +14,16 @@ export class VaFeaturedContent {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
+
+  /**
+   *  In styleUrl,  import/prep pertinent styles.
+   *  Those are rules any that begin with:
+   *  .usa-summary-box__heading,
+   *  .usa-summary-box__text 
+   *  Please note any styles that rely on ancesters
+   *  of the above will not be applied
+   **/
+
   @Prop() uswds?: boolean = false;
 
   @Element() el: HTMLElement;
@@ -30,6 +40,11 @@ export class VaFeaturedContent {
     
     headline.classList.add('usa-summary-box__heading');
     content.classList.add('usa-summary-box__text');
+    // Here I move the content of each of 
+    // the targeted slot elements into the shadow DOM
+    headline.append(...headline.assignedElements());
+    content.append(...content.assignedElements());
+
   }
 
   render() {


### PR DESCRIPTION
A test solution to:
When creating v3/USWDS components, we import USWDS styles and apply them by marking up the component with USWDS classes (starting with usa-). However, when we accept slot content it is isolated from outside styles, including USWDS, and so the content remains unstyled.

In this attempt, I move the content of pertinent slots, into the shadow DOM. This allows all the shadow DOM custom HTML element styles to apply, at the cost of  having those slots (behavior wise).

Consequently, the desired styles need to be imported into the custom HTML element. Also note  that as such selectors with ancestor to the desired classes will not be honored.

[https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2298](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2298)