### PR TITLE
Fixes error when  no headline slot is passed

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-summary-box/va-summary-box.tsx
+++ b/packages/web-components/src/components/va-summary-box/va-summary-box.tsx
@@ -26,24 +26,29 @@ export class VaSummaryBox {
 
   componentWillLoad() {
     let childElements = Array.from(this.el.children);
-    this.headlineText = childElements.find(element => element.slot === "headline").textContent.trim();
+    this.headlineText =
+      childElements
+        .find(element => element.slot === 'headline')
+        ?.textContent.trim() || null;
   }
 
   componentDidLoad() {
     if (!this.uswds) {
-      return
+      return;
     }
     // add uswds classes
-    const nodes = this.el.shadowRoot
-      .querySelectorAll('slot')
+    const nodes = this.el.shadowRoot.querySelectorAll('slot');
     const headline = nodes[0];
     const content = nodes[1];
-    
+
     headline.classList.add('usa-summary-box__heading');
     content.classList.add('usa-summary-box__text');
 
     let childElements = Array.from(this.el.children);
-    this.headlineText = childElements.find(element => element.slot === "headline").textContent.trim();
+    this.headlineText =
+      childElements
+        .find(element => element.slot === 'headline')
+        ?.textContent.trim() || null;
   }
 
   render() {
@@ -51,7 +56,11 @@ export class VaSummaryBox {
     if (uswds) {
       return (
         <Host>
-          <div class="usa-summary-box" role="region" aria-label={this.headlineText}>
+          <div
+            class="usa-summary-box"
+            role="region"
+            aria-label={this.headlineText}
+          >
             <div class="usa-summary-box__body">
               <slot name="headline"></slot>
               <slot />


### PR DESCRIPTION
## Chromatic
<!-- This `2557-rm-no-headline-fix` is a placeholder for a CI job - it will be updated automatically -->
https://2557-rm-no-headline-fix--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes [2557](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2557)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
