### PR TITLE
Add class to file input labels to fix text resizing

### DIFF
--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.scss
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.scss
@@ -2,6 +2,7 @@
 
 @use '../va-file-input/va-file-input';
 @import '../../mixins/uswds-error-border.scss';
+@import '../../mixins/headers.css';
 
 :host {
   &.has-error {

--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -187,14 +187,14 @@ export class VaFileInputMultiple {
             class="label-header-tag"
           >
             {label}
+            {requiredSpan}
           </HeaderTag>
-          {requiredSpan}
         </div>
       );
     } else {
       return (
         <div class="label-header">
-          <span part="label">{label}</span>
+          <span part="label" class="usa-label">{label}</span>
           {requiredSpan}
         </div>
       );

--- a/packages/web-components/src/components/va-file-input/va-file-input.scss
+++ b/packages/web-components/src/components/va-file-input/va-file-input.scss
@@ -7,6 +7,7 @@
 
 @import '../../mixins/uswds-error-border.scss';
 @import '../../mixins/focusable.css';
+@import '../../mixins/headers.css';
 
 [hidden] {
   display: none;

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -258,17 +258,17 @@ export class VaFileInput {
             class="label-header-tag"
           >
             {label}
+            {requiredSpan}
           </HeaderTag>
-          {requiredSpan}
         </div>
       );
     } else {
       return (
         <div class="label-header">
-          <label htmlFor="fileInputField" part="label">
+          <label htmlFor="fileInputField" part="label" class="usa-label">
             {label}
+            {requiredSpan}
           </label>
-          {requiredSpan}
         </div>
       );
     }


### PR DESCRIPTION
## Chromatic
<!-- This `update-file-input-label` is a placeholder for a CI job - it will be updated automatically -->
https://update-file-input-label--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
When using browser text resizing, labels are not resizing on the file input.

<img width="1791" alt="image" src="https://github.com/user-attachments/assets/8a232916-5c24-4c6b-a5ff-35e0257f3cd2">


## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

**Before/After** - Only with font size set to extra large in the browser.

<img width="1791" alt="image" src="https://github.com/user-attachments/assets/df0aee6b-d339-4bc2-948f-db453a01f4ee">
<img width="1791" alt="image" src="https://github.com/user-attachments/assets/62b11601-b4e0-4f83-bac2-75247db591ec">
<img width="1791" alt="image" src="https://github.com/user-attachments/assets/8ec02e00-a086-490e-bacf-989e2adcb4f8">
<img width="1791" alt="image" src="https://github.com/user-attachments/assets/dd9b0987-4750-4f5c-b40e-e7297bccd6d3">



## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
