### PR TITLE
va-alert: add specificity to slot style

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-alert/va-alert-slot.css
+++ b/packages/web-components/src/components/va-alert/va-alert-slot.css
@@ -6,7 +6,7 @@
   margin-bottom: 8px; /* 0.5rem */
 }
 
-p {
+va-alert p {
   max-width: 100%;
   margin-bottom: 1em;
   margin-top: 1em;


### PR DESCRIPTION
## Chromatic
<!-- This `va-alert-slot-style` is a placeholder for a CI job - it will be updated automatically -->
https://va-alert-slot-style--65a6e2ed2314f7b8f98609d8.chromatic.com

We noticed that some slot styles for `va-alert` were applying to global paragraph styles so this update will make it specific to the component itself.

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
