### PR TITLE
update formation@10.1.2

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-components",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "description": "VA.gov component library in React",
   "keywords": [
     "react",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -50,7 +50,7 @@
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/preset-env": "^7.12.10",
     "@babel/preset-react": "^7.14.5",
-    "@department-of-veterans-affairs/formation": "^10.1.0",
+    "@department-of-veterans-affairs/formation": "^10.1.2",
     "@department-of-veterans-affairs/web-components": "workspace:packages/web-components",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.2.1",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",
-    "@department-of-veterans-affairs/formation": "^10.1.0",
+    "@department-of-veterans-affairs/formation": "^10.1.2",
     "@mdx-js/react": "^1.6.22",
     "@storybook/addon-a11y": "6.4.19",
     "@storybook/addon-actions": "^6.4.19",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.4.0",
     "@babel/core": "^7.12.13",
-    "@department-of-veterans-affairs/formation": "^10.1.0",
+    "@department-of-veterans-affairs/formation": "^10.1.2",
     "@stencil/postcss": "^2.0.0",
     "@stencil/react-output-target": "^0.0.9",
     "@stencil/sass": "^2.0.0",
@@ -62,7 +62,7 @@
     "typescript": "^4.3.5"
   },
   "peerDependencies": {
-    "@department-of-veterans-affairs/formation": "^10.1.0",
+    "@department-of-veterans-affairs/formation": "^10.1.2",
     "i18next": "*",
     "i18next-browser-languagedetector": "*"
   }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.54.1",
+  "version": "4.54.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,9 +1949,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@department-of-veterans-affairs/formation@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "@department-of-veterans-affairs/formation@npm:10.1.0"
+"@department-of-veterans-affairs/formation@npm:^10.1.2":
+  version: 10.1.2
+  resolution: "@department-of-veterans-affairs/formation@npm:10.1.2"
   dependencies:
     "@fortawesome/fontawesome-free": ^5.15.4
     domready: ^1.0.8
@@ -1961,7 +1961,7 @@ __metadata:
     "@fortawesome/fontawesome-free": ^5.15.4
     foundation-sites: 5
     uswds: ^1.6.10
-  checksum: 524525c099f20627a6fa87df75d49cd330ebb7b81c66169099f36fc02c3c0348cda38ee16bf25520514d70b938242b5d3dfc3c493ea9c47097d8d9c7f96bebd1
+  checksum: a319fee5ea7ef0cd415e0732fd1075ce1528cb73a42aa7dbe3ba59d8f2b3cfc9a692ea877335bb5b75cc371741281965b8014d9cb79ece48e68f5c53bb5f1f3a
   languageName: node
   linkType: hard
 
@@ -1982,7 +1982,7 @@ __metadata:
     "@babel/plugin-syntax-import-meta": ^7.10.4
     "@babel/preset-env": ^7.12.10
     "@babel/preset-react": ^7.14.5
-    "@department-of-veterans-affairs/formation": ^10.1.0
+    "@department-of-veterans-affairs/formation": ^10.1.2
     "@department-of-veterans-affairs/web-components": "workspace:packages/web-components"
     "@testing-library/react": ^12.0.0
     "@testing-library/user-event": ^13.2.1
@@ -2039,7 +2039,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.15.8
     "@department-of-veterans-affairs/component-library": "workspace:packages/core"
-    "@department-of-veterans-affairs/formation": ^10.1.0
+    "@department-of-veterans-affairs/formation": ^10.1.2
     "@mdx-js/react": ^1.6.22
     "@storybook/addon-a11y": 6.4.19
     "@storybook/addon-actions": ^6.4.19
@@ -2068,7 +2068,7 @@ __metadata:
     "@axe-core/puppeteer": ^4.4.0
     "@babel/core": ^7.12.13
     "@department-of-veterans-affairs/css-library": ^0.2.0
-    "@department-of-veterans-affairs/formation": ^10.1.0
+    "@department-of-veterans-affairs/formation": ^10.1.2
     "@stencil/core": ^2.19.2
     "@stencil/postcss": ^2.0.0
     "@stencil/react-output-target": ^0.0.9
@@ -2096,7 +2096,7 @@ __metadata:
     react-dom: ^16.7.0
     typescript: ^4.3.5
   peerDependencies:
-    "@department-of-veterans-affairs/formation": ^10.1.0
+    "@department-of-veterans-affairs/formation": ^10.1.2
     i18next: "*"
     i18next-browser-languagedetector: "*"
   languageName: unknown


### PR DESCRIPTION
## Chromatic
<!-- This `2321-link-active-color` is a placeholder for a CI job - it will be updated automatically -->
https://2321-link-active-color--60f9b557105290003b387cd5.chromatic.com

## Description
Update formation to 10.1.2
This version fixes a bug with the active state of links where the background color was set instead of the text color causing the text to not be visible.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2321

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
before:
![image](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/de20733b-2eac-438c-9638-ce1cc2a78a47)

after:
![image](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/1c8af7b4-8768-41a0-ac48-d62eac60771c)

## Acceptance criteria
- [x ] QA checklist has been completed
- [x ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x ] Documentation has been updated, if applicable
- [x ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
