### PR TITLE
va-card: add prop to display a gray background

### DIFF
--- a/packages/storybook/stories/va-card.stories.jsx
+++ b/packages/storybook/stories/va-card.stories.jsx
@@ -17,13 +17,16 @@ export default {
 
 const defaultArgs = {
   'show-shadow': false,
+  background: false,
 };
 
 const Template = ({
   'show-shadow': showShadow,
+  background: background,
 }) => (
   <va-card
     show-shadow={showShadow}
+    background={background}
   >
     <p>Example card content</p>
   </va-card>
@@ -34,6 +37,12 @@ Default.args = {
   ...defaultArgs,
 };
 Default.argTypes = propStructure(cardDocs);
+
+export const withBackground = Template.bind(null);
+withBackground.args = {
+  ...defaultArgs,
+  background: true,
+};
 
 export const withDropShadow = Template.bind(null);
 withDropShadow.args = {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.55.0",
+  "version": "4.56.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -260,6 +260,10 @@ export namespace Components {
     }
     interface VaCard {
         /**
+          * If `true`, the card will have a gray background.
+         */
+        "background"?: boolean;
+        /**
           * If `true`, a drop-shadow will be displayed
          */
         "showShadow"?: boolean;
@@ -2144,6 +2148,10 @@ declare namespace LocalJSX {
         "uswds"?: boolean;
     }
     interface VaCard {
+        /**
+          * If `true`, the card will have a gray background.
+         */
+        "background"?: boolean;
         /**
           * If `true`, a drop-shadow will be displayed
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -264,7 +264,7 @@ export namespace Components {
          */
         "background"?: boolean;
         /**
-          * If `true`, a drop-shadow will be displayed
+          * If `true`, a drop-shadow will be displayed with a white background.
          */
         "showShadow"?: boolean;
     }
@@ -2153,7 +2153,7 @@ declare namespace LocalJSX {
          */
         "background"?: boolean;
         /**
-          * If `true`, a drop-shadow will be displayed
+          * If `true`, a drop-shadow will be displayed with a white background.
          */
         "showShadow"?: boolean;
     }

--- a/packages/web-components/src/components/va-card/test/va-card.e2e.ts
+++ b/packages/web-components/src/components/va-card/test/va-card.e2e.ts
@@ -9,7 +9,7 @@ describe('va-card', () => {
         const element = await page.find('va-card');
     
         expect(element).toEqualHtml(`
-            <va-card class="hydrated va-card">
+            <va-card class="hydrated">
                 <mock:shadow-root>
                     <slot></slot>
                 </mock:shadow-root>
@@ -19,14 +19,27 @@ describe('va-card', () => {
         expect(element).not.toHaveClass('show-shadow');
     }); 
 
-    it('renders box shadow', async () => {
+    it('displays a box shadow', async () => {
         const page = await newE2EPage();
     
-        await page.setContent('<va-card show-shadow="true"></va-card>');
-        const element = await page.find('va-card');
-    
-        expect(element).toHaveClass('show-shadow');
+        await page.setContent('<va-card show-shadow></va-card>');
+        const element = await page.find('va-card')
 
+        expect((await element.getComputedStyle()).boxShadow).toEqual(
+            'rgba(0, 0, 0, 0.32) 1px 1px 5px 1px',
+          );
+    });
+
+    it('displays a gray background', async () => {
+        const page = await newE2EPage();
+    
+        await page.setContent('<va-card background></va-card>');
+        const element = await page.find('va-card')
+
+        // --color-gray-lightest which is #f0f0f0 and also rgb(240, 240, 240)
+        expect((await element.getComputedStyle()).backgroundColor).toEqual(
+            'rgb(240, 240, 240)',
+          );
     });
 
     it('passes an axe check', async () => {

--- a/packages/web-components/src/components/va-card/test/va-card.e2e.ts
+++ b/packages/web-components/src/components/va-card/test/va-card.e2e.ts
@@ -19,7 +19,7 @@ describe('va-card', () => {
         expect(element).not.toHaveClass('show-shadow');
     }); 
 
-    it('displays a box shadow', async () => {
+    it('displays a box shadow when show-shadow prop is set', async () => {
         const page = await newE2EPage();
     
         await page.setContent('<va-card show-shadow></va-card>');
@@ -30,7 +30,7 @@ describe('va-card', () => {
           );
     });
 
-    it('displays a gray background', async () => {
+    it('displays a gray background when background prop is set', async () => {
         const page = await newE2EPage();
     
         await page.setContent('<va-card background></va-card>');
@@ -39,6 +39,17 @@ describe('va-card', () => {
         // --color-gray-lightest which is #f0f0f0 and also rgb(240, 240, 240)
         expect((await element.getComputedStyle()).backgroundColor).toEqual(
             'rgb(240, 240, 240)',
+          );
+    });
+
+    it('displays a white background when show-shadow and background is set', async () => {
+        const page = await newE2EPage();
+    
+        await page.setContent('<va-card show-shadow background></va-card>');
+        const element = await page.find('va-card')
+
+        expect((await element.getComputedStyle()).backgroundColor).toEqual(
+            'rgb(255, 255, 255)',
           );
     });
 

--- a/packages/web-components/src/components/va-card/va-card.scss
+++ b/packages/web-components/src/components/va-card/va-card.scss
@@ -5,6 +5,10 @@
   padding: 16px;
 }
 
-:host([show-shadow='true']) {
+:host([show-shadow]:not([show-shadow='false'])) {
   box-shadow: 1px 1px 5px 1px rgba(0, 0, 0, 0.32);
+}
+
+:host([background]:not([background='false'])) {
+  background-color: var(--color-gray-lightest);
 }

--- a/packages/web-components/src/components/va-card/va-card.scss
+++ b/packages/web-components/src/components/va-card/va-card.scss
@@ -11,4 +11,5 @@
 
 :host([background]:not([background='false'])) {
   background-color: var(--color-gray-lightest);
+  border: none;
 }

--- a/packages/web-components/src/components/va-card/va-card.scss
+++ b/packages/web-components/src/components/va-card/va-card.scss
@@ -5,8 +5,12 @@
   padding: 16px;
 }
 
-:host([show-shadow]:not([show-shadow='false'])) {
+:host([show-shadow]:not([show-shadow='false'])),
+// Do not allow a gray background when show-shadow is true
+:host([show-shadow]:not([show-shadow='false'])[background]:not([background='false'])) {
   box-shadow: 1px 1px 5px 1px rgba(0, 0, 0, 0.32);
+  border: 1px solid var(--color-gray-medium);
+  background-color: var(--color-white);
 }
 
 :host([background]:not([background='false'])) {

--- a/packages/web-components/src/components/va-card/va-card.tsx
+++ b/packages/web-components/src/components/va-card/va-card.tsx
@@ -4,7 +4,6 @@ import {
   Prop, 
   h 
 } from '@stencil/core';
-import classnames from 'classnames';
 
 /**
  * @componentName Card
@@ -23,15 +22,14 @@ export class VaCard {
    */
   @Prop() showShadow?: boolean = false;
 
+  /**
+   * If `true`, the card will have a gray background.
+   */
+  @Prop() background?: boolean = false;
+
   render() {
-    const {
-      showShadow
-    } = this;
-
-    const classes = classnames('va-card',  {'show-shadow': showShadow});
-
     return (
-      <Host class={classes}>
+      <Host>
         <slot></slot>
       </Host>
     );

--- a/packages/web-components/src/components/va-card/va-card.tsx
+++ b/packages/web-components/src/components/va-card/va-card.tsx
@@ -18,7 +18,7 @@ import {
 })
 export class VaCard {
   /**
-   * If `true`, a drop-shadow will be displayed
+   * If `true`, a drop-shadow will be displayed with a white background.
    */
   @Prop() showShadow?: boolean = false;
 

--- a/packages/web-components/src/components/va-notification/test/va-notification.e2e.ts
+++ b/packages/web-components/src/components/va-notification/test/va-notification.e2e.ts
@@ -11,7 +11,7 @@ describe('va-notification', () => {
     expect(element).toEqualHtml(`
       <va-notification class="hydrated" has-border="" headline="Notification heading" date-time="Tuesday, July 18">
         <mock:shadow-root>
-          <va-card show-shadow="true" class="hydrated show-shadow va-card">
+          <va-card show-shadow="true" class="hydrated">
             <div class="va-notification none has-border">
               <i aria-hidden="true" role="img" class="none"></i>
               <div class="body" role="presentation">


### PR DESCRIPTION
## Chromatic
<!-- This `2403-va-card-gray-prop` is a placeholder for a CI job - it will be updated automatically -->
https://2403-va-card-gray-prop--60f9b557105290003b387cd5.chromatic.com/?path=/docs/components-va-card--default

## Description
This PR adds a `background` prop to va-card that applies a gray background. It also refactors some of the style and classes to simplify the component.

Figma: https://www.figma.com/file/afurtw4iqQe6y4gXfNfkkk/VADS-Component-Library?type=design&node-id=2795-113&mode=design&t=iGMBkLHNOAVT7XSa-0

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2403

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


![Screenshot 2024-01-18 at 12 55 03 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/1490f5ca-7c04-4c39-8863-3ff6c4242d37)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
