### PR TITLE
Bumping versions to reflect latest release

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "38.0.3",
+  "version": "38.0.4",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Chromatic
<!-- This `9999-icon-release-version-bump` is a placeholder for a CI job - it will be updated automatically -->
https://9999-icon-release-version-bump--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Fix to release version.
