### PR TITLE
Storybook: fix sidebar maturity indicators

### DIFF
--- a/packages/storybook/.storybook/manager.js
+++ b/packages/storybook/.storybook/manager.js
@@ -9,6 +9,9 @@ import { getMaturityScale } from '../stories/wc-helpers';
  * Return the maturity category matching a specific component name
  */
 const getMaturityCategory = (componentName) => {
+  // remove USWDS from the componentName for matching in component-docs.json
+  componentName = componentName.replace(' USWDS', '');
+
   const componentDocs = webComponentDocs.components.filter(comp => 
     comp.docsTags.some(tag => tag.text === componentName))[0];
   
@@ -25,7 +28,8 @@ addons.setConfig({
         item.parent === 'components' ||
         item.parent === 'components-icons' ||
         item.parent === 'deprecated' ||
-        item.parent === 'under-development'
+        item.parent === 'under-development' ||
+        item.parent === 'v1-components'
       ) {
         const maturityCategory = 
           maturityCategoryFromDocs ?? 

--- a/packages/web-components/src/components/va-header-minimal/va-header-minimal.tsx
+++ b/packages/web-components/src/components/va-header-minimal/va-header-minimal.tsx
@@ -10,7 +10,7 @@ import {
 import vaSeal from '../../assets/va-seal.svg';
 
 /**
- * @componentName Header - minimal
+ * @componentName Header - Minimal
  * @maturityCategory caution
  * @maturityLevel candidate
  * @guidanceHref header/header-minimal

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../utils/date-utils';
 
 /**
- * @componentName Maintenance Banner
+ * @componentName Banner - Maintenance
  * @maturityCategory caution
  * @maturityLevel available
  */


### PR DESCRIPTION
## Chromatic
<!-- This `2589-maturity-indicators` is a placeholder for a CI job - it will be updated automatically -->
https://2589-maturity-indicators--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

The maturity indicator dots were not showing for a number of components on Storybook. This PR fixes that.

### Before

| Components    | V1 Components |
| -------- | ------- |
| ![Screenshot 2024-03-29 at 10 38 33 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/5e21a137-14f5-4adb-9809-438ac9e1da35)  | ![Screenshot 2024-03-29 at 10 38 38 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/4aa3b336-da2a-4226-a6fe-3b4f20a82e2c)   |

### After

| Components    | V1 Components |
| -------- | ------- |
| ![Screenshot 2024-03-29 at 10 40 12 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/326677b0-36b9-48c4-b577-3f48aebfa210) | ![Screenshot 2024-03-29 at 10 40 15 AM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/65f3625e-7838-4d2f-97bb-46ad6ef53072)   |

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
