### PR TITLE
va-radio-option: revert z-index and add Formation style overrides for USWDS

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -19,7 +19,7 @@ va-radio-option {
   margin-top: 12px;
 }
 
-:host([uswds]:not([uswds='false'])) input[type=radio] {
+input[type=radio].usa-radio__input {
   margin-left: unset;
   opacity: unset;
   right: auto;

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -19,8 +19,11 @@ va-radio-option {
   margin-top: 12px;
 }
 
-va-radio-option input {
-  z-index: -1;
+:host([uswds]:not([uswds='false'])) input[type=radio] {
+  margin-left: unset;
+  opacity: unset;
+  right: auto;
+  left: -999em;
 }
 
 va-radio-option input:focus {


### PR DESCRIPTION
## Chromatic
<!-- This `2491-va-radio-input` is a placeholder for a CI job - it will be updated automatically -->
https://2491-va-radio-input--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
This will resolve the issue of Formation input styles overriding the USWDS style for the va-radio-option `input` element. The previous solution that added a negative `z-index` caused issue with Cypress testing and it also doesn't follow the USWDS original styles.

USWDS reference: https://designsystem.digital.gov/components/radio-buttons/

related issue https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2491
related pr https://github.com/department-of-veterans-affairs/component-library/pull/1053

**before**

![before](https://github.com/department-of-veterans-affairs/component-library/assets/872479/841abd15-db39-4493-a78a-2d763b53704c)

**after**

![after](https://github.com/department-of-veterans-affairs/component-library/assets/872479/9069969c-e41a-44aa-938c-92415f1d02e8)


## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
