### PR TITLE
va-table: add uswds borderless table variant

### DIFF
--- a/packages/storybook/stories/va-table-uswds.stories.jsx
+++ b/packages/storybook/stories/va-table-uswds.stories.jsx
@@ -18,26 +18,145 @@ export default {
 
 const defaultArgs = {
   uswds: true,
-  tableData: [
-    ["Document title", "Description", "Year"],
-    ["Declaration of Independence", "Statement adopted by the Continental Congress declaring independence from the British Empire.", "1776"],
-    ["Bill of Rights", "The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.", "1791"],
-    ["Declaration of Sentiments", "A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.", "1848"],
-    ["Emancipation Proclamation", "An executive order granting freedom to slaves in designated southern states.", "1863"]
-  ]
-};
+  borderless: true
+}
 
-const Template = ({
-uswds, tableData
-}) => {
+const tableDataNoLinks = [
+  ["Document title", "Description", "Year"],
+  ["Declaration of Independence", "Statement adopted by the Continental Congress declaring independence from the British Empire.", "1776"],
+  ["Bill of Rights", "The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.", "1791"],
+  ["Declaration of Sentiments", "A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.", "1848"],
+  ["Emancipation Proclamation", "An executive order granting freedom to slaves in designated southern states.", "1863"]
+];
+
+const tableDataWithLinks = [
+  ["Document title", "Description", "Year"],
+  [{
+    text: "Declaration of Independence",
+    href: "https://www.archives.gov/founding-docs/declaration-transcript"
+  }, "Statement adopted by the Continental Congress declaring independence from the British Empire.", "1776"],
+  [{
+    text: "Bill of Rights",
+    href: "https://www.archives.gov/founding-docs/bill-of-rights-transcript"
+  }, "The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.", "1791"],
+  [{
+    text: "Declaration of Sentiments",
+    href: "https://www.nps.gov/wori/learn/historyculture/declaration-of-sentiments.htm"
+  }, "A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.", "1848"],
+  [{
+    text: "Emancipation Proclamation",
+    href: "https://www.archives.gov/exhibits/featured-documents/emancipation-proclamation?_ga=2.100862977.1665893808.1712776954-1250436154.1712776953"
+  }, "An executive order granting freedom to slaves in designated southern states.", "1863"]
+];
+
+const tableDataWithRouterLinks = [
+  ["Document title", "Description", "Year"],
+  [{
+    text: "Declaration of Independence",
+    href: "https://www.archives.gov/founding-docs/declaration-transcript",
+    isRouterLink: true
+  }, "Statement adopted by the Continental Congress declaring independence from the British Empire.", "1776"],
+  [{
+    text: "Bill of Rights",
+    href: "https://www.archives.gov/founding-docs/bill-of-rights-transcript",
+    isRouterLink: true
+  }, "The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.", "1791"],
+  [{
+    text: "Declaration of Sentiments",
+    href: "https://www.nps.gov/wori/learn/historyculture/declaration-of-sentiments.htm",
+    isRouterLink: true
+  }, "A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.", "1848"],
+  [{
+    text: "Emancipation Proclamation",
+    href: "https://www.archives.gov/exhibits/featured-documents/emancipation-proclamation?_ga=2.100862977.1665893808.1712776954-1250436154.1712776953",
+    isRouterLink: true
+  }, "An executive order granting freedom to slaves in designated southern states.", "1863"]
+];
+
+const Template = ({ tableData, uswds, borderless }) => {
   return (
-    <VaTable uswds={uswds} tableData={tableData}>
+    <VaTable uswds={uswds} borderless={borderless} tableData={tableData} >
       Borderless table: A borderless table can be useful when you want the information to feel more a part of the text it accompanies and extends.
     </VaTable>
   );
 };
 
-export const BorderlessTable = Template.bind(null);
-BorderlessTable.args = {
-  ...defaultArgs,
+const WithLinks = ({ tableData, uswds, borderless }) => {
+  return (
+    <VaTable uswds={uswds} borderless={borderless} tableData={tableData} >
+      This is a borderless table with links in some of its cells.
+    </VaTable>
+  );
 };
+
+const RouterLinks = ({ tableData, uswds, borderless }) => {
+  function handleEvent({ detail }) {
+    const { href } = detail;
+    console.log(`Route changed for ${href}`);
+  }
+
+  return (
+    <>
+      <p>The cells with links in this table have React Router links. The objects in the table data array that represents these cells have an <code>isRouterLink:true</code> property.
+        When the corresponding anchor tag is clicked these links emit a <code>route-change</code> event.
+        This event can be handled in a React component where utilities provided 
+        by React Router can be used to change the page under view, as in the example below:
+      </p>
+      <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
+        <code>
+import React from 'react';<br/>
+import &#x7b; useHistory &#x7d; from 'react-router-dom';<br/>
+<br/>
+const YourComponent &#61; (&#x7b; uswds, borderless, tableData &#x7d;) &#61;&#62;  &#x7b;<br/>
+&nbsp;const history &#61; useHistory();<br/>
+<br/>
+&nbsp;function handleRouteChange(&#x7b; detail &#x7d;) &#x7b;<br/>
+&nbsp;&nbsp;&nbsp;const &#x7b; href &#x7d; &#61; detail;<br/>
+&nbsp;&nbsp;&nbsp;history.push(href);<br/>
+&nbsp;&#x7d;<br/>
+  <br/>
+
+  &nbsp;return (<br/>
+  &nbsp;&nbsp;&#60;VaTable<br/>
+  &nbsp;&nbsp;&nbsp;uswds=&#x7b;uswds&#x7d;<br />
+  &nbsp;&nbsp;&nbsp;borderless=&#x7b;borderless&#x7d;<br/>        
+  &nbsp;&nbsp;&nbsp;tableData=&#x7b;tableData&#x7d;<br/>
+  &nbsp;&nbsp;&nbsp;onRouteChange=&#x7b;handleRouteChange&#x7d;<br/>
+  &nbsp;&nbsp;&#62;<br />
+  &nbsp;&nbsp;&nbsp;This is a borderless table with React Router links in some of its cells.<br/>
+  &nbsp;&nbsp;&#60;/VaTable&#62;<br />
+  &nbsp;);<br/>
+&#x7d;;
+        </code>
+      </pre>
+      <VaTable
+        uswds={uswds}
+        borderless={borderless}
+        tableData={tableData}
+        onRouteChange={handleEvent}
+      >
+        This is a borderless table with React Router links in some of its cells.
+      </VaTable>
+    </>
+  );
+}
+
+export const Default = Template.bind(null);
+
+Default.args = {
+  tableData: tableDataNoLinks,
+  ...defaultArgs
+}
+
+export const BorderlessWithLinks = WithLinks.bind(null);
+
+BorderlessWithLinks.args = {
+  tableData: tableDataWithLinks,
+  ...defaultArgs
+}
+
+export const BorderlessTableWithRouterLinks = RouterLinks.bind(null);
+BorderlessTableWithRouterLinks.args = {
+  tableData: tableDataWithRouterLinks,
+  ...defaultArgs
+}

--- a/packages/storybook/stories/va-table-uswds.stories.jsx
+++ b/packages/storybook/stories/va-table-uswds.stories.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { getWebComponentDocs, StoryDocs } from './wc-helpers';
+import { VaTable } from '@department-of-veterans-affairs/web-components/react-bindings';
+
+const tableDocs = getWebComponentDocs('va-table');
+VaTable.displayName = 'VaTable';
+
+export default {
+  title: 'Components/Table USWDS',
+  id: 'uswds/va-table',
+  parameters: {
+    componentSubtitle: 'va-table web component',
+    docs: {
+      page: () => <StoryDocs data={tableDocs} />,
+    },
+  },
+};
+
+const defaultArgs = {
+  uswds: true,
+  tableData: [
+    ["Document title", "Description", "Year"],
+    ["Declaration of Independence", "Statement adopted by the Continental Congress declaring independence from the British Empire.", "1776"],
+    ["Bill of Rights", "The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.", "1791"],
+    ["Declaration of Sentiments", "A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.", "1848"],
+    ["Emancipation Proclamation", "An executive order granting freedom to slaves in designated southern states.", "1863"]
+  ]
+};
+
+const Template = ({
+uswds, tableData
+}) => {
+  return (
+    <VaTable uswds={uswds} tableData={tableData}>
+      Borderless table: A borderless table can be useful when you want the information to feel more a part of the text it accompanies and extends.
+    </VaTable>
+  );
+};
+
+export const BorderlessTable = Template.bind(null);
+BorderlessTable.args = {
+  ...defaultArgs,
+};

--- a/packages/storybook/stories/va-table-uswds.stories.jsx
+++ b/packages/storybook/stories/va-table-uswds.stories.jsx
@@ -73,6 +73,14 @@ const tableDataWithRouterLinks = [
   }, "An executive order granting freedom to slaves in designated southern states.", "1863"]
 ];
 
+const tableDataWithTestIds = [
+  ["Document title", "Description", "Year"],
+  [{ text: "Declaration of Independence", testId: "this-is-a-test-id"}, "Statement adopted by the Continental Congress declaring independence from the British Empire.", "1776"],
+  [{ text: "Bill of Rights", testId: "this-is-another-test-id" }, "The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.", "1791"],
+  ["Declaration of Sentiments", "A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.", "1848"],
+  ["Emancipation Proclamation", "An executive order granting freedom to slaves in designated southern states.", "1863"]
+];
+
 const Template = ({ tableData, uswds, borderless }) => {
   return (
     <VaTable uswds={uswds} borderless={borderless} tableData={tableData} >
@@ -141,6 +149,14 @@ const YourComponent &#61; (&#x7b; uswds, borderless, tableData &#x7d;) &#61;&#62
   );
 }
 
+const WithTestId = ({ tableData, uswds, borderless }) => {
+  return (
+    <VaTable uswds={uswds} borderless={borderless} tableData={tableData} >
+      This is a borderless table with test ids in some of its cells.
+    </VaTable>
+  );
+};
+
 export const Default = Template.bind(null);
 
 Default.args = {
@@ -155,8 +171,14 @@ BorderlessWithLinks.args = {
   ...defaultArgs
 }
 
-export const BorderlessTableWithRouterLinks = RouterLinks.bind(null);
-BorderlessTableWithRouterLinks.args = {
+export const BorderlessWithRouterLinks = RouterLinks.bind(null);
+BorderlessWithRouterLinks.args = {
   tableData: tableDataWithRouterLinks,
+  ...defaultArgs
+}
+
+export const BorderlessWithTestId = WithTestId.bind(null);
+BorderlessWithTestId.args = {
+  tableData: tableDataWithTestIds,
   ...defaultArgs
 }

--- a/packages/storybook/stories/va-table.stories.jsx
+++ b/packages/storybook/stories/va-table.stories.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { VaPagination } from "@department-of-veterans-affairs/component-library/dist/react-bindings";
+import { VaPagination, VaTable } from "@department-of-veterans-affairs/component-library/dist/react-bindings";
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const tableDocs = getWebComponentDocs('va-table');
@@ -250,6 +250,22 @@ const Pagination = args => {
     </main>
   );
 };
+
+const V3Template = (args) => {
+  const { borderless } = args;
+  const columns = ['Document title', 'Description', 'Year'];
+  const tableData = [columns, ...data];
+  return (
+    <main>
+      <VaTable uswds={true} borderless={borderless} tableData={tableData} />
+    </main>
+  );
+};
+
+export const Borderless = V3Template.bind({ data });
+Borderless.args = {
+  borderless: true
+}
 
 export const Default = Template.bind({ data });
 Default.args = {

--- a/packages/storybook/stories/va-table.stories.jsx
+++ b/packages/storybook/stories/va-table.stories.jsx
@@ -251,21 +251,6 @@ const Pagination = args => {
   );
 };
 
-const V3Template = (args) => {
-  const { borderless } = args;
-  const columns = ['Document title', 'Description', 'Year'];
-  const tableData = [columns, ...data];
-  return (
-    <main>
-      <VaTable uswds={true} borderless={borderless} tableData={tableData} />
-    </main>
-  );
-};
-
-export const Borderless = V3Template.bind({ data });
-Borderless.args = {
-  borderless: true
-}
 
 export const Default = Template.bind({ data });
 Default.args = {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "6.0.6",
+  "version": "6.1.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1186,6 +1186,7 @@ export namespace Components {
         "uswds"?: boolean;
     }
     interface VaTable {
+        "borderless"?: boolean;
         /**
           * Whether the initial sort state will be descending or not.
          */
@@ -1194,12 +1195,17 @@ export namespace Components {
           * The zero-based index of the column to sort by (Doesn't work in IE11). Optional.
          */
         "sortColumn"?: number;
+        "tableData"?: string | string[][];
         /**
           * The title of the table
          */
         "tableTitle": string;
+        "uswds"?: boolean;
     }
     interface VaTableRow {
+        "isHeader"?: boolean;
+        "rowData"?: string | string[];
+        "uswds"?: boolean;
     }
     interface VaTelephone {
         /**
@@ -3283,6 +3289,7 @@ declare namespace LocalJSX {
         "uswds"?: boolean;
     }
     interface VaTable {
+        "borderless"?: boolean;
         /**
           * Whether the initial sort state will be descending or not.
          */
@@ -3291,12 +3298,17 @@ declare namespace LocalJSX {
           * The zero-based index of the column to sort by (Doesn't work in IE11). Optional.
          */
         "sortColumn"?: number;
+        "tableData"?: string | string[][];
         /**
           * The title of the table
          */
         "tableTitle"?: string;
+        "uswds"?: boolean;
     }
     interface VaTableRow {
+        "isHeader"?: boolean;
+        "rowData"?: string | string[];
+        "uswds"?: boolean;
     }
     interface VaTelephone {
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1211,6 +1211,9 @@ export namespace Components {
           * The title of the table
          */
         "tableTitle": string;
+        /**
+          * Whether this component will use the uswds styling.
+         */
         "uswds"?: boolean;
     }
     interface VaTableRow {
@@ -3332,6 +3335,9 @@ declare namespace LocalJSX {
           * The title of the table
          */
         "tableTitle"?: string;
+        /**
+          * Whether this component will use the uswds styling.
+         */
         "uswds"?: boolean;
     }
     interface VaTableRow {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -5,6 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { TableRows } from "./components/va-table/tableTypes";
 export namespace Components {
     interface VaAccordion {
         /**
@@ -1186,6 +1187,9 @@ export namespace Components {
         "uswds"?: boolean;
     }
     interface VaTable {
+        /**
+          * If uswds is true, shouldl the table be borderless or not.
+         */
         "borderless"?: boolean;
         /**
           * Whether the initial sort state will be descending or not.
@@ -1195,7 +1199,10 @@ export namespace Components {
           * The zero-based index of the column to sort by (Doesn't work in IE11). Optional.
          */
         "sortColumn"?: number;
-        "tableData"?: string | string[][];
+        /**
+          * The data used to render the table. Should be an array of arrays, with the first row representing the table headers and the subsequent rows the table body. Each string or object in the header or table body arrays is rendered in a table cell. The data can be passed as a string (if using the pure web component) or as an  object if using the React binding.  Each cell can be a string or an object; use an object if the cell is to contain a link or a React Router link.
+         */
+        "tableData"?: string | TableRows;
         /**
           * The title of the table
          */
@@ -1531,6 +1538,10 @@ export interface VaSelectCustomEvent<T> extends CustomEvent<T> {
 export interface VaStatementOfTruthCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLVaStatementOfTruthElement;
+}
+export interface VaTableCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLVaTableElement;
 }
 export interface VaTelephoneCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -3289,16 +3300,26 @@ declare namespace LocalJSX {
         "uswds"?: boolean;
     }
     interface VaTable {
+        /**
+          * If uswds is true, shouldl the table be borderless or not.
+         */
         "borderless"?: boolean;
         /**
           * Whether the initial sort state will be descending or not.
          */
         "descending"?: boolean;
         /**
+          * This event is fired if a React Router link in a table cell is clicked on
+         */
+        "onRouteChange"?: (event: VaTableCustomEvent<{ href: string }>) => void;
+        /**
           * The zero-based index of the column to sort by (Doesn't work in IE11). Optional.
          */
         "sortColumn"?: number;
-        "tableData"?: string | string[][];
+        /**
+          * The data used to render the table. Should be an array of arrays, with the first row representing the table headers and the subsequent rows the table body. Each string or object in the header or table body arrays is rendered in a table cell. The data can be passed as a string (if using the pure web component) or as an  object if using the React binding.  Each cell can be a string or an object; use an object if the cell is to contain a link or a React Router link.
+         */
+        "tableData"?: string | TableRows;
         /**
           * The title of the table
          */

--- a/packages/web-components/src/components/va-table/tableTypes.tsx
+++ b/packages/web-components/src/components/va-table/tableTypes.tsx
@@ -1,0 +1,7 @@
+export type TableCell  = {
+  text: string;
+  href?: string;
+  isRouterLink?: boolean;
+} | string;
+
+export type TableRows = TableCell[][];

--- a/packages/web-components/src/components/va-table/tableTypes.tsx
+++ b/packages/web-components/src/components/va-table/tableTypes.tsx
@@ -2,6 +2,7 @@ export type TableCell  = {
   text: string;
   href?: string;
   isRouterLink?: boolean;
+  testId?: string;
 } | string;
 
 export type TableRows = TableCell[][];

--- a/packages/web-components/src/components/va-table/test/va-table.e2e.ts
+++ b/packages/web-components/src/components/va-table/test/va-table.e2e.ts
@@ -274,7 +274,7 @@ describe('va-table', () => {
       expect(links).toHaveLength(4);
     });
 
-    it('does not emit an event when a link is clicked when the link does not have isRouterLink = true', async () {
+    it('does not emit an event when a link is clicked when the link does not have isRouterLink = true', async () => {
       const tableDataWithLinks = '[["Document title","Description","Year"],[{"text":"Declaration of Independence","href":"https://www.archives.gov/founding-docs/declaration-transcript"},"Statement adopted by the Continental Congress declaring independence from the British Empire.","1776"],[{"text":"Bill of Rights","href":"https://www.archives.gov/founding-docs/bill-of-rights-transcript"},"The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.","1791"],[{"text":"Declaration of Sentiments","href":"https://www.nps.gov/wori/learn/historyculture/declaration-of-sentiments.htm"},"A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.","1848"],[{"text":"Emancipation Proclamation","href":"https://www.archives.gov/exhibits/featured-documents/emancipation-proclamation?_ga=2.100862977.1665893808.1712776954-1250436154.1712776953"},"An executive order granting freedom to slaves in designated southern states.","1863"]]';
       const page = await newE2EPage();
       await page.setContent(`
@@ -284,8 +284,8 @@ describe('va-table', () => {
       `);
       const routeChangeSpy = await page.spyOnEvent('routeChange');
 
-      const link = await page.find('va-table >>> va-link');
-      link.click();
+      const vaLink = await page.find('va-table >>> va-link');
+      await vaLink.click();
       expect(routeChangeSpy).not.toHaveReceivedEvent();
 
 
@@ -301,8 +301,8 @@ describe('va-table', () => {
       `);
       const routeChangeSpy = await page.spyOnEvent('routeChange');
 
-      const link = await page.find('va-table >>> va-link');
-      link.click();
+      const vaLink = await page.find('va-table >>> va-link');
+      await vaLink.click();
       expect(routeChangeSpy).toHaveReceivedEvent();
     });
   })

--- a/packages/web-components/src/components/va-table/test/va-table.e2e.ts
+++ b/packages/web-components/src/components/va-table/test/va-table.e2e.ts
@@ -260,5 +260,50 @@ describe('va-table', () => {
 
       await axeCheck(page);
     });
+
+    it('renders borderless table with links', async () => {
+      const tableDataWithLinks = '[["Document title","Description","Year"],[{"text":"Declaration of Independence","href":"https://www.archives.gov/founding-docs/declaration-transcript"},"Statement adopted by the Continental Congress declaring independence from the British Empire.","1776"],[{"text":"Bill of Rights","href":"https://www.archives.gov/founding-docs/bill-of-rights-transcript"},"The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.","1791"],[{"text":"Declaration of Sentiments","href":"https://www.nps.gov/wori/learn/historyculture/declaration-of-sentiments.htm"},"A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.","1848"],[{"text":"Emancipation Proclamation","href":"https://www.archives.gov/exhibits/featured-documents/emancipation-proclamation?_ga=2.100862977.1665893808.1712776954-1250436154.1712776953"},"An executive order granting freedom to slaves in designated southern states.","1863"]]';
+      const page = await newE2EPage();
+      await page.setContent(`
+        <va-table table-data='${tableDataWithLinks}' uswds>
+          Caption for a table
+        </va-table>
+      `);
+      const links = await page.findAll('va-table >>> va-link');
+
+      expect(links).toHaveLength(4);
+    });
+
+    it('does not emit an event when a link is clicked when the link does not have isRouterLink = true', async () {
+      const tableDataWithLinks = '[["Document title","Description","Year"],[{"text":"Declaration of Independence","href":"https://www.archives.gov/founding-docs/declaration-transcript"},"Statement adopted by the Continental Congress declaring independence from the British Empire.","1776"],[{"text":"Bill of Rights","href":"https://www.archives.gov/founding-docs/bill-of-rights-transcript"},"The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.","1791"],[{"text":"Declaration of Sentiments","href":"https://www.nps.gov/wori/learn/historyculture/declaration-of-sentiments.htm"},"A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.","1848"],[{"text":"Emancipation Proclamation","href":"https://www.archives.gov/exhibits/featured-documents/emancipation-proclamation?_ga=2.100862977.1665893808.1712776954-1250436154.1712776953"},"An executive order granting freedom to slaves in designated southern states.","1863"]]';
+      const page = await newE2EPage();
+      await page.setContent(`
+        <va-table table-data='${tableDataWithLinks}' uswds>
+          Caption for a table
+        </va-table>
+      `);
+      const routeChangeSpy = await page.spyOnEvent('routeChange');
+
+      const link = await page.find('va-table >>> va-link');
+      link.click();
+      expect(routeChangeSpy).not.toHaveReceivedEvent();
+
+
+    });
+
+    it('fires a route-change event when a react router link is clicked', async () => {
+      const tableDataWithRouterLinks = '[["Document title","Description","Year"],[{"text":"Declaration of Independence","href":"https://www.archives.gov/founding-docs/declaration-transcript","isRouterLink":true},"Statement adopted by the Continental Congress declaring independence from the British Empire.","1776"],[{"text":"Bill of Rights","href":"https://www.archives.gov/founding-docs/bill-of-rights-transcript","isRouterLink":true},"The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.","1791"],[{"text":"Declaration of Sentiments","href":"https://www.nps.gov/wori/learn/historyculture/declaration-of-sentiments.htm","isRouterLink":true},"A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.","1848"],[{"text":"Emancipation Proclamation","href":"https://www.archives.gov/exhibits/featured-documents/emancipation-proclamation?_ga=2.100862977.1665893808.1712776954-1250436154.1712776953","isRouterLink":true},"An executive order granting freedom to slaves in designated southern states.","1863"]]';
+      const page = await newE2EPage();
+      await page.setContent(`
+        <va-table table-data='${tableDataWithRouterLinks}' uswds>
+          Caption for a table
+        </va-table>
+      `);
+      const routeChangeSpy = await page.spyOnEvent('routeChange');
+
+      const link = await page.find('va-table >>> va-link');
+      link.click();
+      expect(routeChangeSpy).toHaveReceivedEvent();
+    });
   })
 });

--- a/packages/web-components/src/components/va-table/test/va-table.e2e.ts
+++ b/packages/web-components/src/components/va-table/test/va-table.e2e.ts
@@ -205,4 +205,60 @@ describe('va-table', () => {
       expect(sortIcon.getAttribute('aria-label')).toEqual('descending');
     });
   });
+
+  describe('va-table v3', () => {
+    const tableData = '[["Document title","Description","Year"],["Bill of Rights","The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.","1791"],["Declaration of Sentiments","A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.","1848"]]';
+
+    it('renders borderless table', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <va-table table-data='${tableData}' uswds>
+          Caption for a table
+        </va-table>
+      `);
+      const element = await page.find('va-table');
+      expect(element).toEqualHtml(`
+      <va-table uswds table-data='${tableData}' class="hydrated">
+        <mock:shadow-root>
+          <table class="usa-table usa-table--borderless">
+            <caption>
+              <slot></slot>
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Document title</th>
+                <th scope="col">Description</th>
+                <th scope="col">Year</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Bill of Rights</th>
+                <td>The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.</td>
+                <td>1791</td>
+              </tr>
+              <tr>
+                <th scope="row">Declaration of Sentiments</th>
+                <td>A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
+                <td>1848</td>
+              </tr>
+            </tbody>
+          </table>
+        </mock:shadow-root>
+        Caption for a table
+      </va-table>
+      `);
+    });
+
+    it('passes an axe check', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <va-table table-data='${tableData}' uswds>
+          Caption for a table
+        </va-table>
+      `);
+
+      await axeCheck(page);
+    });
+  })
 });

--- a/packages/web-components/src/components/va-table/test/va-table.e2e.ts
+++ b/packages/web-components/src/components/va-table/test/va-table.e2e.ts
@@ -305,5 +305,20 @@ describe('va-table', () => {
       await vaLink.click();
       expect(routeChangeSpy).toHaveReceivedEvent();
     });
+
+
+    it('adds a test id', async () => {
+      const tableDataWithTestIds = '[["Document title","Description","Year"],[{"text":"Declaration of Independence","testId":"this-is-a-test-id","isRouterLink":true},"Statement adopted by the Continental Congress declaring independence from the British Empire.","1776"],[{"text":"Bill of Rights","href":"https://www.archives.gov/founding-docs/bill-of-rights-transcript","isRouterLink":true},"The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.","1791"],[{"text":"Declaration of Sentiments","href":"https://www.nps.gov/wori/learn/historyculture/declaration-of-sentiments.htm","isRouterLink":true},"A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.","1848"],[{"text":"Emancipation Proclamation","href":"https://www.archives.gov/exhibits/featured-documents/emancipation-proclamation?_ga=2.100862977.1665893808.1712776954-1250436154.1712776953","isRouterLink":true},"An executive order granting freedom to slaves in designated southern states.","1863"]]';
+      const page = await newE2EPage();
+      await page.setContent(`
+        <va-table table-data='${tableDataWithTestIds}' uswds>
+          Caption for a table
+        </va-table>
+      `);
+
+      const dataElement = await page.find('va-table >>> span[data-testid="this-is-a-test-id"]');
+
+      expect(dataElement).toBeDefined()
+    })
   })
 });

--- a/packages/web-components/src/components/va-table/va-table-row.tsx
+++ b/packages/web-components/src/components/va-table/va-table-row.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, Host, Prop, State, JSX, h } from '@stencil/core';
 
 @Component({
   tag: 'va-table-row',
@@ -6,11 +6,53 @@ import { Component, Host, h } from '@stencil/core';
   shadow: true,
 })
 export class VaTableRow {
+
+  @Prop() uswds?: boolean = false;
+
+  @Prop() isHeader?: boolean = false;
+
+  @Prop() rowData?: string | string[];
+
+  @State() formattedRowData?: string[];
+
+  componentWillLoad() {
+    if (this.uswds) {
+      const data = typeof this.rowData === 'string'
+        ? JSON.parse(this.rowData)
+        : this.rowData;
+      this.formattedRowData = data;
+    }
+  }
+
+  getHeaderRow(): JSX.Element {
+    return (this.formattedRowData.map(cell =>
+        <th scope="col">{cell}</th>))
+  }
+
+  getRow(): JSX.Element {
+    return (this.formattedRowData.map((item, index) => {
+      const cell = index === 0
+        ? <th scope="row">{item}</th>
+        : <td>{item}</td>;
+      return cell;
+    }));
+  }
+
   render() {
-    return (
-      <Host role="row">
-        <slot></slot>
-      </Host>
-    );
+    const { uswds, isHeader } = this;
+    if (uswds) {
+      return (
+        <tr>
+          {isHeader ? this.getHeaderRow() : this.getRow()}
+        </tr>
+      )
+    } else {
+      return (
+        <Host role="row">
+          <slot></slot>
+        </Host>
+      );
+    }
+
   }
 }

--- a/packages/web-components/src/components/va-table/va-table.scss
+++ b/packages/web-components/src/components/va-table/va-table.scss
@@ -1,3 +1,4 @@
+@forward 'settings';
 @use 'usa-table/src/styles/usa-table';
 @import '~@department-of-veterans-affairs/css-library/dist/tokens/scss/variables.scss';
 

--- a/packages/web-components/src/components/va-table/va-table.scss
+++ b/packages/web-components/src/components/va-table/va-table.scss
@@ -1,0 +1,44 @@
+@use 'usa-table/src/styles/usa-table';
+@import '~@department-of-veterans-affairs/css-library/dist/tokens/scss/variables.scss';
+
+
+:host([uswds='true']) table, 
+:host([uswds='true']) caption {
+  font-size: 1.06 * $v3-font-base-size;
+}
+
+:host(:not([uswds='true'])) {
+  display: table;
+  font-family: var(--font-source-sans);
+  border-collapse: collapse;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+::slotted([slot='headers']) {
+  background: var(--vads-color-base-lightest);
+  font-weight: 700;
+}
+
+:host(:not([uswds='true'])) caption {
+  text-align: left;
+  padding: 0 0 0.5rem;
+  font-weight: 700;
+  font-size: 2rem;
+  font-family: var(--font-serif);
+  margin-bottom: 1.2rem;
+}
+
+@media screen and (max-width: 768px) {
+  :host(:not([uswds='true'])) thead {
+    display: none;
+  }
+
+  ::slotted(va-table-row) {
+    border-bottom: 1px solid var(--vads-color-gray-medium);
+  }
+  ::slotted(va-table-row):first-child {
+    border-top: 1px solid var(--vads-color-gray-medium);
+  }
+}

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -243,7 +243,7 @@ export class VaTable {
     if (typeof cell === 'string') {
       content = cell;
     } else {
-      const { text, href, isRouterLink } = cell;
+      const { text, href, isRouterLink, testId } = cell;
       if (href) {
         if (isRouterLink) {
           content =
@@ -256,6 +256,9 @@ export class VaTable {
         }
       } else {
         content = text;
+      }
+      if (testId) {
+        content = <span data-testid={testId}>{content}</span>
       }
     }
     return content;

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -1,4 +1,5 @@
-import { Component, Element, Host, Prop, State, h } from '@stencil/core';
+import { Component, Element, Host, Prop, State,  h } from '@stencil/core';
+import classnames from 'classnames';
 import { isNumeric } from '../../utils/utils';
 import ascendingIcon from '../../assets/sort-arrow-up.svg?format=text';
 import descendingIcon from '../../assets/sort-arrow-down.svg?format=text';
@@ -18,7 +19,7 @@ import { quicksort, reverseQuicksort } from '../../utils/dom-sort';
 
 @Component({
   tag: 'va-table',
-  styleUrl: 'va-table.css',
+  styleUrl: 'va-table.scss',
   shadow: true,
 })
 export class VaTable {
@@ -41,6 +42,14 @@ export class VaTable {
    */
   @Prop() descending?: boolean = false;
 
+  @Prop() uswds?: boolean = false;
+
+  @Prop() borderless?: boolean = true;
+
+  @Prop() tableData?: string | string[][];// = '[["Document title","Description","Year"],["Bill of Rights","The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.","1791"],["Declaration of Sentiments","A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.","1848"]]';
+
+  @State() formattedTableData?: string[][];
+
   /**
    * The next direction to sort the rows
    */
@@ -48,103 +57,116 @@ export class VaTable {
 
   private observer: MutationObserver;
 
-  componentDidLoad() {
-    // For IE11 compatibility. `el.children` renders booleans instead of html elements,
-    // so instead we use `el.childNodes` and filter out nodes that aren't a proper tag
-    const elementChildren = (el: HTMLElement) =>
-      Array.from(el.childNodes).filter(node => node.nodeName !== '#text');
-
-    const headerRow = Array.from(
-      this.el.querySelectorAll('va-table-row'),
-    )[0] as HTMLVaTableRowElement;
-
-    this.headers = elementChildren(headerRow) as Array<HTMLElement>;
-    const columns = [];
-
-    /* eslint-disable i18next/no-literal-string */
-    this.headers.forEach((item: HTMLVaTableRowElement) => {
-      columns.push(item.textContent);
-      item.setAttribute('role', 'columnheader');
-      item.setAttribute('scope', 'col');
-    });
-    /* eslint-enable i18next/no-literal-string */
-
-    if (this.sortColumn >= 0 && columns.length > this.sortColumn) {
-      const icon = this.sortAscending ? ascendingIcon : descendingIcon;
-      const button = document.createElement('button');
-      button.setAttribute(
-        'aria-label',
-        `sort data by ${this.sortAscending ? 'descending' : 'ascending'}`,
-      );
-      button.classList.add(
-        'vads-u-padding--0',
-        'vads-u-margin--0',
-        'vads-u-text-decoration--none',
-        'vads-u-font-weight--bold',
-        'vads-u-background-color--gray-lightest',
-        'vads-u-color--base',
-      );
-      button.innerHTML = `${columns[this.sortColumn]}${icon}`;
-      button.onclick = this.handleSort.bind(this);
-
-      const sortableHeader = this.headers[this.sortColumn];
-      sortableHeader.childNodes.forEach(child => child.remove());
-      sortableHeader.appendChild(button);
-
-      this.handleSort();
+  componentWillLoad() {
+    if (this.uswds) {
+      debugger
+      const data = typeof this.tableData === 'string'
+        ? JSON.parse(this.tableData)
+        : this.tableData;
+      this.formattedTableData = data;
     }
+  }
 
-    // Store alignment classes by column index.
-    const alignment = {};
+  componentDidLoad() {
+    if (!this.uswds) {
+      // For IE11 compatibility. `el.children` renders booleans instead of html elements,
+      // so instead we use `el.childNodes` and filter out nodes that aren't a proper tag
+      const elementChildren = (el: HTMLElement) =>
+        Array.from(el.childNodes).filter(node => node.nodeName !== '#text');
 
-    const handleCellAdjustments = () => {
-      const rows = Array.from(this.el.querySelectorAll('va-table-row'))
-        .filter((row) => row.slot !== 'headers') as Array<HTMLVaTableRowElement>;
+      const headerRow = Array.from(
+        this.el.querySelectorAll('va-table-row'),
+      )[0] as HTMLVaTableRowElement;
 
-      Array.from(rows).forEach((row, index) => {
-        const cells = elementChildren(row);
+      this.headers = elementChildren(headerRow) as Array<HTMLElement>;
+      const columns = [];
 
-        cells.forEach((cell: HTMLSpanElement, colNum) => {
-          // Look at the first row of data to determine type of data in column
-          // Right align columns with numeric data
-          if (index === 0 && isNumeric(cell.textContent)) {
-            // eslint-disable-next-line i18next/no-literal-string
-            alignment[colNum] = 'text-align-right';
-            (this.headers[colNum] as HTMLElement).classList.add(
-              alignment[colNum],
-            );
-          }
-          if (alignment[colNum]) {
-            cell.classList.add(alignment[colNum]);
-          }
-  
-          // This allows the responsive table in mobile view to display
-          // a column header
-          /* eslint-disable i18next/no-literal-string */
-          cell.setAttribute('data-label', columns[colNum]);
-          cell.setAttribute('role', 'cell');
-        });
+      /* eslint-disable i18next/no-literal-string */
+      this.headers.forEach((item: HTMLVaTableRowElement) => {
+        columns.push(item.textContent);
+        item.setAttribute('role', 'columnheader');
+        item.setAttribute('scope', 'col');
       });
-    };
+      /* eslint-enable i18next/no-literal-string */
 
-    handleCellAdjustments();
+      if (this.sortColumn >= 0 && columns.length > this.sortColumn) {
+        const icon = this.sortAscending ? ascendingIcon : descendingIcon;
+        const button = document.createElement('button');
+        button.setAttribute(
+          'aria-label',
+          `sort data by ${this.sortAscending ? 'descending' : 'ascending'}`,
+        );
+        button.classList.add(
+          'vads-u-padding--0',
+          'vads-u-margin--0',
+          'vads-u-text-decoration--none',
+          'vads-u-font-weight--bold',
+          'vads-u-background-color--gray-lightest',
+          'vads-u-color--base',
+        );
+        button.innerHTML = `${columns[this.sortColumn]}${icon}`;
+        button.onclick = this.handleSort.bind(this);
 
-    // Watch for changes to the table body slot.
-    const slot = this.el.shadowRoot.querySelectorAll('slot')[1].assignedElements()[0] as HTMLSlotElement;
-    const callback = mutationList => {
-      for (const mutation of mutationList) {
-        if (mutation.type === 'childList' || mutation.type === 'characterData') {
-          handleCellAdjustments();
-        }
+        const sortableHeader = this.headers[this.sortColumn];
+        sortableHeader.childNodes.forEach(child => child.remove());
+        sortableHeader.appendChild(button);
+
+        this.handleSort();
       }
-    };
 
-    this.observer = new MutationObserver(callback);
-    this.observer.observe(slot, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    });
+
+      // Store alignment classes by column index.
+      const alignment = {};
+
+      const handleCellAdjustments = () => {
+        const rows = Array.from(this.el.querySelectorAll('va-table-row'))
+          .filter((row) => row.slot !== 'headers') as Array<HTMLVaTableRowElement>;
+
+        Array.from(rows).forEach((row, index) => {
+          const cells = elementChildren(row);
+
+          cells.forEach((cell: HTMLSpanElement, colNum) => {
+            // Look at the first row of data to determine type of data in column
+            // Right align columns with numeric data
+            if (index === 0 && isNumeric(cell.textContent)) {
+              // eslint-disable-next-line i18next/no-literal-string
+              alignment[colNum] = 'text-align-right';
+              (this.headers[colNum] as HTMLElement).classList.add(
+                alignment[colNum],
+              );
+            }
+            if (alignment[colNum]) {
+              cell.classList.add(alignment[colNum]);
+            }
+  
+            // This allows the responsive table in mobile view to display
+            // a column header
+            /* eslint-disable i18next/no-literal-string */
+            cell.setAttribute('data-label', columns[colNum]);
+            cell.setAttribute('role', 'cell');
+          });
+        });
+      };
+
+      handleCellAdjustments();
+
+      // Watch for changes to the table body slot.
+      const slot = this.el.shadowRoot.querySelectorAll('slot')[1].assignedElements()[0] as HTMLSlotElement;
+      const callback = mutationList => {
+        for (const mutation of mutationList) {
+          if (mutation.type === 'childList' || mutation.type === 'characterData') {
+            handleCellAdjustments();
+          }
+        }
+      };
+
+      this.observer = new MutationObserver(callback);
+      this.observer.observe(slot, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      });
+    }
   }
 
   disconnectedCallback() {
@@ -154,12 +176,14 @@ export class VaTable {
   }
 
   componentDidUpdate() {
-    // Update the sort icon
-    if (this.sortColumn >= 0) {
-      const icon = this.sortAscending ? descendingIcon : ascendingIcon;
-      const button = this.el.querySelector('va-table-row[slot] button');
-      const node = button.children[0];
-      node.outerHTML = icon;
+    if (!this.uswds) {
+      // Update the sort icon
+      if (this.sortColumn >= 0) {
+        const icon = this.sortAscending ? descendingIcon : ascendingIcon;
+        const button = this.el.querySelector('va-table-row[slot] button');
+        const node = button.children[0];
+        node.outerHTML = icon;
+      }
     }
   }
 
@@ -177,20 +201,54 @@ export class VaTable {
     this.sortAscending = !this.sortAscending;
   }
 
-  render() {
-    const { tableTitle } = this;
-
+  makeTableRow(row: string[]): JSX.Element {
     return (
-      <Host role="table">
-        {tableTitle && <caption>{tableTitle}</caption>}
-        <thead>
-          <slot name="headers"></slot>
-        </thead>
+      <tr>
+        {row.map((item, i) => {
+          const cell = i === 0
+          ? <th scope="row">{item}</th>
+          : <td>{item}</td>
+          return cell;
+        } )}
+      </tr>
+    )
+  }
 
-        <tbody>
-          <slot></slot>
-        </tbody>
-      </Host>
-    );
+  render() {
+    const { tableTitle, uswds, formattedTableData, borderless } = this;
+    if (uswds) {
+      const tableClasses = classnames({
+        'usa-table': true,
+        'usa-table--borderless': borderless,
+      });
+      const [header, ...rows] = formattedTableData;
+
+      return (
+        <table class={tableClasses}>
+          <caption>
+            <slot></slot>
+          </caption>
+          <thead>
+            <tr>{header.map(cell => <th scope="col">{cell}</th>)}</tr>
+          </thead>
+          <tbody>
+            {rows.map(row => this.makeTableRow(row))}
+          </tbody>
+      </table>
+      )
+    } else {
+      return (
+        <Host role="table">
+          {tableTitle && <caption>{tableTitle}</caption>}
+          <thead>
+            <slot name="headers"></slot>
+          </thead>
+
+          <tbody>
+            <slot></slot>
+          </tbody>
+        </Host>
+      );
+    }
   }
 }

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -50,7 +50,7 @@ export class VaTable {
   @Prop() uswds?: boolean = false;
 
   /**
-   * If uswds is true, shouldl the table be borderless or not.
+   * If uswds is true, should the table be borderless or not.
    */
   @Prop() borderless?: boolean = true;
 

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -6,9 +6,11 @@ import descendingIcon from '../../assets/sort-arrow-down.svg?format=text';
 import { quicksort, reverseQuicksort } from '../../utils/dom-sort';
 import { TableCell, TableRows } from './tableTypes';
 /**
- * This component expects `<va-table-row>` elements as children.
+ * V1 version of this component expects `<va-table-row>` elements as children.
  * Children of each row element should be `<span>` elements. Table
  * semantics will be added and numeric columns will be right aligned.
+ * 
+ * V3 version expects an array of arrays representing table data
  */
 
 /**
@@ -16,14 +18,6 @@ import { TableCell, TableRows } from './tableTypes';
  * @maturityCategory use
  * @maturityLevel best_practice
  */
-
-// type TableCell  = {
-//   text: string;
-//   href?: string;
-//   isRouterLink?: boolean;
-// } | string;
-
-// type TableRows = TableCell[][];
 
 @Component({
   tag: 'va-table',
@@ -50,6 +44,9 @@ export class VaTable {
    */
   @Prop() descending?: boolean = false;
 
+  /**
+   * Whether this component will use the uswds styling.
+   */
   @Prop() uswds?: boolean = false;
 
   /**


### PR DESCRIPTION
## Chromatic
<!-- This `1860-borderless-table` is a placeholder for a CI job - it will be updated automatically -->
https://1860-borderless-table--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR adds the uswds borderless table to the `<va-table>` component.

1. Note: the api supports the inclusion of links, including React Router links, but does not allow for the use of arbitrary elements or styles. Including styles (by means of classes) is not tenable due to the shadow dom. Arbitrary elements cannot be included in the table data through a straightforward process. I did not any instances in `vets-website` where these things would be needed so I opted for a simpler api for the first iteration.

Closes [1860](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1860)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<img width="981" alt="Screenshot 2024-04-11 at 3 12 40 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/16337107-3d69-4654-9821-8adbf529e364">

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
