### PR TITLE
va-pagination: remove active button background color, override overflow opacity

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-pagination/va-pagination.scss
+++ b/packages/web-components/src/components/va-pagination/va-pagination.scss
@@ -15,9 +15,8 @@
   a.usa-pagination__previous-page > div {
     display: flex;
   }
-
-  .usa-pagination .usa-current {
-    background-color: var(--color-primary);
+  .usa-pagination__overflow {
+    opacity: inherit;
   }
 }
 

--- a/packages/web-components/src/components/va-pagination/va-pagination.scss
+++ b/packages/web-components/src/components/va-pagination/va-pagination.scss
@@ -15,6 +15,7 @@
   a.usa-pagination__previous-page > div {
     display: flex;
   }
+  // ToDo: remove this when USWDS package is updated
   .usa-pagination__overflow {
     opacity: inherit;
   }


### PR DESCRIPTION
## Chromatic
<!-- This `2420-pagination-btn-active-color` is a placeholder for a CI job - it will be updated automatically -->
https://2420-pagination-btn-active-color--60f9b557105290003b387cd5.chromatic.com

## Description
Update to sync style for va-pagination with USWDS
- Remove override that made the active page background color blue
- Override overflow opacity to match current USWDS style

USWDS Reference: https://designsystem.digital.gov/components/pagination/
Closes: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2420

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ na - no accessibility changes] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

Before:
![Screenshot 2024-02-16 at 2 04 17 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/1f373b95-72db-40af-938e-ed4b9675e7c1)


After:
![Screenshot 2024-02-16 at 2 03 41 PM](https://github.com/department-of-veterans-affairs/component-library/assets/1776069/dab41551-ab8e-4c43-8995-a187a2bdf40b)


## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
