### PR TITLE
Add css-library label to release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,3 +15,6 @@ changelog:
     - title: Other Changes
       labels:
         - "*"
+    - title: CSS Library
+      labels:
+        - css-library


### PR DESCRIPTION
## Chromatic
<!-- This `000-css-library-release-notes` is a placeholder for a CI job - it will be updated automatically -->
https://000-css-library-release-notes--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This will update our release yml file so that any PRs that have the label `css-library` will be in its own section in the release notes. This is intended to be a bridge solution until we have more time to integrate a longer term release notes management approach.

## Screenshots

The release notes should look something like this when CSS Library PRs are labeled with `css-library`:

![Screenshot 2024-03-19 at 9 53 43 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/0f15beb4-7ce2-424d-8446-15333dcaa906)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
