### PR TITLE
va-text-input: add icon and suffix story

### DIFF
--- a/packages/storybook/stories/va-text-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.jsx
@@ -408,6 +408,15 @@ WithSuffix.args = {
   'input-suffix': 'lbs.',
 };
 
+export const WithIconAndSuffix = Template.bind(null);
+WithIconAndSuffix.args = {
+  ...defaultArgs,
+  'label': 'How often is the payment?',
+  'required': true,
+  'input-icon-prefix': 'attach_money',
+  'input-suffix': 'per year',
+};
+
 export const Widths = WidthsTemplate.bind(null);
 Widths.args = {
   ...defaultArgs,


### PR DESCRIPTION
## Chromatic
<!-- This `add-icon-and-suffix-story` is a placeholder for a CI job - it will be updated automatically -->
https://add-icon-and-suffix-story--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Adding example that has both prefix icon and suffix text to show as an example on doc site.

## Screenshot
<img width="313" alt="image" src="https://github.com/user-attachments/assets/49560a2a-a0eb-4d71-8b5e-8050b6cdf26a">



## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
