### PR TITLE
va-link: Add destination and origin to analytics details

### DIFF
--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -150,31 +150,47 @@ Calendar.args = {
 
 const ReverseTemplate = ({ filename, filetype, href, reverse, text }) => {
   return (
-    <div className="vads-u-background-color--primary vads-u-padding--1">
-      <span className="vads-u-color--white">Default Link: </span>
-      <va-link href={href} reverse={reverse} text={text} />
-      <br />
-      <span className="vads-u-color--white">Active Link: </span>
-      <va-link active={true} href={href} reverse={reverse} text={text} />
-      <br />
-      <span className="vads-u-color--white">Download Link: </span>
+    <div className="vads-u-padding--4" style={{background: 'linear-gradient(to left, var(--vads-color-primary) 30%, var(--vads-color-primary-dark) 60%, var(--vads-color-primary-darker))'}}>
+      <h4 className="vads-u-color--white">Default Link</h4>
+      <va-link href={href} reverse={reverse} text="Contact a local Veterans Service Organization (VSO)" />
+
+      <h4 className="vads-u-color--white">Active Link</h4>
+      <va-link active={true} href={href} reverse={reverse} text="Share your VA medical records" />
+
+      <h4 className="vads-u-color--white">Download Link</h4>
       <va-link
-        download={true}
-        href={href}
-        filename={filename}
-        filetype={filetype}
-        reverse={reverse}
-        text={text}
+        download
+        filetype="PDF"
+        href="https://www.va.gov"
+        pages={5}
+        reverse
+        text="Download VA form 10-10EZ"
       />
-      <br />
-      <span className="vads-u-color--white">Video Link: </span>
-      <va-link href={href} reverse={reverse} text={text} video={true} />
-      <br />
-      <span className="vads-u-color--white">Channel Link: </span>
-      <va-link channel={true} href={href} reverse={reverse} text={text} />
-      <br />
-      <span className="vads-u-color--white">Calendar Link: </span>
-      <va-link calendar={true} href={href} reverse={reverse} text={text} />
+
+      <h4 className="vads-u-color--white">Video Link</h4>
+      <va-link   
+        href="https://www.va.gov"
+        text="Go to the video about VA disability compensation"
+        video 
+        reverse 
+      />
+
+
+      <h4 className="vads-u-color--white">Channel Link</h4>
+      <va-link   
+        channel
+        href="https://www.va.gov"
+        text="Veteran's Affairs" 
+        reverse
+      />
+
+      <h4 className="vads-u-color--white">Calendar Link</h4>
+      <va-link 
+        calendar
+        href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR"
+        text="Add to calendar"
+        reverse
+      />
     </div>
   );
 };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -136,7 +136,8 @@ describe('va-link', () => {
       action: 'click',
       details: {
         label: 'Find out if you qualify for this program and how to apply',
-        href: 'https://www.va.gov',
+        destination: 'https://www.va.gov',
+        origin: 'http://localhost:3333/',
       },
     });
   });

--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -135,7 +135,8 @@ describe('va-link', () => {
       componentName: 'va-link',
       action: 'click',
       details: {
-        label: 'Find out if you qualify for this program and how to apply'
+        label: 'Find out if you qualify for this program and how to apply',
+        href: 'https://www.va.gov',
       },
     });
   });

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -96,6 +96,7 @@ export class VaLink {
         action: 'click',
         details: {
           label: this.text,
+          href: this.href,
         },
       };
       this.componentLibraryAnalytics.emit(detail);

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -96,7 +96,8 @@ export class VaLink {
         action: 'click',
         details: {
           label: this.text,
-          href: this.href,
+          destination: this.href,
+          origin: window.location.href,
         },
       };
       this.componentLibraryAnalytics.emit(detail);


### PR DESCRIPTION
## Chromatic
<!-- This `2693-va-link-analytics` is a placeholder for a CI job - it will be updated automatically -->
https://2693-va-link-analytics--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
This PR will add the `href` prop value (destination) to the analytics details as well as the origin URL based on feedback from the related issue.

related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2693

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

Analytics verified using Verdaccio in vets-website:

<img width="595" alt="Screenshot 2024-05-14 at 2 12 33 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/872479/138d15c1-1f06-42c8-a11e-71942c669f86">


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
