### PR TITLE
va-text-input: address validation bug for currency / valid range

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -815,5 +815,20 @@ describe('va-text-input', () => {
       const inputEl = await page.find('va-text-input >>> input');
       expect(inputEl.getAttribute('pattern')).toEqual("[0-9]+(\.[0-9]{1,})?");
     }
-  })
+  });
+
+  it('sets a default pattern and inputmode if currency is true', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input currency />');
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(inputEl.getAttribute('pattern')).toEqual("^[0-9]+(\.[0-9]{2})?$");
+    expect(inputEl.getAttribute('inputmode')).toEqual("numeric");
+  });
+
+  it('sets type to be number if max or min set', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input max="5" min="1" />');
+    const inputEl = await page.find('va-text-input >>> input');
+    expect(inputEl.getAttribute('type')).toEqual("number");
+  });
 });


### PR DESCRIPTION
## Chromatic
<!-- This `va-text-input-bug-fixes` is a placeholder for a CI job - it will be updated automatically -->
https://va-text-input-bug-fixes--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This ticket addresses two bugs in `va-text-input`: 
* for the [Valid Range story](https://design.va.gov/storybook/?path=/docs/uswds-va-text-input--valid-range), there is no validation or enforcement of the range
* for the [Currency story](https://design.va.gov/storybook/?path=/docs/uswds-va-text-input--with-currency), there is no enforcement of the input (eg only an integer or a float with two decimal places.

Closes [2860](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2860)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

<img width="643" alt="Screenshot 2024-05-22 at 3 04 50 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/32ae9354-724a-4b89-98bc-37036b8b0ef6">

<img width="630" alt="Screenshot 2024-05-22 at 3 06 14 PM" src="https://github.com/department-of-veterans-affairs/component-library/assets/8867779/502cdea9-b051-41fd-84ee-402d4c59f0b8">

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
