### PR TITLE
Dashboard-CLI: Modifying how we tabulate icons

### DIFF
--- a/packages/design-system-dashboard-cli/src/create-spreadsheets.js
+++ b/packages/design-system-dashboard-cli/src/create-spreadsheets.js
@@ -2,7 +2,10 @@
  * Search through vets-website and content-build for instance of DST components, tally them up, and write the results to separate CSV files, one for each type of component (React, V1, V3)
  */
 
-const writeCompPathsToCSV = require('./write-comp-usage-to-csv');
+const {
+  writeCompPathsToCSV,
+  writeIconPathsToCSV,
+} = require('./write-comp-usage-to-csv');
 const {
   readAllModules,
   readFile,
@@ -180,8 +183,13 @@ function findComponentsAndIcons() {
 
 function writeCountsToCSVs(data) {
   Object.entries(data).forEach(([breakoutType, components]) => {
-    // write stuff out for each breakoutType
-    writeCompPathsToCSV({ breakoutType, components });
+    if (breakoutType !== 'icons') {
+      // write stuff out for each breakoutType
+      writeCompPathsToCSV({ breakoutType, components });
+    } else {
+      // write icon stuff out
+      writeIconPathsToCSV(components);
+    }
   });
 }
 

--- a/packages/design-system-dashboard-cli/src/write-comp-usage-to-csv.js
+++ b/packages/design-system-dashboard-cli/src/write-comp-usage-to-csv.js
@@ -10,6 +10,7 @@ const today = require('./today');
  * @typedef {string} Owner
  * @typedef {number} Total
  * @typedef {[Component, Path, Owner, Total]} CompPathOwner
+ * @typedef {[Path, Owner, Total]} IconPathOwner
  */
 
 function cleanPath(pathToClean) {
@@ -105,4 +106,84 @@ function writeCompPathsToCSV({ breakoutType, components }) {
   });
 }
 
-module.exports = writeCompPathsToCSV;
+function writeIconPathsToCSV(icons) {
+  // Big reducer takes a component name and path and determines which owner they belong to
+  /** @type {IconPathOwner[]} */
+  const iconInstPathOwnersOutput = icons.reduce(
+    (/** @type {IconPathOwner[]} */ acc, { path }) => {
+      let pagePath = '';
+      let owner = '';
+      let total = 1;
+      // First, clean the path of the local user's info
+      let compPath = cleanPath(path);
+
+      // Second, replace the reference to the vets-website if present
+      compPath = compPath.replace('vets-website/', '');
+
+      // Assign path and owner directly if belongs in content-build repo
+      if (compPath.startsWith('content-build')) {
+        pagePath = compPath;
+        owner = 'va-platform-cop-frontend';
+      } else {
+        // If no owner yet, find a matching owner path if possible
+        Object.entries(codeowners).forEach(([appPath, appOwner]) => {
+          if (compPath.includes(appPath)) {
+            owner = appOwner;
+          }
+        });
+      }
+
+      // If still no path or owner, assign to COP frontend
+      if (pagePath === '') pagePath = compPath;
+      if (owner === '') owner = 'va-platform-cop-frontend';
+
+      // For each icon, need to determine how many times it gets used per path, so we look to find the item (if it exists) that exactly matches the app, and owner and increase the total value by 1
+      if (acc.length > 0) {
+        const foundIndex = acc.findIndex(
+          ([accPath, accOwner]) => accPath === pagePath && accOwner === owner
+        );
+
+        if (foundIndex > -1) {
+          // Previous path found, so increment total by 1
+          acc[foundIndex][2] += 1;
+        } else {
+          // If no item found, add the current item to the collection
+          acc.push([pagePath, owner, total]);
+        }
+      } else {
+        // Very first time, just add the iconPathOwner array as is
+        acc.push([pagePath, owner, total]);
+      }
+
+      return acc;
+    },
+    []
+  );
+
+  // Alphabetically sorts by [0], the path name
+  iconInstPathOwnersOutput.sort(([compA], [compB]) => {
+    return compA > compB ? 1 : compA === compB ? 0 : -1;
+  });
+
+  // Add a "header" row for the CSV file
+  iconInstPathOwnersOutput.unshift([
+    'Page Path',
+    'Owner',
+    // @ts-ignore
+    `Total Icons - ${icons.length}`,
+  ]);
+
+  // Finally, we write to csv, one file per breakout type
+  // Uses the 'csv' library to transmute the array of arrays into a CSV string, then write it to a file
+  csv.stringify(iconInstPathOwnersOutput, (_, output) => {
+    fs.writeFileSync(
+      path.resolve(__dirname, `../../../componentUsage-icons-${today}.csv`),
+      output
+    );
+  });
+}
+
+module.exports = {
+  writeCompPathsToCSV,
+  writeIconPathsToCSV,
+};


### PR DESCRIPTION
## Chromatic
<!-- This `9999-update-icon-usage-with-pages` is a placeholder for a CI job - it will be updated automatically -->
https://9999-update-icon-usage-with-pages--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Modifies how we tabulate icon data, now shows full page path instead of app path. (No ticket associated with this effort)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2024-06-26 at 11 22 40 AM](https://github.com/department-of-veterans-affairs/component-library/assets/147893/c38a5bdb-435c-488b-b295-f57164e63b37)

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
