### PR TITLE
add yarn install to publish workflow for css-library

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Install dependencies in react-components
       run: yarn install
       working-directory: packages/react-components
-    - run: yarn install
     - name: Install dependencies in css-library
       run: yarn install
       working-directory: packages/css-library

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,10 @@ jobs:
     - name: Install dependencies in react-components
       run: yarn install
       working-directory: packages/react-components
+    - run: yarn install
+    - name: Install dependencies in css-library
+      run: yarn install
+      working-directory: packages/css-library
     - run: yarn workspace @department-of-veterans-affairs/react-components run build
     - run: yarn workspace @department-of-veterans-affairs/web-components run build
     - run: yarn workspace @department-of-veterans-affairs/web-components run build-bindings


### PR DESCRIPTION
## Chromatic
<!-- This `github-workflow-css-library` is a placeholder for a CI job - it will be updated automatically -->
https://github-workflow-css-library--65a6e2ed2314f7b8f98609d8.chromatic.com

During the last component-library release, I got this error when it [tried to publish ](
https://github.com/department-of-veterans-affairs/component-library/actions/runs/9307901591/job/25620161408) the `css-library` package. 

I think that adding `yarn install` similar to how it's done for the `react-components` package will resolve this. 

<img width="950" alt="Screenshot 2024-05-31 at 7 13 31 AM" src="https://github.com/department-of-veterans-affairs/component-library/assets/872479/9d715e36-a547-4deb-8f2f-3ff5e290f506">


## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
