### PR TITLE
update publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,6 @@ jobs:
     - run: yarn workspace @department-of-veterans-affairs/web-components run build-bindings
     - run: yarn workspace @department-of-veterans-affairs/component-library run build
     - run: yarn workspace @department-of-veterans-affairs/css-library run build
-    - run: yarn workspaces foreach --verbose --no-private npm publish --access public --tolerate-republish
+    - run: yarn workspaces foreach --all --verbose --no-private npm publish --access public --tolerate-republish
       env:
         YARN_NPM_AUTH_TOKEN: ${{ env.VA_VSP_BOT_NPM_TOKEN }}


### PR DESCRIPTION
## Description
We switched to node 18.x in our [publishing workflow](https://github.com/department-of-veterans-affairs/component-library/blob/main/.github/workflows/publish.yml#L15) which broke our publishing command. This is because [yarn v4 requires](https://yarnpkg.com/advanced/changelog#major-changes) `yarn workspaces foreach` to include one of `--all`, `--recursive`, `--since`, or `--worktree`