### PR TITLE
Rename medium-mobile breakpoint to tablet

### DIFF
--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,12 +1,12 @@
 /**
  * Do not edit directly
- * Generated on Fri, 29 Mar 2024 17:20:23 GMT
+ * Generated on Fri, 12 Apr 2024 15:25:04 GMT
  */
 
 :root {
   --xsmall-screen: 320px;
   --small-screen: 481px;
-  --medium-mobile: 640px;
+  --tablet: 640px;
   --medium-screen: 768px;
   --small-desktop-screen: 1008px;
   --large-screen: 1201px;

--- a/packages/css-library/dist/tokens/json/variables.json
+++ b/packages/css-library/dist/tokens/json/variables.json
@@ -29,19 +29,19 @@
       "small-screen"
     ]
   },
-  "medium-mobile": {
+  "tablet": {
     "value": "640px",
     "filePath": "tokens/breakpoints.json",
     "isSource": true,
     "original": {
       "value": "640px"
     },
-    "name": "medium-mobile",
+    "name": "tablet",
     "attributes": {
-      "category": "medium-mobile"
+      "category": "tablet"
     },
     "path": [
-      "medium-mobile"
+      "tablet"
     ]
   },
   "medium-screen": {

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,10 +1,10 @@
 
 // Do not edit directly
-// Generated on Fri, 29 Mar 2024 17:20:23 GMT
+// Generated on Fri, 12 Apr 2024 15:25:04 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;
-$medium-mobile: 640px;
+$tablet: 640px;
 $medium-screen: 768px;
 $small-desktop-screen: 1008px;
 $large-screen: 1201px;

--- a/packages/css-library/tokens/breakpoints.json
+++ b/packages/css-library/tokens/breakpoints.json
@@ -5,7 +5,7 @@
   "small-screen": {
     "value": "481px"
   },
-  "medium-mobile": {
+  "tablet": {
     "value": "640px"
   },
   "medium-screen": {


### PR DESCRIPTION
## Chromatic
<!-- This `2679-rename-scss-breakpoint` is a placeholder for a CI job - it will be updated automatically -->
https://2679-rename-scss-breakpoint--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2679

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A

## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
