### PR TITLE
add anchor tag to va-textintro

### DIFF
--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/css-library",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Department of Veterans Affairs stylesheets, tokens, and utilities",
   "packageManager": "yarn@3.2.0",
   "files": [

--- a/packages/css-library/src/stylesheets/base/va.scss
+++ b/packages/css-library/src/stylesheets/base/va.scss
@@ -347,7 +347,7 @@ article > h1 {
   line-height: $lead-line-height;
   max-width: $lead-max-width;
 
-  p {
+  p, a {
     font-size: $lead-font-size;
     font-weight: $font-weight-normal;
     line-height: $lead-line-height;


### PR DESCRIPTION
## Chromatic
<!-- This `mc-2981-add-anchor-tag-to-va-introtext` is a placeholder for a CI job - it will be updated automatically -->
https://mc-2981-add-anchor-tag-to-va-introtext--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Original issue - https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2981

## QA Checklist
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)
  - Just keeping in sync with Formation for the time being

## Acceptance criteria
- [x] QA checklist has been completed
- [ ] 
## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
