### PR TITLE
Align error alert with other statuses

### DIFF
--- a/packages/storybook/stories/va-alert-uswds.stories.jsx
+++ b/packages/storybook/stories/va-alert-uswds.stories.jsx
@@ -185,6 +185,46 @@ const SlimTemplate = ({
   );
 };
 
+const WithARIARoleTemplate = ({}) => {
+  return (
+    <>
+      <va-alert
+        status="error"
+        disable-analytics="false"
+        visible="true"
+        closeable="false"
+        full-width="false"
+        class="vads-u-margin-bottom--1"
+        role="alert"
+      >
+        <h2 id="track-your-status-on-mobile" slot="headline">
+          Alert Role
+        </h2>
+        <p className="vads-u-margin-y--0">
+          Important messages that demand the user's immediate attention, such as an error message.
+        </p>
+      </va-alert>
+
+      <va-alert
+        status="success"
+        disable-analytics="false"
+        visible="true"
+        closeable="false"
+        full-width="false"
+        class="vads-u-margin-bottom--1"
+        role="status"
+      >
+        <h2 id="track-your-status-on-mobile" slot="headline">
+          Status Role
+        </h2>
+        <p className="vads-u-margin-y--0">
+          Messages that provide advisory information but do not have the same urgency as alerts, such as a success message.
+        </p>
+      </va-alert>
+    </>
+  );
+};
+
 export const Default = Template.bind(null);
 Default.args = {
   ...defaultArgs,
@@ -305,4 +345,9 @@ export const NotVisible = Template.bind(null);
 NotVisible.args = {
   ...defaultArgs,
   visible: false,
+};
+
+export const WithARIARole = WithARIARoleTemplate.bind(null);
+WithARIARole.args = {
+  ...defaultArgs,
 };

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -139,20 +139,6 @@ describe('va-alert', () => {
     expect(analyticsSpy).toHaveReceivedEventTimes(0);
   });
 
-  it('has the correct accessibility attributes when in an error state', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-alert status="error" uswds="false"><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
-    );
-
-    const element = await page.find('va-alert >>> .alert');
-
-    expect(element).toEqualAttributes({
-      'role': 'alert',
-      'aria-live': 'assertive',
-    });
-  });
-
   // Skipped because I'm not sure why the test isn't working. I've verified that
   // the event is emitted as expected using the Stencil dev server, so the
   // problem is with this test, not the component.
@@ -374,20 +360,6 @@ describe('va-alert', () => {
     await link.click();
 
     expect(analyticsSpy).toHaveReceivedEventTimes(0);
-  });
-
-  it('uswds has the correct accessibility attributes when in an error state', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-alert status="error"><h4 slot="headline">This is an alert</h4><div>This is the alert content</div>',
-    );
-
-    const element = await page.find('va-alert >>> .usa-alert');
-
-    expect(element).toEqualAttributes({
-      'role': 'alert',
-      'aria-live': 'assertive',
-    });
   });
 
   it('uswds should set status to info if null', async () => {

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -177,8 +177,6 @@ export class VaAlert {
     if (definedStatuses.indexOf(status) === -1) {
       status = 'info';
     }
-    // const role = status === 'error' ? 'alert' : null;
-    // const ariaLive = status === 'error' ? 'assertive' : null;
     /* eslint-enable i18next/no-literal-string */
 
     if (!visible) return <div aria-live="polite" />;
@@ -189,12 +187,10 @@ export class VaAlert {
         'usa-alert--slim': slim,
       });
 
-      {console.log(this.el.getAttribute('data-label'))}
       return (
         <Host>
           <div
             role={this.el.getAttribute('data-role')}
-            // aria-live={ariaLive}
             class={classes}
             aria-label={this.el.getAttribute('data-label')}
           >

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -177,8 +177,8 @@ export class VaAlert {
     if (definedStatuses.indexOf(status) === -1) {
       status = 'info';
     }
-    const role = status === 'error' ? 'alert' : null;
-    const ariaLive = status === 'error' ? 'assertive' : null;
+    // const role = status === 'error' ? 'alert' : null;
+    // const ariaLive = status === 'error' ? 'assertive' : null;
     /* eslint-enable i18next/no-literal-string */
 
     if (!visible) return <div aria-live="polite" />;
@@ -188,13 +188,15 @@ export class VaAlert {
         'usa-alert--success': status === 'continue',
         'usa-alert--slim': slim,
       });
+
+      {console.log(this.el.getAttribute('data-label'))}
       return (
         <Host>
           <div
-            role={this.el.getAttribute('data-role') || role}
-            aria-live={ariaLive}
+            role={this.el.getAttribute('data-role')}
+            // aria-live={ariaLive}
             class={classes}
-            aria-label={this.el.getAttribute('data-label') || role}
+            aria-label={this.el.getAttribute('data-label')}
           >
             <div
               class="usa-alert__body"
@@ -243,10 +245,10 @@ export class VaAlert {
     return (
       <Host>
         <div
-          role={this.el.getAttribute('data-role') || role}
-          aria-live={ariaLive}
+          role={this.el.getAttribute('data-role')}
+          // aria-live={ariaLive}
           class={classes}
-          aria-label={this.el.getAttribute('data-label') || role}
+          aria-label={this.el.getAttribute('data-label')}
         >
           <va-icon
             class="alert__status-icon"

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -242,7 +242,6 @@ export class VaAlert {
       <Host>
         <div
           role={this.el.getAttribute('data-role')}
-          // aria-live={ariaLive}
           class={classes}
           aria-label={this.el.getAttribute('data-label')}
         >

--- a/packages/web-components/src/components/va-banner/test/va-banner.e2e.ts
+++ b/packages/web-components/src/components/va-banner/test/va-banner.e2e.ts
@@ -60,31 +60,6 @@ describe('va-banner', () => {
     expect(button).not.toBeNull();
   });
 
-  it('still shows alert aria', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-banner type="error" headline="This is an alert test"></va-banner>',
-    );
-    const element = await page.find('va-banner >>> va-alert');
-    expect(element).toEqualHtml(`
-      <va-alert class="hydrated uswds-false" data-label="Error banner" data-role="region" full-width="" status="error" uswds="false">
-        <mock:shadow-root>
-           <div aria-label="Error banner" aria-live="assertive" class="alert error" role="region">
-           <va-icon class="alert__status-icon hydrated"></va-icon>
-             <div class="body">
-              <slot name="headline"></slot>
-              <slot></slot>
-            </div>
-          </div>
-        </mock:shadow-root>
-        <h3 slot="headline">
-         This is an alert test
-        </h3>
-        <slot></slot>
-      </va-alert>
-    `);
-  });
-
   it('does not display if dismissed', async () => {
     const page = await newE2EPage();
     await page.setContent(


### PR DESCRIPTION
## Chromatic
<!-- This `alert-error-update` is a placeholder for a CI job - it will be updated automatically -->
https://alert-error-update--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2910

Removed the special conditions for the error status. Adding a `role="alert"` to the web component itself will turn this into an ARIA live region and announce the alert when it appears, so this code was not needed. This gives some flexibility and allows usage of other `role` (`role="status"`, etc.) attributes as well.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
    - N/A - no visual change.
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

No before screenshot: I was previously able to recreate it not doing that for error when it was brought up at DSC, but for some reason I couldn't get that to happen now. But I was able to confirm that with the changes made, it still works as expected. 

This shows how it functions with `role="alert"` added to the host element. When the alert is shown, it correctly interrupts and announces the alerts content.

![alert](https://github.com/department-of-veterans-affairs/component-library/assets/100248909/85178303-96eb-43eb-aa65-745b2dc8f92d)


## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
