### PR TITLE
va-breadcrumbs: Updating language support for breadcrumbs

### DIFF
--- a/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
+++ b/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
@@ -189,13 +189,13 @@ describe('va-breadcrumbs', () => {
           <nav aria-label="test" class="usa-breadcrumb">
             <ol class="usa-breadcrumb__list" role="list">
               <li class="usa-breadcrumb__list-item">
-                <a class="usa-breadcrumb__link" href="#home">
-                  <span lang="en-US">VA.gov home</span>
+                <a class="usa-breadcrumb__link" href="#home" hreflang="en-US" lang="en-US">
+                  <span>VA.gov home</span>
                 </a>
               </li>
               <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-                <a class="usa-breadcrumb__link" href="#content">
-                  <span lang="en-US">Current</span>
+                <a class="usa-breadcrumb__link" href="#content" hreflang="en-US" lang="en-US">
+                  <span>Current</span>
                 </a>
               </li>
             </ol>
@@ -221,20 +221,20 @@ describe('va-breadcrumbs', () => {
           <nav aria-label="test" class="usa-breadcrumb">
             <ol class="usa-breadcrumb__list" role="list">
               <li class="usa-breadcrumb__list-item">
-                <a class="usa-breadcrumb__link" href="#home">
-                  <span lang="en-US">VA.gov home</span>
+                <a class="usa-breadcrumb__link" href="#home" hreflang="en-US" lang="en-US">
+                  <span>VA.gov home</span>
                 </a>
               </li>
               <li class="usa-breadcrumb__list-item">
-                <a class="usa-breadcrumb__link" href="#spanish">
-                  <span lang="es">
+                <a class="usa-breadcrumb__link" href="#spanish" hreflang="es" lang="es">
+                  <span>
                     Spanish Crumb
                   </span>
                 </a>
               </li>
               <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-                <a class="usa-breadcrumb__link" href="#content">
-                  <span lang="tl">Tagalog Crumb</span>
+                <a class="usa-breadcrumb__link" href="#content" hreflang="tl" lang="tl">
+                  <span>Tagalog Crumb</span>
                 </a>
               </li>
             </ol>
@@ -310,18 +310,18 @@ describe('va-breadcrumbs', () => {
           <nav aria-label="test" class="usa-breadcrumb">
             <ol class="usa-breadcrumb__list" role="list">
               <li class="usa-breadcrumb__list-item">
-                <a class="usa-breadcrumb__link" href="/one">
-                  <span lang="en-US">VA.gov home</span>
+                <a class="usa-breadcrumb__link" href="/one" hreflang="en-US" lang="en-US">
+                  <span>VA.gov home</span>
                 </a>
               </li>
               <li class="usa-breadcrumb__list-item">
-                <a class="usa-breadcrumb__link" href="/two">
-                  <span lang="en-US">Two</span>
+                <a class="usa-breadcrumb__link" href="/two" hreflang="en-US" lang="en-US">
+                  <span>Two</span>
                 </a>
               </li>
               <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-                <a class="usa-breadcrumb__link" href="#content">
-                  <span lang="en-US">Three</span>
+                <a class="usa-breadcrumb__link" href="#content" hreflang="en-US" lang="en-US">
+                  <span>Three</span>
                 </a>
               </li>
             </ol>

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -361,8 +361,10 @@ export class VaBreadcrumbs {
                       class="usa-breadcrumb__link"
                       href="#content"
                       onClick={e => this.fireAnalyticsEvent(e)}
+                      lang={item.lang || 'en-US'}
+                      hreflang={item.lang || 'en-US'}
                     >
-                      <span lang={item.lang || 'en-US'}>{item.label}</span>
+                      <span>{item.label}</span>
                     </a>
                   ) : (
                     <a

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -371,8 +371,10 @@ export class VaBreadcrumbs {
                       class="usa-breadcrumb__link"
                       href={item.href}
                       onClick={e => this.handleClick(e, item)}
+                      lang={item.lang || 'en-US'}
+                      hreflang={item.lang || 'en-US'}
                     >
-                      <span lang={item.lang || 'en-US'}>{item.label}</span>
+                      <span>{item.label}</span>
                     </a>
                   )}
                 </li>


### PR DESCRIPTION
## Chromatic
<!-- This `2869-breadcrumb-lang-update` is a placeholder for a CI job - it will be updated automatically -->
https://2869-breadcrumb-lang-update--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Relates to DST [2869](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2869)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
