### PR TITLE
Do Not Merge: test adding an autofill button to file input

### DIFF
--- a/packages/storybook/stories/va-file-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
-import {VaFileInput} from '@department-of-veterans-affairs/web-components/react-bindings';
+import {VaFileInput, VaButton} from '@department-of-veterans-affairs/web-components/react-bindings';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const fileInputDocs = getWebComponentDocs('va-file-input');
@@ -15,6 +15,35 @@ export default {
     },
   },
 };
+
+function loadURLToInputFiled(url){
+  getImgURL(url, (imgBlob)=>{
+    // Load img blob to input
+    // WIP: UTF8 character error
+    let fileName = 'header-logo.png'
+    let file = new File([imgBlob], fileName,{type:"image/png", lastModified:new Date().getTime()}, 'utf-8');
+    let container = new DataTransfer(); 
+    container.items.add(file);
+    let inputs = document.querySelectorAll('va-file-input')
+    inputs.forEach((input) =>{
+      input.shadowRoot.querySelector('#fileInputField')
+      input.files = container.files;
+      let e = new Event("change")
+      input.dispatchEvent(e)
+    })
+    
+  })
+}
+// xmlHTTP return blob respond
+function getImgURL(url, callback){
+  var xhr = new XMLHttpRequest();
+  xhr.onload = function() {
+      callback(xhr.response);
+  };
+  xhr.open('GET', url);
+  xhr.responseType = 'blob';
+  xhr.send();
+}
 
 const defaultArgs = {
   'label': 'Select a file to upload',
@@ -45,6 +74,7 @@ const Template = ({
   children
 }) => {
   return (
+    <>
     <VaFileInput
       label={label}
       name={name}
@@ -58,6 +88,10 @@ const Template = ({
       header-size={headerSize}
       children={children}
     />
+    <VaButton
+      onClick={() => {loadURLToInputFiled('https://i.imgur.com/xyKcUlt.jpeg')}} 
+    />
+  </>
   );
 };
 


### PR DESCRIPTION
Currently just a test

## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
