### PR TITLE
specify storybook build output dir

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn install
         working-directory: packages/storybook
       - name: Publish Storybook
-        run: yarn chromatic build-storybook --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        run: yarn chromatic build-storybook --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --output-dir=/storybook-static
         working-directory: packages/storybook
       - uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
## Chromatic
<!-- This `set-storybook-build-output-dir` is a placeholder for a CI job - it will be updated automatically -->
https://set-storybook-build-output-dir--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
This PR is an attempt to deal with a [failure]() in the Build storybook and deploy action by explicitly setting the build's output dir.

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
