### PR TITLE
Add event to input, listen for that event in statement of truth

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -3440,6 +3440,7 @@ declare namespace LocalJSX {
           * The event used to track usage of the component. This is emitted when the input is blurred and enableAnalytics is true.
          */
         "onComponent-library-analytics"?: (event: VaTextInputCustomEvent<any>) => void;
+        "onInputChanged"?: (event: VaTextInputCustomEvent<any>) => void;
         /**
           * The regular expression that the input element's value is checked against on submission
          */

--- a/packages/web-components/src/components/va-statement-of-truth/va-statement-of-truth.tsx
+++ b/packages/web-components/src/components/va-statement-of-truth/va-statement-of-truth.tsx
@@ -5,7 +5,8 @@ import {
   h,
   Element,
   Event,
-  EventEmitter
+  EventEmitter,
+  Listen
 } from '@stencil/core';
 
 /**
@@ -91,14 +92,26 @@ export class VaStatementOfTruth {
   })
   vaCheckboxChange: EventEmitter;
 
+  @Listen('inputChanged')
+    getChangedValue(event: CustomEvent) {
+      // console.log("inputChanged data:", event);
+        if (event.detail) {
+            let data = event.detail;
+            // do something with your data
+            // console.log("inputChanged data:", data);
+            this.vaInputChange.emit(data);
+
+        }
+    }
+
   /**
    * Reference to host element
    */
   @Element() el: HTMLElement;
 
-  private handleInputChange = (event: Event) => {
-    this.vaInputChange.emit(event);
-  };
+  // private handleInputChange = (event: Event) => {
+  //   this.vaInputChange.emit(event);
+  // };
 
   private handleInputBlur = (event: Event) => {
     this.vaInputBlur.emit(event);
@@ -161,7 +174,7 @@ export class VaStatementOfTruth {
             value={inputValue}
             message-aria-describedby={inputMessageAriaDescribedby}
             required
-            onInput={this.handleInputChange}
+            // onInput={this.handleInputChange}
             onBlur={this.handleInputBlur}
             ref={field => (this.inputField = field)}
           />

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -182,6 +182,16 @@ export class VaTextInput {
   })
   componentLibraryAnalytics: EventEmitter;
 
+  /**
+   * 
+   */
+    @Event({
+      // eventName: 'input-changed',
+      composed: true,
+      bubbles: true,
+    })
+    inputChanged: EventEmitter;
+
   private getInputType() {
     if (!this.allowedInputTypes.includes(this.type)) {
       consoleDevError(
@@ -210,6 +220,7 @@ export class VaTextInput {
   private handleInput = (e: Event) => {
     const target = e.target as HTMLInputElement;
     this.value = target.value;
+    this.inputChanged.emit(target.value);
   };
 
   private handleBlur = () => {


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
