### PR TITLE
va-button | use white background on secondary hover

### DIFF
--- a/packages/storybook/stories/styles/va-icon.scss
+++ b/packages/storybook/stories/styles/va-icon.scss
@@ -17,3 +17,7 @@
 .storybook-background-color-orange {
   background-color: #db7533;
 }
+
+h3#secondary + div:has(#story--uswds-va-button--secondary) {
+  background: var(--vads-color-gray-light-alt);
+}

--- a/packages/web-components/src/components/va-button/va-button.scss
+++ b/packages/web-components/src/components/va-button/va-button.scss
@@ -32,8 +32,15 @@
 }
 
 // Override transparent background from USWDS v3
-.usa-button--outline {
+.usa-button.usa-button--outline {
   background-color: var(--vads-button-color-background-secondary-on-light);
+
+  &:hover,
+  &:focus {
+    background-color: var(--vads-button-color-background-secondary-on-light);
+    text-decoration: none;
+  }
+
 }
 
 .va-button-primary--alternate {


### PR DESCRIPTION
## Chromatic
<!-- This `2628-secondary-hover` is a placeholder for a CI job - it will be updated automatically -->
https://2628-secondary-hover--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#2628](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2628)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

| Before | After |
|----|----|
| <img width="261" alt="secondary va-button hovered showing grey (transparent) background" src="https://github.com/user-attachments/assets/77829a68-b040-4d2f-aa1d-4b50316c93d4"> | <img width="312" alt="secondary va-button hovered showing white background" src="https://github.com/user-attachments/assets/678280ba-21d4-41cc-9db7-ef8e067ece17"> |

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
