### PR TITLE
va-accordion: remove Font Awesome icon override

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.scss
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.scss
@@ -34,19 +34,6 @@
   max-width: 64ex;
 }
 
-/**
-  Override to use font awesome icons
-*/
-.usa-accordion__button[aria-expanded=false] {
-  background-image: url("data:image/svg+xml,%3C%3Fxml version%3D%221.0%22 encoding%3D%22UTF-8%22%3F%3E%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width%3D%2264%22 height%3D%2264%22 viewBox%3D%220 0 64 64%22%3E%3Ctitle%3Eplus%3C%2Ftitle%3E%3Cpath fill%3D%22%23171717%22 fill-rule%3D%22evenodd%22 d%3D%22M36 0c1.111 0 2.056.425 2.833 1.272.778.849 1.166 1.88 1.166 3.091V24h19.636c1.125 0 2.095.335 2.907 1.006l.184.16c.849.778 1.272 1.723 1.272 2.834v8c0 1.112-.425 2.057-1.272 2.834-.849.778-1.88 1.166-3.091 1.166H39.999v19.636c0 1.125-.335 2.094-1.006 2.906l-.16.185c-.778.848-1.722 1.272-2.833 1.272h-8.001c-1.111 0-2.056-.424-2.834-1.272-.778-.849-1.166-1.88-1.166-3.09V39.998H4.363c-1.125 0-2.094-.335-2.906-1.006l-.185-.16C.424 38.054 0 37.11 0 36v-8.001c0-1.111.424-2.056 1.272-2.834C2.121 24.387 3.152 24 4.363 24H24V4.363c0-1.125.335-2.094 1.006-2.906l.16-.185C25.944.423 26.889 0 28 0z%22%2F%3E%3C%2Fsvg%3E");
-  background-size: 1.5rem;
-}
-
-.usa-accordion__button[aria-expanded=true] {
-  background-image: url("data:image/svg+xml,%3C%3Fxml version%3D%221.0%22 encoding%3D%22UTF-8%22%3F%3E%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width%3D%2264%22 height%3D%2216%22 viewBox%3D%220 0 64 16%22%3E%3Ctitle%3Eminus%3C%2Ftitle%3E%3Cpath fill%3D%22%23171717%22 fill-rule%3D%22evenodd%22 d%3D%22M62.726 1.167C61.878.389 60.846 0 59.636 0H4.362C3.151 0 2.12.388 1.272 1.166.422 1.944 0 2.888 0 4v8c0 1.112.424 2.056 1.272 2.833.849.778 1.88 1.167 3.091 1.167h55.272c1.211 0 2.242-.388 3.091-1.167.847-.777 1.272-1.72 1.272-2.832V4c0-1.111-.423-2.056-1.272-2.833z%22%2F%3E%3C%2Fsvg%3E");
-  background-size: 1.5rem;
-}
-
 /** Original Component Style **/
 
 :host {


### PR DESCRIPTION
## Chromatic
<!-- This `000-va-accordion-icon-hover` is a placeholder for a CI job - it will be updated automatically -->
https://000-va-accordion-icon-hover--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
This PR will update the accordion open/close icons from Font Awesome to the USWDS icons.

reference: [Slack thread](https://dsva.slack.com/archives/C01DBGX4P45/p1710200196112369)
see: [USWDS Accordion Component](https://designsystem.digital.gov/components/accordion/)
closes: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2578

**before**

![Screenshot 2024-03-12 at 9 57 20 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/06954b54-f42e-435d-a1aa-cd2c6aabfb8a)



**after**

![Screenshot 2024-03-12 at 9 55 56 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/bb6683c5-81a8-4908-a26b-801021e272b9)


## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
