### PR TITLE
va-file-input test updates

### DIFF
--- a/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
+++ b/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
@@ -88,7 +88,7 @@ describe('va-file-input', () => {
 
   it('emits the vaChange event only once', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-file-input buttonText="Upload a file" />`);
+    await page.setContent(`<va-file-input button-text="Upload a file" />`);
 
     const fileUploadSpy = await page.spyOnEvent('vaChange');
     const filePath = path.relative(process.cwd(), __dirname + '/1x1.png');
@@ -209,16 +209,13 @@ describe('va-file-input', () => {
 
     const fileUploadSpy = await page.spyOnEvent('vaChange');
     const filePath = path.relative(process.cwd(), __dirname + '/1x1.png');
-    const input = (
-      await page.waitForFunction(() =>
-        document
-          .querySelector('va-file-input')
-          .shadowRoot.querySelector('input[type=file]'),
-      )
-    ).asElement();
+    const instructions = await page.find('va-file-input >>> .usa-file-input__instructions');
+    expect(instructions).not.toBeNull();
 
-    await input.uploadFile(filePath);
-    await page.waitForChanges();
+    const input = await page.$('pierce/.usa-file-input__input');
+    expect(input).not.toBeNull();
+
+    await input.uploadFile(filePath).catch((e) => console.log('uploadFile error', e));
 
     expect(fileUploadSpy).toHaveReceivedEventTimes(1);
   });

--- a/packages/web-components/src/components/va-file-input/va-file-input-upgrader.ts
+++ b/packages/web-components/src/components/va-file-input/va-file-input-upgrader.ts
@@ -572,19 +572,9 @@ export const fileInput = {
       );
 
       fileInputEl.addEventListener(
-        'change',
-        e => {
-          // Send off a change event that can be picked up and processed by the web component
-          const target = e.target as HTMLInputElement;
-          const inputId = target.getAttribute('data-input-id');
-          const changeEvent = new CustomEvent(`fileInputChange${inputId}`, {
-            detail: { files: target.files },
-          });
-          document.dispatchEvent(changeEvent);
-
-          handleUpload(e, fileInputEl, instructions, dropTarget);
-        },
-        false,
+        "change",
+        (e) => handleUpload(e, fileInputEl, instructions, dropTarget),
+        false
       );
     });
   },

--- a/packages/web-components/src/components/va-file-input/va-file-input.scss
+++ b/packages/web-components/src/components/va-file-input/va-file-input.scss
@@ -29,6 +29,11 @@ va-button {
 }
 
 /* V3/USWDS Styles */
+
+[hidden] {
+  display: none;
+}
+
 .usa-label--required,
 .usa-error-message {
   color: var(--v3-color-error-dark);

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -199,6 +199,7 @@ export class VaFileInput {
             accept={accept}
             multiple={multiple}
             aria-describedby={ariaDescribedbyIds}
+            onChange = {this.handleChange}
           />
         </Host>
       );

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -132,41 +132,22 @@ export class VaFileInput {
     return this.buttonText ? this.buttonText : 'Upload file';
   };
 
-  private handleFileInputChange = (e: Event | CustomEvent) => {
-    const files = (e as CustomEvent).detail.files;
-    this.handleChange(e, files);
-  };
-
   componentDidLoad() {
-    if (this.uswds === true) fileInput.init(this.el);
-  }
-
-  connectedCallback() {
-    if (this.uswds === true) {
-      // Generate and add a unique-ish id
-      const randomId = Math.floor(Math.random() * 10000);
-      this.changeListenerId = randomId;
-
-      document.addEventListener(
-        `fileInputChange${randomId}`,
-        this.handleFileInputChange,
-      );
+    if (this.uswds) {
+      fileInput.init(this.el);
     }
   }
 
-  disconnectedCallback() {
-    if (this.uswds === true) {
-      document.removeEventListener(
-        `fileInputChange${this.changeListenerId}`,
-        this.handleFileInputChange,
-      );
+
+  connectedCallback() {
+    if (this.uswds) {
+      this.el.addEventListener('change', this.handleChange);
     }
   }
 
   render() {
     const { label, name, required, accept, error, hint, multiple, uswds } =
       this;
-
     const text = this.getButtonText();
 
     if (uswds) {
@@ -218,7 +199,6 @@ export class VaFileInput {
             accept={accept}
             multiple={multiple}
             aria-describedby={ariaDescribedbyIds}
-            data-input-id={this.changeListenerId}
           />
         </Host>
       );

--- a/packages/web-components/src/global/_formation_overrides.scss
+++ b/packages/web-components/src/global/_formation_overrides.scss
@@ -565,4 +565,16 @@
   &__instructions {
     padding: rem-override(2rem) rem-override(1rem);
   }
+  &__preview {
+    padding: rem-override(0.25rem) rem-override(0.5rem);
+    font-size: rem-override(0.87rem);
+  }
+  &__preview-image--generic {
+    background-size: rem-override(1.5rem);
+  }
+  &__preview-image {
+    height: rem-override(2.5rem);
+    margin-right: rem-override(0.5rem);
+    width: rem-override(2.5rem);
+  }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `1500-file-input-v3-update` is a placeholder for a CI job - it will be updated automatically -->
https://1500-file-input-v3-update--60f9b557105290003b387cd5.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
