### PR TITLE
va-file-input: Fix for screen readers not reading changed file name

### DIFF
--- a/packages/web-components/src/components/va-file-input/va-file-input-upgrader.ts
+++ b/packages/web-components/src/components/va-file-input/va-file-input-upgrader.ts
@@ -395,7 +395,7 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
       );
     };
 
-    // Not all files will be able to generate previews. In case this happens, we provide several types "generic previews" based on the file extension.
+    // Not all files will be able to generate previews. In case this happens, we provide several types of "generic previews" based on the file extension.
     reader.onloadend = function createFilePreview() {
       const previewImage = dropTarget.querySelector(
         `#${imageId}`,
@@ -547,7 +547,7 @@ export const fileInput = {
   init(root: HTMLElement) {
     selectOrMatches(DROPZONE, root).forEach(fileInputEl => {
       const { instructions, dropTarget } = enhanceFileInput(fileInputEl);
-            
+
       dropTarget.addEventListener(
         'dragover',
         function handleDragOver() {
@@ -566,20 +566,20 @@ export const fileInput = {
 
       dropTarget.addEventListener(
         'drop',
-        function handleDrop(e) {          
+        function handleDrop(e) {
           e.preventDefault(); // Prevents browser from opening file instead of adding it to input
           this.classList.remove(DRAG_CLASS);
-          
+
           // Because of the way 'drop' works differently from 'change', need to get files from the dataTransfer object
           const dt = e.dataTransfer;
           (e.target as HTMLInputElement).files = dt.files;
-          
+
           // Don't allow user to drop multiple files
           if (dt.files.length > 1) {
             return;
           }
           handleUpload(e, fileInputEl, instructions, dropTarget);
-          
+
           // Because we're preventing the default behavior, need to manually fire off a change event
           const changeEvent = new CustomEvent('change', {
             detail: { files: dt.files },

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -97,12 +97,6 @@ export class VaFileInput {
   private handleChange = (e: Event, files?: any) => {
     const target = e.target as HTMLInputElement;
     this.vaChange.emit({ files: target.files || files });
-    /**
-     * Clear the original input, otherwise events will be triggered
-     * with empty file arrays and sometimes uploading a file twice will
-     * not work.
-     */
-    target.value = null;
 
     if (this.enableAnalytics) {
       this.componentLibraryAnalytics.emit({


### PR DESCRIPTION
## Chromatic
<!-- This `2442-file-input-a11y` is a placeholder for a CI job - it will be updated automatically -->
https://2442-file-input-a11y--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes [#2442](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2442)

Removes legacy code that was unnecessarily 'deleting' the file input's chosen file, thus preventing screen readers from reading out that a file was selected.

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
  - No design changes
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No design changes

## Acceptance criteria
- [ ] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
