### PR TITLE
va-telephone: remove number formatting from aria-label

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "11.2.2",
+  "version": "11.2.3",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -47,7 +47,6 @@ describe('va-telephone', () => {
     await page.setContent('<va-telephone contact="(877) 955-1234"></va-telephone>');
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual('8 7 7. 9 5 5. 1 2 3 4.');
     expect(link.getAttribute('href')).toEqual('tel:+18779551234');
     expect(link.innerText).toEqual('877-955-1234');
   });
@@ -57,7 +56,6 @@ describe('va-telephone', () => {
     await page.setContent('<va-telephone contact="8779551234"></va-telephone>');
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual('8 7 7. 9 5 5. 1 2 3 4.');
     expect(link.getAttribute('href')).toEqual('tel:+18779551234');
     expect(link.innerText).toEqual('877-955-1234');
   });
@@ -69,9 +67,6 @@ describe('va-telephone', () => {
     );
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual(
-      '1. 8 7 7. 9 5 5. 1 2 3 4.',
-    );
     expect(link.getAttribute('href')).toEqual('tel:+18779551234');
     expect(link.innerText).toEqual('+1-877-955-1234');
   });
@@ -88,9 +83,6 @@ describe('va-telephone', () => {
         <mock:shadow-root>
           <span aria-hidden="true">
             877-955-1234
-          </span>
-          <span class="sr-only">
-            8 7 7. 9 5 5. 1 2 3 4.
           </span>
         </mock:shadow-root>
       </va-telephone>
@@ -110,9 +102,6 @@ describe('va-telephone', () => {
           <span aria-hidden="true">
             877-955-1234, ext. 123
           </span>
-          <span class="sr-only">
-            8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3.
-          </span>
         </mock:shadow-root>
       </va-telephone>
     `);
@@ -125,9 +114,6 @@ describe('va-telephone', () => {
     );
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual(
-      '8 7 7. 9 5 5. 1 2 3 4. extension. 1 2 3.',
-    );
     expect(link.getAttribute('href')).toEqual('tel:+18779551234,123');
     expect(link.innerText).toEqual('877-955-1234, ext. 123');
   });
@@ -137,7 +123,6 @@ describe('va-telephone', () => {
     await page.setContent('<va-telephone contact="711"></va-telephone>');
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual('7 1 1.');
     expect(link.getAttribute('href')).toEqual('tel:711');
     expect(link.innerText).toEqual('711');
   });
@@ -147,7 +132,6 @@ describe('va-telephone', () => {
     await page.setContent('<va-telephone contact="711" tty></va-telephone>');
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual('TTY. 7 1 1.');
     expect(link.getAttribute('href')).toEqual('tel:711');
     expect(link.innerText).toEqual('TTY: 711');
   });
@@ -157,7 +141,6 @@ describe('va-telephone', () => {
     await page.setContent('<va-telephone contact="123456" sms></va-telephone>');
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual('1 2 3 4 5 6.');
     expect(link.getAttribute('href')).toEqual('sms:123456');
     expect(link.innerText).toEqual('123456');
   });
@@ -167,9 +150,6 @@ describe('va-telephone', () => {
     await page.setContent('<va-telephone contact="8772228387" vanity="VETS"></va-telephone>');
 
     const link = await page.find('va-telephone >>> a');
-    expect(link.getAttribute('aria-label')).toEqual(
-      '8 7 7. 2 2 2. 8 3 8 7.',
-    );
     expect(link.getAttribute('href')).toEqual('tel:+18772228387');
     expect(link.innerText).toEqual('877-222-VETS (8387)');
   });

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -36,35 +36,6 @@ describe('formatPhoneNumber', () => {
   });
 });
 
-describe('formatTelLabel', () => {
-  const contact = '8885551234';
-  const extension = 123;
-  it('formats a phone number into an assistive tech label', () => {
-    expect(VaTelephone.formatTelLabel(contact, null, false, false)).toBe(
-      '8 8 8. 5 5 5. 1 2 3 4',
-    );
-  });
-
-  it('formats a phone number with extension into an assistive tech label', () => {
-    expect(VaTelephone.formatTelLabel(contact, extension, false, false)).toBe(
-      '8 8 8. 5 5 5. 1 2 3 4. extension. 1 2 3',
-    );
-  });
-
-  it('formats a TTY phone number', () => {
-    expect(VaTelephone.formatTelLabel(contact, null, true, false)).toBe(
-      'TTY. 8 8 8. 5 5 5. 1 2 3 4',
-    );
-  });
-
-  it('formats an international phone number', () => {
-    expect(VaTelephone.formatTelLabel(contact, null, false, true)).toBe(
-      '1. 8 8 8. 5 5 5. 1 2 3 4',
-    );
-  });
-
-});
-
 describe('createHref', () => {
   const contact = '8885551234';
   const contactSms = '123456';

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -123,31 +123,6 @@ export class VaTelephone {
     return formattedNum;
   }
 
-  /**
-   * Format telephone number for screen readers
-   * @param {string} contact - The 10 or 3 digit contact prop
-   * @param {string} ext - The extension numeric string
-   * @param {boolean} tty - Whether or not this is a TTY number
-   * @return {string} - Combined phone number parts within the label separated by
-   * periods, e.g. "800-555-1212" becomes "8 0 0. 5 5 5. 1 2 1 2"
-   */
-  static formatTelLabel(contact: string, ext: string, tty: boolean, international: boolean): string {
-    const spaceCharsOut = chars => chars.split('').join(' ');
-    let labelPieces = VaTelephone.splitContact(contact)
-      .map(spaceCharsOut);
-
-    if (international)
-      labelPieces.unshift('1');
-    if (tty)
-      labelPieces.unshift('TTY');
-    if (ext) {
-      labelPieces.push('extension');
-      labelPieces.push(spaceCharsOut(ext.toString()));
-    }
-
-    return labelPieces.join('. ');
-  }
-
   static createHref(contact: string, extension: string, sms: boolean): string {
     const cleanedContact = VaTelephone.cleanContact(contact);
     const isN11 = cleanedContact.length === 3;
@@ -194,12 +169,6 @@ export class VaTelephone {
       vanity,
       tty
     );
-    const formattedAriaLabel = `${VaTelephone.formatTelLabel(
-      contact,
-      extension,
-      tty,
-      international
-    )}.`;
 
     // Null so we don't add the attribute if we have an empty string
     const ariaDescribedbyIds = messageAriaDescribedby ? 'number-description' : null;
@@ -209,13 +178,11 @@ export class VaTelephone {
         {notClickable ? (
           <Fragment>
             <span aria-hidden="true" aria-describedby={ariaDescribedbyIds}>{formattedNumber}</span>
-            <span class="sr-only">{formattedAriaLabel}</span>
           </Fragment>
         ) : (
           <a
             aria-describedby={ariaDescribedbyIds}
             href={VaTelephone.createHref(contact, extension, sms)}
-            aria-label={formattedAriaLabel}
             onClick={this.handleClick.bind(this)}
           >
             {formattedNumber}


### PR DESCRIPTION
## Chromatic
<!-- This `2884-va-telephone-aria-label` is a placeholder for a CI job - it will be updated automatically -->
https://2884-va-telephone-aria-label--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Based on a [discussion with the accessibility group at VA.gov](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2884), the `aria-label` should be removed from the telephone link.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2884

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
