### PR TITLE
Add pre-commit script for checking branch name

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,10 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+##
+# Check if the branch name is valid for generating Chromatic Storybook preview links
+##
+
 # Get the current branch name
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
@@ -14,6 +18,7 @@ if [ $BRANCH_NAME_LENGTH -gt 37 ]; then
   exit 1
 fi
 
+# lowercase letters, numbers, and dashes only
 VALID_BRANCH_REGEX='^[a-z\d]+[a-z\d\-]*$'
 
 if [[ ! $BRANCH_NAME =~ $VALID_BRANCH_REGEX ]]; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,6 +9,7 @@ BRANCH_NAME_LENGTH=${#BRANCH_NAME}
 
 # Check if the length is greater than 37
 if [ $BRANCH_NAME_LENGTH -gt 37 ]; then
+  echo "Length of the current branch name is: $BRANCH_NAME_LENGTH"
   echo "Branch name length is greater than 37 characters."
   exit 1
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Get the current branch name
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+# Calculate the length of the branch name
+BRANCH_NAME_LENGTH=${#BRANCH_NAME}
+
+# Check if the length is greater than 37
+if [ $BRANCH_NAME_LENGTH -gt 37 ]; then
+  echo "Branch name length is greater than 37 characters."
+  exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,3 +13,11 @@ if [ $BRANCH_NAME_LENGTH -gt 37 ]; then
   echo "Branch name length is greater than 37 characters."
   exit 1
 fi
+
+VALID_BRANCH_REGEX='^[a-z\d]+[a-z\d\-]*'
+
+if [[ ! $BRANCH_NAME =~ $VALID_BRANCH_REGEX ]]; then
+  echo "Invalid branch name, name must start with a lowercase letter or"
+  echo "number, and include only lowercase letters, numbers, and dashes."
+  exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,15 +9,15 @@ BRANCH_NAME_LENGTH=${#BRANCH_NAME}
 
 # Check if the length is greater than 37
 if [ $BRANCH_NAME_LENGTH -gt 37 ]; then
-  echo "Length of the current branch name is: $BRANCH_NAME_LENGTH"
   echo "Branch name length is greater than 37 characters."
+  echo "Length of the current branch name is: $BRANCH_NAME_LENGTH"
   exit 1
 fi
 
-VALID_BRANCH_REGEX='^[a-z\d]+[a-z\d\-]*'
+VALID_BRANCH_REGEX='^[a-z\d]+[a-z\d\-]*$'
 
 if [[ ! $BRANCH_NAME =~ $VALID_BRANCH_REGEX ]]; then
-  echo "Invalid branch name, name must start with a lowercase letter or"
+  echo "Branch name must start with a lowercase letter or"
   echo "number, and include only lowercase letters, numbers, and dashes."
   exit 1
 fi

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "dependencies": {
     "@department-of-veterans-affairs/css-library": "^0.0.1",
     "webpack": "5"
+  },
+  "devDependencies": {
+    "husky": "^9.0.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,6 +1892,7 @@ __metadata:
   resolution: "@department-of-veterans-affairs/component-library-monorepo@workspace:."
   dependencies:
     "@department-of-veterans-affairs/css-library": ^0.0.1
+    husky: ^9.0.11
     webpack: 5
   languageName: unknown
   linkType: soft
@@ -11632,6 +11633,15 @@ fsevents@^1.2.7:
   bin:
     husky: lib/bin.js
   checksum: 80af5b882c3f37d72d775f15dc8d5a74f27856881f92338278ac017ab447695ee0d958cffec22ba4d0ae96532fb8ee5f99f4ca7b869bc91285e5adc0b8cdfeb3
+  languageName: node
+  linkType: hard
+
+"husky@npm:^9.0.11":
+  version: 9.0.11
+  resolution: "husky@npm:9.0.11"
+  bin:
+    husky: bin.mjs
+  checksum: 1aebc3334dc7ac6288ff5e1fb72cfb447cfa474e72cf7ba692e8c5698c573ab725c28c6a5088c9f8e6aca5f47d40fa7261beffbc07a4d307ca21656dc4571f07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Chromatic
<!-- This `pre-commit-branch-name` is a placeholder for a CI job - it will be updated automatically -->
https://pre-commit-branch-name--65a6e2ed2314f7b8f98609d8.chromatic.com

In order to generate a Chromatic preview link on PRs, the branch name must follow these rules:

- must not exceed 37 characters
- must contain only lowercase letters, numbers, and dashes

See the repo [readme file](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#contributing).

This PR will add husky so that we can do pre-commit checks and a primitive bash script. But this might also be useful for things in the future as other teams start contributing more to the component library.

## Testing locally

1. Switch to this PRs branch `pre-commit-branch-name`
2. Create a new branch from there that's > 37 chars`pre-commit-branch-name-a-really-long-branch-name-for-testing`
3. Make a change to a file and try to commit (should fail)
4. Rename the new branch so that it has an upper case or contains a non-letter/number/dash `pre-Commit-Branch-name-ca$h-money`
5. Make a change to a file and try to commit (should fail)

## Screenshots

<img width="606" alt="Screenshot 2024-04-03 at 4 35 26 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/872479/7a99b505-13f9-45a0-98aa-7cd96c8f9549">


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
