### PR TITLE
Update branch name check regex

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -19,7 +19,7 @@ if [ $BRANCH_NAME_LENGTH -gt 37 ]; then
 fi
 
 # lowercase letters, numbers, and dashes only
-VALID_BRANCH_REGEX='^[a-z\d]+[a-z\d\-]*$'
+VALID_BRANCH_REGEX='^[a-z0-9]+[a-z0-9\-]*$'
 
 if [[ ! $BRANCH_NAME =~ $VALID_BRANCH_REGEX ]]; then
   echo "Branch name must start with a lowercase letter or"


### PR DESCRIPTION
## Chromatic
<!-- This `000-pre-commit-branch-regex` is a placeholder for a CI job - it will be updated automatically -->
https://000-pre-commit-branch-regex--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

We discovered that bash does not support `\d` so valid a branch name with numbers like `000-example-branch` were not passing the pre-commit check.

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
