### PR TITLE
va-checkbox-group, va-radio - move hint to legend

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.55.0",
+  "version": "4.55.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox-group/test/va-checkbox-group.e2e.ts
@@ -45,7 +45,7 @@ describe('va-checkbox-group', () => {
     await page.setContent('<va-checkbox-group hint="This is hint text" />');
 
     // Render the hint text
-    const hintTextElement = await page.find('va-checkbox-group >>> span.hint-text');
+    const hintTextElement = await page.find('va-checkbox-group >>> div.hint-text');
     expect(hintTextElement.innerText).toContain('This is hint text');
   });
 

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
@@ -135,8 +135,8 @@ export class VaCheckboxGroup {
                 label
               )}&nbsp;
               {required && <span class="usa-label--required">{i18next.t('required')}</span>}
+              {hint && <div class="usa-hint">{hint}</div>}
             </legend>
-            {hint && <span class="usa-hint">{hint}</span>}
             <span id="checkbox-error-message" role="alert">
               {error && (
                 <Fragment>
@@ -162,8 +162,9 @@ export class VaCheckboxGroup {
               {required && (
                 <span class="required">{i18next.t('required')}</span>
               )}
+              {hint && <div class="hint-text">{hint}</div>}
             </legend>
-            {hint && <span class="hint-text">{hint}</span>}
+            
             <span id="error-message" role="alert">
               {error && (
                 <Fragment>

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -251,8 +251,9 @@ export class VaRadio {
                   {i18next.t('required')}
                 </span>
               )}
+              {hint && <div class="usa-hint">{hint}</div>}
             </legend>
-            {hint && <span class="usa-hint">{hint}</span>}
+            
             <span class="usa-error-message" role="alert">
               {error && (
                 <Fragment>
@@ -284,8 +285,8 @@ export class VaRadio {
                   {i18next.t('required')}
                 </span>
               )}
+              {hint && <div class="hint-text">{hint}</div>}
             </legend>
-            {hint && <span class="hint-text">{hint}</span>}
             <span id="error-message" role="alert">
               {error && (
                 <Fragment>


### PR DESCRIPTION
## Chromatic
<!-- This `2342-sr-hint-text` is a placeholder for a CI job - it will be updated automatically -->
https://2342-sr-hint-text--60f9b557105290003b387cd5.chromatic.com

## Description
Move hint text to legend for va-checkbox-group and va-radio. This will ensure that screen readers read the text along with the label.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2342

## QA Checklist
- [x ] Component maintains 1:1 parity with design mocks
- [x ] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x ] Designer has signed off on changes (if applicable. If not applicable provide reason why) - No visual changes
- [x ] Tab order and focus state work as expected
- [x ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
- No visual changes

## Acceptance criteria
- [x ] QA checklist has been completed
- [NA ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x ] Documentation has been updated, if applicable
- [x ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
