### PR TITLE
Add message-aria-describedby to button

### DIFF
--- a/packages/storybook/stories/va-button-uswds.stories.jsx
+++ b/packages/storybook/stories/va-button-uswds.stories.jsx
@@ -25,6 +25,7 @@ const defaultArgs = {
   'primaryAlternate': undefined,
   'submit': undefined,
   'text': 'Default',
+  'message-aria-describedby': 'Optional description text for screen readers',
 };
 
 const Template = ({
@@ -38,6 +39,7 @@ const Template = ({
   primaryAlternate,
   submit,
   text,
+  'message-aria-describedby': messageAriaDescribedby,
 }) => {
   return (
     <va-button
@@ -52,6 +54,7 @@ const Template = ({
       submit={submit}
       text={text}
       onClick={e => console.log(e)}
+      message-aria-describedby={messageAriaDescribedby}
     />
   );
 };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -212,6 +212,10 @@ export namespace Components {
          */
         "label"?: string;
         /**
+          * An optional message that will be read by screen readers when the input is focused.
+         */
+        "messageAriaDescribedby"?: string;
+        /**
           * If `true`, the button will use the primary alternate variant.
          */
         "primaryAlternate"?: boolean;
@@ -2192,6 +2196,10 @@ declare namespace LocalJSX {
           * The aria-label of the component.
          */
         "label"?: string;
+        /**
+          * An optional message that will be read by screen readers when the input is focused.
+         */
+        "messageAriaDescribedby"?: string;
         /**
           * The event used to track usage of the component.
          */

--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -395,4 +395,13 @@ describe('va-button', () => {
     const button = await page.find('va-button >>> button');
     expect(button.getAttribute('aria-label')).toEqual('Edit dependent');
   });
+
+  it('renders a button with an optional screen reader description', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-button text="Edit" message-aria-describedby="Button description."></va-button>');
+
+    const descriptionSpan = await page.find('va-button >>> #button-description');
+    expect(descriptionSpan).not.toBeNull();
+    expect(descriptionSpan.textContent).toBe('Button description.');
+  });
 });

--- a/packages/web-components/src/components/va-button/va-button.scss
+++ b/packages/web-components/src/components/va-button/va-button.scss
@@ -53,7 +53,6 @@
 
 /* Original Component Styles. */
 
-// @import '../../mixins/accessibility.css';
 @import '../../mixins/buttons.css';
 
 :host([uswds='false']) {

--- a/packages/web-components/src/components/va-button/va-button.scss
+++ b/packages/web-components/src/components/va-button/va-button.scss
@@ -1,5 +1,6 @@
 @forward 'settings';
 
+@use 'uswds-helpers/src/styles/usa-sr-only';
 @use 'usa-button/src/styles/usa-button';
 
 @import '../../global/formation_overrides';
@@ -52,6 +53,7 @@
 
 /* Original Component Styles. */
 
+// @import '../../mixins/accessibility.css';
 @import '../../mixins/buttons.css';
 
 :host([uswds='false']) {

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -81,6 +81,11 @@ export class VaButton {
   @Prop({ reflect: true }) uswds?: boolean = true;
 
   /**
+   * An optional message that will be read by screen readers when the input is focused.
+   */
+  @Prop() messageAriaDescribedby?: string;
+
+  /**
    * The event used to track usage of the component.
    */
   @Event({
@@ -107,7 +112,7 @@ export class VaButton {
           type: this.secondary ? 'secondary' : 'primary',
           label: this.getButtonText(),
         },
-      }
+      };
       this.componentLibraryAnalytics.emit(detail);
     }
   };
@@ -135,7 +140,6 @@ export class VaButton {
     this.handleClick();
   }
 
-
   render() {
     const {
       back,
@@ -147,8 +151,11 @@ export class VaButton {
       secondary,
       primaryAlternate,
       big,
-      uswds
+      uswds,
+      messageAriaDescribedby,
     } = this;
+
+    const ariaDescribedbyIds = `${messageAriaDescribedby ? 'button-description' : ''}`.trim() || null;
 
     const ariaDisabled = disabled ? 'true' : undefined;
     const buttonText = getButtonText();
@@ -159,7 +166,7 @@ export class VaButton {
         'usa-button': true,
         'usa-button--big': big,
         'usa-button--outline': back || secondary,
-        'va-button-primary--alternate': primaryAlternate
+        'va-button-primary--alternate': primaryAlternate,
       });
       return (
         <Host>
@@ -167,6 +174,7 @@ export class VaButton {
             class={buttonClass}
             aria-disabled={ariaDisabled}
             aria-label={label}
+            aria-describedby={ariaDescribedbyIds}
             type={type}
             part="button"
           >
@@ -186,11 +194,16 @@ export class VaButton {
               ></va-icon>
             )}
           </button>
+          {messageAriaDescribedby && (
+              <span id="button-description" class="usa-sr-only">
+                {messageAriaDescribedby}
+              </span>
+            )}
         </Host>
       );
     } else {
       const buttonClass = classnames({
-        'va-button-primary--alternate': primaryAlternate
+        'va-button-primary--alternate': primaryAlternate,
       });
       return (
         <Host>
@@ -220,6 +233,5 @@ export class VaButton {
         </Host>
       );
     }
-
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `aria-describedby-button` is a placeholder for a CI job - it will be updated automatically -->
https://aria-describedby-button--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2739

Adds in optional screen reader text for buttons. To test:
- Open Chromatic link > Button > open example in a new tab
- Open VoiceOver (Command + F5) > tab to button
- It should read out the button text and optional description

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
  - **N/A** - no visual change.
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

No visual change.

## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
