### PR TITLE
va-file-input: stop multiple file drag and drop

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "4.59.1",
+  "version": "4.59.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-file-input/va-file-input-upgrader.ts
+++ b/packages/web-components/src/components/va-file-input/va-file-input-upgrader.ts
@@ -547,7 +547,7 @@ export const fileInput = {
   init(root: HTMLElement) {
     selectOrMatches(DROPZONE, root).forEach(fileInputEl => {
       const { instructions, dropTarget } = enhanceFileInput(fileInputEl);
-
+            
       dropTarget.addEventListener(
         'dragover',
         function handleDragOver() {
@@ -566,15 +566,20 @@ export const fileInput = {
 
       dropTarget.addEventListener(
         'drop',
-        function handleDrop(e) {
+        function handleDrop(e) {          
           e.preventDefault(); // Prevents browser from opening file instead of adding it to input
           this.classList.remove(DRAG_CLASS);
-
+          
           // Because of the way 'drop' works differently from 'change', need to get files from the dataTransfer object
           const dt = e.dataTransfer;
           (e.target as HTMLInputElement).files = dt.files;
+          
+          // Don't allow user to drop multiple files
+          if (dt.files.length > 1) {
+            return;
+          }
           handleUpload(e, fileInputEl, instructions, dropTarget);
-
+          
           // Because we're preventing the default behavior, need to manually fire off a change event
           const changeEvent = new CustomEvent('change', {
             detail: { files: dt.files },


### PR DESCRIPTION
## Chromatic
<!-- This `2479-drag-drop-bug` is a placeholder for a CI job - it will be updated automatically -->
https://2479-drag-drop-bug--60f9b557105290003b387cd5.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
This PR fixes a bug that allowed a user to drag and drop multiple files onto the input after which the first file would be added and the others discarded. But the desired behavior is for all files to be rejected in this case, ie we don't support multiple files at this time.

Closes [2479](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2479)

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

Before:

https://github.com/department-of-veterans-affairs/component-library/assets/8867779/3307fe83-c818-4f7d-babe-5d2b43359086

After:

https://github.com/department-of-veterans-affairs/component-library/assets/8867779/3736a465-119a-4708-8c02-89c0f1890db1


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
