### PR TITLE
va-search-input: fix suggestion box from always staying open

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "11.1.0",
+  "version": "11.1.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -133,7 +133,7 @@ export class VaSearchInput {
       },
     });
 
-    if (!this.formattedSuggestions.length) return;
+    this.isTouched = false;
     this.isListboxOpen = false;
   };
 
@@ -300,6 +300,7 @@ export class VaSearchInput {
         this.inputRef.focus();
         this.inputRef.removeAttribute('aria-activedescendant');
         this.isListboxOpen = false;
+        this.isTouched = false;
         this.handleSubmit();
         break;
       case 'Escape':


### PR DESCRIPTION
## Chromatic
<!-- This `2795-close-search-suggestions` is a placeholder for a CI job - it will be updated automatically -->
https://2795-close-search-suggestions--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
- Fix the va-search-input component from having suggestions list stuck open

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2795

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

https://github.com/department-of-veterans-affairs/component-library/assets/15200011/827ab0b4-485f-45cc-afde-24d9b42cc5b2



## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
