### PR TITLE
Set the uswds prop's default value to true for all compoents with a v…

### DIFF
--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -87,6 +87,7 @@ export const parameters = {
       order: [
         'About',
         ['Introduction'],
+        'USWDS',
         'Components',
         'Under development',
         'Deprecated',

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.59.0",
+  "version": "5.0.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -58,7 +58,7 @@ export class VaAccordionItem {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Local State for slot=headline replacement of props (header).

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -67,7 +67,7 @@ export class VaAccordion {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * If `true`, doesn't fire the CustomEvent which can be used for analytics tracking.

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
@@ -33,7 +33,7 @@ export class VaAdditionalInfo {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
   /**
    * If `true`, doesn't fire the CustomEvent which can be used for analytics tracking.
    */

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -74,7 +74,7 @@ export class VaAlert {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Displays the slim variation. Available when USWDS is true.

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -31,7 +31,7 @@ export class VaBreadcrumbs {
   /**
      * Whether or not the component will use USWDS v3 styling.
      */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
   /**
    *  Whether or not the component will wrap the breadcrumbs. This prop is available when `uswds` is set to `true`.
    */

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
@@ -45,7 +45,7 @@ export class VaButtonPair {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Fires when the primary button is clicked.

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
@@ -66,7 +66,7 @@ export class VaCheckboxGroup {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Insert a header with defined level inside the label (legend)

--- a/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
+++ b/packages/web-components/src/components/va-featured-content/va-featured-content.tsx
@@ -14,7 +14,7 @@ export class VaFeaturedContent {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Local state for slot=headline's text.

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -76,7 +76,7 @@ export class VaFileInput {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * The event emitted when the file input value changes.

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -58,7 +58,7 @@ export class VaMemorableDate {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Enabling this will add a heading and description for integrating into the forms pattern. Accepts `single` or `multiple` to indicate if the form is a single input or will have multiple inputs. `uswds` should be true.

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -124,7 +124,7 @@ export class VaModal {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Whether or not the component will be forced to take action.

--- a/packages/web-components/src/components/va-number-input/va-number-input.tsx
+++ b/packages/web-components/src/components/va-number-input/va-number-input.tsx
@@ -109,7 +109,7 @@ export class VaNumberInput {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Enabling this will add a heading and description for integrating into the forms pattern. Accepts `single` or `multiple` to indicate if the form is a single input or will have multiple inputs. `uswds` should be true.

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -93,7 +93,7 @@ export class VaPagination {
   /**
   * Whether or not the component will use USWDS v3 styling.
   */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * If the page total is less than or equal to this limit, show all pages.

--- a/packages/web-components/src/components/va-privacy-agreement/va-privacy-agreement.tsx
+++ b/packages/web-components/src/components/va-privacy-agreement/va-privacy-agreement.tsx
@@ -24,7 +24,7 @@ export class VaPrivacyAgreement {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
   /**
    * Emit component-library-analytics events on the blur event.
    */

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -40,7 +40,7 @@ export class VaRadioOption {
   /**
    * Whether or not the component will use USWDS v3. styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Whether or not the component will display as a tile. Available when uswds is true.

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -69,7 +69,7 @@ export class VaRadio {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-   @Prop() uswds?: boolean = false;
+   @Prop() uswds?: boolean = true;
 
   /**
    * Insert a header with defined level inside the label (legend)

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -76,7 +76,7 @@ export class VaSearchInput {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * If `true`, the component will use the big variant. Only available when `uswds` is `true`.

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -92,7 +92,7 @@ export class VaTextarea {
   /**
    * Whether or not the component will use USWDS v3 styling.
    */
-  @Prop() uswds?: boolean = false;
+  @Prop() uswds?: boolean = true;
 
   /**
    * Enabling this will add a heading and description for integrating into the forms pattern. Accepts `single` or `multiple` to indicate if the form is a single input or will have multiple inputs. `uswds` should be true.


### PR DESCRIPTION
…3 version

## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com

---
## Configuring this pull request

## Description
This PR sets the default value for the `uswds` prop to true for all components with a v3 variant. It also moves up v3 stories to the top of the sidebar in Storybook.

Closes [2405](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2405)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
