### PR TITLE
Updating Chromatic Link in Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 ## Chromatic
 <!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
-https://{{head.ref}}--60f9b557105290003b387cd5.chromatic.com
+https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com
 
 ---
 ## Configuring this pull request
 - [ ] Link to any related issues in the description so they can be cross-referenced.
-- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`). 
+- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
     - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
     - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
 - [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.


### PR DESCRIPTION
## Chromatic
<!-- This `2481-update-chromatic` is a placeholder for a CI job - it will be updated automatically -->
https://2481-update-chromatic--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
Closes [#2481](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2481)

This PR updates the pull request template to utilize the new Chromatic App ID.

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
