### PR TITLE
DO-NOT-MERGE: Test PR to see if Chromatic integration is working

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 ## Chromatic
 <!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
-https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com
+https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com
 
 ---
 ## Configuring this pull request
 - [ ] Link to any related issues in the description so they can be cross-referenced.
-- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
+- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
     - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
     - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
 - [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.


### PR DESCRIPTION
## Chromatic
<!-- This `9999-chromatic-test-pr` is a placeholder for a CI job - it will be updated automatically -->
https://9999-chromatic-test-pr--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Just a test PR to see that the new Chromatic integration is working.

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
