### PR TITLE
CSS-Library: Adding mobile-medium breakpoint and replacing medium-screen with 768px

### DIFF
--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "patch, minor, major, ignore-for-release"
+          labels: "patch, minor, major, ignore-for-release, css-library"

--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,12 +1,13 @@
 /**
  * Do not edit directly
- * Generated on Mon, 18 Mar 2024 21:10:45 GMT
+ * Generated on Fri, 29 Mar 2024 17:20:23 GMT
  */
 
 :root {
   --xsmall-screen: 320px;
   --small-screen: 481px;
-  --medium-screen: 640px;
+  --medium-mobile: 640px;
+  --medium-screen: 768px;
   --small-desktop-screen: 1008px;
   --large-screen: 1201px;
   --color-link-default-hover: rgba(#000000, 0.05);

--- a/packages/css-library/dist/tokens/json/variables.json
+++ b/packages/css-library/dist/tokens/json/variables.json
@@ -29,12 +29,27 @@
       "small-screen"
     ]
   },
-  "medium-screen": {
+  "medium-mobile": {
     "value": "640px",
     "filePath": "tokens/breakpoints.json",
     "isSource": true,
     "original": {
       "value": "640px"
+    },
+    "name": "medium-mobile",
+    "attributes": {
+      "category": "medium-mobile"
+    },
+    "path": [
+      "medium-mobile"
+    ]
+  },
+  "medium-screen": {
+    "value": "768px",
+    "filePath": "tokens/breakpoints.json",
+    "isSource": true,
+    "original": {
+      "value": "768px"
     },
     "name": "medium-screen",
     "attributes": {

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,10 +1,11 @@
 
 // Do not edit directly
-// Generated on Mon, 18 Mar 2024 21:10:45 GMT
+// Generated on Fri, 29 Mar 2024 17:20:23 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;
-$medium-screen: 640px;
+$medium-mobile: 640px;
+$medium-screen: 768px;
 $small-desktop-screen: 1008px;
 $large-screen: 1201px;
 $color-link-default-hover: rgba(#000000, 0.05);

--- a/packages/css-library/tokens/breakpoints.json
+++ b/packages/css-library/tokens/breakpoints.json
@@ -5,8 +5,11 @@
   "small-screen": {
     "value": "481px"
   },
-  "medium-screen": {
+  "medium-mobile": {
     "value": "640px"
+  },
+  "medium-screen": {
+    "value": "768px"
   },
   "small-desktop-screen": {
     "value": "1008px"


### PR DESCRIPTION
## Chromatic
<!-- This `2533-add-768-breakpoint` is a placeholder for a CI job - it will be updated automatically -->
https://2533-add-768-breakpoint--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#2533](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2533)

Replaces the "medium-screen" breakpoint with 768px in order to keep in line with how Formation currently acts. Adding "medium-mobile" breakpoint for early adopters of the 640px breakpoint style.

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
