### PR TITLE
Update readme with more versioning examples 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repo follows [semantic versioning](https://semver.org/). Here are some exam
 #### Major
 
 - Component is removed
-- Component API is changed that causes a breaking change
+- Component API is changed and it causes a breaking change
 
 #### Minor
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This repo follows [semantic versioning](https://semver.org/). Here are some exam
 - New variant is added for a component
 - Non-breaking or backwards compatible component API change
 
-### Patch
+#### Patch
 
 - Accessibility fix
 - Styling fix

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ This repo follows [semantic versioning](https://semver.org/). Here are some exam
 
 - New component is added
 - New variant is added for a component
-- Component API is changed that does not cause a breaking change
+- Non-breaking or backwards compatible component API change
 
 ### Patch
 
 - Accessibility fix
 - Styling fix
-- Functionality fix that does not change the API
+- Functionality fix
 
 ### Releasing
 

--- a/README.md
+++ b/README.md
@@ -41,17 +41,19 @@ This repo follows [semantic versioning](https://semver.org/). Here are some exam
 #### Major
 
 - Component is removed
-- Component API is changed
+- Component API is changed that causes a breaking change
 
 #### Minor
 
 - New component is added
 - New variant is added for a component
+- Component API is changed that does not cause a breaking change
 
 ### Patch
 
 - Accessibility fix
 - Styling fix
+- Functionality fix that does not change the API
 
 ### Releasing
 


### PR DESCRIPTION
## Chromatic
<!-- This `readme-version-guidance` is a placeholder for a CI job - it will be updated automatically -->
https://readme-version-guidance--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This will add a few more examples to the [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) section of the readme for selecting a label for PRs (which will ultimately determine the `core` version when creating a release).

These examples should relate to the general [semver guidance on versioning](https://semver.org/#summary).


## Screenshots

![Screenshot 2024-07-12 at 9 41 40 AM](https://github.com/user-attachments/assets/b6ed89ee-c8a2-4b1a-9d54-6b949800d6a5)



## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
