### PR TITLE
Add css and tests to FA icon search

### DIFF
--- a/packages/design-system-dashboard-cli/src/create-spreadsheets.js
+++ b/packages/design-system-dashboard-cli/src/create-spreadsheets.js
@@ -72,10 +72,10 @@ function findReactComponents(modulesOrTemplates, regexPattern) {
 const flattenMatches = (flattened, compPathObj) => {
   const path = compPathObj.path;
   // Ignores the tag, just need the component's name
-  const newFlat = compPathObj.matches.map(([, component, comp2]) => {
+  const newFlat = compPathObj.matches.map(([, component]) => {
     // Some component name matches include the ending '>', so we remove that here
     // For icons, sometimes the first component match is empty, so assigning the second match if needed
-    component = component?.replace('>', '') ?? comp2;
+    component = component?.replace('>', '');
     return { path, component };
   });
   return flattened.concat(newFlat);
@@ -178,7 +178,7 @@ function findComponentsAndIcons() {
   );
 
   // Also look into VW stylesheets for obvious mentions of Font Awesome
-  const styleRegex = /("Font Awesome)|(\.fa-)/g;
+  const styleRegex = /("Font Awesome|\.fa-|\.fa[srb]?[\s.{,])/g;
   const vwStyleIcons = [...search(vwStylesheets, styleRegex)].reduce(
     flattenMatches,
     []

--- a/packages/design-system-dashboard-cli/src/create-spreadsheets.js
+++ b/packages/design-system-dashboard-cli/src/create-spreadsheets.js
@@ -170,7 +170,7 @@ function findComponentsAndIcons() {
   const v3WebComponents = [...vwV3WC, ...cbV3WC];
 
   // Now, we look through the vw and cb modules and templates again, this time looking for potential Font Awesome icons
-  const iconRegex = /<i[\s].+(fa-[a-zA-Z0-9_-]+)/gm;
+  const iconRegex = /<i[\s]/gm;
   const vwIcons = [...search(vwModules, iconRegex)].reduce(flattenMatches, []);
   const cbIcons = [...search(cbTemplates, iconRegex)].reduce(
     flattenMatches,
@@ -184,8 +184,8 @@ function findComponentsAndIcons() {
     []
   );
 
-  // Also look into VW tests for fa- classes
-  const testRegex = /(fa-)/g;
+  // Also look into VW tests for fa- classes (filtering out "mfa")
+  const testRegex = /[^m](fa-)/g;
   const vwTestIcons = [...search(vwTests, testRegex)].reduce(
     flattenMatches,
     []

--- a/packages/design-system-dashboard-cli/src/create-spreadsheets.js
+++ b/packages/design-system-dashboard-cli/src/create-spreadsheets.js
@@ -10,6 +10,7 @@ const {
   readAllModules,
   readAllStylesheets,
   readAllTemplates,
+  readAllTests,
   readFile,
   search,
 } = require('./search-files');
@@ -87,6 +88,7 @@ function findComponentsAndIcons() {
   const vwModules = readAllModules(`${repos['vets-website']}/src`);
   const cbTemplates = readAllTemplates(`${repos['content-build']}/src`);
   const vwStylesheets = readAllStylesheets(`${repos['vets-website']}/src`);
+  const vwTests = readAllTests(`${repos['vets-website']}/src`);
 
   // First thing we do is find all of the React components
   // This regex finds all of the non-react-binding imports
@@ -182,7 +184,14 @@ function findComponentsAndIcons() {
     []
   );
 
-  const iconMatches = [...vwIcons, ...cbIcons, ...vwStyleIcons];
+  // Also look into VW tests for fa- classes
+  const testRegex = /(fa-)/g;
+  const vwTestIcons = [...search(vwTests, testRegex)].reduce(
+    flattenMatches,
+    []
+  );
+
+  const iconMatches = [...vwIcons, ...cbIcons, ...vwStyleIcons, ...vwTestIcons];
 
   return {
     react: allReactComponents,

--- a/packages/design-system-dashboard-cli/src/search-files.js
+++ b/packages/design-system-dashboard-cli/src/search-files.js
@@ -38,6 +38,27 @@ function readAllModules(rootDir) {
 }
 
 /**
+ * Find all .css and .scss files.
+ *
+ * @param rootDir {string} - The path to the root directory to search
+ * @return {Module[]}
+ */
+function readAllStylesheets(rootDir) {
+  const cssFiles = glob.sync(`${rootDir}/**/*.@(css|scss)`, {
+    ignore: [
+      `${rootDir}/**/tests/**`,
+      // This mock-form directory exists in vets-website and we don't want to include it
+      `${rootDir}/**/_mock-form/**`,
+    ],
+  });
+
+  return cssFiles.map(filePath => ({
+    path: filePath,
+    contents: fs.readFileSync(filePath, 'utf8'),
+  }));
+}
+
+/**
  * This reads a single file and exports it the same way
  * as `readAllModules` in order to keep the interface
  * the same across the script
@@ -99,6 +120,7 @@ function search(allModules, term) {
 
 module.exports = {
   readAllModules,
+  readAllStylesheets,
   readAllTemplates,
   search,
   readFile,

--- a/packages/design-system-dashboard-cli/src/search-files.js
+++ b/packages/design-system-dashboard-cli/src/search-files.js
@@ -59,6 +59,26 @@ function readAllStylesheets(rootDir) {
 }
 
 /**
+ * Find all .unit and .spec files.
+ *
+ * @param rootDir {string} - The path to the root directory to search
+ * @return {Module[]}
+ */
+function readAllTests(rootDir) {
+  const cssFiles = glob.sync(`${rootDir}/**/*.@(unit|spec).*`, {
+    ignore: [
+      // This mock-form directory exists in vets-website and we don't want to include it
+      `${rootDir}/**/_mock-form/**`,
+    ],
+  });
+
+  return cssFiles.map(filePath => ({
+    path: filePath,
+    contents: fs.readFileSync(filePath, 'utf8'),
+  }));
+}
+
+/**
  * This reads a single file and exports it the same way
  * as `readAllModules` in order to keep the interface
  * the same across the script
@@ -122,6 +142,7 @@ module.exports = {
   readAllModules,
   readAllStylesheets,
   readAllTemplates,
-  search,
+  readAllTests,
   readFile,
+  search,
 };

--- a/packages/design-system-dashboard-cli/src/write-comp-usage-to-csv.js
+++ b/packages/design-system-dashboard-cli/src/write-comp-usage-to-csv.js
@@ -160,9 +160,9 @@ function writeIconPathsToCSV(icons) {
     []
   );
 
-  // Alphabetically sorts by [0], the path name
-  iconInstPathOwnersOutput.sort(([compA], [compB]) => {
-    return compA > compB ? 1 : compA === compB ? 0 : -1;
+  // Alphabetically sorts by [1], the code owner
+  iconInstPathOwnersOutput.sort(([, iconOwnerA], [, iconOwnerB]) => {
+    return iconOwnerA > iconOwnerB ? 1 : iconOwnerA === iconOwnerB ? 0 : -1;
   });
 
   // Add a "header" row for the CSV file


### PR DESCRIPTION
## Chromatic
<!-- This `9999-add-css-to-icon-search` is a placeholder for a CI job - it will be updated automatically -->
https://9999-add-css-to-icon-search--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Adds looking at css/scss and unit/spec tests to Font Awesome icon searches

## Definition of done
- [X] Documentation has been updated, if applicable
