### PR TITLE
va-promo-banner: Renaming localstorage key var name

### DIFF
--- a/packages/web-components/src/components/va-promo-banner/va-promo-banner.tsx
+++ b/packages/web-components/src/components/va-promo-banner/va-promo-banner.tsx
@@ -9,7 +9,7 @@ import {
   State,
 } from '@stencil/core';
 
-const DISMISSED_PROMO_BANNERS_LOCAL_STORAGE_KEY = 'DISMISSED_PROMO_BANNERS';
+const DISMISSED_PROMO_BANNERS_LOCAL_STORAGE_NAME = 'DISMISSED_PROMO_BANNERS';
 
 /**
  * Reset the banner in storage by opening Developer Tools in the browser and
@@ -85,7 +85,7 @@ export class VaPromoBanner {
 
       // Add the promo banner ID to local storage.
       localStorage.setItem(
-        DISMISSED_PROMO_BANNERS_LOCAL_STORAGE_KEY,
+        DISMISSED_PROMO_BANNERS_LOCAL_STORAGE_NAME,
         JSON.stringify(updatedDismissedBanners),
       );
     }
@@ -121,7 +121,7 @@ export class VaPromoBanner {
   componentWillLoad() {
     // Derive dismissed banners from storage.
     const dismissedBannersString = localStorage.getItem(
-      DISMISSED_PROMO_BANNERS_LOCAL_STORAGE_KEY,
+      DISMISSED_PROMO_BANNERS_LOCAL_STORAGE_NAME,
     );
     this.dismissedBanners = dismissedBannersString
       ? JSON.parse(dismissedBannersString)


### PR DESCRIPTION
## Chromatic
<!-- This `85927-rename-promo-key` is a placeholder for a CI job - it will be updated automatically -->
https://85927-rename-promo-key--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#85927](https://github.com/department-of-veterans-affairs/va.gov-team/issues/85927)

Fixes a Snyk issue where the variable name had the word "key" in it and caused false positive security errors.

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
