### PR TITLE
Storybook example improvements

### DIFF
--- a/packages/storybook/stories/va-back-to-top.stories.jsx
+++ b/packages/storybook/stories/va-back-to-top.stories.jsx
@@ -14,7 +14,9 @@ export default {
   },
 };
 
-const Template = () => {
+const defaultArgs = {};
+
+const Template = (defaultArgs) => {
   return (
     <>
       <div className="usa-grid usa-grid-full">

--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
@@ -1,16 +1,20 @@
 /* eslint-disable react/prop-types */
-import React, {useState} from 'react';
-import {VaFileInputMultiple} from '@department-of-veterans-affairs/web-components/react-bindings';
-import {getWebComponentDocs, propStructure} from './wc-helpers';
+import React, { useState } from 'react';
+import { VaFileInputMultiple } from '@department-of-veterans-affairs/web-components/react-bindings';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
-const fileInputDocs = getWebComponentDocs('va-file-input-multiple');
+VaFileInputMultiple.displayName = 'VaFileInputMultiple';
+
+const fileInputMultipleDocs = getWebComponentDocs('va-file-input-multiple');
 
 export default {
   title: 'Components/File input multiple USWDS',
   id: 'uswds/va-file-input-multiple',
   parameters: {
-    componentSubtitle: `va-file-input-multiple web component`,
-
+    componentSubtitle: 'va-file-input-multiple web component',
+    docs: {
+      page: () => <StoryDocs storyDefault={Default} data={fileInputMultipleDocs} />,
+    },
   },
 };
 
@@ -57,7 +61,7 @@ const Template = ({
 
 export const Default = Template.bind(null);
 Default.args = { ...defaultArgs };
-Default.argTypes = propStructure(fileInputDocs);
+Default.argTypes = propStructure(fileInputMultipleDocs);
 
 export const Accept = Template.bind(null);
 Accept.args = {

--- a/packages/storybook/stories/va-file-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.jsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import {VaFileInput} from '@department-of-veterans-affairs/web-components/react-bindings';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
+VaFileInput.displayName = 'VaFileInput';
+
 const fileInputDocs = getWebComponentDocs('va-file-input');
 
 export default {

--- a/packages/storybook/stories/va-process-list-uswds.stories.jsx
+++ b/packages/storybook/stories/va-process-list-uswds.stories.jsx
@@ -9,6 +9,7 @@ export default {
   title: 'Components/Process list USWDS',
   id: 'uswds/va-process-list',
   subcomponents: componentStructure(processListItemDocs),
+  argTypes: propStructure(processListItemDocs),
   parameters: {
     componentSubtitle: 'va-process-list web component',
     docs: {
@@ -62,7 +63,7 @@ const Template = ({}) => {
 };
 
 
-const StatusTemplate = () => {
+const StatusTemplate = (defaultArgs) => {
   return (
     <va-process-list>
       <va-process-list-item checkmark header='Checkmark Icon'>  
@@ -80,7 +81,7 @@ const StatusTemplate = () => {
 };
 
 
-const HeaderSizeTemplate = () => {
+const HeaderSizeTemplate = (defaultArgs) => {
   return (
     <va-process-list>
       <va-process-list-item header='Size h1' level='1'/>
@@ -93,7 +94,7 @@ const HeaderSizeTemplate = () => {
   );
 };
 
-const CustomSizingTemplate = () => {
+const CustomSizingTemplate = (defaultArgs) => {
   return (
     <va-process-list>
       
@@ -111,7 +112,7 @@ const CustomSizingTemplate = () => {
   );
 };
 
-const UtilityStyling = () => {
+const UtilityStyling = (defaultArgs) => {
   return (
     <va-process-list>
       <va-process-list-item>
@@ -120,7 +121,7 @@ const UtilityStyling = () => {
           trigger="Show more"
           class="medium-screen:vads-u-display--none"
         >
-          <img src="https://via.placeholder.com/350" />
+          <img src="https://via.placeholder.com/350" alt="a placeholder image that displays the text 350 x 350" />
         </va-additional-info>
       </va-process-list-item>
       <va-process-list-item>


### PR DESCRIPTION
## Chromatic
<!-- This `storybook-example-improvements` is a placeholder for a CI job - it will be updated automatically -->
https://storybook-example-improvements--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
While upgrading the `va-process-list` component to the USWDS version in vets-website, I noticed that the Storybook page was not displaying any of the child component properties. There were also a few other components missing some details that was making the technical docs seem incomplete.

I think there may have been a change with the way Storybook 6 displayed child component properties after we upgraded to Storybook 7. I'm manually adding them using the [argTypes setting](https://storybook.js.org/docs/7/api/arg-types) here but I think when we update to Storybook 8, we should instead use the [subcomponent setting](https://storybook.js.org/docs/writing-stories/stories-for-multiple-components#subcomponents) for components that have a child (which does not seem to be available in Storybook 6 or 7).

## Screenshots

### va-process-list

**before**

<img width="1043" alt="Screenshot 2024-07-22 at 3 37 21 PM" src="https://github.com/user-attachments/assets/f81c5930-b09f-4130-aba4-0f81ce02acf0">

**after**

<img width="1037" alt="Screenshot 2024-07-22 at 3 36 55 PM" src="https://github.com/user-attachments/assets/2d30f0e3-1fbd-4cf8-9863-19ae6f913fcb">

### va-back-to-top

**before**

<img width="409" alt="Screenshot 2024-07-22 at 3 38 18 PM" src="https://github.com/user-attachments/assets/9598505f-7b26-4be0-9dd0-9b5486424972">

**after**

<img width="542" alt="Screenshot 2024-07-22 at 3 39 17 PM" src="https://github.com/user-attachments/assets/f1f4c115-e3db-4a04-b28b-b3462ac77e41">

### va-file-input-multiple

**before**

<img width="627" alt="Screenshot 2024-07-22 at 3 39 50 PM" src="https://github.com/user-attachments/assets/4cbc7a6b-3cf6-4580-bfbb-16ea0ba9f478">

**after**

<img width="624" alt="Screenshot 2024-07-22 at 3 40 18 PM" src="https://github.com/user-attachments/assets/4cf76389-f120-482b-bc8b-8a257e3dbcc4">

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
