### PR TITLE
cleanup: auto generated component type changes

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -622,10 +622,6 @@ export namespace Components {
     }
     interface VaMinimalFooter {
     }
-    interface VaMinimalHeader {
-        "header"?: string;
-        "subheader"?: string;
-    }
     interface VaModal {
         /**
           * Additional DOM-nodes that should not be hidden from screen readers. Useful when an open modal shouldn't hide all content behind the overlay.
@@ -1675,12 +1671,6 @@ declare global {
         prototype: HTMLVaMinimalFooterElement;
         new (): HTMLVaMinimalFooterElement;
     };
-    interface HTMLVaMinimalHeaderElement extends Components.VaMinimalHeader, HTMLStencilElement {
-    }
-    var HTMLVaMinimalHeaderElement: {
-        prototype: HTMLVaMinimalHeaderElement;
-        new (): HTMLVaMinimalHeaderElement;
-    };
     interface HTMLVaModalElement extends Components.VaModal, HTMLStencilElement {
     }
     var HTMLVaModalElement: {
@@ -1850,7 +1840,6 @@ declare global {
         "va-maintenance-banner": HTMLVaMaintenanceBannerElement;
         "va-memorable-date": HTMLVaMemorableDateElement;
         "va-minimal-footer": HTMLVaMinimalFooterElement;
-        "va-minimal-header": HTMLVaMinimalHeaderElement;
         "va-modal": HTMLVaModalElement;
         "va-need-help": HTMLVaNeedHelpElement;
         "va-notification": HTMLVaNotificationElement;
@@ -2609,10 +2598,6 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface VaMinimalFooter {
-    }
-    interface VaMinimalHeader {
-        "header"?: string;
-        "subheader"?: string;
     }
     interface VaModal {
         /**
@@ -3522,7 +3507,6 @@ declare namespace LocalJSX {
         "va-maintenance-banner": VaMaintenanceBanner;
         "va-memorable-date": VaMemorableDate;
         "va-minimal-footer": VaMinimalFooter;
-        "va-minimal-header": VaMinimalHeader;
         "va-modal": VaModal;
         "va-need-help": VaNeedHelp;
         "va-notification": VaNotification;
@@ -3577,7 +3561,6 @@ declare module "@stencil/core" {
             "va-maintenance-banner": LocalJSX.VaMaintenanceBanner & JSXBase.HTMLAttributes<HTMLVaMaintenanceBannerElement>;
             "va-memorable-date": LocalJSX.VaMemorableDate & JSXBase.HTMLAttributes<HTMLVaMemorableDateElement>;
             "va-minimal-footer": LocalJSX.VaMinimalFooter & JSXBase.HTMLAttributes<HTMLVaMinimalFooterElement>;
-            "va-minimal-header": LocalJSX.VaMinimalHeader & JSXBase.HTMLAttributes<HTMLVaMinimalHeaderElement>;
             "va-modal": LocalJSX.VaModal & JSXBase.HTMLAttributes<HTMLVaModalElement>;
             "va-need-help": LocalJSX.VaNeedHelp & JSXBase.HTMLAttributes<HTMLVaNeedHelpElement>;
             "va-notification": LocalJSX.VaNotification & JSXBase.HTMLAttributes<HTMLVaNotificationElement>;


### PR DESCRIPTION
## Chromatic
<!-- This `2393-header-minimal-clean-up` is a placeholder for a CI job - it will be updated automatically -->
https://2393-header-minimal-clean-up--60f9b557105290003b387cd5.chromatic.com

---
## Description
This pull request includes updates to the `components.d.ts` file, which contains auto-generated typings for our Stencil components.
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2393

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
