### PR TITLE
va-link: add style inheritance to anchor element

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "11.2.3",
+  "version": "11.2.4",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-link/va-link.css
+++ b/packages/web-components/src/components/va-link/va-link.css
@@ -8,10 +8,7 @@
 :host a {
   cursor: pointer;
   text-decoration: underline;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  line-height: inherit;
+  font: inherit;
 }
 
 :host a.va-link--reverse {

--- a/packages/web-components/src/components/va-link/va-link.css
+++ b/packages/web-components/src/components/va-link/va-link.css
@@ -8,6 +8,10 @@
 :host a {
   cursor: pointer;
   text-decoration: underline;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  line-height: inherit;
 }
 
 :host a.va-link--reverse {


### PR DESCRIPTION
## Chromatic
<!-- This `va-link-inherit-style` is a placeholder for a CI job - it will be updated automatically -->
https://va-link-inherit-style--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

When the `va-link` component is used with a header element, the anchor link inside of the component was not inheriting the header styles. 

[Slack convo](https://dsva.slack.com/archives/C01DBGX4P45/p1720728278101819) for reference

## Screenshots

**before**

<img width="620" alt="Screenshot 2024-07-11 at 4 25 39 PM" src="https://github.com/user-attachments/assets/0612ae54-e6f7-4fb8-b05c-f6c97ab0596f">

**after**

<img width="578" alt="Screenshot 2024-07-11 at 4 25 46 PM" src="https://github.com/user-attachments/assets/d33c6d05-5a36-4765-aad0-d8fd09c32eef">

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
