### PR TITLE
Fixes line-height on va-file-input

### DIFF
--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -218,8 +218,7 @@ export class VaFileInput {
   };
 
   private generateFileContents(file: File) {
-    if (!file)
-      return;
+    if (!file) return;
 
     const reader = new FileReader();
     this.fileType = file.type;
@@ -228,7 +227,11 @@ export class VaFileInput {
       this.fileContents = reader.result as string;
     };
 
-    if (this.fileType && (this.fileType === 'application/pdf' || this.fileType.startsWith('image/'))) {
+    if (
+      this.fileType &&
+      (this.fileType === 'application/pdf' ||
+        this.fileType.startsWith('image/'))
+    ) {
       reader.readAsDataURL(file);
     }
   }
@@ -250,7 +253,20 @@ export class VaFileInput {
   }
 
   render() {
-    const { label, name, required, accept, error, hint, uswds, file, uploadStatus, headerSize, fileContents, fileType } = this;
+    const {
+      label,
+      name,
+      required,
+      accept,
+      error,
+      hint,
+      uswds,
+      file,
+      uploadStatus,
+      headerSize,
+      fileContents,
+      fileType,
+    } = this;
 
     const text = this.getButtonText();
 
@@ -263,20 +279,36 @@ export class VaFileInput {
         this.error ? 'file-input-target-error' : ''
       }`.trim();
 
-      let fileThumbnail = (<div class="thumbnail-container">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" fill="#07648d" width="40px" height="40px">
-          <path d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"/>
-        </svg>
-      </div>);
+      let fileThumbnail = (
+        <div class="thumbnail-container">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 384 512"
+            fill="#07648d"
+            width="40px"
+            height="40px"
+          >
+            <path d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z" />
+          </svg>
+        </div>
+      );
       if (fileContents) {
         if (fileType.startsWith('image/')) {
-          fileThumbnail = (<div class="thumbnail-container">
-            <img class="thumbnail-preview" src={fileContents} alt="image" />
-          </div>);
+          fileThumbnail = (
+            <div class="thumbnail-container">
+              <img class="thumbnail-preview" src={fileContents} alt="image" />
+            </div>
+          );
         } else if (fileType === 'application/pdf') {
-          fileThumbnail = (<div class="thumbnail-container">
-            <object class="thumbnail-preview" data={fileContents} type="application/pdf"/>
-          </div>);
+          fileThumbnail = (
+            <div class="thumbnail-container">
+              <object
+                class="thumbnail-preview"
+                data={fileContents}
+                type="application/pdf"
+              />
+            </div>
+          );
         }
       }
 
@@ -333,7 +365,7 @@ export class VaFileInput {
                 <va-card class="va-card">
                   <div class="file-info-section">
                     {fileThumbnail}
-                    <div class="file-info-group">
+                    <div class="file-info-group vads-u-line-height--2">
                       <span class="file-label">{file.name}</span>
                       <span class="file-size-label">
                         {this.formatFileSize(file.size)}


### PR DESCRIPTION
## Chromatic
<!-- This `rm-lineheight-hotfix` is a placeholder for a CI job - it will be updated automatically -->
https://rm-lineheight-hotfix--65a6e2ed2314f7b8f98609d8.chromatic.com

 This is a quick fix,  adding vads-u-line-height--2 class to va-file-input to tighten the line-height  (so as to be in step with figma). It seems the was reverted  before merging, so I am adding it again.