### PR TITLE
Update accordion styling

### DIFF
--- a/packages/storybook/stories/va-accordion-uswds.stories.jsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.jsx
@@ -49,7 +49,7 @@ const Template = args => (
 const BorderedTemplate = args => {
   return (
     <va-accordion {...args}>
-      <va-accordion-item id="first" bordered="true" header="First Amendment" uswds>
+      <va-accordion-item id="first" bordered="true" header="First Amendment">
           <p>
             Congress shall make no law respecting an establishment of religion, or
             prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -57,13 +57,13 @@ const BorderedTemplate = args => {
             petition the Government for a redress of grievances.
           </p>
       </va-accordion-item>
-      <va-accordion-item id="second" bordered="true" header="Second Amendment" uswds>
+      <va-accordion-item id="second" bordered="true" header="Second Amendment">
           <p>
             A well regulated Militia, being necessary to the security of a free State,
             the right of the people to keep and bear Arms, shall not be infringed.
           </p>
       </va-accordion-item>
-      <va-accordion-item id="third" bordered="true" header="Third Amendment" uswds>
+      <va-accordion-item id="third" bordered="true" header="Third Amendment">
           <p>
             No Soldier shall, in time of peace be quartered in any house, without the
             consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
@@ -75,7 +75,7 @@ const BorderedTemplate = args => {
 
 const TemplateSubheader = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment" subheader="Subheader" uswds>
+    <va-accordion-item id="first" header="First Amendment" subheader="Subheader">
         <p>
           Congress shall make no law respecting an establishment of religion, or
           prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -83,13 +83,13 @@ const TemplateSubheader = args => (
           petition the Government for a redress of grievances.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment" subheader="Subheader" uswds>
+    <va-accordion-item id="second" header="Second Amendment" subheader="Subheader">
         <p>
           A well regulated Militia, being necessary to the security of a free State,
           the right of the people to keep and bear Arms, shall not be infringed.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment" subheader="Subheader" uswds>
+    <va-accordion-item id="third" header="Third Amendment" subheader="Subheader">
         <p>
           No Soldier shall, in time of peace be quartered in any house, without the
           consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
@@ -100,7 +100,7 @@ const TemplateSubheader = args => (
 
 const TemplateIconHeaders = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment" subheader="Subheader" uswds>
+    <va-accordion-item id="first" header="First Amendment" subheader="Subheader">
       <i slot="icon" className="fas fa-info-circle vads-u-color--green"/>
       <i aria-hidden="true" className="fas fa-envelope" slot="subheader-icon"/>
       <p>
@@ -110,7 +110,7 @@ const TemplateIconHeaders = args => (
         petition the Government for a redress of grievances.
       </p>
     </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment" subheader="Subheader" uswds>
+    <va-accordion-item id="second" header="Second Amendment" subheader="Subheader">
       <i slot="icon" className="fas fa-info-circle vads-u-color--green"/>
       <i aria-hidden="true" className="fas fa-envelope" slot="subheader-icon"/>
       <p>
@@ -118,7 +118,7 @@ const TemplateIconHeaders = args => (
         the right of the people to keep and bear Arms, shall not be infringed.
       </p>
     </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment" subheader="Subheader" uswds>
+    <va-accordion-item id="third" header="Third Amendment" subheader="Subheader">
       <i slot="icon" className="fas fa-info-circle vads-u-color--green"/>
       <i aria-hidden="true" className="fas fa-envelope" slot="subheader-icon"/>
       <p>
@@ -131,7 +131,7 @@ const TemplateIconHeaders = args => (
 
 const TemplateHeadlineSlot = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first" uswds>
+    <va-accordion-item id="first">
       <h6 slot="headline">First Amendment</h6>
       <p>
         Congress shall make no law respecting an establishment of religion, or
@@ -140,14 +140,14 @@ const TemplateHeadlineSlot = args => (
         petition the Government for a redress of grievances.
       </p>
     </va-accordion-item>
-    <va-accordion-item id="second" uswds>
+    <va-accordion-item id="second">
       <h6 slot="headline">Second Amendment</h6>
       <p>
         A well regulated Militia, being necessary to the security of a free State,
         the right of the people to keep and bear Arms, shall not be infringed.
       </p>
     </va-accordion-item>
-    <va-accordion-item id="third" uswds>
+    <va-accordion-item id="third">
       <h6 slot="headline">Third Amendment</h6>
       <p>
         No Soldier shall, in time of peace be quartered in any house, without the
@@ -160,7 +160,7 @@ const TemplateHeadlineSlot = args => (
 
 const TemplateLevel = args => (
   <va-accordion {...args}>
-    <va-accordion-item level="5" id="first" header="First Amendment" uswds>
+    <va-accordion-item level="5" id="first" header="First Amendment">
       <p>
         Congress shall make no law respecting an establishment of religion, or
         prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -168,13 +168,13 @@ const TemplateLevel = args => (
         petition the Government for a redress of grievances.
       </p>
     </va-accordion-item>
-    <va-accordion-item level="5" id="second" header="Second Amendment" uswds>
+    <va-accordion-item level="5" id="second" header="Second Amendment">
       <p>
         A well regulated Militia, being necessary to the security of a free State,
         the right of the people to keep and bear Arms, shall not be infringed.
       </p>
     </va-accordion-item>
-    <va-accordion-item level="5" id="third" header="Third Amendment" uswds>
+    <va-accordion-item level="5" id="third" header="Third Amendment">
         <p>
           No Soldier shall, in time of peace be quartered in any house, without the
           consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
@@ -195,8 +195,8 @@ const I18nTemplate = args => {
       <va-button onClick={e => setLang('es')} text="Español"/>
       <va-button onClick={e => setLang('en')} text="English"/>
       <va-button onClick={e => setLang('tl')} text="Tagalog"/>
-      <va-accordion uswds>
-        <va-accordion-item id="first" header="First Amendment" uswds>
+      <va-accordion>
+        <va-accordion-item id="first" header="First Amendment">
           <p>
             Congress shall make no law respecting an establishment of religion, or
             prohibiting the free exercise thereof; or abridging the freedom of
@@ -204,14 +204,14 @@ const I18nTemplate = args => {
             assemble, and to petition the Government for a redress of grievances.
           </p>
         </va-accordion-item>
-        <va-accordion-item id="second" header="Second Amendment" uswds>
+        <va-accordion-item id="second" header="Second Amendment">
           <p>
             A well regulated Militia, being necessary to the security of a free
             State, the right of the people to keep and bear Arms, shall not be
             infringed.
           </p>
         </va-accordion-item>
-        <va-accordion-item id="third" header="Third Amendment" uswds>
+        <va-accordion-item id="third" header="Third Amendment">
           <p>
             No Soldier shall, in time of peace be quartered in any house, without
             the consent of the Owner, nor in time of war, but in a manner to be
@@ -225,7 +225,7 @@ const I18nTemplate = args => {
 
 const ManyItemsTemplate = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment" uswds>
+    <va-accordion-item id="first" header="First Amendment">
         <p>
           Congress shall make no law respecting an establishment of religion, or
           prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -233,26 +233,26 @@ const ManyItemsTemplate = args => (
           petition the Government for a redress of grievances.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment" uswds>
+    <va-accordion-item id="second" header="Second Amendment">
         <p>
           A well regulated Militia, being necessary to the security of a free State,
           the right of the people to keep and bear Arms, shall not be infringed.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment" uswds>
+    <va-accordion-item id="third" header="Third Amendment">
         <p>
           No Soldier shall, in time of peace be quartered in any house, without the
           consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="fourth" header="Fourth Amendment" uswds>
+    <va-accordion-item id="fourth" header="Fourth Amendment">
         <p>
         The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures,
         shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly
         describing the place to be searched, and the persons or things to be seized.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="fifth" header="Fifth Amendment" uswds>
+    <va-accordion-item id="fifth" header="Fifth Amendment">
         <p>
         No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury,
         except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger;
@@ -261,7 +261,7 @@ const ManyItemsTemplate = args => (
         shall private property be taken for public use, without just compensation.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="sixth" header="Sixth Amendment" uswds>
+    <va-accordion-item id="sixth" header="Sixth Amendment">
         <p>
         In all criminal prosecutions, the accused shall enjoy the right to a speedy and public trial, by an impartial jury of the State
         and district wherein the crime shall have been committed, which district shall have been previously ascertained by law, and to
@@ -269,23 +269,23 @@ const ManyItemsTemplate = args => (
         for obtaining witnesses in his favor, and to have the Assistance of Counsel for his defence.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="seventh" header="Seventh Amendment" uswds>
+    <va-accordion-item id="seventh" header="Seventh Amendment">
         <p>
         In Suits at common law, where the value in controversy shall exceed twenty dollars, the right of trial by jury shall be preserved,
         and no fact tried by a jury, shall be otherwise re-examined in any Court of the United States, than according to the rules of the common law.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="eighth" header="Eighth Amendment" uswds>
+    <va-accordion-item id="eighth" header="Eighth Amendment">
         <p>
         Excessive bail shall not be required, nor excessive fines imposed, nor cruel and unusual punishments inflicted.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="ninth" header="Ninth Amendment" uswds>
+    <va-accordion-item id="ninth" header="Ninth Amendment">
         <p>
         The enumeration in the Constitution, of certain rights, shall not be construed to deny or disparage others retained by the people.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="tenth" header="Tenth Amendment" uswds>
+    <va-accordion-item id="tenth" header="Tenth Amendment">
         <p>
         The powers not delegated to the United States by the Constitution, nor prohibited by it to the States, are reserved to the States respectively, or to the people.
         </p>

--- a/packages/storybook/stories/va-accordion-uswds.stories.jsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.jsx
@@ -23,7 +23,7 @@ export default {
 
 const Template = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment">
+    <va-accordion-item id="first" header="First Amendment" uswds={args.uswds}>
         <p>
           Congress shall make no law respecting an establishment of religion, or
           prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -31,25 +31,25 @@ const Template = args => (
           petition the Government for a redress of grievances.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment">
+    <va-accordion-item id="second" header="Second Amendment" uswds={args.uswds}>
         <p>
-          A well regulated Militia, being necessary to the security of a free State, 
+          A well regulated Militia, being necessary to the security of a free State,
           the right of the people to keep and bear Arms, shall not be infringed.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment">
+    <va-accordion-item id="third" header="Third Amendment" uswds={args.uswds}>
         <p>
-          No Soldier shall, in time of peace be quartered in any house, without the 
+          No Soldier shall, in time of peace be quartered in any house, without the
           consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
         </p>
     </va-accordion-item>
   </va-accordion>
 );
 
-const BorderedTemplate = args => {  
+const BorderedTemplate = args => {
   return (
     <va-accordion {...args}>
-      <va-accordion-item id="first" bordered="true" header="First Amendment">
+      <va-accordion-item id="first" bordered="true" header="First Amendment" uswds>
           <p>
             Congress shall make no law respecting an establishment of religion, or
             prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -57,15 +57,15 @@ const BorderedTemplate = args => {
             petition the Government for a redress of grievances.
           </p>
       </va-accordion-item>
-      <va-accordion-item id="second" bordered="true" header="Second Amendment">
+      <va-accordion-item id="second" bordered="true" header="Second Amendment" uswds>
           <p>
-            A well regulated Militia, being necessary to the security of a free State, 
+            A well regulated Militia, being necessary to the security of a free State,
             the right of the people to keep and bear Arms, shall not be infringed.
           </p>
       </va-accordion-item>
-      <va-accordion-item id="third" bordered="true" header="Third Amendment">
+      <va-accordion-item id="third" bordered="true" header="Third Amendment" uswds>
           <p>
-            No Soldier shall, in time of peace be quartered in any house, without the 
+            No Soldier shall, in time of peace be quartered in any house, without the
             consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
           </p>
       </va-accordion-item>
@@ -75,7 +75,7 @@ const BorderedTemplate = args => {
 
 const TemplateSubheader = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment" subheader="Subheader">
+    <va-accordion-item id="first" header="First Amendment" subheader="Subheader" uswds>
         <p>
           Congress shall make no law respecting an establishment of religion, or
           prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -83,15 +83,15 @@ const TemplateSubheader = args => (
           petition the Government for a redress of grievances.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment" subheader="Subheader">
+    <va-accordion-item id="second" header="Second Amendment" subheader="Subheader" uswds>
         <p>
-          A well regulated Militia, being necessary to the security of a free State, 
+          A well regulated Militia, being necessary to the security of a free State,
           the right of the people to keep and bear Arms, shall not be infringed.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment" subheader="Subheader">
+    <va-accordion-item id="third" header="Third Amendment" subheader="Subheader" uswds>
         <p>
-          No Soldier shall, in time of peace be quartered in any house, without the 
+          No Soldier shall, in time of peace be quartered in any house, without the
           consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
         </p>
     </va-accordion-item>
@@ -100,9 +100,9 @@ const TemplateSubheader = args => (
 
 const TemplateIconHeaders = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment" subheader="Subheader">
+    <va-accordion-item id="first" header="First Amendment" subheader="Subheader" uswds>
       <i slot="icon" className="fas fa-info-circle vads-u-color--green"/>
-      <i aria-hidden="true" className="fas fa-envelope" slot="subheader-icon"/>  
+      <i aria-hidden="true" className="fas fa-envelope" slot="subheader-icon"/>
       <p>
         Congress shall make no law respecting an establishment of religion, or
         prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -110,19 +110,19 @@ const TemplateIconHeaders = args => (
         petition the Government for a redress of grievances.
       </p>
     </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment" subheader="Subheader">
+    <va-accordion-item id="second" header="Second Amendment" subheader="Subheader" uswds>
       <i slot="icon" className="fas fa-info-circle vads-u-color--green"/>
-      <i aria-hidden="true" className="fas fa-envelope" slot="subheader-icon"/>  
+      <i aria-hidden="true" className="fas fa-envelope" slot="subheader-icon"/>
       <p>
-        A well regulated Militia, being necessary to the security of a free State, 
+        A well regulated Militia, being necessary to the security of a free State,
         the right of the people to keep and bear Arms, shall not be infringed.
       </p>
     </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment" subheader="Subheader">
+    <va-accordion-item id="third" header="Third Amendment" subheader="Subheader" uswds>
       <i slot="icon" className="fas fa-info-circle vads-u-color--green"/>
-      <i aria-hidden="true" className="fas fa-envelope" slot="subheader-icon"/>  
+      <i aria-hidden="true" className="fas fa-envelope" slot="subheader-icon"/>
       <p>
-        No Soldier shall, in time of peace be quartered in any house, without the 
+        No Soldier shall, in time of peace be quartered in any house, without the
         consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
       </p>
     </va-accordion-item>
@@ -131,7 +131,7 @@ const TemplateIconHeaders = args => (
 
 const TemplateHeadlineSlot = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first">
+    <va-accordion-item id="first" uswds>
       <h6 slot="headline">First Amendment</h6>
       <p>
         Congress shall make no law respecting an establishment of religion, or
@@ -140,17 +140,17 @@ const TemplateHeadlineSlot = args => (
         petition the Government for a redress of grievances.
       </p>
     </va-accordion-item>
-    <va-accordion-item id="second">
+    <va-accordion-item id="second" uswds>
       <h6 slot="headline">Second Amendment</h6>
       <p>
-        A well regulated Militia, being necessary to the security of a free State, 
+        A well regulated Militia, being necessary to the security of a free State,
         the right of the people to keep and bear Arms, shall not be infringed.
       </p>
     </va-accordion-item>
-    <va-accordion-item id="third">
+    <va-accordion-item id="third" uswds>
       <h6 slot="headline">Third Amendment</h6>
       <p>
-        No Soldier shall, in time of peace be quartered in any house, without the 
+        No Soldier shall, in time of peace be quartered in any house, without the
         consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
       </p>
     </va-accordion-item>
@@ -160,7 +160,7 @@ const TemplateHeadlineSlot = args => (
 
 const TemplateLevel = args => (
   <va-accordion {...args}>
-    <va-accordion-item level="5" id="first" header="First Amendment">
+    <va-accordion-item level="5" id="first" header="First Amendment" uswds>
       <p>
         Congress shall make no law respecting an establishment of religion, or
         prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -168,15 +168,15 @@ const TemplateLevel = args => (
         petition the Government for a redress of grievances.
       </p>
     </va-accordion-item>
-    <va-accordion-item level="5" id="second" header="Second Amendment">
+    <va-accordion-item level="5" id="second" header="Second Amendment" uswds>
       <p>
-        A well regulated Militia, being necessary to the security of a free State, 
+        A well regulated Militia, being necessary to the security of a free State,
         the right of the people to keep and bear Arms, shall not be infringed.
       </p>
     </va-accordion-item>
-    <va-accordion-item level="5" id="third" header="Third Amendment">
+    <va-accordion-item level="5" id="third" header="Third Amendment" uswds>
         <p>
-          No Soldier shall, in time of peace be quartered in any house, without the 
+          No Soldier shall, in time of peace be quartered in any house, without the
           consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
         </p>
     </va-accordion-item>
@@ -195,8 +195,8 @@ const I18nTemplate = args => {
       <va-button onClick={e => setLang('es')} text="Español"/>
       <va-button onClick={e => setLang('en')} text="English"/>
       <va-button onClick={e => setLang('tl')} text="Tagalog"/>
-      <va-accordion>
-        <va-accordion-item id="first" header="First Amendment">
+      <va-accordion uswds>
+        <va-accordion-item id="first" header="First Amendment" uswds>
           <p>
             Congress shall make no law respecting an establishment of religion, or
             prohibiting the free exercise thereof; or abridging the freedom of
@@ -204,14 +204,14 @@ const I18nTemplate = args => {
             assemble, and to petition the Government for a redress of grievances.
           </p>
         </va-accordion-item>
-        <va-accordion-item id="second" header="Second Amendment">
+        <va-accordion-item id="second" header="Second Amendment" uswds>
           <p>
             A well regulated Militia, being necessary to the security of a free
             State, the right of the people to keep and bear Arms, shall not be
             infringed.
           </p>
         </va-accordion-item>
-        <va-accordion-item id="third" header="Third Amendment">
+        <va-accordion-item id="third" header="Third Amendment" uswds>
           <p>
             No Soldier shall, in time of peace be quartered in any house, without
             the consent of the Owner, nor in time of war, but in a manner to be
@@ -225,7 +225,7 @@ const I18nTemplate = args => {
 
 const ManyItemsTemplate = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment">
+    <va-accordion-item id="first" header="First Amendment" uswds>
         <p>
           Congress shall make no law respecting an establishment of religion, or
           prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -233,59 +233,59 @@ const ManyItemsTemplate = args => (
           petition the Government for a redress of grievances.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment">
+    <va-accordion-item id="second" header="Second Amendment" uswds>
         <p>
-          A well regulated Militia, being necessary to the security of a free State, 
+          A well regulated Militia, being necessary to the security of a free State,
           the right of the people to keep and bear Arms, shall not be infringed.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment">
+    <va-accordion-item id="third" header="Third Amendment" uswds>
         <p>
-          No Soldier shall, in time of peace be quartered in any house, without the 
+          No Soldier shall, in time of peace be quartered in any house, without the
           consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="fourth" header="Fourth Amendment">
+    <va-accordion-item id="fourth" header="Fourth Amendment" uswds>
         <p>
-        The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, 
-        shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly 
+        The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures,
+        shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly
         describing the place to be searched, and the persons or things to be seized.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="fifth" header="Fifth Amendment">
+    <va-accordion-item id="fifth" header="Fifth Amendment" uswds>
         <p>
-        No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, 
-        except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; 
-        nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any 
+        No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury,
+        except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger;
+        nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any
         criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor
         shall private property be taken for public use, without just compensation.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="sixth" header="Sixth Amendment">
+    <va-accordion-item id="sixth" header="Sixth Amendment" uswds>
         <p>
-        In all criminal prosecutions, the accused shall enjoy the right to a speedy and public trial, by an impartial jury of the State 
-        and district wherein the crime shall have been committed, which district shall have been previously ascertained by law, and to 
-        be informed of the nature and cause of the accusation; to be confronted with the witnesses against him; to have compulsory process 
+        In all criminal prosecutions, the accused shall enjoy the right to a speedy and public trial, by an impartial jury of the State
+        and district wherein the crime shall have been committed, which district shall have been previously ascertained by law, and to
+        be informed of the nature and cause of the accusation; to be confronted with the witnesses against him; to have compulsory process
         for obtaining witnesses in his favor, and to have the Assistance of Counsel for his defence.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="seventh" header="Seventh Amendment">
+    <va-accordion-item id="seventh" header="Seventh Amendment" uswds>
         <p>
-        In Suits at common law, where the value in controversy shall exceed twenty dollars, the right of trial by jury shall be preserved, 
+        In Suits at common law, where the value in controversy shall exceed twenty dollars, the right of trial by jury shall be preserved,
         and no fact tried by a jury, shall be otherwise re-examined in any Court of the United States, than according to the rules of the common law.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="eighth" header="Eighth Amendment">
+    <va-accordion-item id="eighth" header="Eighth Amendment" uswds>
         <p>
         Excessive bail shall not be required, nor excessive fines imposed, nor cruel and unusual punishments inflicted.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="ninth" header="Ninth Amendment">
+    <va-accordion-item id="ninth" header="Ninth Amendment" uswds>
         <p>
         The enumeration in the Constitution, of certain rights, shall not be construed to deny or disparage others retained by the people.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="tenth" header="Tenth Amendment">
+    <va-accordion-item id="tenth" header="Tenth Amendment" uswds>
         <p>
         The powers not delegated to the United States by the Constitution, nor prohibited by it to the States, are reserved to the States respectively, or to the people.
         </p>
@@ -297,6 +297,7 @@ const ManyItemsTemplate = args => (
 const defaultArgs = {
   'bordered': false,
   'open-single': undefined,
+  'uswds': true,
 };
 
 export const Default = Template.bind(null);

--- a/packages/storybook/stories/va-accordion-uswds.stories.jsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.jsx
@@ -23,7 +23,7 @@ export default {
 
 const Template = args => (
   <va-accordion {...args}>
-    <va-accordion-item id="first" header="First Amendment" uswds={args.uswds}>
+    <va-accordion-item id="first" header="First Amendment">
         <p>
           Congress shall make no law respecting an establishment of religion, or
           prohibiting the free exercise thereof; or abridging the freedom of speech,
@@ -31,13 +31,13 @@ const Template = args => (
           petition the Government for a redress of grievances.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="second" header="Second Amendment" uswds={args.uswds}>
+    <va-accordion-item id="second" header="Second Amendment">
         <p>
           A well regulated Militia, being necessary to the security of a free State,
           the right of the people to keep and bear Arms, shall not be infringed.
         </p>
     </va-accordion-item>
-    <va-accordion-item id="third" header="Third Amendment" uswds={args.uswds}>
+    <va-accordion-item id="third" header="Third Amendment">
         <p>
           No Soldier shall, in time of peace be quartered in any house, without the
           consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
@@ -297,7 +297,6 @@ const ManyItemsTemplate = args => (
 const defaultArgs = {
   'bordered': false,
   'open-single': undefined,
-  'uswds': true,
 };
 
 export const Default = Template.bind(null);

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -245,9 +245,9 @@ describe('va-accordion-item', () => {
 
 
 /**
- * 
+ *
  * Begin V3 Tests
- * 
+ *
  */
 describe('va-accordion-item', () => {
   it('renders', async () => {
@@ -261,14 +261,14 @@ describe('va-accordion-item', () => {
       <mock:shadow-root>
         <div>
           <h2 class="usa-accordion__heading">
-            <button aria-controls="content" aria-expanded="false" class="usa-accordion__button" type="button">
+            <button aria-controls="content" aria-expanded="false" class="usa-accordion__button" type="button" part="accordion-header">
               <span class="usa-accordion__header va-accordion__header">
                 <slot name="icon"></slot>
               </span>
             </button>
           </h2>
           <slot name="headline"></slot>
-          <div class="usa-accordion__content usa-prose" hidden="" id="content">
+          <div class="usa-accordion__content usa-prose" hidden="" id="content" part="accordion-content">
             <slot></slot>
           </div>
         </div>
@@ -418,7 +418,7 @@ describe('va-accordion-item', () => {
         <mock:shadow-root>
           <div>
             <h2 class="usa-accordion__heading">
-              <button aria-controls="content" aria-expanded="false" class="usa-accordion__button" type="button">
+              <button aria-controls="content" aria-expanded="false" class="usa-accordion__button" type="button" part="accordion-header">
                 <span class="usa-accordion__header va-accordion__header">
                   <slot name="icon"></slot>
                   The header
@@ -430,7 +430,7 @@ describe('va-accordion-item', () => {
               </button>
             </h2>
             <slot name="headline"></slot>
-            <div class="usa-accordion__content usa-prose" hidden="" id="content">
+            <div class="usa-accordion__content usa-prose" hidden="" id="content" part="accordion-content">
               <slot></slot>
             </div>
         </div>
@@ -451,7 +451,7 @@ describe('va-accordion-item', () => {
       <mock:shadow-root>
         <div>
           <h2 class="usa-accordion__heading">
-            <button aria-controls="content" aria-expanded="false" class="usa-accordion__button" type="button">
+            <button aria-controls="content" aria-expanded="false" class="usa-accordion__button" type="button" part="accordion-header">
               <span class="usa-accordion__header va-accordion__header">
                 <slot name="icon"></slot>
                 The header
@@ -459,7 +459,7 @@ describe('va-accordion-item', () => {
             </button>
           </h2>
           <slot name="headline"></slot>
-          <div class="usa-accordion__content usa-prose" hidden="" id="content">
+          <div class="usa-accordion__content usa-prose" hidden="" id="content" part="accordion-content">
             <slot></slot>
           </div>
         </div>

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -96,7 +96,7 @@ export class VaAccordionItem {
     // auto-expand accordion if the window hash matches the ID
     if (this.el.id && this.el.id === window.location.hash.slice(1)) {
       const currentTarget = this.expandButton;
-      
+
       if (currentTarget) {
         this.open = true;
         this.el.setAttribute('open', 'true');
@@ -133,6 +133,7 @@ export class VaAccordionItem {
               ref={el => {
                 this.expandButton = el;
               }}
+              part="accordion-header"
             >
               <span class="usa-accordion__header va-accordion__header">
                 <slot name="icon" />
@@ -153,7 +154,12 @@ export class VaAccordionItem {
           <div class={accordionItemClass}>
             <Header/>
             <slot name="headline" onSlotchange={() => this.populateStateValues()} />
-            <div id="content" class="usa-accordion__content usa-prose" hidden={!open}>
+            <div
+              id="content"
+              class="usa-accordion__content usa-prose"
+              hidden={!open}
+              part="accordion-content"
+            >
               <slot/>
             </div>
           </div>


### PR DESCRIPTION
## Chromatic
<!-- This `77064-accordion-styling` is a placeholder for a CI job - it will be updated automatically -->
https://77064-accordion-styling--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Adds `part` to both the `va-accordion-item` header button and content to allow adding a background to the button and border to the content to alert Veterans that there is something that needs attention on the review & submit page (see screenshots) - I'm not sure why a horizontal scrollbar shows up in the screenshot, but I'll look into it.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/77064

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

|  | Desktop | Mobile |
|---|---|---|
|Before| <img width="623" alt="Screenshot 2024-03-28 at 11 23 28 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/0958c29c-cb32-48d0-bd76-3460a532154a"> | <img width="301" alt="Screenshot 2024-03-28 at 11 30 12 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/bc66e050-93ba-46e9-9f74-35cefb73644e"> |
| After | <img width="627" alt="Screenshot 2024-03-28 at 11 24 42 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/2401e1e2-84b2-4563-a452-8c149a14707a"> | <img width="288" alt="Screenshot 2024-03-28 at 11 29 46 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/5861da4e-f7c5-475f-b16a-16df32bf0ecd"> |

## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
