### PR TITLE
va-accordion: add duplicate print media to unhide print content

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion-item.scss
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.scss
@@ -32,6 +32,7 @@
   max-width: 64ex;
 }
 
+/* overrides hidden attribute on #content */
 @media print {
   :host(:not([open])) #content,
   :host([open='false']) #content {
@@ -56,6 +57,14 @@
 :host(:not([open])) #content,
 :host([open='false']) #content {
   display: none;
+}
+
+/* duplicate print media block needed to override above definition */
+@media print {
+  :host(:not([open])) #content,
+  :host([open='false']) #content {
+    display: block;
+  }
 }
 
 h1,


### PR DESCRIPTION
## Chromatic
<!-- This `2206-accordion-print2` is a placeholder for a CI job - it will be updated automatically -->
https://2206-accordion-print2--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Previous changes to add print media are overridden by original component definitions, so this PR adds a duplicate print media definition below the original component definition. Eventually all definitions below the original component definitions comment will be removed, including the duplicate print media definition.

see [#2206](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2206)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

<img width="1252" alt="collapsed accordion with print modal showing all accordion content" src="https://github.com/department-of-veterans-affairs/component-library/assets/136959/99aabbbb-6c2f-4f7b-8453-ac825daffcf0">

## Acceptance criteria
- [ ] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
