### PR TITLE
va-radio: set display to block for .usa-hint class

### DIFF
--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
@@ -191,7 +191,7 @@ export class VaCheckboxGroup {
                   )
                 }
                 {required && <span class="usa-label--required">{i18next.t('required')}</span>}
-                {hint && <span class="usa-hint">{hint}</span>}
+                {hint && <div class="usa-hint">{hint}</div>}
               </legend>
               <span id="checkbox-error-message" role="alert">
                 {error && (

--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -49,7 +49,3 @@
   line-height: inherit;
   padding-inline: 0;
 }
-
-.usa-hint {
-  display: block;
-}

--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -49,3 +49,7 @@
   line-height: inherit;
   padding-inline: 0;
 }
+
+.usa-hint {
+  display: block;
+}

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -296,7 +296,7 @@ export class VaRadio {
                       {i18next.t('required')}
                     </span>
                   )}
-                  {hint && <span class="usa-hint">{hint}</span>}
+                  {hint && <div class="usa-hint">{hint}</div>}
                 </legend>
               )}
               <span class="usa-error-message" role="alert">


### PR DESCRIPTION
## Chromatic
<!-- This `2269-radio-hint-text-fix` is a placeholder for a CI job - it will be updated automatically -->
https://2269-radio-hint-text-fix--60f9b557105290003b387cd5.chromatic.com

---
## Description
This pull request updates the CSS for the `va-radio` v3 hint element. The change involves setting the display property to block.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2269

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2024-01-30 at 12 49 45 PM](https://github.com/department-of-veterans-affairs/component-library/assets/22892911/e36806f8-590c-4cbf-9705-739fcad6f149)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
