### PR TITLE
va-select: Add aria-describedby-message for screen readers

### DIFF
--- a/packages/storybook/stories/va-select-uswds.stories.jsx
+++ b/packages/storybook/stories/va-select-uswds.stories.jsx
@@ -23,6 +23,7 @@ const defaultArgs = {
   'error': undefined,
   'hint': null,
   'aria-live-region-text': 'You selected',
+  'aria-describedby-message': 'Optional description text for screen readers',
   'options': [
     <option key="1" value="navy">
       Navy
@@ -51,6 +52,7 @@ const Template = ({
   error,
   hint,
   'aria-live-region-text': ariaLiveRegionText,
+  'aria-describedby-message': ariaDescribedbyMessage,
   options,
   'use-add-button': useAddButton,
 }) => {
@@ -79,6 +81,7 @@ const Template = ({
         error={error}
         hint={hint}
         aria-live-region-text={ariaLiveRegionText}
+        message-aria-describedby={ariaDescribedbyMessage}
         use-add-button={useAddButton}
       >
         {modifiedOptions}

--- a/packages/storybook/stories/va-select.stories.jsx
+++ b/packages/storybook/stories/va-select.stories.jsx
@@ -23,6 +23,7 @@ const defaultArgs = {
   'error': undefined,
   hint: null,
   'aria-live-region-text': 'You selected',
+  'aria-describedby-message': 'Optional description text for screen readers',
   'options': [
     <option key="1" value="navy">
       Navy
@@ -52,6 +53,7 @@ const Template = ({
   error,
   hint,
   'aria-live-region-text': ariaLiveRegionText,
+  'aria-describedby-message': ariaDescribedbyMessage,
   options,
   'use-add-button': useAddButton,
   uswds,
@@ -82,6 +84,7 @@ const Template = ({
         error={error}
         hint={hint}
         aria-live-region-text={ariaLiveRegionText}
+        message-aria-describedby={ariaDescribedbyMessage}
         use-add-button={useAddButton}
         uswds={uswds}
       >

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1125,6 +1125,10 @@ export namespace Components {
          */
         "label": string;
         /**
+          * An optional message that will be read by screen readers when the input is focused.
+         */
+        "messageAriaDescribedby"?: string;
+        /**
           * Name attribute for the select field.
          */
         "name": string;
@@ -3197,6 +3201,10 @@ declare namespace LocalJSX {
           * Text label for the field.
          */
         "label": string;
+        /**
+          * An optional message that will be read by screen readers when the input is focused.
+         */
+        "messageAriaDescribedby"?: string;
         /**
           * Name attribute for the select field.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1125,7 +1125,7 @@ export namespace Components {
          */
         "label": string;
         /**
-          * An optional message that will be read by screen readers when the input is focused.
+          * An optional message that will be read by screen readers when the select is focused.
          */
         "messageAriaDescribedby"?: string;
         /**
@@ -3202,7 +3202,7 @@ declare namespace LocalJSX {
          */
         "label": string;
         /**
-          * An optional message that will be read by screen readers when the input is focused.
+          * An optional message that will be read by screen readers when the select is focused.
          */
         "messageAriaDescribedby"?: string;
         /**

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -214,13 +214,13 @@ describe('va-select', () => {
   it('adds aria-describedby input-message id', async () => {
     const page = await newE2EPage();
     await page.setContent(`
-      <va-select label="A label" value="foo" enable-analytics aria-describedby-message="example message">
+      <va-select label="A label" value="foo" enable-analytics message-aria-describedby="example message">
         <option value="foo">Foo</option>
         <option value="bar">Bar</option>
       </va-select>
     `);
     const el = await page.find('va-select');
-    const inputEl = await page.find('va-select >>> input');
+    const inputEl = await page.find('va-select >>> select');
 
     // Render the example message aria-describedby id.
     expect(inputEl.getAttribute('aria-describedby')).not.toBeNull();

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -210,4 +210,27 @@ describe('va-select', () => {
       </va-select>
     `);
   });
+
+  it('adds aria-describedby input-message id', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-select label="A label" value="foo" enable-analytics aria-describedby-message="example message">
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </va-select>
+    `);
+    const el = await page.find('va-select');
+    const inputEl = await page.find('va-select >>> input');
+
+    // Render the example message aria-describedby id.
+    expect(inputEl.getAttribute('aria-describedby')).not.toBeNull();
+    expect(inputEl.getAttribute('aria-describedby')).toContain('input-message');
+
+    // If an error and aria-describedby-message is set, id's exist in aria-describedby.
+    el.setProperty('error', 'Testing Error');
+    await page.waitForChanges();
+    expect(inputEl.getAttribute('aria-describedby')).not.toBeNull();
+    expect(inputEl.getAttribute('aria-describedby')).toContain('error-message');
+    expect(inputEl.getAttribute('aria-describedby')).toContain('input-message');
+  });
 });

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -85,6 +85,11 @@ export class VaSelect {
   @Prop() hint?: string;
 
   /**
+   * An optional message that will be read by screen readers when the input is focused.
+   */
+  @Prop() messageAriaDescribedby?: string;
+
+  /**
    * The event attached to select's onkeydown
    */
   @Event() vaKeyDown: EventEmitter;
@@ -173,8 +178,15 @@ export class VaSelect {
   }
 
   render() {
-    const { error, reflectInputError, invalid, label, required, name, hint, uswds } = this;
+    const { error, reflectInputError, invalid, label, required, name, hint, messageAriaDescribedby, uswds } = this;
 
+    const errorID = uswds ? 'input-error-message': 'error-message';
+    const ariaDescribedbyIds = 
+      `${messageAriaDescribedby ? 'input-message' : ''} ${
+        error ? errorID : ''} ${
+        hint ? 'input-hint' : ''}`.trim() || null; // Null so we don't add the attribute if we have an empty string
+    console.log({ariaDescribedbyIds})
+    console.log({messageAriaDescribedby})
     if (uswds) {
       const labelClass = classnames({
         'usa-label': true,
@@ -193,7 +205,7 @@ export class VaSelect {
             </label>
           )}
           {hint && <span class="usa-hint" id="input-hint">{hint}</span>}
-          <span id="input-error-message" role="alert">
+          <span id={errorID} role="alert">
             {error && (
               <Fragment>
                 <span class="usa-sr-only">{i18next.t('error')}</span> 
@@ -204,7 +216,7 @@ export class VaSelect {
           <slot onSlotchange={() => this.populateOptions()}></slot>
           <select
             class={selectClass}
-            aria-describedby={error ? 'input-error-message' : hint ? 'input-hint' : undefined}
+            aria-describedby={ariaDescribedbyIds}
             aria-invalid={invalid || error ? 'true' : 'false'}
             id="options"
             name={name}
@@ -216,6 +228,11 @@ export class VaSelect {
             <option key="0" value="" selected>{i18next.t('select')}</option>
             {this.options}
           </select>
+          {messageAriaDescribedby && (
+            <span id="input-message" class="sr-only dd-privacy-hidden">
+              {messageAriaDescribedby}
+            </span>
+          )}
         </Host>
       )
     } else {
@@ -226,7 +243,7 @@ export class VaSelect {
             {required && <span class="required">{i18next.t('required')}</span>}
           </label>
           {hint && <span class="hint-text" id="input-hint">{hint}</span>}
-          <span id="error-message" role="alert">
+          <span id={errorID} role="alert">
             {error && (
               <Fragment>
                 <span class="sr-only">{i18next.t('error')}</span> {error}
@@ -235,7 +252,7 @@ export class VaSelect {
           </span>
           <slot onSlotchange={() => this.populateOptions()}></slot>
           <select
-            aria-describedby={error ? 'error-message' : hint ? 'input-hint' : undefined}
+            aria-describedby={ariaDescribedbyIds}
             aria-invalid={invalid || error ? 'true' : 'false'}
             id="select"
             name={name}
@@ -246,6 +263,11 @@ export class VaSelect {
           >
             {this.options}
           </select>
+          {messageAriaDescribedby && (
+            <span id="input-message" class="sr-only dd-privacy-hidden">
+              {messageAriaDescribedby}
+            </span>
+          )}
         </Host>
       );
     };

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -85,7 +85,7 @@ export class VaSelect {
   @Prop() hint?: string;
 
   /**
-   * An optional message that will be read by screen readers when the input is focused.
+   * An optional message that will be read by screen readers when the select is focused.
    */
   @Prop() messageAriaDescribedby?: string;
 
@@ -185,8 +185,7 @@ export class VaSelect {
       `${messageAriaDescribedby ? 'input-message' : ''} ${
         error ? errorID : ''} ${
         hint ? 'input-hint' : ''}`.trim() || null; // Null so we don't add the attribute if we have an empty string
-    console.log({ariaDescribedbyIds})
-    console.log({messageAriaDescribedby})
+    
     if (uswds) {
       const labelClass = classnames({
         'usa-label': true,


### PR DESCRIPTION
## Chromatic
<!-- This `dst25-87-va-select-add-aria-describedby` is a placeholder for a CI job - it will be updated automatically -->
https://dst25-87-va-select-add-aria-describedby--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Adds `aria-describedby` to `va-select` for screen readers.

Closes [va-select needs describedby property #2587](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2587)

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] ~~Designer has signed off on changes (if applicable. If not applicable provide reason why)~~ No design changes
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes
![Screenshot 2024-04-02 at 14 56 36](https://github.com/department-of-veterans-affairs/component-library/assets/1413938/166c1af6-d5e9-4918-91cc-33eb73ae92e3)
Screen reader text:
![Screenshot 2024-04-03 at 14 20 43](https://github.com/department-of-veterans-affairs/component-library/assets/1413938/d513d513-d1dc-44fd-ba67-6ea2a23f3c13)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
