### PR TITLE
va-file-input: address storybook story bug and vaChange event payload bug

### DIFF
--- a/packages/storybook/stories/va-file-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.jsx
@@ -24,7 +24,8 @@ const defaultArgs = {
   'error': '',
   'enable-analytics': false,
   'hint': 'You can upload a .pdf, .gif, .jpg, .bmp, or .txt file.',
-  'vaChange': null,
+  'vaChange': event =>
+    alert(`File change event received: ${event?.detail?.files[0]?.name}`),
   'uswds': true,
   'header-size': null,
   'children': null

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -162,12 +162,12 @@ export class VaFileInput {
 
   private removeFile = (notifyParent: boolean = true) => {
     this.closeModal();
-    this.file = null;
     this.uploadStatus = 'idle';
     this.internalError = null;
     if (notifyParent) {
       this.vaChange.emit({ files: [this.file] });
     }
+    this.file = null;
   };
 
   private openModal = () => {


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR addresses two minor related bugs:
* in va-file-input's storybook story where a function is not passed as a prop to the component to fire in response to the vaChange event. 
* in the component, the file name is also set to null after firing the event so that the event carries the file name after delete.

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
**before**: 

https://github.com/department-of-veterans-affairs/component-library/assets/8867779/740e40f4-aa70-4ad3-a04b-e593ab5ccf64

**after**:  (note the file name is printed in the alert after delete):

https://github.com/department-of-veterans-affairs/component-library/assets/8867779/bc9de00f-ce6a-43f0-af0f-4e2af8edfe68



## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
