### PR TITLE
Storybook: Move VA specific components in the sidebar

### DIFF
--- a/packages/storybook/stories/va-alert-expandable.stories.jsx
+++ b/packages/storybook/stories/va-alert-expandable.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const alertExpandableDocs = getWebComponentDocs('va-alert-expandable');
 
 export default {
-  title: 'V1 Components/Alert - expandable',
+  title: 'Components/Alert - expandable',
   id: 'components/va-alert-expandable',
   parameters: {
     componentSubtitle: `va-alert-expandable web component`,

--- a/packages/storybook/stories/va-back-to-top.stories.jsx
+++ b/packages/storybook/stories/va-back-to-top.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const bttDocs = getWebComponentDocs('va-back-to-top');
 
 export default {
-  title: 'V1 Components/Back to top',
+  title: 'Components/Back to top',
   id: 'components/va-back-to-top',
   parameters: {
     componentSubtitle: `va-back-to-top web component`,

--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const bannerDocs = getWebComponentDocs('va-banner');
 
 export default {
-  title: 'V1 Components/Banner',
+  title: 'Components/Banner',
   id: 'components/va-banner',
   parameters: {
     componentSubtitle: `va-banner web component`,

--- a/packages/storybook/stories/va-card.stories.jsx
+++ b/packages/storybook/stories/va-card.stories.jsx
@@ -5,7 +5,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const cardDocs = getWebComponentDocs('va-card');
 
 export default {
-  title: 'V1 Components/Card',
+  title: 'Components/Card',
   id: 'components/va-card',
   parameters: {
     componentSubtitle: `va-card web component`,

--- a/packages/storybook/stories/va-date.stories.jsx
+++ b/packages/storybook/stories/va-date.stories.jsx
@@ -7,7 +7,7 @@ VaDate.displayName = 'VaDate';
 const dateDocs = getWebComponentDocs('va-date');
 
 export default {
-  title: 'V1 Components/Date input',
+  title: 'Components/Date input',
   id: 'components/va-date',
   parameters: {
     componentSubtitle: `va-date web component`,

--- a/packages/storybook/stories/va-header-minimal.stories.jsx
+++ b/packages/storybook/stories/va-header-minimal.stories.jsx
@@ -9,7 +9,7 @@ import {
 const minimalHeaderDocs = getWebComponentDocs('va-header-minimal');
 
 export default {
-  title: 'V1 Components/Header - Minimal',
+  title: 'Components/Header - Minimal',
   id: 'components/va-header-minimal',
   parameters: {
     componentSubtitle: `va-header-minimal web component`,

--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const linkDocs = getWebComponentDocs('va-link');
 
 export default {
-  title: 'V1 Components/Link',
+  title: 'Components/Link',
   id: 'components/va-link',
   parameters: {
     componentSubtitle: `va-link web component`,

--- a/packages/storybook/stories/va-loading-indicator.stories.jsx
+++ b/packages/storybook/stories/va-loading-indicator.stories.jsx
@@ -5,7 +5,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const loadingIndicatorDocs = getWebComponentDocs('va-loading-indicator');
 
 export default {
-  title: 'V1 Components/Loading indicator',
+  title: 'Components/Loading indicator',
   id: 'components/va-loading-indicator',
   parameters: {
     componentSubtitle: `va-loading-indicator web component`,

--- a/packages/storybook/stories/va-maintenance-banner.stories.jsx
+++ b/packages/storybook/stories/va-maintenance-banner.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const maintenanceBannerDocs = getWebComponentDocs('va-maintenance-banner');
 
 export default {
-  title: 'V1 Components/Banner - Maintenance',
+  title: 'Components/Banner - Maintenance',
   id: 'components/va-maintenance-banner',
   parameters: {
     componentSubtitle: `va-maintenance-banner web component`,

--- a/packages/storybook/stories/va-minimal-footer.stories.jsx
+++ b/packages/storybook/stories/va-minimal-footer.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const minimalFooterDocs = getWebComponentDocs('va-minimal-footer');
 
 export default {
-  title: 'V1 Components/Minimal Footer',
+  title: 'Components/Minimal Footer',
   id: 'components/va-minimal-footer',
   parameters: {
     componentSubtitle: `va-minimal-footer web component`,

--- a/packages/storybook/stories/va-need-help.stories.jsx
+++ b/packages/storybook/stories/va-need-help.stories.jsx
@@ -5,7 +5,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const needHelpDocs = getWebComponentDocs('va-need-help');
 
 export default {
-  title: 'V1 Components/Need help?',
+  title: 'Components/Need help?',
   id: 'components/va-need-help',
   parameters: {
     componentSubtitle: `va-need-help web component`,

--- a/packages/storybook/stories/va-official-gov-banner.stories.jsx
+++ b/packages/storybook/stories/va-official-gov-banner.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const officialGovBannerDocs = getWebComponentDocs('va-official-gov-banner');
 
 export default {
-  title: 'V1 Components/Banner - Official Gov',
+  title: 'Components/Banner - Official Gov',
   id: 'components/va-official-gov-banner',
   parameters: {
     componentSubtitle: `va-official-gov-banner web component`,

--- a/packages/storybook/stories/va-omb-info.stories.jsx
+++ b/packages/storybook/stories/va-omb-info.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const ombInfoDocs = getWebComponentDocs('va-omb-info');
 
 export default {
-  title: 'V1 Components/OMB info',
+  title: 'Components/OMB info',
   id: 'components/va-omb-info',
   parameters: {
     componentSubtitle: `va-omb-info web component`,

--- a/packages/storybook/stories/va-on-this-page.stories.jsx
+++ b/packages/storybook/stories/va-on-this-page.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, StoryDocs } from './wc-helpers';
 const otpDocs = getWebComponentDocs('va-on-this-page');
 
 export default {
-  title: 'V1 Components/On this page',
+  title: 'Components/On this page',
   id: 'components/va-on-this-page',
   parameters: {
     componentSubtitle: 'va-on-this-page web component',

--- a/packages/storybook/stories/va-progress-bar.stories.jsx
+++ b/packages/storybook/stories/va-progress-bar.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const progressBarDocs = getWebComponentDocs('va-progress-bar');
 
 export default {
-  title: 'V1 Components/Progress bar - activity',
+  title: 'Components/Progress bar - activity',
   id: 'components/va-progress-bar',
   parameters: {
     componentSubtitle: `va-progress-bar web component`,

--- a/packages/storybook/stories/va-promo-banner.stories.jsx
+++ b/packages/storybook/stories/va-promo-banner.stories.jsx
@@ -4,7 +4,7 @@ import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 const promoBannerDocs = getWebComponentDocs('va-promo-banner');
 
 export default {
-  title: `V1 Components/Banner - Promo`,
+  title: `Components/Banner - Promo`,
   id: 'components/va-promo-banner',
   parameters: {
     componentSubtitle: 'va-promo-banner web component',

--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -37,7 +37,7 @@ const Contacts = () => (
 );
 
 export default {
-  title: `V1 Components/Telephone`,
+  title: `Components/Telephone`,
   id: 'components/va-telephone',
   parameters: {
     componentSubtitle: `va-telephone web component`,


### PR DESCRIPTION
## Chromatic
<!-- This `2589-storybook-sidebar` is a placeholder for a CI job - it will be updated automatically -->
https://2589-storybook-sidebar--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This will move components that are essentially VA specific that we want to continue offering as part of the design system up in the Storybook sidebar (alongside USWDS variations).

The result of this should be that any component under the `V1 Components` section are variations that **we will be removing** in the near future in favor of the USWDS variation:

![Screenshot 2024-03-28 at 12 18 32 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/43c004e3-d95a-48a6-a65e-ec55358729fa)


Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2589

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
