### PR TITLE
va-checkbox: Add part attribute to label and description

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -242,7 +242,7 @@ export class VaCheckbox {
             <label htmlFor="checkbox-element" id="option-label" class="usa-checkbox__label" part="label">
               {label}&nbsp;
               {required && <span class="usa-label--required">{i18next.t('required')}</span>}
-              {checkboxDescription && <span class="usa-checkbox__label-description" aria-describedby="option-label">{checkboxDescription}</span>}
+              {checkboxDescription && <span class="usa-checkbox__label-description" aria-describedby="option-label" part="description">{checkboxDescription}</span>}
             </label>
             {messageAriaDescribedby && (
               <span id='input-message' class="sr-only dd-privacy-hidden">

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -239,7 +239,7 @@ export class VaCheckbox {
               disabled={disabled}
               onChange={this.handleChange}
             />
-            <label htmlFor="checkbox-element" id="option-label" class="usa-checkbox__label">
+            <label htmlFor="checkbox-element" id="option-label" class="usa-checkbox__label" part="label">
               {label}&nbsp;
               {required && <span class="usa-label--required">{i18next.t('required')}</span>}
               {checkboxDescription && <span class="usa-checkbox__label-description" aria-describedby="option-label">{checkboxDescription}</span>}


### PR DESCRIPTION
## Chromatic
<!-- This `Add-label-prop-to-va-checkbox` is a placeholder for a CI job - it will be updated automatically -->
https://Add-label-prop-to-va-checkbox--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2606

Added label prop to allow bold label for va-checkbox 

## Screenshots
There is no UI change for this, a "label" prop was added to the component. We can then reference this prop in a CSS file to make a custom bold label.
