### PR TITLE
va-text-input: incorporate non-overlapping va-number-input functions

### DIFF
--- a/packages/storybook/stories/va-text-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.jsx
@@ -58,6 +58,9 @@ const defaultArgs = {
   'form-heading': null,
   'form-description': null,
   'charcount': false,
+  'max': undefined,
+  'min': undefined,
+  'currency': undefined
 };
 
 const Template = ({
@@ -75,7 +78,10 @@ const Template = ({
   pattern,
   hint,
   'message-aria-describedby': messageAriaDescribedby,
-  charcount
+  charcount,
+  max,
+  min,
+  currency
 }) => {
   return (
     <va-text-input
@@ -96,6 +102,9 @@ const Template = ({
       onInput={e => console.log('input event value', e.target.value)}
       message-aria-describedby={messageAriaDescribedby}
       charcount={charcount}
+      min={min}
+      max={max}
+      currency={currency}
     />
   );
 };
@@ -323,6 +332,15 @@ Pattern.args = {
   pattern: '[0-9]{4}',
 };
 
+export const ValidRange = Template.bind(null);
+ValidRange.args = {
+  ...defaultArgs,
+  inputmode: 'numeric',
+  min: 0,
+  max: 4,
+  hint: "The valid range is 0 to 4",
+};
+
 export const Autocomplete = Template.bind(null);
 Autocomplete.args = {
   ...defaultArgs,
@@ -369,7 +387,13 @@ WithAdditionalInfo.args = {
 };
 
 export const WithCharacterCount = Template.bind(null);
-WithCharacterCount.args = { ...defaultArgs, maxlength: '10', charcount: true }
+WithCharacterCount.args = { ...defaultArgs, maxlength: '10', charcount: true };
+
+export const WithCurrency = Template.bind(null);
+WithCurrency.args = {
+  ...defaultArgs,
+  currency: true
+};
 
 export const Widths = WidthsTemplate.bind(null);
 Widths.args = {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1295,6 +1295,10 @@ export namespace Components {
          */
         "charcount"?: boolean;
         /**
+          * Whether this component will be used to accept a currency value.
+         */
+        "currency"?: boolean;
+        /**
           * Emit component-library-analytics events on the blur event.
          */
         "enableAnalytics"?: boolean;
@@ -1333,6 +1337,10 @@ export namespace Components {
          */
         "label"?: string;
         /**
+          * The max attribute specifies the maximum value for an input element if the inputmode is numeric.
+         */
+        "max"?: number | string;
+        /**
           * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */
         "maxlength"?: number;
@@ -1340,6 +1348,10 @@ export namespace Components {
           * An optional message that will be read by screen readers when the input is focused.
          */
         "messageAriaDescribedby"?: string;
+        /**
+          * The min attribute specifies the minimum value for an input element if the inputmode is numeric.
+         */
+        "min"?: number | string;
         /**
           * The minimum number of characters allowed in the input.
          */
@@ -3468,6 +3480,10 @@ declare namespace LocalJSX {
          */
         "charcount"?: boolean;
         /**
+          * Whether this component will be used to accept a currency value.
+         */
+        "currency"?: boolean;
+        /**
           * Emit component-library-analytics events on the blur event.
          */
         "enableAnalytics"?: boolean;
@@ -3506,6 +3522,10 @@ declare namespace LocalJSX {
          */
         "label"?: string;
         /**
+          * The max attribute specifies the maximum value for an input element if the inputmode is numeric.
+         */
+        "max"?: number | string;
+        /**
           * The maximum number of characters allowed in the input. Negative and zero values will be ignored.
          */
         "maxlength"?: number;
@@ -3513,6 +3533,10 @@ declare namespace LocalJSX {
           * An optional message that will be read by screen readers when the input is focused.
          */
         "messageAriaDescribedby"?: string;
+        /**
+          * The min attribute specifies the minimum value for an input element if the inputmode is numeric.
+         */
+        "min"?: number | string;
         /**
           * The minimum number of characters allowed in the input.
          */

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -769,4 +769,29 @@ describe('va-text-input', () => {
 
     await axeCheck(page);
   });
+
+  it('sets a range based on min and max attributes', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input min="0" max="4"/>');
+
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(inputEl.getAttribute('min')).toBe('0');
+    expect(inputEl.getAttribute('max')).toBe('4');
+  });
+
+  it('renders a "$" if currency flag set to true', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input currency />');
+    const currencyTextElement = await page.find('va-text-input >>> div > div > div');
+    expect(currencyTextElement.innerText).toContain('$');
+  });
+
+  it('sets the input mode to a default pattern if inputmode is numerical or decimal', async () => {
+    for (const inputMode of ['numeric', 'decimal']) {
+      const page = await newE2EPage();
+      await page.setContent(`<va-text-input inputmode="${inputMode}" />`);
+      const inputEl = await page.find('va-text-input >>> input');
+      expect(inputEl.getAttribute('pattern')).toEqual("[0-9]+(\.[0-9]{1,})?");
+    }
+  })
 });

--- a/packages/web-components/src/components/va-text-input/va-text-input.scss
+++ b/packages/web-components/src/components/va-text-input/va-text-input.scss
@@ -46,6 +46,29 @@ input.usa-input {
   display: block;
 }
 
+
+.currency-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  > div {
+    position: absolute;
+    left: 10px;
+  }
+
+  // for v3
+  #symbol {
+    margin-top: 8px;
+  }
+
+  #inputField {
+    padding-left: 25px;
+  }
+}
+
+
+
 /** Original Component Style **/
 @import '../../mixins/accessibility.css';
 @import '../../mixins/form-field-error.css';


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR adds non-overlapping functions from `va-number-input` to `va-text-input` in preparation for deprecation/removal of `va-number-input`.

Closes [2613](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2613)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
