### PR TITLE
Chromatic Turbosnap: turn back on the onlyChanged flag

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -32,6 +32,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          #onlyChanged: true
+          onlyChanged: true
           workingDir: packages/storybook
           skip: "dependabot/**"

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
@@ -92,7 +92,7 @@ export class VaBackToTop {
                 <va-icon icon="arrow_upward" size={3}></va-icon>
                 <span class="sr-only">Back to top</span>{' '}
                 {/* For small screen that only displays the arrow */}
-                <span class="text">Back to top test</span>
+                <span class="text">Back to top</span>
               </span>
             </a>
           </div>

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
@@ -92,7 +92,7 @@ export class VaBackToTop {
                 <va-icon icon="arrow_upward" size={3}></va-icon>
                 <span class="sr-only">Back to top</span>{' '}
                 {/* For small screen that only displays the arrow */}
-                <span class="text">Back to top</span>
+                <span class="text">Back to top test</span>
               </span>
             </a>
           </div>


### PR DESCRIPTION
## Chromatic
<!-- This `3005-chromatic-turbosnap` is a placeholder for a CI job - it will be updated automatically -->
https://3005-chromatic-turbosnap--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

I noticed that the `onlyChanged` flag was commented out in the Chromatic workflow but the [Turbosnap docs](https://www.chromatic.com/docs/turbosnap/setup/#configure) say that this should be on.

In a test run, I can see now that there's a Turbosnap icon showing up so maybe this is a quick fix for other PRs? 🤞 

![Screenshot 2024-07-25 at 2 29 20 PM](https://github.com/user-attachments/assets/b5f7a77a-b51d-4a1f-bb77-fded180df8b4)


related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3005

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
