### PR TITLE
File input testing

### DIFF
--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -156,6 +156,12 @@ export class VaFileInputMultiple {
     } else {
       // Deleted file
       this.files.splice(pageIndex, 1);
+      const statusMessageDiv = this.el.shadowRoot.querySelector("#statusMessage");
+      // empty status message so it is read when updated
+      statusMessageDiv.textContent = ""
+      setTimeout(() => {
+        statusMessageDiv.textContent = "File removed."
+      }, 1000);
     }
 
     this.vaMultipleChange.emit({ files: this.files.map(fileObj => fileObj.file) });
@@ -252,6 +258,7 @@ export class VaFileInputMultiple {
           </div>
         )}
         <div class={outerWrapClass}>
+          <div class='usa-sr-only' aria-live="polite" id="statusMessage"></div>
           {!this.isEmpty() && (
             <div class="selected-files-label">Selected files</div>
           )}

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -198,7 +198,8 @@ export class VaFileInput {
   private updateStatusMessage(message:string) {
     // Add delay to encourage screen reader readout
     setTimeout(() => {
-      this.el.shadowRoot.querySelector("#statusMessage").textContent = message
+      const statusMessageDiv = this.el.shadowRoot.querySelector("#statusMessage");
+      statusMessageDiv ? statusMessageDiv.textContent = message : "";
     }, 1000);
   }
 

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -426,7 +426,7 @@ export class VaFileInput {
                     </Fragment>
                   )}
                 </span>
-                <div class='usa-sr-only' aria-live="polite" id="statusMessage">No files selected.</div>
+                <div class='usa-sr-only' aria-live="polite" id="statusMessage"></div>
                 <div class={fileInputTargetClasses}>
                   <div class="file-input-box"></div>
                   <div class="file-input-instructions">
@@ -445,7 +445,7 @@ export class VaFileInput {
                 {!headless &&
                   <div class="selected-files-label">Selected files</div>
                 }
-                <div class='usa-sr-only' aria-live="polite" id="statusMessage">No files selected.</div>
+                <div class='usa-sr-only' aria-live="polite" id="statusMessage"></div>
                 <va-card class="va-card">
                   <div class="file-info-section">
                     {fileThumbnail}

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -144,6 +144,8 @@ export class VaFileInput {
     this.uploadStatus = 'success';
     this.internalError = null;
     this.generateFileContents(this.file);
+    this.updateStatusMessage(`You have selected the file: ${this.file.name}`);
+    this.el.focus();
 
     if (this.enableAnalytics) {
       this.componentLibraryAnalytics.emit({
@@ -168,6 +170,8 @@ export class VaFileInput {
       this.vaChange.emit({ files: [] });
     }
     this.file = null;
+    this.updateStatusMessage(`File removed. No file selected.`);
+    this.el.focus();
   };
 
   private openModal = () => {
@@ -190,6 +194,13 @@ export class VaFileInput {
       this.fileInputRef.click();
     }
   };
+
+  private updateStatusMessage(message:string) {
+    // Add delay to encourage screen reader readout
+    setTimeout(() => {
+      this.el.shadowRoot.querySelector("#statusMessage").textContent = message
+    }, 1000);
+  }
 
   /**
    * Makes sure the button text always has a value.
@@ -414,7 +425,7 @@ export class VaFileInput {
                     </Fragment>
                   )}
                 </span>
-                <div class="sr-only">No files selected.</div>
+                <div class='usa-sr-only' aria-live="polite" id="statusMessage">No files selected.</div>
                 <div class={fileInputTargetClasses}>
                   <div class="file-input-box"></div>
                   <div class="file-input-instructions">
@@ -433,6 +444,7 @@ export class VaFileInput {
                 {!headless &&
                   <div class="selected-files-label">Selected files</div>
                 }
+                <div class='usa-sr-only' aria-live="polite" id="statusMessage">No files selected.</div>
                 <va-card class="va-card">
                   <div class="file-info-section">
                     {fileThumbnail}


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
