### PR TITLE
Add label property to link

### DIFF
--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -28,6 +28,7 @@ const defaultArgs = {
   'reverse': undefined,
   'text': undefined,
   'video': undefined,
+  'label': undefined
 };
 
 const Template = ({
@@ -44,6 +45,7 @@ const Template = ({
   reverse,
   text,
   video,
+  label,
 }) => {
   return (
     <Fragment>
@@ -63,6 +65,7 @@ const Template = ({
         reverse={reverse}
         text={text}
         video={video}
+        label={label}
       />
     </Fragment>
   );
@@ -90,6 +93,7 @@ const VariantTemplate = ({
   reverse,
   text,
   video,
+  label,
 }) => {
   return (
     <va-link
@@ -106,6 +110,7 @@ const VariantTemplate = ({
       reverse={reverse}
       text={text}
       video={video}
+      label={label}
     />
   );
 };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -524,6 +524,10 @@ export namespace Components {
          */
         "href": string;
         /**
+          * Adds an aria-label attribute to the link element.
+         */
+        "label"?: string;
+        /**
           * The number of pages of the file. Only displayed if download is `true`.
          */
         "pages"?: number;
@@ -2576,6 +2580,10 @@ declare namespace LocalJSX {
           * The href attribute of the anchor.
          */
         "href": string;
+        /**
+          * Adds an aria-label attribute to the link element.
+         */
+        "label"?: string;
         /**
           * The event used to track usage of the component.
          */

--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -115,6 +115,14 @@ describe('va-link', () => {
     `);
   });
 
+  it('renders a link with a screen reader label', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<va-link href="https://www.va.gov" text="Veteran's Affairs" label="Example label" />`);
+
+    const label = await page.find('va-link >>> a[aria-label]');
+    expect(label.getAttribute("aria-label")).toBe('Example label');
+  });
+
   it('passes an axe check', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -77,6 +77,11 @@ export class VaLink {
    * If 'true', will represent the link with white text instead of blue.
    */
   @Prop() reverse?: boolean = false;
+ 
+  /**
+   * Adds an aria-label attribute to the link element.
+   */
+    @Prop() label?: string = null;
 
   /**
    * The event used to track usage of the component.
@@ -135,7 +140,7 @@ export class VaLink {
     if (active) {
       return (
         <Host>
-          <a href={href} class={linkClass} onClick={handleClick}>
+          <a href={href} class={linkClass} onClick={handleClick} aria-label={this.label}>
             {text}
             <va-icon class="link-icon--active" icon="chevron_right"></va-icon>
           </a>
@@ -205,7 +210,7 @@ export class VaLink {
     // Default
     return (
       <Host>
-        <a href={href} class={linkClass} onClick={handleClick}>
+        <a href={href} class={linkClass} onClick={handleClick} aria-label={this.label}>
           {text}
         </a>
       </Host>


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---


## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1644

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
  - N/A, no visual change.
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

N/A, no visual change.

## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
