### PR TITLE
va-breadcrumbs: Fix for focusability of 'hidden' breadcrumbs

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "9.1.3",
+  "version": "9.1.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
@@ -10,6 +10,12 @@
   pointer-events: none;
 }
 
+@media screen and (max-width: 29.99em) {
+  .usa-breadcrumb__list-item:not(:nth-last-child(2)) {
+    display: none;
+  }
+}
+
 // Styles for V1 mode
 :host([uswds='false']) {
   nav {


### PR DESCRIPTION
Fix to visually hidden breadcrumbs so that they are hidden from keyboard focus, too.

## Chromatic
<!-- This `2837-visually-hidden-breadcrumbs` is a placeholder for a CI job - it will be updated automatically -->
https://2837-visually-hidden-breadcrumbs--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#2837](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2837)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A

## Acceptance criteria
- [x] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
