### PR TITLE
Add export to Breadcrumb type so components.d.ts can find it

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -5,6 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { Breadcrumb } from "./components/va-breadcrumbs/va-breadcrumbs";
 export namespace Components {
     interface VaAccordion {
         /**
@@ -164,7 +165,7 @@ export namespace Components {
         /**
           * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`. This prop is available when `uswds` is set to `true`.
          */
-        "breadcrumbList"?: any;
+        "breadcrumbList"?: Breadcrumb[] | string;
         /**
           * Analytics tracking function(s) will not be called
          */
@@ -2263,7 +2264,7 @@ declare namespace LocalJSX {
         /**
           * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`. This prop is available when `uswds` is set to `true`.
          */
-        "breadcrumbList"?: any;
+        "breadcrumbList"?: Breadcrumb[] | string;
         /**
           * Analytics tracking function(s) will not be called
          */

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -11,7 +11,7 @@ import {
 } from '@stencil/core';
 import classnames from 'classnames';
 
-type Breadcrumb = {
+export type Breadcrumb = {
   label: string;
   href: string;
   isRouterLink?: boolean;


### PR DESCRIPTION
Fixes a build error where components.d.ts couldn't find the type with out the export:

```
[ ERROR ]  TypeScript: ./src/components.d.ts:167:28
           Cannot find name 'Breadcrumb'.

    L166:   */
    L167:  "breadcrumbList"?: Breadcrumb[] | string;
    L168:  /**
```