### PR TITLE
Update USWDS package to v3.8.1

### DIFF
--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@divriots/style-dictionary-to-figma": "^0.4.0",
-    "@uswds/uswds": "^3.7.1",
+    "@uswds/uswds": "^3.8.0",
     "rimraf": "^5.0.5"
   }
 }

--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@divriots/style-dictionary-to-figma": "^0.4.0",
-    "@uswds/uswds": "^3.8.0",
+    "@uswds/uswds": "^3.8.1",
     "rimraf": "^5.0.5"
   }
 }

--- a/packages/css-library/yarn.lock
+++ b/packages/css-library/yarn.lock
@@ -10,7 +10,7 @@ __metadata:
   resolution: "@department-of-veterans-affairs/css-library@workspace:."
   dependencies:
     "@divriots/style-dictionary-to-figma": "npm:^0.4.0"
-    "@uswds/uswds": "npm:^3.7.1"
+    "@uswds/uswds": "npm:^3.8.1"
     rimraf: "npm:^5.0.5"
     sass: "npm:^1.64.1"
     style-dictionary: "npm:3.8.0"
@@ -67,7 +67,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uswds/uswds@npm:^3.7.1":
+"@uswds/uswds@npm:^3.8.1":
   version: 3.8.1
   resolution: "@uswds/uswds@npm:3.8.1"
   dependencies:

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -48,7 +48,7 @@
     "@types/react-dom": "16.0.9",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
-    "@uswds/uswds": "^3.8.0",
+    "@uswds/uswds": "^3.8.1",
     "animate.css": "^4.1.1",
     "babel-loader": "^8.2.2",
     "eslint": "^8.19.0",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -48,7 +48,7 @@
     "@types/react-dom": "16.0.9",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
-    "@uswds/uswds": "^3.7.1",
+    "@uswds/uswds": "^3.8.0",
     "animate.css": "^4.1.1",
     "babel-loader": "^8.2.2",
     "eslint": "^8.19.0",

--- a/packages/web-components/src/components/va-button-icon/va-button-icon.scss
+++ b/packages/web-components/src/components/va-button-icon/va-button-icon.scss
@@ -30,8 +30,3 @@
     background: var(--vads-color-secondary-lightest);
   }
 }
-
-// Fix to off-centered content when icon present
-:host button.usa-button va-icon {
-    margin-right: 8px;
-}

