### PR TITLE
Updated version of @stencil/react-output-target

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -41,7 +41,7 @@
     "@babel/core": "^7.12.13",
     "@department-of-veterans-affairs/formation": "^10.1.2",
     "@stencil/postcss": "^2.0.0",
-    "@stencil/react-output-target": "^0.4.0",
+    "@stencil/react-output-target": "^0.5.3",
     "@stencil/sass": "^2.0.0",
     "@types/jest": "^26.0.20",
     "@types/puppeteer": "^5.4.3",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -41,7 +41,7 @@
     "@babel/core": "^7.12.13",
     "@department-of-veterans-affairs/formation": "^10.1.2",
     "@stencil/postcss": "^2.0.0",
-    "@stencil/react-output-target": "^0.0.9",
+    "@stencil/react-output-target": "^0.4.0",
     "@stencil/sass": "^2.0.0",
     "@types/jest": "^26.0.20",
     "@types/puppeteer": "^5.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2063,7 +2063,7 @@ __metadata:
     "@department-of-veterans-affairs/formation": ^10.1.2
     "@stencil/core": ^2.19.2
     "@stencil/postcss": ^2.0.0
-    "@stencil/react-output-target": ^0.0.9
+    "@stencil/react-output-target": ^0.4.0
     "@stencil/sass": ^2.0.0
     "@types/jest": ^26.0.20
     "@types/puppeteer": ^5.4.3
@@ -3043,12 +3043,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/react-output-target@npm:^0.0.9":
-  version: 0.0.9
-  resolution: "@stencil/react-output-target@npm:0.0.9"
+"@stencil/react-output-target@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@stencil/react-output-target@npm:0.4.0"
   peerDependencies:
-    "@stencil/core": ">=1.8.0"
-  checksum: 974deacb010b9d7ca9ce195f5001f157b013a328be2d0d142e7a4e5094f251dfdd7f50a094acb1e906dabbaf69a84c1fb7e7aaaa6cd754b1bbe919f574cc447b
+    "@stencil/core": ^2.9.0 || ^3.0.0-beta.0
+  checksum: a88a53f4d8f41c0b0a665f59dddd88986be095b6ed3d9fbbab30f5376cd1247c7d04711fe6ac0530777ddb67d5b79bbc2c6660d49409449e39fb2bf186f76ccd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2063,7 +2063,7 @@ __metadata:
     "@department-of-veterans-affairs/formation": ^10.1.2
     "@stencil/core": ^2.19.2
     "@stencil/postcss": ^2.0.0
-    "@stencil/react-output-target": ^0.4.0
+    "@stencil/react-output-target": ^0.5.3
     "@stencil/sass": ^2.0.0
     "@types/jest": ^26.0.20
     "@types/puppeteer": ^5.4.3
@@ -3043,12 +3043,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/react-output-target@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@stencil/react-output-target@npm:0.4.0"
+"@stencil/react-output-target@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "@stencil/react-output-target@npm:0.5.3"
   peerDependencies:
-    "@stencil/core": ^2.9.0 || ^3.0.0-beta.0
-  checksum: a88a53f4d8f41c0b0a665f59dddd88986be095b6ed3d9fbbab30f5376cd1247c7d04711fe6ac0530777ddb67d5b79bbc2c6660d49409449e39fb2bf186f76ccd
+    "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
+  checksum: ce762ecd37fe8b04b4193402f8999b44291d18af59e488ab4571528473aec9cac60c508df5db68298c78a493779e4781433dc2390ce7c34039b2a7a2455bd7db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
