### PR TITLE
va-breadcrumb: Add lang attr support

### DIFF
--- a/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
+++ b/packages/storybook/stories/va-breadcrumbs-uswds.stories.jsx
@@ -104,6 +104,35 @@ const WrappingCrumbsTemplate = ({
   );
 };
 
+const MultipleLanguagesTemplate = ({
+  label,
+  'disable-analytics': disableAnalytics,
+}) => {
+  const breadcrumbs = [
+    { label: 'VA.gov home', href: '/#1' },
+    { label: 'Resources', href: '/#2' },
+    {
+      label: 'Asistencia y recursos del VA en español',
+      href: '/#3',
+      lang: 'es',
+    },
+    {
+      label: 'VA Tagalog wika mapagkukunan at tulong',
+      href: '/#4',
+      lang: 'tl',
+    },
+  ];
+  return (
+    <div>
+      <VaBreadcrumbs
+        label={label}
+        disableAnalytics={disableAnalytics}
+        breadcrumbList={breadcrumbs}
+      ></VaBreadcrumbs>
+    </div>
+  );
+};
+
 
 const WithRouterTemplate = ({
   label,
@@ -130,7 +159,7 @@ const WithRouterTemplate = ({
     <div>
       <p>Some of the breadcrumbs in this example have an <code>isRouterLink:true</code> property.
         When the corresponding anchor tag is clicked these links emit a <code>route-change</code> event.
-        This event can be handled in a React component where utilities provided 
+        This event can be handled in a React component where utilities provided
         by React Router can be used to change the page under view, as in the example below:
       </p>
       <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
@@ -192,6 +221,9 @@ RerenderState.args = { ...defaultArgs };
 
 export const WrappingState = WrappingCrumbsTemplate.bind(null);
 WrappingState.args = { ...defaultArgs, wrapping: true };
+
+export const MultipleLanguages = MultipleLanguagesTemplate.bind(null);
+MultipleLanguages.args = { ...defaultArgs };
 
 export const WithRouterLinkSupport = WithRouterTemplate.bind(null);
 WithRouterLinkSupport.args = { ...defaultArgs }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "10.0.1",
+  "version": "11.0.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
+++ b/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
@@ -156,7 +156,7 @@ describe('va-breadcrumbs', () => {
 
     const anchorElements = await page.findAll('pierce/a');
     const firstAnchorText = anchorElements[0].innerText;
-    
+
     expect(firstAnchorText).toBe('VA.gov home');
   });
 
@@ -172,7 +172,7 @@ describe('va-breadcrumbs', () => {
 
     const anchorElements = await page.findAll('pierce/a');
     const firstAnchorText = anchorElements[0].innerText;
-    
+
     expect(firstAnchorText).toBe('home');
   });
 
@@ -190,12 +190,51 @@ describe('va-breadcrumbs', () => {
             <ol class="usa-breadcrumb__list" role="list">
               <li class="usa-breadcrumb__list-item">
                 <a class="usa-breadcrumb__link" href="#home">
-                  <span>VA.gov home</span>
+                  <span lang="en-US">VA.gov home</span>
                 </a>
               </li>
               <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
                 <a class="usa-breadcrumb__link" href="#content">
-                  <span>Current</span>
+                  <span lang="en-US">Current</span>
+                </a>
+              </li>
+            </ol>
+          </nav>
+        </mock:shadow-root>
+      </va-breadcrumbs>
+    `);
+  });
+
+  it('uswds - renders different language breadcrumbs', async () => {
+    const crumbs = JSON.stringify([
+      { label: 'Home', href: '#home' },
+      { label: 'Spanish Crumb', href: '#spanish', lang: 'es' },
+      { label: 'Tagalog Crumb', href: '#tagalog', lang: 'tl' },
+    ]);
+    const page = await newE2EPage({
+      html: `<va-breadcrumbs class="hydrated" label="test" disable-analytics="false" breadcrumb-list=\'${crumbs}\'></va-breadcrumbs>`,
+    });
+    const element = await page.find('va-breadcrumbs');
+    expect(element).toEqualHtml(`
+      <va-breadcrumbs class="hydrated" disable-analytics="false" label="test" breadcrumb-list='[{"label":"Home","href":"#home"},{"label":"Spanish Crumb","href":"#spanish","lang":"es"},{"label":"Tagalog Crumb","href":"#tagalog","lang":"tl"}]'>
+        <mock:shadow-root>
+          <nav aria-label="test" class="usa-breadcrumb">
+            <ol class="usa-breadcrumb__list" role="list">
+              <li class="usa-breadcrumb__list-item">
+                <a class="usa-breadcrumb__link" href="#home">
+                  <span lang="en-US">VA.gov home</span>
+                </a>
+              </li>
+              <li class="usa-breadcrumb__list-item">
+                <a class="usa-breadcrumb__link" href="#spanish">
+                  <span lang="es">
+                    Spanish Crumb
+                  </span>
+                </a>
+              </li>
+              <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
+                <a class="usa-breadcrumb__link" href="#content">
+                  <span lang="tl">Tagalog Crumb</span>
                 </a>
               </li>
             </ol>
@@ -213,7 +252,7 @@ describe('va-breadcrumbs', () => {
     const element = await page.find('va-breadcrumbs');
     const indicator = element.shadowRoot.querySelector('.usa-breadcrumb');
     expect(indicator.classList.contains('usa-breadcrumb--wrap')).toBe(true);
-  })
+  });
 
   it('uswds - passes an axe check', async () => {
     const page = await newE2EPage();
@@ -272,17 +311,17 @@ describe('va-breadcrumbs', () => {
             <ol class="usa-breadcrumb__list" role="list">
               <li class="usa-breadcrumb__list-item">
                 <a class="usa-breadcrumb__link" href="/one">
-                  <span>VA.gov home</span>
+                  <span lang="en-US">VA.gov home</span>
                 </a>
               </li>
               <li class="usa-breadcrumb__list-item">
                 <a class="usa-breadcrumb__link" href="/two">
-                  <span>Two</span>
+                  <span lang="en-US">Two</span>
                 </a>
               </li>
               <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
                 <a class="usa-breadcrumb__link" href="#content">
-                  <span>Three</span>
+                  <span lang="en-US">Three</span>
                 </a>
               </li>
             </ol>
@@ -304,7 +343,7 @@ describe('va-breadcrumbs', () => {
     await anchorElements[1].click();
 
     expect(routeChangeSpy).toHaveReceivedEventDetail({
-      href: "/two",
+      href: '/two',
     });
   });
 
@@ -346,7 +385,7 @@ describe('va-breadcrumbs', () => {
 
     const anchorElements = await page.findAll('pierce/a');
     const firstAnchorText = anchorElements[0].innerText;
-    
+
     expect(firstAnchorText).toBe('home');
   });
 

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -11,6 +11,13 @@ import {
 } from '@stencil/core';
 import classnames from 'classnames';
 
+type Breadcrumb = {
+  label: string;
+  href: string;
+  isRouterLink?: boolean;
+  lang?: string;
+};
+
 /**
  * @componentName Breadcrumbs
  * @maturityCategory use
@@ -39,7 +46,7 @@ export class VaBreadcrumbs {
   /**
    *  Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`. This prop is available when `uswds` is set to `true`.
    */
-  @Prop() breadcrumbList?: any;
+  @Prop() breadcrumbList?: Breadcrumb[] | string;
 
   /**
    *  When true, the first breadcrumb label will be "VA.gov home".
@@ -49,10 +56,10 @@ export class VaBreadcrumbs {
   /**
    *
    * Represents an internal state of the component which stores the list of breadcrumbs parsed from the 'breadcrumbList' prop.
-   * Each breadcrumb is represented as an object with two properties: 'label' and 'href'.
+   * Each breadcrumb is represented as an object with at least two properties: 'label' and 'href'.
    * This state is used when `uswds` is set to `true`.
    */
-  @State() formattedBreadcrumbs?: Array<{ label: string; href: string }> = [];
+  @State() formattedBreadcrumbs?: Breadcrumb[] = [];
   /**
    *
    * This is a method that watches for changes in the 'breadcrumbList' prop.
@@ -62,7 +69,10 @@ export class VaBreadcrumbs {
   @Watch('breadcrumbList')
   watchBreadcrumbListHandler(breadcrumbList) {
     if (!this.breadcrumbList?.length) return;
-    this.updateBreadCrumbList(breadcrumbList);
+    let potentialBreadcrumbs = this.validateBreadcrumbs(breadcrumbList);
+    if (potentialBreadcrumbs) {
+      this.updateBreadCrumbList(potentialBreadcrumbs);
+    }
   }
   /**
    * Analytics tracking function(s) will not be called
@@ -99,24 +109,13 @@ export class VaBreadcrumbs {
    * @param breadcrumbList - An array of breadcrumb objects or a stringified version of it.
    * @private
    */
-  private updateBreadCrumbList(
-    breadcrumbList:
-      | Array<{ label: string; href: string; isRouterLink?: boolean }>
-      | string,
-  ) {
-    const firstBreadcrumb = breadcrumbList[0] as {
-      label: string;
-      href: string;
-    };
-
+  private updateBreadCrumbList(breadcrumbList: Breadcrumb[]) {
+    const firstBreadcrumb = breadcrumbList[0];
     if (firstBreadcrumb && this.homeVeteransAffairs) {
       firstBreadcrumb.label = 'VA.gov home';
     }
 
-    this.formattedBreadcrumbs =
-      typeof breadcrumbList === 'string'
-        ? JSON.parse(breadcrumbList)
-        : breadcrumbList;
+    this.formattedBreadcrumbs = breadcrumbList;
   }
 
   private getClickLevel(target: HTMLAnchorElement) {
@@ -178,6 +177,36 @@ export class VaBreadcrumbs {
     }
   }
 
+  private validateBreadcrumbs(breadcrumbList: Breadcrumb[] | string) {
+    let potentialBreadcrumbs: Breadcrumb[];
+
+    if (Array.isArray(breadcrumbList)) {
+      potentialBreadcrumbs = breadcrumbList;
+    } else if (typeof breadcrumbList === 'string') {
+      try {
+        potentialBreadcrumbs = JSON.parse(breadcrumbList);
+      } catch (e) {
+        return false;
+      }
+    } else return false;
+
+    // Now validate that potentialBreadcrumbs is an array of objects with the properties "label" and "href"
+    // eslint-disable-next-line i18next/no-literal-string
+    if (
+      Array.isArray(potentialBreadcrumbs) &&
+      potentialBreadcrumbs.every(
+        item =>
+          typeof item === 'object' &&
+          item.hasOwnProperty('label') &&
+          item.hasOwnProperty('href'),
+      )
+    ) {
+      return potentialBreadcrumbs;
+    } else {
+      return false;
+    }
+  }
+
   componentDidLoad() {
     // We are getting the slot nodes so that we can handle either receiving an
     // anchor tag or a list item with an anchor tag.
@@ -208,31 +237,11 @@ export class VaBreadcrumbs {
     if (this.uswds) {
       if (!this.breadcrumbList?.length) return;
 
-      let potentialBreadcrumbs;
+      let potentialBreadcrumbs = this.validateBreadcrumbs(this.breadcrumbList);
 
-      if (Array.isArray(this.breadcrumbList)) {
-        potentialBreadcrumbs = this.breadcrumbList;
-      } else if (typeof this.breadcrumbList === 'string') {
-        try {
-          potentialBreadcrumbs = JSON.parse(this.breadcrumbList);
-        } catch (e) {
-          return;
-        }
-      } else return;
-
-      // Now validate that potentialBreadcrumbs is an array of objects with the properties "label" and "href"
-      // eslint-disable-next-line i18next/no-literal-string
-      if (
-        Array.isArray(potentialBreadcrumbs) &&
-        potentialBreadcrumbs.every(
-          item =>
-            typeof item === 'object' &&
-            item.hasOwnProperty('label') &&
-            item.hasOwnProperty('href'),
-        )
-      ) {
-        this.formattedBreadcrumbs = potentialBreadcrumbs;
-        this.updateBreadCrumbList(this.formattedBreadcrumbs);
+      console.log('potentialBreadcrumbs:', potentialBreadcrumbs);
+      if (potentialBreadcrumbs) {
+        this.updateBreadCrumbList(potentialBreadcrumbs);
       } else return;
     }
   }
@@ -354,7 +363,7 @@ export class VaBreadcrumbs {
                       href="#content"
                       onClick={e => this.fireAnalyticsEvent(e)}
                     >
-                      <span>{item.label}</span>
+                      <span lang={item.lang || 'en-US'}>{item.label}</span>
                     </a>
                   ) : (
                     <a
@@ -362,7 +371,7 @@ export class VaBreadcrumbs {
                       href={item.href}
                       onClick={e => this.handleClick(e, item)}
                     >
-                      <span>{item.label}</span>
+                      <span lang={item.lang || 'en-US'}>{item.label}</span>
                     </a>
                   )}
                 </li>


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#2868](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2868)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A, no graphical changes

## Acceptance criteria
- [ ] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
