### PR TITLE
removes the usage of getAssetPath() and changes /assets to /img

### DIFF
--- a/packages/web-components/src/components/va-icon/va-icon.tsx
+++ b/packages/web-components/src/components/va-icon/va-icon.tsx
@@ -48,7 +48,7 @@ export class VaIcon {
       'usa-icon': true,
       [`usa-icon--size-${size}`]: !!size,
     });
-    const imageSrc = `${getAssetPath('/assets/sprite.svg')}#${icon}`;
+    const imageSrc = `/img/sprite.svg#${icon}`;
     return (
       <Host>
         <svg


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

This PR attempts to reconcile the asset path structure of va-icon with  vets-website and other va-components 
