### PR TITLE
Rename Additional Info in file input to Additional Form Inputs

### DIFF
--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
@@ -75,7 +75,7 @@ HeaderSize.args = {
   headerSize: 1
 };
 
-const additionalInfoContent = (
+const additionalFormInputsContent = (
   <div>
     <va-select className="hydrated" uswds label='What kind of file is this?' required>
       <option key="1" value="1">Public Document</option>
@@ -83,7 +83,7 @@ const additionalInfoContent = (
     </va-select>
   </div>);
 
-const AdditionalInfoTemplate = ({
+const AdditionalFormInputsContentTemplate = ({
   label,
   name,
   accept,
@@ -117,7 +117,7 @@ const AdditionalInfoTemplate = ({
       <div className="vads-u-margin-top--2">
           <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
             <code>
-  {`const additionalInfoContent = (
+  {`const additionalFormInputsContent = (
   <div>
     <va-select className="hydrated" uswds label='What kind of file is this?' required>
       <option key="1" value="1">Public Document</option>
@@ -127,7 +127,7 @@ const AdditionalInfoTemplate = ({
 );
   
 <VaFileInputMultiple ... >
-  {additionalInfoContent}
+  {additionalFormInputsContent}
 </VaFileInputMultiple>`}
             </code>
           </pre>
@@ -142,11 +142,11 @@ const AdditionalInfoTemplate = ({
   );
 };
 
-export const AdditionalInfo = AdditionalInfoTemplate.bind(null);
-AdditionalInfo.args = {
+export const AdditionalFormInputs = AdditionalFormInputsContentTemplate.bind(null);
+AdditionalFormInputs.args = {
   ...defaultArgs,
   label: 'Label Header',
-  additional: additionalInfoContent
+  additional: additionalFormInputsContent
 }
 
 const ErrorsTemplate = ({label, name, hint}) => {

--- a/packages/storybook/stories/va-file-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.jsx
@@ -100,7 +100,7 @@ HeaderLabel.args = {
   required: true
 }
 
-const additionalInfoContent = (
+const additionalFormInputsContent = (
   <div>
     <va-select className="hydrated" uswds label='What kind of file is this?' required>
       <option key="1" value="1">Public Document</option>
@@ -108,11 +108,11 @@ const additionalInfoContent = (
     </va-select>
   </div>);
 
-export const AdditionalInfo = Template.bind(null);
-AdditionalInfo.args = {
+export const AdditionalFormInputs = Template.bind(null);
+AdditionalFormInputs.args = {
   ...defaultArgs,
   label: 'Label Header',
-  children: additionalInfoContent
+  children: additionalFormInputsContent
 }
 
 const CustomValidationTemplate = ({ label, name, accept, required, error, hint }) => {


### PR DESCRIPTION
## Chromatic
<!-- This `rename-file-input-addt-component` is a placeholder for a CI job - it will be updated automatically -->
https://rename-file-input-addt-component--65a6e2ed2314f7b8f98609d8.chromatic.com

Per [Matt's request](https://dsva.slack.com/archives/G01BJ3ESXL4/p1719329042817809?thread_ts=1719328004.131279&cid=G01BJ3ESXL4), rename the Additional Info story in file input storybook to Additional Form Inputs to be more accurate and to not be confused with Additional Info component