### PR TITLE
Update references for testing single components in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This will allow you to run Storybook locally to view all components
 
 ### Running tests for web components
 
-To run units for the web-components project, the commands are:
+To run unit tests for all components, the commands are:
 
 ```bash
 yarn test
@@ -125,20 +125,20 @@ and
 yarn test.watch
 ```
 
-In order to a single file, you can run:
+To test a single file, run:
 
 ```bash
-npx stencil test --e2e -- src/components/[component-name]/[component-name].e2e.ts
+npx stencil test --e2e -- src/components/[component-name]/test/[component-name].e2e.ts
 ```
 
 Replace `[component-name]` with the name of the component you want to test. Optionally, you can add `--watchAll` after `--e2e` to watch the file for changes. For example:
 
 ```bash
-npx stencil test --e2e --watchAll -- src/components/[component-name]/[component-name].e2e.ts
+npx stencil test --e2e --watchAll -- src/components/[component-name]/test/[component-name].e2e.ts
 ```
 
-Another option is to use wildcards to query for certain tests. For example, to run all tests for the `va-alert` component, you can run:
+Another option is to use wildcards to query for certain tests. For example, to run all tests for the `va-accordion` component, you can run:
 
 ```bash
-npx stencil test --e2e  -- src/components/va-accordion/va-accordion-*
+npx stencil test --e2e  -- src/components/va-accordion/test/va-accordion-*
 ```


### PR DESCRIPTION
## Chromatic
<!-- This `update-readme-testing` is a placeholder for a CI job - it will be updated automatically -->
https://update-readme-testing--60f9b557105290003b387cd5.chromatic.com

## Description
This fixes some of the Stencil testing references so that it points to the correct file path. Also minor grammar updates to the section.

## Screenshots
![Screenshot 2024-01-17 at 10 44 53 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/39d3f579-bc5c-40e9-badf-508ea1a24c5a)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
