### PR TITLE
CSS Library: Add breakpoints

### DIFF
--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Jan 2024 20:32:33 GMT
+ * Generated on Wed, 31 Jan 2024 21:35:35 GMT
  */
 
 :root {
@@ -8,7 +8,6 @@
   --small-screen: 481px;
   --medium-screen: 640px;
   --small-desktop-screen: 1008px;
-  --medium-large-screen: 640px;
   --large-screen: 1201px;
   --color-base: #1b1b1b;
   --color-white: #ffffff;

--- a/packages/css-library/dist/tokens/json/variables.json
+++ b/packages/css-library/dist/tokens/json/variables.json
@@ -59,21 +59,6 @@
       "small-desktop-screen"
     ]
   },
-  "medium-large-screen": {
-    "value": "640px",
-    "filePath": "tokens/breakpoints.json",
-    "isSource": true,
-    "original": {
-      "value": "640px"
-    },
-    "name": "medium-large-screen",
-    "attributes": {
-      "category": "medium-large-screen"
-    },
-    "path": [
-      "medium-large-screen"
-    ]
-  },
   "large-screen": {
     "value": "1201px",
     "filePath": "tokens/breakpoints.json",

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,12 +1,11 @@
 
 // Do not edit directly
-// Generated on Tue, 30 Jan 2024 20:32:33 GMT
+// Generated on Wed, 31 Jan 2024 21:35:35 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;
 $medium-screen: 640px;
 $small-desktop-screen: 1008px;
-$medium-large-screen: 640px;
 $large-screen: 1201px;
 $color-base: #1b1b1b;
 $color-white: #ffffff;

--- a/packages/css-library/tokens/breakpoints.json
+++ b/packages/css-library/tokens/breakpoints.json
@@ -11,9 +11,6 @@
   "small-desktop-screen": {
     "value": "1008px"
   },
-  "medium-large-screen": {
-    "value": "640px"
-  },
   "large-screen": {
     "value": "1201px"
   }


### PR DESCRIPTION
## Chromatic
<!-- This `2334-css-library-breakpoints` is a placeholder for a CI job - it will be updated automatically -->
https://2334-css-library-breakpoints--60f9b557105290003b387cd5.chromatic.com

## Description

This will add the key breakpoints of the designs system to the CSS Library. [They are located in Formation here](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation/sass/base/_b-breakpoints.scss#L27-L46).

Additionally, this will change the medium breakpoint from `768px` to `640px` based on the [rollout guidance](https://vfs.atlassian.net/wiki/spaces/DST/pages/2731245815/DR001+VA+Design+System+v3+upgrade+rollout+steps).

![Screenshot 2024-01-30 at 12 02 26 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/af3edc8b-b8af-4a5d-95d8-d34e7d0765b3)

- Image Reference: https://design.va.gov/foundation/breakpoints#names-and-values

closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2334

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
