### PR TITLE
va-accordion: unhide content in print media

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion-item.scss
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.scss
@@ -130,3 +130,10 @@ p.subheader {
 ::slotted([slot='subheader-icon']) {
   margin-top: 0.5rem;
 }
+
+@media print {
+  :host(:not([open])) #content,
+  :host([open='false']) #content {
+    display: block;
+  }
+}

--- a/packages/web-components/src/components/va-accordion/va-accordion.scss
+++ b/packages/web-components/src/components/va-accordion/va-accordion.scss
@@ -32,3 +32,9 @@ button.va-accordion__button {
   font-weight: bold;
   float: right;
 }
+
+@media print {
+  button.va-accordion__button {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes [#2206](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2206)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

| | |
|---|---|
| Default | <img width="1275" alt="default accordion with print window showing all content" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/37c43937-fa4a-4d14-9eeb-604a90401b8b"> |
| Icon headers | <img width="1277" alt="accordion icon headers with print window showing all content" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/a2a67832-5fed-4fe6-b499-6c10462d4702"> |
| Accordions with subheaders | <img width="1279" alt="accordions with subheaders with print window showing all content" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/d943bfc2-f0e9-4ec2-9d82-4865a77e95ec"> |
| Many accordions | <img width="1278" alt="many accordions with print window showing all content" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/9a600b0f-16e7-4134-a69e-cf7213c1cdaf"> |

## Acceptance criteria
- [ ] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
