### PR TITLE
Add disable prop to va-select

### DIFF
--- a/packages/storybook/stories/va-select-uswds.stories.jsx
+++ b/packages/storybook/stories/va-select-uswds.stories.jsx
@@ -42,6 +42,7 @@ const defaultArgs = {
     </option>,
   ],
   'use-add-button': false,
+  'disabled': false,
 };
 
 const Template = ({
@@ -55,6 +56,7 @@ const Template = ({
   'aria-describedby-message': ariaDescribedbyMessage,
   options,
   'use-add-button': useAddButton,
+  disabled,
 }) => {
   const [modifiedOptions, setModifiedOptions] = useState(options);
 
@@ -83,6 +85,7 @@ const Template = ({
         aria-live-region-text={ariaLiveRegionText}
         message-aria-describedby={ariaDescribedbyMessage}
         use-add-button={useAddButton}
+        disabled={disabled}
       >
         {modifiedOptions}
       </va-select>

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1112,6 +1112,10 @@ export namespace Components {
     }
     interface VaSelect {
         /**
+          * disable select
+         */
+        "disabled"?: boolean;
+        /**
           * Whether or not to fire the analytics events
          */
         "enableAnalytics"?: boolean;
@@ -3256,6 +3260,10 @@ declare namespace LocalJSX {
         "uswds"?: boolean;
     }
     interface VaSelect {
+        /**
+          * disable select
+         */
+        "disabled"?: boolean;
         /**
           * Whether or not to fire the analytics events
          */

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -176,6 +176,15 @@ describe('va-select', () => {
     expect(keyDownSpy).toHaveReceivedEventTimes(2);
   });
 
+  it('renders disabled select', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-select disabled />');
+
+    // Render a disabled select
+    const selectElement = await page.find('va-select >>> select');
+    expect(selectElement.disabled).toBe.true;
+  });
+
   // Begin USWDS v3 test
   it('uswds v3 renders', async () => {
     const page = await newE2EPage();
@@ -232,5 +241,14 @@ describe('va-select', () => {
     expect(inputEl.getAttribute('aria-describedby')).not.toBeNull();
     expect(inputEl.getAttribute('aria-describedby')).toContain('error-message');
     expect(inputEl.getAttribute('aria-describedby')).toContain('input-message');
+  });
+
+  it('renders disabled select', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-select disabled />');
+
+    // Render a disabled select
+    const selectElement = await page.find('va-select >>> select');
+    expect(selectElement.disabled).toBe.true;
   });
 });

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -90,6 +90,11 @@ export class VaSelect {
   @Prop() messageAriaDescribedby?: string;
 
   /**
+   * disable select
+   */
+  @Prop() disabled?: boolean = false;
+
+  /**
    * The event attached to select's onkeydown
    */
   @Event() vaKeyDown: EventEmitter;
@@ -178,14 +183,14 @@ export class VaSelect {
   }
 
   render() {
-    const { error, reflectInputError, invalid, label, required, name, hint, messageAriaDescribedby, uswds } = this;
+    const { error, reflectInputError, invalid, label, required, name, hint, messageAriaDescribedby, uswds, disabled } = this;
 
     const errorID = uswds ? 'input-error-message': 'error-message';
-    const ariaDescribedbyIds = 
+    const ariaDescribedbyIds =
       `${messageAriaDescribedby ? 'input-message' : ''} ${
         error ? errorID : ''} ${
         hint ? 'input-hint' : ''}`.trim() || null; // Null so we don't add the attribute if we have an empty string
-    
+
     if (uswds) {
       const labelClass = classnames({
         'usa-label': true,
@@ -207,7 +212,7 @@ export class VaSelect {
           <span id={errorID} role="alert">
             {error && (
               <Fragment>
-                <span class="usa-sr-only">{i18next.t('error')}</span> 
+                <span class="usa-sr-only">{i18next.t('error')}</span>
                 <span class="usa-error-message">{error}</span>
               </Fragment>
             )}
@@ -223,6 +228,7 @@ export class VaSelect {
             onKeyDown={() => this.handleKeyDown()}
             onChange={e => this.handleChange(e)}
             part="select"
+            disabled={disabled}
           >
             <option key="0" value="" selected>{i18next.t('select')}</option>
             {this.options}
@@ -259,6 +265,7 @@ export class VaSelect {
             onKeyDown={() => this.handleKeyDown()}
             onChange={e => this.handleChange(e)}
             part="select"
+            disabled={disabled}
           >
             {this.options}
           </select>


### PR DESCRIPTION
## Chromatic
<!-- This `81600-disable-select` is a placeholder for a CI job - it will be updated automatically -->
https://81600-disable-select--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Related to work in ticket [#81600](https://github.com/department-of-veterans-affairs/va.gov-team/issues/81600)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<img width="549" alt="military base outside U.S. checkbox selected, but the va-select country is not disabled" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/fa5e79ea-6f9c-4064-924d-a8e9b06d9173">
<img width="600" alt="Disabled prop selected in storybook, showing a disabled select" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/2772adf2-d76e-4765-be89-950705078653">

## Acceptance criteria
- [ ] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
