### PR TITLE
va-file-input: Add focus border, fix input alignment, and update error state

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-file-input/va-file-input.scss
+++ b/packages/web-components/src/components/va-file-input/va-file-input.scss
@@ -4,15 +4,21 @@
 @use 'usa-label/src/styles/usa-label';
 @use 'usa-hint/src/styles/usa-hint';
 @use 'uswds-helpers/src/styles/usa-sr-only';
+
 @import '../../mixins/uswds-error-border.scss';
 @import '../../global/formation_overrides';
+@import '../../mixins/focusable.css';
 
-/* V3/USWDS Styles */
 [hidden] {
   display: none;
 }
 
-/* Original Styles */
+.usa-file-input__input {
+  box-sizing: border-box; // Formation override.
+  font-family: var(--font-source-sans);
+}
+
+/** Original Component Style **/
 @import '../../mixins/accessibility.css';
 @import '../../mixins/form-field-error.css';
 @import '../../mixins/hint-text.css';

--- a/packages/web-components/src/components/va-file-input/va-file-input.scss
+++ b/packages/web-components/src/components/va-file-input/va-file-input.scss
@@ -18,6 +18,11 @@
   font-family: var(--font-source-sans);
 }
 
+:host([error]:not([error=''])) .usa-file-input__target {
+  border-color: var(--color-secondary-dark);
+  border-width: 2px;
+}
+
 /** Original Component Style **/
 @import '../../mixins/accessibility.css';
 @import '../../mixins/form-field-error.css';

--- a/packages/web-components/src/components/va-file-input/va-file-input.scss
+++ b/packages/web-components/src/components/va-file-input/va-file-input.scss
@@ -14,7 +14,7 @@
 }
 
 .usa-file-input__input {
-  box-sizing: border-box; // Formation override.
+  box-sizing: inherit;
   font-family: var(--font-source-sans);
 }
 

--- a/packages/web-components/src/components/va-file-input/va-file-input.scss
+++ b/packages/web-components/src/components/va-file-input/va-file-input.scss
@@ -14,7 +14,7 @@
 }
 
 .usa-file-input__input {
-  box-sizing: inherit;
+  box-sizing: border-box;
   font-family: var(--font-source-sans);
 }
 

--- a/packages/web-components/src/global/_settings.scss
+++ b/packages/web-components/src/global/_settings.scss
@@ -2,5 +2,4 @@
   $theme-image-path: '../../../../../node_modules/@uswds/uswds/dist/img/',
   $theme-font-type-sans: 'source-sans-pro', // Formation override.
   $theme-font-sans-custom-stack: '"Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans', // Formation override.
-  $theme-global-border-box-sizing: true,
 );

--- a/packages/web-components/src/global/_settings.scss
+++ b/packages/web-components/src/global/_settings.scss
@@ -2,4 +2,5 @@
   $theme-image-path: '../../../../../node_modules/@uswds/uswds/dist/img/',
   $theme-font-type-sans: 'source-sans-pro', // Formation override.
   $theme-font-sans-custom-stack: '"Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans', // Formation override.
+  $theme-global-border-box-sizing: true,
 );


### PR DESCRIPTION
## Chromatic
<!-- This `2441-file-input` is a placeholder for a CI job - it will be updated automatically -->
https://2441-file-input--60f9b557105290003b387cd5.chromatic.com

## Description

Figma: https://www.figma.com/file/afurtw4iqQe6y4gXfNfkkk/VADS-Component-Library?node-id=199%3A1212&mode=dev
USWDS Example: https://designsystem.digital.gov/components/file-input/

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2441

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

**Focus Before**

![Screenshot 2024-02-16 at 12 47 23 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/a908526f-6cb1-4650-b192-c8649c9778ce)

**Focus After**

![Screenshot 2024-02-16 at 12 49 15 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/71a5c85d-ba42-4aa9-b900-0902c1cd942a)

**Error Before**

<img width="552" alt="Screenshot 2024-02-16 at 2 36 50 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/872479/688f72e0-64b4-4947-8240-7ddda91c1333">

**Error After**

<img width="551" alt="Screenshot 2024-02-16 at 2 37 33 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/872479/8d1b443f-0a4d-4b55-a9d7-0fa6d21f34a7">

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
