### PR TITLE
va-memorable-date: remove "Please" from hint text

### DIFF
--- a/packages/core/src/i18n/translations/en.js
+++ b/packages/core/src/i18n/translations/en.js
@@ -29,7 +29,7 @@ export default {
   'november': 'November',
   'december': 'December',
   'on-this-page': 'On this page',
-  'date-hint': 'Please enter 2 digits for the month and day and 4 digits for the year',
+  'date-hint': 'Enter 2 digits for the month and day and 4 digits for the year',
   'date-hint-with-select': 'For example: January 19 2000',
   'date-error': 'Please enter a complete date',
   'number-error': 'Please enter a valid number',

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "11.2.5",
+  "version": "11.2.6",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Chromatic
<!-- This `3046-mem-date-hint-text` is a placeholder for a CI job - it will be updated automatically -->
https://3046-mem-date-hint-text--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

[CAIA has advised](https://dsva.slack.com/archives/C01K37HRUAH/p1721313563386869) that they are updating their guidelines to remove "Please" from hint text and error messages. We will probably want to do a full review of components and guidelines to adjust for that but in the mean time, this PR will remove it from the hint text of va-memorable-date because a team is needing it now.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3046

## Screenshots

**before**

![Screenshot 2024-07-18 at 10 18 10 AM](https://github.com/user-attachments/assets/2b7c498e-b1cb-4d01-bceb-39195d0f3677)

**after**

![Screenshot 2024-07-18 at 10 18 19 AM](https://github.com/user-attachments/assets/feb437ea-568e-4821-8e2b-6aaffa468d00)

The [Spanish translation](https://github.com/department-of-veterans-affairs/component-library/blob/92aec15998a697ef9622278e0b033bb328ee890d/packages/core/src/i18n/translations/es.js#L31) already appear to be correct:

![Screenshot 2024-07-18 at 10 24 10 AM](https://github.com/user-attachments/assets/5cb2738f-9c12-4612-a135-6bc4e8d5fe1b)


## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
