### PR TITLE
va-alert: fix close button position on full-width

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.55.0",
+  "version": "4.55.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-alert/va-alert.scss
+++ b/packages/web-components/src/components/va-alert/va-alert.scss
@@ -79,8 +79,8 @@
 
 @media screen and (min-width: 1024px) {
 
-  :host([full-width='true']) .va-alert-close,
-  :host([full-width='']) .va-alert-close {
+  :host(:not([uswds='true'], [uswds='']))[full-width='true'] .va-alert-close,
+  :host(:not([uswds='true'], [uswds='']))[full-width=''] .va-alert-close {
     position: relative;
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `2354-va-alert` is a placeholder for a CI job - it will be updated automatically -->
https://2354-va-alert--60f9b557105290003b387cd5.chromatic.com

---
## Description
This ticket addresses a bug in the v3 `va-alert` component. When the `full-width` and `closeable` attributes are set, the close button is rendered below the alert. This change preserves the button's `absolute` position when `full-width` is true, so that it is positioned correctly.

Closes [2354](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2354)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

Before:

<img width="1104" alt="Screenshot 2024-01-19 at 1 42 09 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/e3957b4d-f629-4101-a9e5-b4cad67e5f4b">

After:
<img width="1259" alt="Screenshot 2024-01-19 at 12 40 09 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/31f5ffc1-8a7a-4481-94f5-3cb6b3cff0e9">

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
