### PR TITLE
va-maintenance-banner: Removing maintenance banner's banner role

### DIFF
--- a/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
+++ b/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
@@ -17,7 +17,7 @@ describe('USWDS maintenance-banner', () => {
     expect(element).toEqualHtml(`
       <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" maintenance-end-date-time="${expiresAt}" maintenance-title="Site maintenance" maintenance-start-date-time="${startsAt}" upcoming-warn-start-date-time="${startsAt}" upcoming-warn-title="Upcoming site maintenance">
         <mock:shadow-root>
-          <div class="maintenance-banner maintenance-banner--error" role="banner">
+          <div class="maintenance-banner maintenance-banner--error">
             <div class="maintenance-banner__body">
               <h4 class="maintenance-banner__title">
                 Site maintenance
@@ -31,13 +31,17 @@ describe('USWDS maintenance-banner', () => {
                   <strong>
                     Date:
                   </strong>
-                    ${formatDate(startsAt, {dateStyle: 'full'})}
+                    ${formatDate(startsAt, { dateStyle: 'full' })}
                   </p>
                 <p>
                   <strong>
                     Time:
                   </strong>
-                    ${formatDate(startsAt, {hour:'numeric', minute: 'numeric', timeZoneName: 'short'})}
+                    ${formatDate(startsAt, {
+                      hour: 'numeric',
+                      minute: 'numeric',
+                      timeZoneName: 'short',
+                    })}
                   </p>
                   <p>
                     <strong>
@@ -51,7 +55,7 @@ describe('USWDS maintenance-banner', () => {
                 <i aria-hidden="true"></i>
               </button>
             </div>
-            
+
           </div>
         </mock:shadow-root>
         <div slot="maintenance-content">
@@ -117,7 +121,7 @@ describe('USWDS maintenance-banner', () => {
     expect(element).toEqualHtml(`
       <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" maintenance-end-date-time="${expiresAt}" maintenance-title="Site maintenance" maintenance-start-date-time="${startsAt}" upcoming-warn-start-date-time="${warnStartsAt}" upcoming-warn-title="Upcoming site maintenance">
         <mock:shadow-root>
-          <div class="maintenance-banner maintenance-banner--warning" role="banner">
+          <div class="maintenance-banner maintenance-banner--warning">
             <div class="maintenance-banner__body">
               <h4 class="maintenance-banner__title">
                 Upcoming site maintenance
@@ -131,13 +135,17 @@ describe('USWDS maintenance-banner', () => {
                   <strong>
                     Date:
                   </strong>
-                    ${formatDate(startsAt, {dateStyle: 'full'})}
+                    ${formatDate(startsAt, { dateStyle: 'full' })}
                   </p>
                 <p>
                   <strong>
                     Time:
                   </strong>
-                    ${formatDate(startsAt, {hour:'numeric', minute: 'numeric', timeZoneName: 'short'})}
+                    ${formatDate(startsAt, {
+                      hour: 'numeric',
+                      minute: 'numeric',
+                      timeZoneName: 'short',
+                    })}
                   </p>
                   <p>
                     <strong>

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
@@ -152,12 +152,12 @@ export class VaMaintenanceBanner {
 
       return (
         <Host>
-            <div class={maintenanceBannerClass} role="banner" ref={el => (this.maintenanceBannerEl = el as HTMLDivElement)}>
+            <div class={maintenanceBannerClass} ref={el => (this.maintenanceBannerEl = el as HTMLDivElement)}>
                 <div class="maintenance-banner__body">
                   <h4 class="maintenance-banner__title">{isWarning ? upcomingWarnTitle : maintenanceTitle}</h4>
-                  <div class="maintenance-banner__content" ref={el => (this.maintenanceBannerContent = el as HTMLDivElement)}>{ 
-                    isWarning ? 
-                      <slot name="warn-content"></slot> : 
+                  <div class="maintenance-banner__content" ref={el => (this.maintenanceBannerContent = el as HTMLDivElement)}>{
+                    isWarning ?
+                      <slot name="warn-content"></slot> :
                       <slot name="maintenance-content"></slot>
                   }</div>
                   <div class="maintenance-banner__derived-content">{this.derivePostContent(new Date(maintenanceStartDateTime), new Date(maintenanceEndDateTime))}</div>
@@ -170,13 +170,13 @@ export class VaMaintenanceBanner {
                     <i aria-hidden="true" />
                 </button>
                 </div>
-                
+
             </div>
         </Host>
       )
     } else {
       return null
     }
-    
+
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `2429-maint-banner-role` is a placeholder for a CI job - it will be updated automatically -->
https://2429-maint-banner-role--60f9b557105290003b387cd5.chromatic.com

---

## Description
Closes [#2429](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2429)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No design changes.

## Acceptance criteria
- [ ] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