--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -244,7 +244,7 @@ describe('va-button', () => {
     <va-button back="" class="hydrated" uswds="">
       <mock:shadow-root>
         <button class="usa-button usa-button--outline" type="button" part="button">
-          <va-icon class="hydrated margin-right-8px va-button--icon"></va-icon>
+          <va-icon class="hydrated"></va-icon>
           Back
         </button>
       </mock:shadow-root>
@@ -261,7 +261,7 @@ describe('va-button', () => {
       <mock:shadow-root>
         <button class="usa-button" type="button" part="button">
           Continue
-          <va-icon class="hydrated margin-left-8px va-button--icon"></va-icon>
+          <va-icon class="hydrated"></va-icon>
         </button>
       </mock:shadow-root>
     </va-button>

--- a/packages/web-components/src/components/va-button/va-button.scss
+++ b/packages/web-components/src/components/va-button/va-button.scss
@@ -14,17 +14,7 @@
   cursor: not-allowed;
 }
 
-// Fix to off-centered content in V3 when icon present
-.va-button--icon {
-  position: relative;
-  top: 0.1em;
-  &.margin-right-8px {
-    margin-right: 8px;
-  }
-  &.margin-left-8px {
-    margin-left: 8px;
-  }
-}
+
 :host([big]:not([big="false"]):is([back], [continue])) {
   .usa-button--big {
     padding-top: 14px;

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -179,17 +179,11 @@ export class VaButton {
             part="button"
           >
             {back && !_continue && (
-              <va-icon
-                class="va-button--icon margin-right-8px"
-                icon="navigate_far_before"
-              ></va-icon>
+              <va-icon icon="navigate_far_before" />
             )}
             {buttonText}
             {_continue && !back && (
-              <va-icon
-                class="va-button--icon margin-left-8px"
-                icon="navigate_far_next"
-              ></va-icon>
+              <va-icon icon="navigate_far_next" />
             )}
           </button>
           {messageAriaDescribedby && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3074,7 +3074,7 @@ __metadata:
   resolution: "@department-of-veterans-affairs/css-library@workspace:packages/css-library"
   dependencies:
     "@divriots/style-dictionary-to-figma": "npm:^0.4.0"
-    "@uswds/uswds": "npm:^3.7.1"
+    "@uswds/uswds": "npm:^3.8.0"
     rimraf: "npm:^5.0.5"
     sass: "npm:^1.64.1"
     style-dictionary: "npm:3.8.0"
@@ -3214,7 +3214,7 @@ __metadata:
     "@types/react-dom": "npm:16.0.9"
     "@typescript-eslint/eslint-plugin": "npm:^5.30.5"
     "@typescript-eslint/parser": "npm:^5.30.5"
-    "@uswds/uswds": "npm:^3.7.1"
+    "@uswds/uswds": "npm:^3.8.0"
     animate.css: "npm:^4.1.1"
     aria-hidden: "npm:^1.1.3"
     babel-loader: "npm:^8.2.2"
@@ -6665,15 +6665,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uswds/uswds@npm:^3.7.1":
-  version: 3.7.1
-  resolution: "@uswds/uswds@npm:3.7.1"
+"@uswds/uswds@npm:^3.8.0":
+  version: 3.8.1
+  resolution: "@uswds/uswds@npm:3.8.1"
   dependencies:
     classlist-polyfill: "npm:1.2.0"
     object-assign: "npm:4.1.1"
     receptor: "npm:1.0.0"
     resolve-id-refs: "npm:0.1.0"
-  checksum: 10/1d0ccda0d0b8833e0db7ff122dcd5e00bfe659fca0c9e5d18eb2664983a80298db7fbf174696fcd17b4956bb4df8c4431e73169ccf96128e1709f3a1b01ba197
+  checksum: 10/69859ff4c2da126a425b21fc7346023c793ba0fc517a3c52ff23f9466e8c45e4a0b8a534997f15a9611ee525b639000213b045242cf577e3e31a9f131810a47e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3074,7 +3074,7 @@ __metadata:
   resolution: "@department-of-veterans-affairs/css-library@workspace:packages/css-library"
   dependencies:
     "@divriots/style-dictionary-to-figma": "npm:^0.4.0"
-    "@uswds/uswds": "npm:^3.8.0"
+    "@uswds/uswds": "npm:^3.8.1"
     rimraf: "npm:^5.0.5"
     sass: "npm:^1.64.1"
     style-dictionary: "npm:3.8.0"
@@ -3214,7 +3214,7 @@ __metadata:
     "@types/react-dom": "npm:16.0.9"
     "@typescript-eslint/eslint-plugin": "npm:^5.30.5"
     "@typescript-eslint/parser": "npm:^5.30.5"
-    "@uswds/uswds": "npm:^3.8.0"
+    "@uswds/uswds": "npm:^3.8.1"
     animate.css: "npm:^4.1.1"
     aria-hidden: "npm:^1.1.3"
     babel-loader: "npm:^8.2.2"
@@ -6665,7 +6665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uswds/uswds@npm:^3.8.0":
+"@uswds/uswds@npm:^3.8.1":
   version: 3.8.1
   resolution: "@uswds/uswds@npm:3.8.1"
   dependencies:


### PR DESCRIPTION
## Chromatic
<!-- This `2612-uswds-upgrade` is a placeholder for a CI job - it will be updated automatically -->
https://2612-uswds-upgrade--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

**USWDS v3.8.0 [release notes](https://github.com/uswds/uswds/releases/tag/v3.8.0)**

- Basic style support was added for [usa-icons in buttons](https://github.com/uswds/uswds/pull/5398/files). Before this was added, we were needing to add our own style to accommodate the positioning of icons in `va-button` which we can now remove. There is just a very slight adjustment to the button text which I think actually makes it better aligned.
- The [Chromatic diff](https://www.chromatic.com/build?appId=65a6e2ed2314f7b8f98609d8&number=1017) can be reviewed again if necessary.
- Follow-up ticket for adding indeterminate state to `va-checkbox` is here: 
  - https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2652

**USWDS v3.8.1 [release notes](https://github.com/uswds/uswds/releases/tag/v3.8.1)**

- No visual or functional changes to the component-library found
- The [Chromatic diff](https://www.chromatic.com/build?appId=65a6e2ed2314f7b8f98609d8&number=1020) can be reviewed again if necessary.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2612

## Screenshots

![Screenshot 2024-07-26 at 8 16 01 AM](https://github.com/user-attachments/assets/3c923f02-2ca6-41c4-9f53-aa3125d2b905)
![Screenshot 2024-07-26 at 8 16 14 AM](https://github.com/user-attachments/assets/d0e5287a-0ee2-4946-aba7-737131eff0a6)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
