### PR TITLE
2198 - switch fa for va icon

### DIFF
--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -25,6 +25,7 @@ const defaultArgs = {
   'filename': undefined,
   'filetype': undefined,
   'pages': undefined,
+  'reverse': undefined,
   'text': undefined,
   'video': undefined,
 };
@@ -40,6 +41,7 @@ const Template = ({
   filename,
   filetype,
   pages,
+  reverse,
   text,
   video,
 }) => {
@@ -58,6 +60,7 @@ const Template = ({
         filename={filename}
         filetype={filetype}
         pages={pages}
+        reverse={reverse}
         text={text}
         video={video}
       />
@@ -84,6 +87,7 @@ const VariantTemplate = ({
   filename,
   filetype,
   pages,
+  reverse,
   text,
   video,
 }) => {
@@ -99,6 +103,7 @@ const VariantTemplate = ({
       filename={filename}
       filetype={filetype}
       pages={pages}
+      reverse={reverse}
       text={text}
       video={video}
     />
@@ -141,4 +146,43 @@ Calendar.args = {
   calendar: true,
   href: 'data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR',
   text: `Add to calendar`,
+};
+
+const ReverseTemplate = ({ filename, filetype, href, reverse, text }) => {
+  return (
+    <div className="vads-u-background-color--primary vads-u-padding--1">
+      <span className="vads-u-color--white">Default Link: </span>
+      <va-link href={href} reverse={reverse} text={text} />
+      <br />
+      <span className="vads-u-color--white">Active Link: </span>
+      <va-link active={true} href={href} reverse={reverse} text={text} />
+      <br />
+      <span className="vads-u-color--white">Download Link: </span>
+      <va-link
+        download={true}
+        href={href}
+        filename={filename}
+        filetype={filetype}
+        reverse={reverse}
+        text={text}
+      />
+      <br />
+      <span className="vads-u-color--white">Video Link: </span>
+      <va-link href={href} reverse={reverse} text={text} video={true} />
+      <br />
+      <span className="vads-u-color--white">Channel Link: </span>
+      <va-link channel={true} href={href} reverse={reverse} text={text} />
+      <br />
+      <span className="vads-u-color--white">Calendar Link: </span>
+      <va-link calendar={true} href={href} reverse={reverse} text={text} />
+    </div>
+  );
+};
+
+export const Reverse = ReverseTemplate.bind(null);
+Reverse.args = {
+  ...defaultArgs,
+  href: 'https://va.gov/',
+  text: 'Example Link',
+  reverse: true,
 };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -524,6 +524,10 @@ export namespace Components {
          */
         "pages"?: number;
         /**
+          * If 'true', will represent the link with white text instead of blue.
+         */
+        "reverse"?: boolean;
+        /**
           * The anchor text.
          */
         "text": string;
@@ -2560,6 +2564,10 @@ declare namespace LocalJSX {
           * The number of pages of the file. Only displayed if download is `true`.
          */
         "pages"?: number;
+        /**
+          * If 'true', will represent the link with white text instead of blue.
+         */
+        "reverse"?: boolean;
         /**
           * The anchor text.
          */

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.e2e.ts
@@ -163,7 +163,7 @@ describe('va-accordion-item', () => {
   it("render the sub header icon", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-accordion-item header="The header" subheader="The subheader" uswds="false"><i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>Content inside</va-accordion-item>',
+      '<va-accordion-item header="The header" subheader="The subheader" uswds="false"></i>Content inside</va-accordion-item>',
     );
     const element = await page.find('va-accordion-item');
     expect(element).toEqualHtml(
@@ -186,14 +186,13 @@ describe('va-accordion-item', () => {
           <slot></slot>
         </div>
       </mock:shadow-root>
-      <i aria-hidden="true" classname="fas fa-envelope" slot="subheader-icon"></i>
       Content inside
     </va-accordion-item>`);
   });
   it("does not render the sub header icon if there is no sub header", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-accordion-item header="The header" uswds="false"><i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>Content inside</va-accordion-item>',
+      '<va-accordion-item header="The header" uswds="false"></i>Content inside</va-accordion-item>',
     );
     const element = await page.find('va-accordion-item');
     expect(element).toEqualHtml(`
@@ -212,14 +211,13 @@ describe('va-accordion-item', () => {
           <slot></slot>
         </div>
       </mock:shadow-root>
-      <i aria-hidden="true" classname="fas fa-envelope" slot="subheader-icon"></i>
       Content inside
     </va-accordion-item>`);
   });
   it('passes axe check with subheader icon', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-accordion-item header="The header" subheader="The subheader" uswds="false"><i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>Content inside</va-accordion-item>',
+      '<va-accordion-item header="The header" subheader="The subheader" uswds="false"></i>Content inside</va-accordion-item>',
     );
 
     await axeCheck(page);
@@ -410,7 +408,7 @@ describe('va-accordion-item', () => {
   it("render the sub header icon", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-accordion-item uswds header="The header" subheader="The subheader"><i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>Content inside</va-accordion-item>',
+      '<va-accordion-item uswds header="The header" subheader="The subheader"></i>Content inside</va-accordion-item>',
     );
     const element = await page.find('va-accordion-item');
     expect(element).toEqualHtml(
@@ -435,7 +433,7 @@ describe('va-accordion-item', () => {
             </div>
         </div>
         </mock:shadow-root>
-        <i aria-hidden="true" classname="fas fa-envelope" slot="subheader-icon"></i>
+
         Content inside
       </va-accordion-item>`
     );
@@ -443,7 +441,7 @@ describe('va-accordion-item', () => {
   it("does not render the sub header icon if there is no sub header", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-accordion-item uswds header="The header"><i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>Content inside</va-accordion-item>',
+      '<va-accordion-item uswds header="The header"></i>Content inside</va-accordion-item>',
     );
     const element = await page.find('va-accordion-item');
     expect(element).toEqualHtml(`
@@ -464,14 +462,13 @@ describe('va-accordion-item', () => {
           </div>
         </div>
       </mock:shadow-root>
-      <i aria-hidden="true" classname="fas fa-envelope" slot="subheader-icon"></i>
       Content inside
     </va-accordion-item>`);
   });
   it('passes axe check with subheader icon', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-accordion-item uswds header="The header" subheader="The subheader"><i slot="subheader-icon" aria-hidden="true" className="fas fa-envelope"></i>Content inside</va-accordion-item>',
+      '<va-accordion-item uswds header="The header" subheader="The subheader"></i>Content inside</va-accordion-item>',
     );
 
     await axeCheck(page);

--- a/packages/web-components/src/components/va-alert-expandable/test/va-alert-expandable.e2e.ts
+++ b/packages/web-components/src/components/va-alert-expandable/test/va-alert-expandable.e2e.ts
@@ -2,7 +2,7 @@ import { newE2EPage } from '@stencil/core/testing';
 import { axeCheck } from '../../../testing/test-helpers';
 
 describe('va-alert-expandable', () => {
-  it.skip('renders', async () => {
+  it('renders', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-alert-expandable status="warning" trigger="Limited services and hours"></va-alert-expandable>',
@@ -15,16 +15,16 @@ describe('va-alert-expandable', () => {
         <mock:shadow-root>
         <div class="alert-expandable warning">
           <a role="button" aria-controls="alert-body" aria-expanded="false" tabindex="0" class="alert-expandable-trigger">
-            <i class="alert-status-icon" aria-hidden="true" role="img"></i>
+            <va-icon class="alert-expandable__status-icon hydrated"></va-icon>
             <div>
               <span class="alert-expandable-title">
                 <span class="sr-only">Alert:&nbsp;</span>
                 Limited services and hours
               </span>
-              <i class="fa-angle-down" role="presentation"></i>
+              <va-icon class="alert-expandable-icon hydrated"></va-icon>
             </div>
           </a>
-          <div id="alert-body" class="alert-expandable-body closed" style="--calc-max-height:calc(20px + 2rem);"><div id="slot-wrap"><slot></slot></div></div>
+          <div id="alert-body" class="alert-expandable-body closed" style="--calc-max-height:calc(19px + 2rem);"><div id="slot-wrap"><slot></slot></div></div>
         </div>
         </mock:shadow-root>
       </va-alert-expandable>

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
@@ -82,59 +82,25 @@ div.continue .alert-expandable-trigger:hover {
   margin: 1.2rem;
 }
 
-i {
-  font-family: 'Font Awesome 5 Free';
-  font-style: normal;
-  font-weight: 900;
-  line-height: 1;
-}
-
-i.fa-angle-down {
+.alert-expandable-icon {
   display: inline-block;
-  color: var(--vads-color-base-darker);
-  font-size: 1.6rem;
-  margin: 0.5rem;
-  transform: rotate(0deg);
+  color: var(--vads-color-primary-alt-darkest);
+  font-size: 16px;
+  transform: rotate(90deg);
+  transition: transform 0.15s linear;
+  line-height: 1;
+  vertical-align: bottom;
+}
+
+a[aria-expanded='true'] .alert-expandable-icon {
+  transform: rotate(270deg);
   transition: transform 0.15s linear;
 }
 
-i.fa-angle-down::before {
-  content: '\F107'; /* fa-angle-down*/
-}
-
-a[aria-expanded='true'] i.fa-angle-down {
-  transform: rotate(180deg);
-  transition: transform 0.15s linear;
-}
-
-i.alert-status-icon {
+.alert-expandable__status-icon {
   color: var(--vads-color-base-darker);
-  margin-top: 0.4rem;
-  margin-right: 1.2rem;
-}
-
-div.hide-icon i.alert-status-icon {
-  display: none;
-}
-
-div.info i.alert-status-icon::before {
-  content: '\F05A';
-}
-
-div.continue i.alert-status-icon::before {
-  content: '\F023';
-}
-
-div.success i.alert-status-icon::before {
-  content: '\F00C';
-}
-
-div.warning i.alert-status-icon::before {
-  content: '\F071';
-}
-
-div.error i.alert-status-icon::before {
-  content: '\F06A';
+  margin-right: 8px;
+  margin-top: 0.4em;
 }
 
 ::slotted(*) {

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
@@ -112,6 +112,13 @@ export class VaAlertExpandable {
       closed: !open,
     });
     /* eslint-disable i18next/no-literal-string */
+    const statusIcons = {
+      continue: 'lock',
+      error: 'info',
+      warning: 'warning',
+      info: 'info',
+      success: 'check_circle',
+    };
     const role = status === 'error' ? 'alert' : null;
     const ariaLive = status === 'error' ? 'assertive' : null;
     /* eslint-enable i18next/no-literal-string */
@@ -128,13 +135,22 @@ export class VaAlertExpandable {
             onKeyDown={this.handleKeydown.bind(this)}
             class="alert-expandable-trigger"
           >
-            <i class="alert-status-icon" aria-hidden="true" role="img"></i>
+            {!iconless && (
+              <va-icon
+                class="alert-expandable__status-icon"
+                icon={statusIcons[status] || 'info'}
+              ></va-icon>
+            )}
             <div>
               <span class="alert-expandable-title">
                 <span class="sr-only">Alert:&nbsp;</span>
                 {this.trigger}
               </span>
-              <i class="fa-angle-down" role="presentation" />
+              <va-icon
+                class="alert-expandable-icon"
+                icon="chevron_right"
+                size={3}
+              ></va-icon>
             </div>
           </a>
           <div id="alert-body" class={bodyClasses}>

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -12,7 +12,7 @@ describe('va-alert', () => {
       <va-alert class="hydrated" status="info" uswds="false">
         <mock:shadow-root>
           <div class="alert info">
-            <i aria-hidden="true"></i>
+            <va-icon class="alert__status-icon hydrated"></va-icon>
             <div class="body">
               <slot name="headline"></slot>
               <slot></slot>

--- a/packages/web-components/src/components/va-alert/va-alert.scss
+++ b/packages/web-components/src/components/va-alert/va-alert.scss
@@ -141,11 +141,6 @@
     border-left-width: 8px;
   }
 
-  div.alert>i::before {
-    display: flex;
-    margin-right: 1.6rem;
-  }
-
   div.body {
     padding-left: 0;
     padding-right: 0;
@@ -163,26 +158,16 @@
     /* Fix for Safari 15.3 and lower. */
   }
 
-  div.info>i::before {
-    content: '\F05A';
+  .alert__status-icon {
+    color: var(--vads-color-base-darker);
+    margin-right: 8px;
   }
 
-  div.continue>i::before {
-    content: '\F023';
+  .continue .alert__status-icon, .success .alert__status-icon {
     color: var(--vads-color-success-dark);
   }
 
-  div.success>i::before {
-    content: '\F00C';
-    color: var(--vads-color-success-dark);
-  }
-
-  div.warning>i::before {
-    content: '\F071';
-  }
-
-  div.error>i::before {
-    content: '\F06A';
+  .error .alert__status-icon {
     color: var(--vads-color-secondary-dark);
   }
 
@@ -209,14 +194,6 @@
 
   .error.bg-only {
     background-color: var(--vads-color-secondary-lightest);
-  }
-
-  i {
-    font-family: 'Font Awesome 5 Free';
-    font-size: 2.4rem;
-    font-style: normal;
-    font-weight: 900;
-    line-height: 1;
   }
 }
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -230,6 +230,16 @@ export class VaAlert {
       'bg-only': backgroundOnly,
     });
 
+    /* eslint-disable i18next/no-literal-string */
+    const statusIcons = {
+      continue: 'lock',
+      error: 'info',
+      warning: 'warning',
+      info: 'info',
+      success: 'check_circle',
+    };
+    /* eslint-enable i18next/no-literal-string */
+
     return (
       <Host>
         <div
@@ -238,7 +248,11 @@ export class VaAlert {
           class={classes}
           aria-label={this.el.getAttribute('data-label') || role}
         >
-          <i aria-hidden="true"></i>
+          <va-icon
+            class="alert__status-icon"
+            icon={statusIcons[status] || 'info'}
+            size={3}
+          ></va-icon>
           <div class="body" onClick={this.handleAlertBodyClick.bind(this)}>
             {!backgroundOnly && <slot name="headline"></slot>}
             <slot></slot>

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
@@ -116,16 +116,8 @@ div.docked a {
   position: relative;
 }
 
-i {
-  align-self: flex-start;
-  font-family: 'Font Awesome 5 Free';
-  font-size: 2rem;
-  font-style: normal;
-  font-weight: 900;
-  padding-top: 10px;
-}
-i::before {
-  content: '\F062'; /* fa-arrow-up*/
+va-icon {
+  margin-right: 8px;
 }
 
 @media (min-width: 768px) {

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
@@ -89,8 +89,9 @@ export class VaBackToTop {
           >
             <a href="#ds-back-to-top" onClick={this.navigateToTop.bind(this)}>
               <span>
-                <i aria-hidden="true" role="img"></i>
-                <span class="sr-only">Back to top</span> {/* For small screen that only displays the arrow */}
+                <va-icon icon="arrow_upward"></va-icon>
+                <span class="sr-only">Back to top</span>{' '}
+                {/* For small screen that only displays the arrow */}
                 <span class="text">Back to top</span>
               </span>
             </a>

--- a/packages/web-components/src/components/va-banner/test/va-banner.e2e.ts
+++ b/packages/web-components/src/components/va-banner/test/va-banner.e2e.ts
@@ -70,7 +70,7 @@ describe('va-banner', () => {
       <va-alert class="hydrated uswds-false" data-label="Error banner" data-role="region" full-width="" status="error" uswds="false">
         <mock:shadow-root>
            <div aria-label="Error banner" aria-live="assertive" class="alert error" role="region">
-           <i aria-hidden="true"></i>
+           <va-icon class="alert__status-icon hydrated"></va-icon>
              <div class="body">
               <slot name="headline"></slot>
               <slot></slot>

--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -32,7 +32,7 @@ describe('va-link', () => {
       <mock:shadow-root>
         <a href="https://www.va.gov">
           Share your VA medical records
-          <i aria-hidden="true"></i>
+          <va-icon class="hydrated link-icon--active"></va-icon>
         </a>
       </mock:shadow-root>
     </va-link>
@@ -50,7 +50,7 @@ describe('va-link', () => {
     <va-link class="hydrated" calendar filename="Appointment_at_Cheyenne_VA_Medical_Center.ics" href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR" text="Add to calendar">
       <mock:shadow-root>
         <a download="Appointment_at_Cheyenne_VA_Medical_Center.ics" href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR">
-          <i aria-hidden="true"></i>
+          <va-icon class="hydrated link-icon--left"></va-icon>
           Add to calendar
         </a>
       </mock:shadow-root>
@@ -69,7 +69,7 @@ describe('va-link', () => {
     <va-link class="hydrated" download filename="10-10ez.pdf" filetype="PDF" href="https://www.va.gov" pages=5 text="Download VA form 10-10EZ">
       <mock:shadow-root>
         <a download="10-10ez.pdf" href="https://www.va.gov">
-          <i aria-hidden="true"></i>
+          <va-icon class="hydrated link-icon--left"></va-icon>
           Download VA form 10-10EZ <dfn>(<abbr title="Portable Document Format">PDF</abbr>, 5 pages)</dfn>
         </a>
       </mock:shadow-root>
@@ -88,7 +88,7 @@ describe('va-link', () => {
     <va-link class="hydrated" video href="https://www.va.gov" text="Go to the video about VA disability compensation">
       <mock:shadow-root>
         <a href="https://www.va.gov" rel="noopener" target="_blank">
-          <i aria-hidden="true"></i>
+          <va-icon class="hydrated link-icon--left"></va-icon>
           Go to the video about VA disability compensation <dfn>on YouTube</dfn>
         </a>
       </mock:shadow-root>
@@ -107,7 +107,7 @@ describe('va-link', () => {
     <va-link class="hydrated" channel href="https://www.va.gov" text="Veteran's Affairs">
       <mock:shadow-root>
         <a href="https://www.va.gov" rel="noopener" target="_blank">
-          <i aria-hidden="true"></i>
+          <va-icon class="hydrated link-icon--left"></va-icon>
           Veteran's Affairs <dfn>YouTube</dfn>
         </a>
       </mock:shadow-root>

--- a/packages/web-components/src/components/va-link/va-link.css
+++ b/packages/web-components/src/components/va-link/va-link.css
@@ -9,6 +9,15 @@
   text-decoration: underline;
 }
 
+:host a.va-link--reverse {
+  color: var(--vads-color-white);
+
+  &:hover, &:active {
+    color: var(--vads-color-action-focus-on-light);
+    background-color: transparent;
+  }
+}
+
 :host([active]:not([active='false'])) a {
   font-weight: 700;
 }

--- a/packages/web-components/src/components/va-link/va-link.css
+++ b/packages/web-components/src/components/va-link/va-link.css
@@ -22,52 +22,8 @@
   font-weight: 700;
 }
 
-i::before {
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  display: inline-block;
-  font-family: 'Font Awesome 5 Free';
-  font-size: 1.6rem;
-  font-style: normal;
-  font-variant: normal;
-  font-weight: 900;
-  line-height: 1;
-  margin-right: 0.8rem;
-  text-rendering: auto;
-}
-
-:host([active]:not([active='false'])) i::before {
-  content: '\f105'; /* fa-angle-right */
-  margin-bottom: 0.1rem;
-  margin-left: 0.8rem;
-  margin-right: 0;
-  vertical-align: middle;
-}
-
-:host([active]:not([active='false'])) a:focus i::before,
-:host([active]:not([active='false'])) a:hover i::before {
-  margin-left: 1.2rem;
-  transition-duration: 0.3s;
-  transition-timing-function: ease-in-out;
-  transition-property: margin;
-}
-
-:host([download]:not([download='false'])) i::before {
-  content: '\f019'; /* fa-download */
-}
-
-:host([video]:not([video='false'])) i::before {
-  content: '\f144'; /* fa-circle-play */
-}
-
-:host([channel]:not([channel='false'])) i::before {
-  content: '\f167'; /* fa-youtube */
-  font-family: 'Font Awesome 5 Brands';
-  font-weight: 400;
-}
-
-:host([calendar]:not([calendar='false'])) i::before {
-  content: '\f133'; /* fa-calendar */
+.link-icon--left {
+  margin-right: 8px;
 }
 
 dfn {

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -135,7 +135,11 @@ export class VaLink {
         <Host>
           <a href={href} class={linkClass} onClick={handleClick}>
             {text}
-            <i aria-hidden="true" />
+            <va-icon
+              class="link-icon--active"
+              icon="chevron_right"
+              size={3}
+            ></va-icon>
           </a>
         </Host>
       );
@@ -152,7 +156,11 @@ export class VaLink {
             rel="noopener"
             target="_blank"
           >
-            <i aria-hidden="true" />
+            <va-icon
+              class="link-icon--left"
+              icon="play_circle"
+              size={3}
+            ></va-icon>
             {text} <dfn>{channel ? 'YouTube' : 'on YouTube'}</dfn>
           </a>
         </Host>
@@ -169,7 +177,11 @@ export class VaLink {
             download={filename}
             onClick={handleClick}
           >
-            <i aria-hidden="true" />
+            <va-icon
+              class="link-icon--left"
+              icon="calendar_today"
+              size={3}
+            ></va-icon>
             {text}
           </a>
         </Host>
@@ -186,7 +198,11 @@ export class VaLink {
             download={filename}
             onClick={handleClick}
           >
-            <i aria-hidden="true" />
+            <va-icon
+              class="link-icon--left"
+              icon="file_download"
+              size={3}
+            ></va-icon>
             {text}{' '}
             {filetype && (
               <dfn>

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -1,4 +1,5 @@
 import { Component, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
+import classNames from 'classnames';
 
 /**
  * @componentName Link
@@ -20,7 +21,7 @@ export class VaLink {
   /**
    * If `true`, the anchor text will be bolded and include a right arrow icon.
    */
-  @Prop({reflect: true}) active?: boolean = false;
+  @Prop({ reflect: true }) active?: boolean = false;
 
   /**
    * If `true`, a calendar icon will be displayed before the anchor text.
@@ -73,6 +74,11 @@ export class VaLink {
   @Prop() video?: boolean = false;
 
   /**
+   * If 'true', will represent the link with white text instead of blue.
+   */
+  @Prop() reverse?: boolean = false;
+
+  /**
    * The event used to track usage of the component.
    */
   @Event({
@@ -91,7 +97,7 @@ export class VaLink {
         details: {
           label: this.text,
         },
-      }
+      };
       this.componentLibraryAnalytics.emit(detail);
     }
   };
@@ -116,13 +122,18 @@ export class VaLink {
       pages,
       text,
       video,
+      reverse,
     } = this;
+
+    const linkClass = classNames({
+      'va-link--reverse': reverse,
+    });
 
     // Active link variant
     if (active) {
       return (
         <Host>
-          <a href={href} onClick={handleClick}>
+          <a href={href} class={linkClass} onClick={handleClick}>
             {text}
             <i aria-hidden="true" />
           </a>
@@ -134,7 +145,13 @@ export class VaLink {
     if (channel || video) {
       return (
         <Host>
-          <a href={href} onClick={handleClick} rel="noopener" target="_blank">
+          <a
+            href={href}
+            class={linkClass}
+            onClick={handleClick}
+            rel="noopener"
+            target="_blank"
+          >
             <i aria-hidden="true" />
             {text} <dfn>{channel ? 'YouTube' : 'on YouTube'}</dfn>
           </a>
@@ -146,19 +163,29 @@ export class VaLink {
     if (calendar) {
       return (
         <Host>
-         <a href={href} download={filename} onClick={handleClick}>
-          <i aria-hidden="true" />
-          {text}
-        </a>
-      </Host>
-      )
+          <a
+            href={href}
+            class={linkClass}
+            download={filename}
+            onClick={handleClick}
+          >
+            <i aria-hidden="true" />
+            {text}
+          </a>
+        </Host>
+      );
     }
 
     // Download link variant
     if (download) {
       return (
         <Host>
-          <a href={href} download={filename} onClick={handleClick}>
+          <a
+            href={href}
+            class={linkClass}
+            download={filename}
+            onClick={handleClick}
+          >
             <i aria-hidden="true" />
             {text}{' '}
             {filetype && (
@@ -175,7 +202,7 @@ export class VaLink {
     // Default
     return (
       <Host>
-        <a href={href} onClick={handleClick}>
+        <a href={href} class={linkClass} onClick={handleClick}>
           {text}
         </a>
       </Host>

--- a/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
+++ b/packages/web-components/src/components/va-maintenance-banner/test/va-maintenance-banner.e2e.ts
@@ -5,7 +5,7 @@ import { formatDate } from '../../../utils/date-utils';
 describe('USWDS maintenance-banner', () => {
   it('uswds - renders', async () => {
     let startsAt = new Date(),
-        expiresAt = new Date();
+      expiresAt = new Date();
     expiresAt.setHours(expiresAt.getHours(), expiresAt.getMinutes() + 10);
     const page = await newE2EPage({
       html: `<va-maintenance-banner banner-id="maintenance-banner" maintenance-title="Site maintenance" upcoming-warn-title="Upcoming site maintenance" maintenance-start-date-time="${startsAt}" maintenance-end-date-time="${expiresAt}" upcoming-warn-start-date-time="${startsAt}">
@@ -18,6 +18,7 @@ describe('USWDS maintenance-banner', () => {
       <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" maintenance-end-date-time="${expiresAt}" maintenance-title="Site maintenance" maintenance-start-date-time="${startsAt}" upcoming-warn-start-date-time="${startsAt}" upcoming-warn-title="Upcoming site maintenance">
         <mock:shadow-root>
           <div class="maintenance-banner maintenance-banner--error">
+            <va-icon class="hydrated maintenance-banner__icon"></va-icon>
             <div class="maintenance-banner__body">
               <h4 class="maintenance-banner__title">
                 Site maintenance
@@ -51,11 +52,10 @@ describe('USWDS maintenance-banner', () => {
                   </p>
                 </div>
               </div>
-              <button aria-label="Close notification" class="maintenance-banner__close" type="button">
-                <i aria-hidden="true"></i>
-              </button>
             </div>
-
+            <button aria-label="Close notification" class="maintenance-banner__close" type="button">
+              <va-icon class="hydrated"></va-icon>
+            </button>
           </div>
         </mock:shadow-root>
         <div slot="maintenance-content">
@@ -68,10 +68,9 @@ describe('USWDS maintenance-banner', () => {
     `);
   });
 
-
   it('uswds - Does not render when expiration date is in the past', async () => {
     let startsAt = new Date(),
-        expiresAt = new Date();
+      expiresAt = new Date();
     startsAt.setDate(startsAt.getDate() - 2);
     expiresAt.setDate(expiresAt.getDate() - 1);
     const page = await newE2EPage({
@@ -88,8 +87,8 @@ describe('USWDS maintenance-banner', () => {
 
   it('uswds - does not render if before warning start date', async () => {
     let startsAt = new Date(),
-        expiresAt = new Date(),
-        warnStartsAt = new Date();
+      expiresAt = new Date(),
+      warnStartsAt = new Date();
     warnStartsAt.setHours(warnStartsAt.getHours() + 4);
     startsAt.setDate(startsAt.getDate() + 1);
     expiresAt.setDate(expiresAt.getDate() + 2);
@@ -107,8 +106,8 @@ describe('USWDS maintenance-banner', () => {
 
   it('uswds - renders warning if before maintenance', async () => {
     let startsAt = new Date(),
-        expiresAt = new Date(),
-        warnStartsAt = new Date();
+      expiresAt = new Date(),
+      warnStartsAt = new Date();
     startsAt.setDate(startsAt.getDate() + 1);
     expiresAt.setDate(expiresAt.getDate() + 2);
     const page = await newE2EPage({
@@ -122,6 +121,7 @@ describe('USWDS maintenance-banner', () => {
       <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" maintenance-end-date-time="${expiresAt}" maintenance-title="Site maintenance" maintenance-start-date-time="${startsAt}" upcoming-warn-start-date-time="${warnStartsAt}" upcoming-warn-title="Upcoming site maintenance">
         <mock:shadow-root>
           <div class="maintenance-banner maintenance-banner--warning">
+            <va-icon class="hydrated maintenance-banner__icon"></va-icon>
             <div class="maintenance-banner__body">
               <h4 class="maintenance-banner__title">
                 Upcoming site maintenance
@@ -155,10 +155,10 @@ describe('USWDS maintenance-banner', () => {
                   </p>
                 </div>
               </div>
-              <button aria-label="Close notification" class="maintenance-banner__close" type="button">
-                <i aria-hidden="true"></i>
-              </button>
             </div>
+            <button aria-label="Close notification" class="maintenance-banner__close" type="button">
+              <va-icon class="hydrated"></va-icon>
+            </button>
           </div>
         </mock:shadow-root>
         <div slot="maintenance-content">
@@ -173,8 +173,8 @@ describe('USWDS maintenance-banner', () => {
 
   it('uswds - renders error if before maintenance but isError is true', async () => {
     let startsAt = new Date(),
-        expiresAt = new Date(),
-        warnStartsAt = new Date();
+      expiresAt = new Date(),
+      warnStartsAt = new Date();
     startsAt.setDate(startsAt.getDate() + 1);
     expiresAt.setDate(expiresAt.getDate() + 2);
     const page = await newE2EPage({
@@ -188,6 +188,7 @@ describe('USWDS maintenance-banner', () => {
       <va-maintenance-banner banner-id="maintenance-banner" class="hydrated" is-error="" maintenance-end-date-time="${expiresAt}" maintenance-title="Site maintenance" maintenance-start-date-time="${startsAt}" upcoming-warn-start-date-time="${warnStartsAt}" upcoming-warn-title="Upcoming site maintenance">
         <mock:shadow-root>
           <div class="maintenance-banner maintenance-banner--error">
+            <va-icon class="hydrated maintenance-banner__icon"></va-icon>
             <div class="maintenance-banner__body">
               <h4 class="maintenance-banner__title">
                 Site maintenance
@@ -221,10 +222,10 @@ describe('USWDS maintenance-banner', () => {
                   </p>
                 </div>
               </div>
-              <button aria-label="Close notification" class="maintenance-banner__close" type="button">
-                <i aria-hidden="true"></i>
-              </button>
             </div>
+            <button aria-label="Close notification" class="maintenance-banner__close" type="button">
+              <va-icon class="hydrated"></va-icon>
+            </button>
 
           </div>
         </mock:shadow-root>
@@ -236,7 +237,7 @@ describe('USWDS maintenance-banner', () => {
         </div>
       </va-maintenance-banner>
     `);
-   });
+  });
   it('uswds - passes an axe check', async () => {
     let currentDate = new Date(),
         expiresAt = new Date();

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.scss
@@ -6,6 +6,8 @@
   border-top: 8px solid;
   background-color: var(--vads-color-base-lightest);
   position: relative;
+  display: flex;
+  flex-direction: row;
 }
 
 .maintenance-banner--warning {
@@ -14,6 +16,16 @@
 
 .maintenance-banner--error {
   border-color: var(--vads-color-secondary-dark);
+}
+
+.maintenance-banner__icon {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+}
+
+.maintenance-banner--error .maintenance-banner__icon {
+  color: var(--vads-color-secondary-dark);
 }
 
 .maintenance-banner__title {
@@ -29,54 +41,12 @@
   margin: 0px auto;
 }
 
-.maintenance-banner__body::before {
-  font-family: "Font Awesome 5 Free";
-  font-size: 26px;
-  font-style: normal;
-  font-weight: 900;
-  line-height: 1;
-  position: absolute;
-  height: 32px;
-  width: 32px;
-  top: 18px;
-  left: 18px;
-}
-
-.maintenance-banner--warning .maintenance-banner__body::before {
-  content: '\F071'; /* fa-exclamation-triangle */
-}
-
-.maintenance-banner--error .maintenance-banner__body::before {
-  content: '\F06A'; /* fa-exclamation-circle */
-  color: var(--vads-color-secondary-dark);
-}
-
 .maintenance-banner__close {
-  background-color: transparent;
-  color: var(--vads-color-base-darker);
-  font-size: 24px;
-  padding: 0;
-  position: absolute;
-  margin: 16px;
-  right: 0;
-  top: 0;
-  width: auto;
-  z-index: 9;
-  white-space: nowrap;
+  align-self: flex-start;
+  color: var(--vads-color-base);
+  margin-top: 8px;
 }
 
 .maintenance-banner__close:hover {
   color: var(--vads-color-base);
-}
-
-.maintenance-banner i::before {
-  -webkit-font-smoothing: antialiased;
-  content: '\F057'; /* fa-times-circle*/
-  display: inline-block;
-  font-family: 'Font Awesome 5 Free';
-  font-style: normal;
-  font-variant: normal;
-  font-weight: 900;
-  line-height: 1;
-  text-rendering: auto;
 }

--- a/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
+++ b/packages/web-components/src/components/va-maintenance-banner/va-maintenance-banner.tsx
@@ -155,30 +155,53 @@ export class VaMaintenanceBanner {
         'maintenance-banner--error': !isWarning
       })
 
+      const bannerIconName = isError ? 'error' : 'warning';
+
       return (
         <Host>
-            <div class={maintenanceBannerClass} ref={el => (this.maintenanceBannerEl = el as HTMLDivElement)}>
-                <div class="maintenance-banner__body">
-                  <h4 class="maintenance-banner__title">{isWarning ? upcomingWarnTitle : maintenanceTitle}</h4>
-                  <div class="maintenance-banner__content" ref={el => (this.maintenanceBannerContent = el as HTMLDivElement)}>{
-                    isWarning ?
-                      <slot name="warn-content"></slot> :
-                      <slot name="maintenance-content"></slot>
-                  }</div>
-                  <div class="maintenance-banner__derived-content">{this.derivePostContent(new Date(maintenanceStartDateTime), new Date(maintenanceEndDateTime))}</div>
-                  <button
-                    aria-label="Close notification"
-                    class="maintenance-banner__close"
-                    onClick={this.onCloseAlert}
-                    type="button"
-                  >
-                    <i aria-hidden="true" />
-                </button>
-                </div>
-
+          <div
+            class={maintenanceBannerClass}
+            ref={el => (this.maintenanceBannerEl = el as HTMLDivElement)}
+          >
+            <va-icon
+              class="maintenance-banner__icon"
+              icon={bannerIconName}
+              size={3}
+            ></va-icon>
+            <div class="maintenance-banner__body">
+              <h4 class="maintenance-banner__title">
+                {isWarning ? upcomingWarnTitle : maintenanceTitle}
+              </h4>
+              <div
+                class="maintenance-banner__content"
+                ref={el =>
+                  (this.maintenanceBannerContent = el as HTMLDivElement)
+                }
+              >
+                {isWarning ? (
+                  <slot name="warn-content"></slot>
+                ) : (
+                  <slot name="maintenance-content"></slot>
+                )}
+              </div>
+              <div class="maintenance-banner__derived-content">
+                {this.derivePostContent(
+                  new Date(maintenanceStartDateTime),
+                  new Date(maintenanceEndDateTime),
+                )}
+              </div>
             </div>
+            <button
+              aria-label="Close notification"
+              class="maintenance-banner__close"
+              onClick={this.onCloseAlert}
+              type="button"
+            >
+              <va-icon icon="cancel" size={3}></va-icon>
+            </button>
+          </div>
         </Host>
-      )
+      );
     } else {
       return null
     }

--- a/packages/web-components/src/components/va-modal/va-modal.scss
+++ b/packages/web-components/src/components/va-modal/va-modal.scss
@@ -222,43 +222,20 @@ h1 {
   border-left-color: var(--vads-color-success-dark);
 }
 
-:host([status='continue']) .va-modal-inner::before {
-  color: var(--vads-color-success-dark);
-  content: '\F023'; /* fa-lock */
-}
-
 :host([status='error']) .va-modal-inner {
   border-left-color: var(--vads-color-secondary-dark);
-}
-
-:host([status='error']) .va-modal-inner::before {
-  color: var(--vads-color-secondary-dark);
-  content: '\F06A'; /* fa-circle-exclamation */
 }
 
 :host([status='info']) .va-modal-inner {
   border-left-color: var(--vads-color-primary-alt-dark);
 }
 
-:host([status='info']) .va-modal-inner::before {
-  content: '\F05A'; /* fa-circle-info */
-}
-
 :host([status='success']) .va-modal-inner {
   border-left-color: var(--vads-color-success-dark);
 }
 
-:host([status='success']) .va-modal-inner::before {
-  color: var(--vads-color-success-dark);
-  content: '\F00C'; /* fa-check */
-}
-
 :host([status='warning']) .va-modal-inner {
   border-left-color: var(--vads-color-warning);
-}
-
-:host([status='warning']) .va-modal-inner::before {
-  content: '\F071'; /* fa-triangle-exclamation */
 }
 
 .va-modal-alert .alert-actions {

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -410,116 +410,122 @@ export class VaModal {
       ? `Close ${modalTitle} modal`
       : 'Close modal';
 
-      const wrapperClass = classnames({
-        'usa-modal': true,
-        'va-modal-alert': status,
-        'usa-modal--lg': this.large,
-      });
-      const contentClass = classnames({
-        'usa-modal__content': true,
-        'usa-modal-alert': status,
-      });
-      const bodyClass = classnames({
-        'usa-modal__main': true,
-        'usa-modal-alert': status,
-        'va-modal-alert-body': status,
-      });
-      const titleClass = classnames({
-        'usa-modal__heading': true,
-        'va-modal-alert-title': status,
-      });
-      const closingButton = forcedModal ? (
-        ''
-      ) : (
-        <button
-          aria-label={btnAriaLabel}
-          class="va-modal-close"
-          onClick={e => this.handleClose(e)}
-          ref={el => (this.closeButton = el as HTMLButtonElement)}
-          type="button"
+    const wrapperClass = classnames({
+      'usa-modal': true,
+      'va-modal-alert': status,
+      'usa-modal--lg': this.large,
+    });
+    const contentClass = classnames({
+      'usa-modal__content': true,
+      'usa-modal-alert': status,
+    });
+    const bodyClass = classnames({
+      'usa-modal__main': true,
+      'usa-modal-alert': status,
+      'va-modal-alert-body': status,
+    });
+    const titleClass = classnames({
+      'usa-modal__heading': true,
+      'va-modal-alert-title': status,
+    });
+    const closingButton = forcedModal ? (
+      ''
+    ) : (
+      <button
+        aria-label={btnAriaLabel}
+        class="va-modal-close"
+        onClick={e => this.handleClose(e)}
+        ref={el => (this.closeButton = el as HTMLButtonElement)}
+        type="button"
+      >
+        <va-icon icon="cancel" size={4}></va-icon>
+      </button>
+    );
+    /* eslint-disable i18next/no-literal-string */
+    /** Icons to show for each status type */
+    const statusIcons = {
+      continue: 'lock',
+      error: 'error',
+      info: 'info',
+      success: 'check',
+      warning: 'warning',
+    };
+    /* eslint-enable i18next/no-literal-string */
+    const statusIcon = statusIcons[status];
+    return (
+      <Host>
+        <div
+          class={wrapperClass}
+          role={
+            status === 'warning' || status === 'error'
+              ? 'alertdialog'
+              : 'dialog'
+          }
+          aria-label={ariaLabel}
+          aria-modal="true"
         >
-          <va-icon icon="cancel" size={4}></va-icon>
-        </button>
-      );
-      /**
-       * Icons to show for each status type
-       */
-      const statusIcons = {
-        continue: 'lock',
-        error: 'error',
-        info: 'info',
-        success: 'check',
-        warning: 'warning',
-      };
-      const statusIcon = statusIcons[status];
-      return (
-        <Host>
-          <div
-            class={wrapperClass}
-            role={
-              status === 'warning' || status === 'error'
-                ? 'alertdialog'
-                : 'dialog'
-            }
-            aria-label={ariaLabel}
-            aria-modal="true"
-          >
-            <div class={contentClass}>
-              {closingButton}
-              {status && <va-icon class="va-modal-alert__icon" icon={statusIcon} size={4}></va-icon>}
-              <div class={bodyClass}>
-                <div role="document">
-                  {modalTitle && (
-                    <h2 class={titleClass} tabindex={-1} id="heading">
-                      {modalTitle}
-                    </h2>
-                  )}
-                  <div class="usa-prose" id="description">
-                    <slot></slot>
-                  </div>
-                </div>
-                {((primaryButtonClick && primaryButtonText) ||
-                  (secondaryButtonClick && secondaryButtonText)) && (
-                  <div
-                    class="usa-modal__footer"
-                    ref={el => (this.alertActions = el as HTMLDivElement)}
-                  >
-                    <ul class="usa-button-group">
-                      {primaryButtonClick && primaryButtonText && (
-                        <li class="usa-button-group__item">
-                          <va-button
-                            onClick={e => this.handlePrimaryButtonClick(e)}
-                            text={primaryButtonText}
-                          />
-                        </li>
-                      )}
-                      {secondaryButtonClick && secondaryButtonText && (
-                        <li class="usa-button-group__item">
-                          {!unstyled && (
-                            <va-button
-                              onClick={e => this.handleSecondaryButtonClick(e)}
-                              secondary
-                              text={secondaryButtonText}
-                            />
-                          )}
-                          {unstyled && (
-                            <button
-                              onClick={e => this.handlePrimaryButtonClick(e)}
-                              type="button"
-                              class="usa-button usa-button--unstyled"
-                            >
-                              {secondaryButtonText}
-                            </button>
-                          )}
-                        </li>
-                      )}
-                    </ul>
-                  </div>
+          <div class={contentClass}>
+            {closingButton}
+            {status && (
+              <va-icon
+                class="va-modal-alert__icon"
+                icon={statusIcon}
+                size={4}
+              ></va-icon>
+            )}
+            <div class={bodyClass}>
+              <div role="document">
+                {modalTitle && (
+                  <h2 class={titleClass} tabindex={-1} id="heading">
+                    {modalTitle}
+                  </h2>
                 )}
+                <div class="usa-prose" id="description">
+                  <slot></slot>
+                </div>
               </div>
+              {((primaryButtonClick && primaryButtonText) ||
+                (secondaryButtonClick && secondaryButtonText)) && (
+                <div
+                  class="usa-modal__footer"
+                  ref={el => (this.alertActions = el as HTMLDivElement)}
+                >
+                  <ul class="usa-button-group">
+                    {primaryButtonClick && primaryButtonText && (
+                      <li class="usa-button-group__item">
+                        <va-button
+                          onClick={e => this.handlePrimaryButtonClick(e)}
+                          text={primaryButtonText}
+                        />
+                      </li>
+                    )}
+                    {secondaryButtonClick && secondaryButtonText && (
+                      <li class="usa-button-group__item">
+                        {!unstyled && (
+                          <va-button
+                            onClick={e => this.handleSecondaryButtonClick(e)}
+                            secondary
+                            text={secondaryButtonText}
+                          />
+                        )}
+                        {unstyled && (
+                          <button
+                            onClick={e => this.handlePrimaryButtonClick(e)}
+                            type="button"
+                            class="usa-button usa-button--unstyled"
+                          >
+                            {secondaryButtonText}
+                          </button>
+                        )}
+                      </li>
+                    )}
+                  </ul>
+                </div>
+              )}
             </div>
           </div>
-        </Host>
-      );
+        </div>
+      </Host>
+    );
   }
 }

--- a/packages/web-components/src/components/va-on-this-page/test/va-on-this-page.e2e.ts
+++ b/packages/web-components/src/components/va-on-this-page/test/va-on-this-page.e2e.ts
@@ -63,11 +63,11 @@ describe('va-on-this-page', () => {
               <dt id="on-this-page">on-this-page</dt>
               <dd role="definition">
                 <a href="#an-id">
-                  <i aria-hidden="true" class="fa-arrow-down fas"></i>
+                  <va-icon class="hydrated"></va-icon>
                   Hello
                 </a>
                 <a href="#its-me">
-                  <i aria-hidden="true" class="fa-arrow-down fas"></i>
+                  <va-icon class="hydrated"></va-icon>
                   It's me
                 </a>
               </dd>
@@ -102,7 +102,7 @@ describe('va-on-this-page', () => {
           <dt id="on-this-page">on-this-page</dt>
           <dd role="definition">
             <a href="#foo">
-              <i aria-hidden="true" class="fa-arrow-down fas"></i>
+              <va-icon class="hydrated"></va-icon>
               Foo
             </a>
           </dd>
@@ -139,11 +139,11 @@ describe('va-on-this-page', () => {
               <dt id="on-this-page">on-this-page</dt>
               <dd role="definition">
                 <a href="#an-id">
-                  <i aria-hidden="true" class="fa-arrow-down fas"></i>
+                  <va-icon class="hydrated"></va-icon>
                   Hello
                 </a>
                 <a href="#its-me">
-                  <i aria-hidden="true" class="fa-arrow-down fas"></i>
+                  <va-icon class="hydrated"></va-icon>
                   It's me
                 </a>
               </dd>

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
@@ -39,17 +39,6 @@ dd a {
   max-width: 285px;
 }
 
-i {
-  font-family: 'Font Awesome 5 Free';
-  font-style: normal;
-  font-weight: 900;
-  margin-right: 8px;
-  font-size: 0.75em;
-}
-i::before {
-  content: '\F063'; /* fa-arrow-down */
-}
-
 a:active {
   background-color: var(--vads-color-base-lighter);
 }

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
@@ -95,7 +95,7 @@ export class VaOnThisPage {
           <dd role="definition">
             {h2s.map(heading => (
               <a href={`#${heading.id}`} onClick={handleOnClick}>
-                <i aria-hidden="true" class="fas fa-arrow-down"></i>
+                <va-icon icon="arrow_downward"></va-icon>
                 {heading.innerText}
               </a>
             ))}

--- a/packages/web-components/src/components/va-promo-banner/test/va-promo-banner.e2e.ts
+++ b/packages/web-components/src/components/va-promo-banner/test/va-promo-banner.e2e.ts
@@ -12,13 +12,13 @@ describe('va-promo-banner', () => {
       <va-promo-banner class="hydrated">
         <mock:shadow-root>
           <div class="va-banner-body">
-            <i aria-hidden="true" role="presentation"></i>
+            <va-icon class="hydrated va-promo-banner__icon"></va-icon>
             <a class="va-banner-content-link">
               <slot></slot>
-              <i aria-hidden="true" role="presentation"></i>
+              <va-icon class="hydrated"></va-icon>
             </a>
             <button aria-label="Dismiss this promo banner" type="button">
-              <i aria-hidden="true" role="presentation"></i>
+              <va-icon class="hydrated"></va-icon>
             </button>
           </div>
         </mock:shadow-root>
@@ -100,13 +100,13 @@ describe('va-promo-banner', () => {
     <va-promo-banner class="hydrated" href="#" type="news">
       <mock:shadow-root>
         <div class="va-banner-body">
-          <i aria-hidden="true" class="news" role="presentation"></i>
+          <va-icon class="hydrated va-promo-banner__icon"></va-icon>
           <a class="va-banner-content-link" href="#">
             <slot></slot>
-            <i aria-hidden="true" role="presentation"></i>
+            <va-icon class="hydrated"></va-icon>
           </a>
           <button aria-label="Dismiss this promo banner" type="button">
-            <i aria-hidden="true" role="presentation"></i>
+            <va-icon class="hydrated"></va-icon>
           </button>
         </div>
       </mock:shadow-root>

--- a/packages/web-components/src/components/va-promo-banner/va-promo-banner.css
+++ b/packages/web-components/src/components/va-promo-banner/va-promo-banner.css
@@ -16,38 +16,16 @@
   align-items: center;
 }
 
-.va-banner-body > i {
-  display: none;
-  text-align: center;
-  width: 100%;
-  font-size: 2.15rem;
+.va-promo-banner__icon {
   background-color: var(--vads-color-white);
   border-radius: 50%;
-  height: 100%;
   height: 4.2rem;
-  position: relative;
   width: 4.2rem;
   margin-left: 0.5rem;
   margin-right: 0.8rem;
   margin-top: 0.8rem;
   margin-bottom: 0.8rem;
-}
-
-.va-banner-body > i::before {
-  position: relative;
-  top: 0.8rem;
-}
-
-.va-banner-body > i.announcement::before {
-  content: '\F0A1'; /* fa-bullhorn */
-}
-
-.va-banner-body > i.news::before {
-  content: '\F1EA'; /* fa-newspaper */
-}
-
-.va-banner-body > i.email-signup::before {
-  content: '\F0E0'; /* fa-envelope */
+  text-align: center;
 }
 
 .va-banner-content-link {

--- a/packages/web-components/src/components/va-promo-banner/va-promo-banner.css
+++ b/packages/web-components/src/components/va-promo-banner/va-promo-banner.css
@@ -41,10 +41,6 @@
   text-decoration: underline;
 }
 
-.va-banner-content-link i::before {
-  content: '\F105'; /* fa-angle-right */
-}
-
 button {
   background: none;
   background-color: transparent;
@@ -56,21 +52,6 @@ button {
 
 button:hover {
   cursor: pointer;
-}
-
-button i::before {
-  content: '\F057'; /* fa-times-circle */
-}
-
-i {
-  font-family: 'Font Awesome 5 Free';
-  font-style: normal;
-  font-weight: 900;
-  display: inline-block;
-  font-style: normal;
-  font-variant: normal;
-  text-rendering: auto;
-  line-height: 1;
 }
 
 @media screen and (min-width: 768px) {

--- a/packages/web-components/src/components/va-promo-banner/va-promo-banner.tsx
+++ b/packages/web-components/src/components/va-promo-banner/va-promo-banner.tsx
@@ -141,23 +141,34 @@ export class VaPromoBanner {
       return null;
     }
 
+    /* eslint-disable i18next/no-literal-string */
+    const typeIconName = {
+      'announcement': 'campaign',
+      'email-signup': 'mail',
+      'news': 'info',
+    };
+
     return (
       <Host>
         <div class="va-banner-body">
-          <i aria-hidden="true" class={this.type} role="presentation" />
+          <va-icon
+            class="va-promo-banner__icon"
+            icon={typeIconName[this.type]}
+            size={4}
+          ></va-icon>
           <a
             class="va-banner-content-link"
             href={this.href}
             onClick={() => this.handleLinkClick()}
           >
-            <slot></slot> <i aria-hidden="true" role="presentation" />
+            <slot></slot> <va-icon icon="chevron_right"></va-icon>
           </a>
           <button
             type="button"
             aria-label="Dismiss this promo banner"
             onClick={() => this.closeHandler()}
           >
-            <i aria-hidden="true" role="presentation" />
+            <va-icon icon="cancel" size={3}></va-icon>
           </button>
         </div>
       </Host>

--- a/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
+++ b/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
@@ -47,7 +47,7 @@ describe('va-search-input', () => {
         <mock:shadow-root>
           <input aria-autocomplete="none" aria-label="Search" autocomplete="off" id="va-search-input" type="text">
           <button aria-label="Search" id="va-search-button" type="submit">
-            <i aria-hidden="true" class="fa fa-search"></i>
+            <va-icon class="hydrated"></va-icon>
             <span id="va-search-button-text">
               Search VA.gov
             </span>

--- a/packages/web-components/src/components/va-search-input/va-search-input.scss
+++ b/packages/web-components/src/components/va-search-input/va-search-input.scss
@@ -79,17 +79,6 @@
   background-color: var(--vads-color-primary-dark);
 }
 
-i::before {
-  content: '\F002'; /* fa-search is now fa-magnifying-glass */
-  display: inline-block;
-  font-family: 'Font Awesome 5 Free';
-  font-style: normal;
-  font-variant: normal;
-  font-weight: 900;
-  line-height: 1;
-  text-rendering: auto;
-}
-
 #va-search-button-text {
   margin-left: 4px;
 }

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -378,7 +378,7 @@ export class VaSearchInput {
    */
   private updateSuggestions = (suggestionsArr: string[]) => {
     // If it's an empty array, reset formatted suggestions and close the listbox
-    
+
     if (!suggestionsArr.length) {
       this.formattedSuggestions = [];
       this.isListboxOpen = false;
@@ -534,7 +534,7 @@ export class VaSearchInput {
           aria-label={label}
           onClick={handleButtonClick}
         >
-          <i aria-hidden="true" class="fa fa-search" />
+          <va-icon icon="search" size={3}></va-icon>
           {buttonText && <span id="va-search-button-text">{buttonText}</span>}
         </button>
         {isListboxOpen && (


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#2198](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2198)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
* va-alert (v1, but used by va-banner)
  * Before
    * ![Screenshot 2024-05-09 at 1 15 04 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/84ebbaae-2e90-4db0-b22d-0ae1605b6faa)
  * After
    * ![Screenshot 2024-05-09 at 1 15 24 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/2228c1e9-8147-4b9b-8e48-8a6a541d7ffe)
* va-alert-expandable
  * Before
    * ![Screenshot 2024-05-03 at 10 20 21 AM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/8b9fb56d-6d93-43b5-868f-4a72d22239ba)
  * After
    * ![Screenshot 2024-05-03 at 11 09 06 AM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/624b1adf-824c-44e4-abf8-e7ea69d038bc)
* va-back-to-top
  * Before
    * ![Screenshot 2024-05-09 at 1 17 46 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/1baeb270-95c4-4522-8c99-891ea78b45a8)
  * After
    * ![Screenshot 2024-05-09 at 1 18 27 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/d9b049d0-cc4b-4b8e-b91b-57a59c24e576)
* va-link
  * Before
    * ![Screenshot 2024-05-09 at 1 20 24 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/f307871e-4d2c-4990-b408-b6c36be995cc)
  * After
    * ![Screenshot 2024-05-09 at 1 21 11 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/995a6a36-b1fa-4221-9b51-42937e754421)
* va-maintenance-banner
  * Before
    * ![Screenshot 2024-05-09 at 1 22 08 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/eda149a8-bc92-4b9b-86c3-7b519764deba)
  * After
    * ![Screenshot 2024-05-09 at 1 23 11 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/d64f8845-04af-4237-8a76-26712a0c019b)
* va-modal
  * Before
    * ![Screenshot 2024-05-09 at 1 24 13 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/2795f32a-0008-4df9-b176-0677195fca30)
  * After
    * ![Screenshot 2024-05-09 at 1 25 13 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/85d2dea9-bc50-47e3-bffa-9ab17439e4b4)
* va-on-this-page
  * Before
    * ![Screenshot 2024-05-09 at 1 26 47 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/72a30317-a51c-4f98-b8c9-a1b512653e8b)
  * After
    * ![Screenshot 2024-05-09 at 1 27 03 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/96a10eec-466a-4631-be57-d27958ddf25c)
* va-promo-banner
  * Before
    * ![Screenshot 2024-05-09 at 1 28 18 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/02724e63-471e-4f96-a4f4-6d12b9cbe894)
  * After
    * ![Screenshot 2024-05-09 at 1 29 00 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/a2fa1eea-d4b2-423d-ad89-cc28a9d15369)
* va-search-input
  * Before
    * ![Screenshot 2024-05-09 at 1 29 38 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/2ca74c9c-8162-4b29-aee7-7b4c60cb4181)
  * After
    * ![Screenshot 2024-05-09 at 1 29 51 PM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/01535cbd-8a7f-4170-9ef6-e31bf928592a)

## Acceptance criteria
- [ ] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
