### PR TITLE
Add override to header margin on adjacent selector

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "11.1.0",
+  "version": "11.1.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/mixins/headers.css
+++ b/packages/web-components/src/mixins/headers.css
@@ -15,3 +15,7 @@
 :host h1 + *, :host h2 + *, :host h3 + *, :host h4 + *, :host h5 + *, :host h6 + * {
   margin-top: unset;
 }
+
+:host #form-question {
+  margin-bottom: 1rem;
+}

--- a/packages/web-components/src/mixins/headers.css
+++ b/packages/web-components/src/mixins/headers.css
@@ -11,3 +11,7 @@
 :host label :is(h1, h2, h3, h4, h5)  {
   font-family: var(--font-serif);
 }
+
+:host h1 + *, :host h2 + *, :host h3 + *, :host h4 + *, :host h5 + *, :host h6 + * {
+  margin-top: unset;
+}


### PR DESCRIPTION
## Chromatic
<!-- This `2629-hint-text-spacing` is a placeholder for a CI job - it will be updated automatically -->
https://2629-hint-text-spacing--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

In form components that have headers instead of labels, legends, etc., a style was being applied that would add a margin to the first adjacent selector. This extra margin is not intended to be in the web components specifically so this PR will `unset` those styles.

It was introduced when we started using USWDS `usa-heading-styles` mixin via CSS Library:

https://github.com/department-of-veterans-affairs/component-library/blob/ff8d9cfaa01e5c01ed85dbb4e2d053830f4932e9/packages/css-library/src/stylesheets/base/headings.scss#L10

https://github.com/uswds/uswds/blob/369cf3fdf9abf721a357e864a0f6adbf667ba862/packages/uswds-core/src/styles/mixins/typography/typeset.scss#L43-L53

```sass
@mixin typeset-heading {
  @include typeset-heading-base;

  * + & {
    margin-top: $theme-heading-margin-top;
  }

  + * {
    margin-top: $theme-paragraph-margin-top;
  }
}
```

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2629



## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

**before**

![Screenshot 2024-06-28 at 12 33 46 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/2098255a-1164-4862-ac14-64f707d95e3d)

**after**

![Screenshot 2024-06-28 at 12 33 49 PM](https://github.com/department-of-veterans-affairs/component-library/assets/872479/f2a485c4-88cc-4bb2-8741-73449724cf1b)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
