### PR TITLE
add consistent types to call signatures

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.tsx
@@ -37,12 +37,12 @@ export class VaAccordionItem {
 
   /**
    * Optional accordion item subheader text. Default is null.
-  */
+   */
   @Prop() subheader?: string = null;
 
   /**
    * True if the item is open
-  */
+   */
   @Prop() open?: boolean = false;
 
   /**
@@ -85,7 +85,7 @@ export class VaAccordionItem {
   // Data access from slot html element is being perfomed by this function
   // Function allows us to provide context to state
   // State is then being digested by the Header Function below
-  private populateStateValues() {
+  private populateStateValues(): void {
     getSlottedNodes(this.el, null).forEach((node: HTMLSlotElement) => {
       this.slotHeader = node.innerHTML;
       this.slotTag = node.tagName.toLowerCase();
@@ -106,10 +106,10 @@ export class VaAccordionItem {
   }
 
   render() {
-    const {uswds} = this;
+    const { uswds } = this;
 
     if (uswds) {
-      const {bordered, header, subheader, level, open} = this;
+      const { bordered, header, subheader, level, open } = this;
       const accordionItemClass = classNames({
         'usa-accordion--bordered': bordered,
       });
@@ -117,10 +117,11 @@ export class VaAccordionItem {
         const headline = this.el.querySelector('[slot="headline"]');
         const ieSlotCheckHeader = headline?.innerHTML;
         // eslint-disable-next-line i18next/no-literal-string
-        const Tag = (headline && headline.tagName.includes("H"))
-          ? headline.tagName.toLowerCase()
-          // eslint-disable-next-line i18next/no-literal-string
-          : `h${level}`;
+        const Tag =
+          headline && headline.tagName.includes('H')
+            ? headline.tagName.toLowerCase()
+            : // eslint-disable-next-line i18next/no-literal-string
+              `h${level}`;
 
         return (
           <Tag class="usa-accordion__heading">
@@ -139,44 +140,47 @@ export class VaAccordionItem {
                 <slot name="icon" />
                 {this.slotHeader || header || ieSlotCheckHeader}
               </span>
-              {this.subheader &&
+              {this.subheader && (
                 <span class="va-accordion__subheader">
                   <slot name="subheader-icon" />
                   {subheader}
-                </span>}
+                </span>
+              )}
             </button>
-          </Tag >
+          </Tag>
         );
-      }
+      };
 
       return (
         <Host>
           <div class={accordionItemClass}>
-            <Header/>
-            <slot name="headline" onSlotchange={() => this.populateStateValues()} />
+            <Header />
+            <slot
+              name="headline"
+              onSlotchange={() => this.populateStateValues()}
+            />
             <div
               id="content"
               class="usa-accordion__content usa-prose"
               hidden={!open}
               part="accordion-content"
             >
-              <slot/>
+              <slot />
             </div>
           </div>
         </Host>
-      )
-
+      );
     } else {
-
       const Header = () => {
         const headline = this.el.querySelector('[slot="headline"]');
         const ieSlotCheckHeader = headline?.innerHTML;
 
         // eslint-disable-next-line i18next/no-literal-string
-        const Tag = (headline && headline.tagName.includes("H"))
-          ? headline.tagName.toLowerCase()
-          // eslint-disable-next-line i18next/no-literal-string
-          : `h${this.level}`;
+        const Tag =
+          headline && headline.tagName.includes('H')
+            ? headline.tagName.toLowerCase()
+            : // eslint-disable-next-line i18next/no-literal-string
+              `h${this.level}`;
 
         return (
           <Tag>
@@ -193,19 +197,23 @@ export class VaAccordionItem {
                 <slot name="icon" />
                 {this.slotHeader || this.header || ieSlotCheckHeader}
               </span>
-              {this.subheader &&
-                <p class="subheader" part='accordion-subheader'>
+              {this.subheader && (
+                <p class="subheader" part="accordion-subheader">
                   <slot name="subheader-icon" />
                   {this.subheader}
-                </p>}
+                </p>
+              )}
             </button>
-          </Tag >
+          </Tag>
         );
-      }
+      };
       return (
         <Host>
           <Header />
-          <slot name="headline" onSlotchange={() => this.populateStateValues()} />
+          <slot
+            name="headline"
+            onSlotchange={() => this.populateStateValues()}
+          />
           <div id="content">
             <slot />
           </div>

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -92,58 +92,59 @@ export class VaAccordion {
 
   @Listen('accordionItemToggled')
   itemToggledHandler(event: CustomEvent) {
-      // eslint-disable-next-line i18next/no-literal-string
-      const clickedItem = (event.target as HTMLElement).closest('va-accordion-item');
-      // Usage for slot to provide context to analytics for header and level
-      const header = clickedItem.querySelector('[slot="headline"]');
-      // using the slot to provide context to analytics for header and level
-      let headerText
-      let headerLevel
-      if (header) {
-        headerText = header?.innerHTML
-        headerLevel = parseInt(header?.tagName?.toLowerCase().split('')[1]);
-      } else {
-        // using the props to provide context to analytics for header and level
-        headerText = clickedItem.header
-        headerLevel = clickedItem.level
-      }
+    // eslint-disable-next-line i18next/no-literal-string
+    const clickedItem = (event.target as HTMLElement).closest(
+      'va-accordion-item',
+    );
+    // Usage for slot to provide context to analytics for header and level
+    const header = clickedItem.querySelector('[slot="headline"]');
+    // using the slot to provide context to analytics for header and level
+    let headerText;
+    let headerLevel;
+    if (header) {
+      headerText = header?.innerHTML;
+      headerLevel = parseInt(header?.tagName?.toLowerCase().split('')[1]);
+    } else {
+      // using the props to provide context to analytics for header and level
+      headerText = clickedItem.header;
+      headerLevel = clickedItem.level;
+    }
 
-      if (this.openSingle) {
-        getSlottedNodes(this.el, 'va-accordion-item')
-          .filter(item => item !== clickedItem)
-          /* eslint-disable-next-line i18next/no-literal-string */
-          .forEach(item => (item as Element).setAttribute('open', 'false'));
-      }
+    if (this.openSingle) {
+      getSlottedNodes(this.el, 'va-accordion-item')
+        .filter(item => item !== clickedItem)
+        /* eslint-disable-next-line i18next/no-literal-string */
+        .forEach(item => (item as Element).setAttribute('open', 'false'));
+    }
 
-      const prevAttr = clickedItem.getAttribute('open') === 'true' ? true : false;
+    const prevAttr = clickedItem.getAttribute('open') === 'true' ? true : false;
 
-      if (!this.disableAnalytics) {
+    if (!this.disableAnalytics) {
+      const detail = {
+        componentName: 'va-accordion',
+        action: prevAttr ? 'collapse' : 'expand',
+        details: {
+          header: headerText || clickedItem.header,
+          subheader: clickedItem.subheader,
+          level: headerLevel || clickedItem.level,
+          sectionHeading: this.sectionHeading,
+        },
+      };
+      this.componentLibraryAnalytics.emit(detail);
+    }
 
-        const detail = {
-          componentName: 'va-accordion',
-          action: prevAttr ? 'collapse' : 'expand',
-          details: {
-            header: headerText || clickedItem.header,
-            subheader: clickedItem.subheader,
-            level: headerLevel || clickedItem.level,
-            sectionHeading: this.sectionHeading,
-          },
-        };
-        this.componentLibraryAnalytics.emit(detail);
-      }
+    /* eslint-disable-next-line i18next/no-literal-string */
+    clickedItem.setAttribute('open', !prevAttr ? 'true' : 'false');
 
-      /* eslint-disable-next-line i18next/no-literal-string */
-      clickedItem.setAttribute('open', !prevAttr ? "true" : "false");
+    if (!this.isScrolledIntoView(clickedItem)) {
+      clickedItem.scrollIntoView();
+    }
 
-      if (!this.isScrolledIntoView(clickedItem)) {
-        clickedItem.scrollIntoView();
-      }
-
-      // Check if all accordions are open or closed due to user clicks
-      this.accordionsOpened();
+    // Check if all accordions are open or closed due to user clicks
+    this.accordionsOpened();
   }
 
-  private accordionsOpened() {
+  private accordionsOpened(): void {
     // Track user clicks on va-accordion-item within an array to compare if all values are true or false
     let accordionItems = [];
     getSlottedNodes(this.el, 'va-accordion-item').forEach(item => {
@@ -160,14 +161,16 @@ export class VaAccordion {
   }
 
   // Expand or Collapse All Function for Button Click
-  private expandCollapseAll = (expanded: boolean) => {
+  private expandCollapseAll = (expanded: boolean): void => {
     this.expanded = expanded;
-    getSlottedNodes(this.el, 'va-accordion-item').forEach((item:HTMLElement) => {
-      item.setAttribute('open', `${expanded}`)
-    });
+    getSlottedNodes(this.el, 'va-accordion-item').forEach(
+      (item: HTMLElement) => {
+        item.setAttribute('open', `${expanded}`);
+      },
+    );
   };
 
-  isScrolledIntoView(el: Element) {
+  isScrolledIntoView(el: Element): boolean {
     const elemTop = el?.getBoundingClientRect().top;
 
     if (!elemTop && elemTop !== 0) {
@@ -189,45 +192,48 @@ export class VaAccordion {
   }
 
   render() {
-    const {uswds, openSingle} = this;
+    const { uswds, openSingle } = this;
     if (uswds) {
       const accordionClass = classNames({
         'usa-accordion': true,
       });
       const accordionItemIDs = [...this.el.children]
-        .filter((el) => el.tagName.toLowerCase() === 'va-accordion-item')
-        .map((el) => el.id);
+        .filter(el => el.tagName.toLowerCase() === 'va-accordion-item')
+        .map(el => el.id);
       return (
         <Host>
-          <div class={ accordionClass } ref={(accordionContainer) => this.accordionContainer = accordionContainer}>
-            {
-              !openSingle ? (
-                <button
-                  class="va-accordion__button"
-                  ref={el => (this.expandCollapseBtn = el as HTMLButtonElement)}
-                  onClick={() => this.expandCollapseAll(!this.expanded)}
-                  aria-label={
-                    this.expanded
-                      ? i18next.t('collapse-all-aria-label')
-                      : i18next.t('expand-all-aria-label')
-                  }
-                  aria-controls={accordionItemIDs.join(' ')}
-                  aria-expanded={`${this.expanded}`}
-                >
-                  {this.expanded
-                    ? `${i18next.t('collapse-all')} -`
-                    : `${i18next.t('expand-all')} +`}
-                </button>
-              ) : null
+          <div
+            class={accordionClass}
+            ref={accordionContainer =>
+              (this.accordionContainer = accordionContainer)
             }
+          >
+            {!openSingle ? (
+              <button
+                class="va-accordion__button"
+                ref={el => (this.expandCollapseBtn = el as HTMLButtonElement)}
+                onClick={() => this.expandCollapseAll(!this.expanded)}
+                aria-label={
+                  this.expanded
+                    ? i18next.t('collapse-all-aria-label')
+                    : i18next.t('expand-all-aria-label')
+                }
+                aria-controls={accordionItemIDs.join(' ')}
+                aria-expanded={`${this.expanded}`}
+              >
+                {this.expanded
+                  ? `${i18next.t('collapse-all')} -`
+                  : `${i18next.t('expand-all')} +`}
+              </button>
+            ) : null}
             <slot></slot>
           </div>
         </Host>
-      )
+      );
     } else {
       const accordionItemIDs = [...this.el.children]
-        .filter((el) => el.tagName.toLowerCase() === 'va-accordion-item')
-        .map((el) => el.id);
+        .filter(el => el.tagName.toLowerCase() === 'va-accordion-item')
+        .map(el => el.id);
       return (
         <Host>
           {!openSingle && (

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
@@ -83,7 +83,7 @@ export class VaAdditionalInfo {
   }
 
   // Ensures that the CSS animation is consistent and uses the correct max-height for its content
-  updateInfoMaxHeight() {
+  updateInfoMaxHeight(): void {
     const infoElm = this.el.shadowRoot.getElementById('info');
     /* eslint-disable i18next/no-literal-string */
     const contentHeight = infoElm.scrollHeight + 'px';
@@ -102,8 +102,8 @@ export class VaAdditionalInfo {
   render() {
     if (this.uswds) {
       const infoClass = classnames({
-        'open': this.open,
-        'closed': !this.open
+        open: this.open,
+        closed: !this.open,
       });
       return (
         <Host>

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
@@ -87,7 +87,7 @@ export class VaAlertExpandable {
 
   // Ensures that the CSS animation is consistent and uses the correct max-height for its content
   /* eslint-disable i18next/no-literal-string */
-  updateAlertBodyMaxHeight() {
+  updateAlertBodyMaxHeight(): void {
     const bodyElm = this.el.shadowRoot.getElementById('alert-body');
     const contentHeight = bodyElm.scrollHeight + 'px';
     // the additional 2em is #alert-body margin-top and margin-bottom when open

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
@@ -52,7 +52,7 @@ export class VaBackToTop {
     revealObserver.observe(this.revealPixel);
   }
 
-  navigateToTop(event) {
+  navigateToTop(event): void {
     event.preventDefault();
     // Focus the h1 tag on the page.
     const el = document.querySelector('h1');

--- a/packages/web-components/src/components/va-banner/va-banner.tsx
+++ b/packages/web-components/src/components/va-banner/va-banner.tsx
@@ -87,9 +87,10 @@ export class VaBanner {
   componentLibraryAnalytics: EventEmitter;
 
   /* eslint-disable-next-line i18next/no-literal-string */
-  private prepareBannerID = () => `${this.headline}:${this.el.innerHTML}`;
+  private prepareBannerID = (): string =>
+    `${this.headline}:${this.el.innerHTML}`;
 
-  private dismiss = () => {
+  private dismiss = (): string => {
     // Derive the current banner ID.
     const currentBannerID = this.prepareBannerID();
 

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -7,7 +7,7 @@ import {
   h,
   Prop,
   Watch,
-  State
+  State,
 } from '@stencil/core';
 import classnames from 'classnames';
 
@@ -69,9 +69,10 @@ export class VaBreadcrumbs {
   @Watch('breadcrumbList')
   watchBreadcrumbListHandler(breadcrumbList) {
     if (!this.breadcrumbList?.length) return;
-    let potentialBreadcrumbs = this.validateBreadcrumbs(breadcrumbList);
+    let potentialBreadcrumbs: Breadcrumb[] | boolean =
+      this.validateBreadcrumbs(breadcrumbList);
     if (potentialBreadcrumbs) {
-      this.updateBreadCrumbList(potentialBreadcrumbs);
+      this.updateBreadCrumbList(potentialBreadcrumbs as Breadcrumb[]);
     }
   }
   /**
@@ -109,7 +110,7 @@ export class VaBreadcrumbs {
    * @param breadcrumbList - An array of breadcrumb objects or a stringified version of it.
    * @private
    */
-  private updateBreadCrumbList(breadcrumbList: Breadcrumb[]) {
+  private updateBreadCrumbList(breadcrumbList: Breadcrumb[]): void {
     const firstBreadcrumb = breadcrumbList[0];
     if (firstBreadcrumb && this.homeVeteransAffairs) {
       firstBreadcrumb.label = 'VA.gov home';
@@ -118,7 +119,7 @@ export class VaBreadcrumbs {
     this.formattedBreadcrumbs = breadcrumbList;
   }
 
-  private getClickLevel(target: HTMLAnchorElement) {
+  private getClickLevel(target: HTMLAnchorElement): number {
     const anchorNodes = this.uswds
       ? Array.from(this.el.shadowRoot.querySelectorAll('a'))
       : Array.from(this.el.querySelectorAll('a'));
@@ -153,7 +154,7 @@ export class VaBreadcrumbs {
     node: HTMLSlotElement,
     index: number,
     slotNodes: Node[],
-  ) {
+  ): void {
     const li = document.createElement('li');
     li.classList.add('va-breadcrumbs-li');
     if (index === slotNodes.length - 1) {
@@ -168,7 +169,7 @@ export class VaBreadcrumbs {
     node: HTMLSlotElement,
     index: number,
     slotNodes: Node[],
-  ) {
+  ): void {
     node.classList.add('va-breadcrumbs-li');
     const anchor = node.querySelector('a');
     if (anchor && index === slotNodes.length - 1) {
@@ -177,7 +178,9 @@ export class VaBreadcrumbs {
     }
   }
 
-  private validateBreadcrumbs(breadcrumbList: Breadcrumb[] | string) {
+  private validateBreadcrumbs(
+    breadcrumbList: Breadcrumb[] | string,
+  ): boolean | Breadcrumb[] {
     let potentialBreadcrumbs: Breadcrumb[];
 
     if (Array.isArray(breadcrumbList)) {
@@ -237,10 +240,11 @@ export class VaBreadcrumbs {
     if (this.uswds) {
       if (!this.breadcrumbList?.length) return;
 
-      let potentialBreadcrumbs = this.validateBreadcrumbs(this.breadcrumbList);
+      let potentialBreadcrumbs: Breadcrumb[] | boolean =
+        this.validateBreadcrumbs(this.breadcrumbList);
 
       if (potentialBreadcrumbs) {
-        this.updateBreadCrumbList(potentialBreadcrumbs);
+        this.updateBreadCrumbList(potentialBreadcrumbs as Breadcrumb[]);
       } else return;
     }
   }
@@ -251,7 +255,7 @@ export class VaBreadcrumbs {
    * aria-current attribute on the last anchor tag and add the
    * va-breadcrumbs-li class to the list item.
    */
-  handleSlotChange() {
+  handleSlotChange(): void {
     // Get all of the slot nodes and filter out only the list items.
     const slotNodes = (
       this.el.shadowRoot.querySelector('slot') as HTMLSlotElement

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
@@ -1,4 +1,12 @@
-import { Component, Event, EventEmitter, Host, h, Prop, Listen } from '@stencil/core';
+import {
+  Component,
+  Event,
+  EventEmitter,
+  Host,
+  h,
+  Prop,
+  Listen,
+} from '@stencil/core';
 
 /**
  * @componentName Button pair
@@ -76,12 +84,12 @@ export class VaButtonPair {
   componentLibraryAnalytics: EventEmitter;
 
   /**
-   * Listen for the va-button GA event and capture it so 
+   * Listen for the va-button GA event and capture it so
    * that we can emit a single va-button-pair GA event that includes
    * the va-button details.
    */
   @Listen('component-library-analytics')
-  handleButtonAnalytics(event) {
+  handleButtonAnalytics(event): void {
     // Prevent va-button-pair GA event from firing multiple times.
     if (event.detail.componentName === 'va-button-pair') return;
 
@@ -93,20 +101,20 @@ export class VaButtonPair {
         componentName: 'va-button-pair',
         action: 'click',
         details: {
-          type: null, 
-          label: null, 
-          ...event.detail?.details // Merging the va-button GA event details.
+          type: null,
+          label: null,
+          ...event.detail?.details, // Merging the va-button GA event details.
         },
       };
       this.componentLibraryAnalytics.emit(detail);
     }
   }
 
-  private handlePrimaryClick = (e: MouseEvent) => {
+  private handlePrimaryClick = (e: MouseEvent): void => {
     this.primaryClick.emit(e);
   };
 
-  private handleSecondaryClick = (e: MouseEvent) => {
+  private handleSecondaryClick = (e: MouseEvent): void => {
     this.secondaryClick.emit(e);
   };
 
@@ -179,13 +187,13 @@ export class VaButtonPair {
           <Host>
             <ul class="usa-button-group">
               <li class="usa-button-group__item">
-              <va-button
-                disable-analytics={disableAnalytics}
-                label={primaryLabel}
-                onClick={handlePrimaryClick}
-                text={update ? 'Update' : 'Yes'}
-                submit={submit}
-              />
+                <va-button
+                  disable-analytics={disableAnalytics}
+                  label={primaryLabel}
+                  onClick={handlePrimaryClick}
+                  text={update ? 'Update' : 'Yes'}
+                  submit={submit}
+                />
               </li>
               <li class="usa-button-group__item">
                 <va-button
@@ -198,7 +206,7 @@ export class VaButtonPair {
               </li>
             </ul>
           </Host>
-        )
+        );
       } else {
         return (
           <Host>
@@ -224,6 +232,5 @@ export class VaButtonPair {
         );
       }
     }
-
   }
 }

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
@@ -72,20 +72,20 @@ export class VaCheckboxGroup {
    * Insert a header with defined level inside the label (legend)
    */
   @Prop() labelHeaderLevel?: string;
-   /**
+  /**
    * Enabling this will add a heading and description for integrating into the forms pattern. Accepts `single` or `multiple` to indicate if the form is a single input or will have multiple inputs. `uswds` should be true.
    */
-   @Prop() useFormsPattern?: string;
+  @Prop() useFormsPattern?: string;
 
-   /**
-    * The heading level for the heading if `useFormsPattern` and `uswds` are true.
-    */
-   @Prop() formHeadingLevel?: number = 3;
- 
-   /**
-    * The content of the heading if `useFormsPattern` and `uswds` are true.
-    */
-   @Prop() formHeading?: string;
+  /**
+   * The heading level for the heading if `useFormsPattern` and `uswds` are true.
+   */
+  @Prop() formHeadingLevel?: number = 3;
+
+  /**
+   * The content of the heading if `useFormsPattern` and `uswds` are true.
+   */
+  @Prop() formHeading?: string;
 
   /**
    * The event used to track usage of the component. This is emitted when an
@@ -104,7 +104,7 @@ export class VaCheckboxGroup {
     if (this.enableAnalytics) this.fireAnalyticsEvent(clickedItem.label);
   }
 
-  private fireAnalyticsEvent(optionLabel) {
+  private fireAnalyticsEvent(optionLabel): void {
     this.componentLibraryAnalytics.emit({
       componentName: 'va-checkbox-group',
       action: 'change',
@@ -116,7 +116,7 @@ export class VaCheckboxGroup {
     });
   }
 
-  private getHeaderLevel() {
+  private getHeaderLevel(): string | null {
     const number = parseInt(this.labelHeaderLevel, 10);
     return number >= 1 && number <= 6 ? `h${number}` : null;
   }
@@ -140,36 +140,40 @@ export class VaCheckboxGroup {
       uswds,
       useFormsPattern,
       formHeadingLevel,
-      formHeading, } = this;
+      formHeading,
+    } = this;
     const HeaderLevel = this.getHeaderLevel();
-    const ariaLabeledByIds = 
-        `${useFormsPattern && formHeading ? 'form-question' : ''} ${ 
-        useFormsPattern ? 'form-description' : ''} ${
-        useFormsPattern === 'multiple' ? 'header-message' : ''}`.trim() || null;
-
+    const ariaLabeledByIds =
+      `${useFormsPattern && formHeading ? 'form-question' : ''} ${
+        useFormsPattern ? 'form-description' : ''
+      } ${useFormsPattern === 'multiple' ? 'header-message' : ''}`.trim() ||
+      null;
 
     if (uswds) {
       const legendClass = classnames({
         'usa-legend': true,
-        'usa-label--error': error
+        'usa-label--error': error,
       });
-      const isFormsPattern = useFormsPattern === 'single' || useFormsPattern === 'multiple' ? true : false;
+      const isFormsPattern =
+        useFormsPattern === 'single' || useFormsPattern === 'multiple'
+          ? true
+          : false;
 
       let formsHeading = null;
       if (isFormsPattern) {
         const HeaderLevel = getHeaderLevel(formHeadingLevel);
         formsHeading = (
           <Fragment>
-            {formHeading &&
+            {formHeading && (
               <HeaderLevel id="form-question" part="form-header">
                 {formHeading}
               </HeaderLevel>
-            }
+            )}
             <div id="form-description">
               <slot name="form-description"></slot>
             </div>
           </Fragment>
-        )
+        );
       }
 
       return (
@@ -182,15 +186,18 @@ export class VaCheckboxGroup {
                   <HeaderLevel part="header">{label}</HeaderLevel>
                 ) : (
                   label
-                )}&nbsp;
-                {
-                  useFormsPattern === 'multiple' && (
-                    <span id="header-message" class="sr-only">
-                      {label}
-                    </span>
-                  )
-                }
-                {required && <span class="usa-label--required">{i18next.t('required')}</span>}
+                )}
+                &nbsp;
+                {useFormsPattern === 'multiple' && (
+                  <span id="header-message" class="sr-only">
+                    {label}
+                  </span>
+                )}
+                {required && (
+                  <span class="usa-label--required">
+                    {i18next.t('required')}
+                  </span>
+                )}
                 {hint && <div class="usa-hint">{hint}</div>}
               </legend>
               <span id="checkbox-error-message" role="alert">
@@ -205,8 +212,8 @@ export class VaCheckboxGroup {
             </fieldset>
           </div>
         </Host>
-      )
-    } else  {
+      );
+    } else {
       return (
         <Host role="group">
           <fieldset>
@@ -221,7 +228,7 @@ export class VaCheckboxGroup {
               )}
               {hint && <div class="hint-text">{hint}</div>}
             </legend>
-            
+
             <span id="error-message" role="alert">
               {error && (
                 <Fragment>

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -49,7 +49,7 @@ export class VaCheckbox {
   /**
    * The error message to render.
    */
-   @Prop({ reflect: true }) error?: string;
+  @Prop({ reflect: true }) error?: string;
 
   /**
    * The description to render. If this prop exists, va-checkbox will render it
@@ -79,7 +79,7 @@ export class VaCheckbox {
   /**
    * Optional hint text.
    */
-   @Prop() hint?: string;
+  @Prop() hint?: string;
 
   /**
    * Whether or not the component will display as a tile. Available when uswds is true.
@@ -122,7 +122,7 @@ export class VaCheckbox {
   })
   componentLibraryAnalytics: EventEmitter;
 
-  private fireAnalyticsEvent = () => {
+  private fireAnalyticsEvent = (): void => {
     // Either the description prop or the text content of the description slots
     const description =
       this.description ||
@@ -153,7 +153,7 @@ export class VaCheckbox {
     });
   };
 
-  private handleChange = (e: Event) => {
+  private handleChange = (e: Event): void => {
     this.checked = (e.target as HTMLInputElement).checked;
     this.vaChange.emit({ checked: this.checked });
     if (this.enableAnalytics) this.fireAnalyticsEvent();
@@ -190,10 +190,11 @@ export class VaCheckbox {
       checkboxDescription,
       disabled,
       messageAriaDescribedby,
-      name
+      name,
     } = this;
 
-    const hasDescription = description || !!this.el.querySelector('[slot="description"]');
+    const hasDescription =
+      description || !!this.el.querySelector('[slot="description"]');
 
     if (uswds) {
       const inputClass = classnames({
@@ -202,21 +203,28 @@ export class VaCheckbox {
       });
       const descriptionClass = classnames({
         'usa-legend': true,
-        'usa-label--error': error
+        'usa-label--error': error,
       });
-      const ariaDescribedbyIds = [
-        messageAriaDescribedby ? 'input-message' : '',
-        error ? 'checkbox-error-message' : '',
-        hasDescription ? 'description' : '',
-        // Return null so we don't add the attribute if we have an empty string
-      ].filter(Boolean).join(' ').trim() || null;
+      const ariaDescribedbyIds =
+        [
+          messageAriaDescribedby ? 'input-message' : '',
+          error ? 'checkbox-error-message' : '',
+          hasDescription ? 'description' : '',
+          // Return null so we don't add the attribute if we have an empty string
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .trim() || null;
 
       return (
         <Host>
-          {description ?
-            <legend id="description" class={descriptionClass}>{description}</legend> :
+          {description ? (
+            <legend id="description" class={descriptionClass}>
+              {description}
+            </legend>
+          ) : (
             <slot name="description" />
-          }
+          )}
 
           {hint && <span class="usa-hint">{hint}</span>}
           <span id="checkbox-error-message" role="alert">
@@ -239,13 +247,28 @@ export class VaCheckbox {
               disabled={disabled}
               onChange={this.handleChange}
             />
-            <label htmlFor="checkbox-element" id="option-label" class="usa-checkbox__label" part="label">
+            <label
+              htmlFor="checkbox-element"
+              id="option-label"
+              class="usa-checkbox__label"
+              part="label"
+            >
               {label}&nbsp;
-              {required && <span class="usa-label--required">{i18next.t('required')}</span>}
-              {checkboxDescription && <span class="usa-checkbox__label-description" aria-describedby="option-label" part="description">{checkboxDescription}</span>}
+              {required && (
+                <span class="usa-label--required">{i18next.t('required')}</span>
+              )}
+              {checkboxDescription && (
+                <span
+                  class="usa-checkbox__label-description"
+                  aria-describedby="option-label"
+                  part="description"
+                >
+                  {checkboxDescription}
+                </span>
+              )}
             </label>
             {messageAriaDescribedby && (
-              <span id='input-message' class="sr-only dd-privacy-hidden">
+              <span id="input-message" class="sr-only dd-privacy-hidden">
                 {messageAriaDescribedby}
               </span>
             )}
@@ -253,19 +276,27 @@ export class VaCheckbox {
         </Host>
       );
     } else {
-      const ariaDescribedbyIds = [
-        messageAriaDescribedby ? 'input-message' : '',
-        error ? 'checkbox-error-message' : '',
-        hasDescription ? 'description' : '',
-      // Return null so we don't add the attribute if we have an empty string
-      ].filter(Boolean).join(' ').trim() || null;
+      const ariaDescribedbyIds =
+        [
+          messageAriaDescribedby ? 'input-message' : '',
+          error ? 'checkbox-error-message' : '',
+          hasDescription ? 'description' : '',
+          // Return null so we don't add the attribute if we have an empty string
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .trim() || null;
       return (
         <Host>
           <div id="description">
             {description ? <p>{description}</p> : <slot name="description" />}
           </div>
           {hint && <span class="hint-text">{hint}</span>}
-          <span id="checkbox-error-message" class="usa-error-message" role="alert">
+          <span
+            id="checkbox-error-message"
+            class="usa-error-message"
+            role="alert"
+          >
             {error && (
               <Fragment>
                 <span class="sr-only">{i18next.t('error')}</span> {error}
@@ -282,11 +313,14 @@ export class VaCheckbox {
           />
           <label htmlFor="checkbox-element">
             <span>
-              {label} {required && <span class="required">{i18next.t('required')}</span>}
+              {label}{' '}
+              {required && (
+                <span class="required">{i18next.t('required')}</span>
+              )}
             </span>
           </label>
           {messageAriaDescribedby && (
-            <span id='input-message' class="sr-only dd-privacy-hidden">
+            <span id="input-message" class="sr-only dd-privacy-hidden">
               {messageAriaDescribedby}
             </span>
           )}

--- a/packages/web-components/src/components/va-crisis-line-modal/va-crisis-line-modal.tsx
+++ b/packages/web-components/src/components/va-crisis-line-modal/va-crisis-line-modal.tsx
@@ -22,22 +22,22 @@ export class VACrisisLineModal {
    */
   @State() shifted: boolean = false;
 
-  setVisible() {
+  setVisible(): void {
     this.isOpen = true;
   }
 
-  setNotVisible() {
+  setNotVisible(): void {
     this.isOpen = false;
   }
 
   // This keydown event listener tracks if the shift key is held down while changing focus
   @Listen('keydown', { target: 'window' })
-  trackShiftKey(e: KeyboardEvent) {
+  trackShiftKey(e: KeyboardEvent): void {
     this.shifted = e.shiftKey;
   }
 
   // Redirects focus back to the modal, if the modal is open/visible
-  private trapFocus() {
+  private trapFocus(): void {
     const modal = this.el?.shadowRoot.querySelector('va-modal');
     const modalVisible = modal?.getAttribute('visible');
 

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -64,8 +64,9 @@ export class VaDate {
    */
   @Prop({
     mutable: true,
-    reflect: true
-  }) error?: string;
+    reflect: true,
+  })
+  error?: string;
 
   /**
    * Whether or not only the Month and Year inputs should be displayed.
@@ -77,8 +78,9 @@ export class VaDate {
    */
   @Prop({
     mutable: true,
-    reflect: true
-  }) value?: string;
+    reflect: true,
+  })
+  value?: string;
 
   /**
    * Fires when the date input loses focus after its value was changed
@@ -137,28 +139,28 @@ export class VaDate {
     // Ternary to prevent NaN displaying as value for Year
     // Ternary to prevent Month or Day from displaying as single digit
     /* eslint-disable i18next/no-literal-string */
-    const val = `${year ? year : ''}-${
-      month ? zeroPadStart(month) : ''
-    }-${day ? zeroPadStart(day) : ''}`.replace(/-+$/, '');
+    const val = `${year ? year : ''}-${month ? zeroPadStart(month) : ''}-${
+      day ? zeroPadStart(day) : ''
+    }`.replace(/-+$/, '');
     /* eslint-enable i18next/no-literal-string */
 
     this.value = val ? val : null;
   }
 
-  private handleDateBlur = (event: FocusEvent) => {
+  private handleDateBlur = (event: FocusEvent): void => {
     const [year, month, day] = (this.value || '')
       .split('-')
       .map(val => Number(val));
 
     validate({
-               component: this,
-               year,
-               month,
-               day,
-               yearTouched: this.yearTouched,
-               monthTouched: this.monthTouched,
-               dayTouched: this.dayTouched
-             });
+      component: this,
+      year,
+      month,
+      day,
+      yearTouched: this.yearTouched,
+      monthTouched: this.monthTouched,
+      dayTouched: this.dayTouched,
+    });
 
     if (this.error) {
       return;
@@ -182,7 +184,7 @@ export class VaDate {
     }
   };
 
-  private handleDateChange = (event: Event) => {
+  private handleDateChange = (event: Event): void => {
     const target = event.target as HTMLSelectElement | HTMLInputElement;
     let [currentYear, currentMonth, currentDay] = (this.value || '').split('-');
     if (target.classList.contains('select-month')) {
@@ -206,17 +208,17 @@ export class VaDate {
     this.dateChange.emit(event);
   };
 
-  private handleMonthBlur = () => {
+  private handleMonthBlur = (): void => {
     this.monthTouched = true;
-  }
+  };
 
-  private handleDayBlur = () => {
+  private handleDayBlur = (): void => {
     this.dayTouched = true;
-  }
+  };
 
-  private handleYearBlur = () => {
+  private handleYearBlur = (): void => {
     this.yearTouched = true;
-  }
+  };
 
   render() {
     const {
@@ -237,7 +239,7 @@ export class VaDate {
     const daysForSelectedMonth = month > 0 ? days[month] : [];
     const errorParameters = (error: string) => {
       return getErrorParameters(error, year, month);
-    }
+    };
 
     // Fieldset has an implicit aria role of group
     return (
@@ -251,7 +253,8 @@ export class VaDate {
           <span id="error-message" role="alert">
             {error && (
               <Fragment>
-                <span class="sr-only">Error</span> {i18next.t(error, errorParameters(error))}
+                <span class="sr-only">Error</span>{' '}
+                {i18next.t(error, errorParameters(error))}
               </Fragment>
             )}
           </span>

--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -9,7 +9,7 @@ import {
   EventEmitter,
 } from '@stencil/core';
 import i18next from 'i18next';
-import { FileIndex } from "./FileIndex";
+import { FileIndex } from './FileIndex';
 
 /**
  * A component that manages multiple file inputs, allowing users to upload several files.
@@ -76,7 +76,7 @@ export class VaFileInputMultiple {
   /**
    * Internal state to track files and their unique keys.
    */
-  @State() files: FileIndex[] = [{ key: 0, file: null , content: null}];
+  @State() files: FileIndex[] = [{ key: 0, file: null, content: null }];
 
   /**
    * Counter to assign unique keys to new file inputs.
@@ -106,12 +106,12 @@ export class VaFileInputMultiple {
    * If there is no additionalSlot set, it fetches the assigned elements to this slot, ensuring that content
    * is managed only if the slot exists. This prevents the default slot content from rendering.
    */
-  private setSlotContent() {
+  private setSlotContent(): void {
     const slot = this.el.shadowRoot.querySelector('slot');
     if (!this.additionalSlot) {
       this.additionalSlot = slot
-                            ? slot.assignedElements({ flatten: true })
-                            : [];
+        ? slot.assignedElements({ flatten: true })
+        : [];
     }
     slot?.remove();
   }
@@ -123,17 +123,17 @@ export class VaFileInputMultiple {
    *
    * @returns {Node[]} An array of cloned nodes from the additionalSlot.
    */
-  private getAdditionalContent() {
+  private getAdditionalContent(): Node[] {
     return this.additionalSlot.map(n => n.cloneNode(true));
   }
 
   /**
    * Handles file input changes by updating, adding, or removing files based on user interaction.
-   * @param {any} event - The event object containing file details.
+   * @param {CustomEvent} event - The event object containing file details.
    * @param {number} fileKey - The key of the file being changed.
    * @param {number} pageIndex - The index of the file in the files array.
    */
-  private handleChange(event: any, fileKey: number, pageIndex: number) {
+  private handleChange(event: CustomEvent, fileKey: number, pageIndex: number) {
     const newFile = event.detail.files[0];
 
     if (newFile) {
@@ -156,15 +156,18 @@ export class VaFileInputMultiple {
     } else {
       // Deleted file
       this.files.splice(pageIndex, 1);
-      const statusMessageDiv = this.el.shadowRoot.querySelector("#statusMessage");
+      const statusMessageDiv =
+        this.el.shadowRoot.querySelector('#statusMessage');
       // empty status message so it is read when updated
-      statusMessageDiv.textContent = ""
+      statusMessageDiv.textContent = '';
       setTimeout(() => {
-        statusMessageDiv.textContent = "File removed."
+        statusMessageDiv.textContent = 'File removed.';
       }, 1000);
     }
 
-    this.vaMultipleChange.emit({ files: this.files.map(fileObj => fileObj.file) });
+    this.vaMultipleChange.emit({
+      files: this.files.map(fileObj => fileObj.file),
+    });
     this.files = Array.of(...this.files);
   }
 
@@ -179,7 +182,7 @@ export class VaFileInputMultiple {
     label: string,
     required: boolean,
     headerSize?: number,
-  ) => {
+  ): JSX.Element => {
     const requiredSpan = required ? (
       <span class="required"> {i18next.t('required')}</span>
     ) : null;
@@ -200,7 +203,9 @@ export class VaFileInputMultiple {
     } else {
       return (
         <div class="label-header">
-          <span part="label" class="usa-label">{label}</span>
+          <span part="label" class="usa-label">
+            {label}
+          </span>
           {requiredSpan}
         </div>
       );
@@ -228,7 +233,7 @@ export class VaFileInputMultiple {
    */
   private hasErrors = () => {
     return this.errors.some(error => !!error);
-  }
+  };
 
   /**
    * The render method to display the component structure.
@@ -247,7 +252,7 @@ export class VaFileInputMultiple {
       enableAnalytics,
     } = this;
     const outerWrapClass = this.isEmpty() ? '' : 'outer-wrap';
-    const hasError = this.hasErrors() ? 'has-error': '';
+    const hasError = this.hasErrors() ? 'has-error' : '';
 
     return (
       <Host class={hasError}>
@@ -258,7 +263,7 @@ export class VaFileInputMultiple {
           </div>
         )}
         <div class={outerWrapClass}>
-          <div class='usa-sr-only' aria-live="polite" id="statusMessage"></div>
+          <div class="usa-sr-only" aria-live="polite" id="statusMessage"></div>
           {!this.isEmpty() && (
             <div class="selected-files-label">Selected files</div>
           )}

--- a/packages/web-components/src/components/va-file-input/va-file-input-upgrader.ts
+++ b/packages/web-components/src/components/va-file-input/va-file-input-upgrader.ts
@@ -46,14 +46,14 @@ let DEFAULT_FILE_STATUS_TEXT = '';
  * @param {HTMLElement} el the element within the file input
  * @returns {FileInputContext} elements
  */
-const getFileInputContext = el => {
-  const dropZoneEl = el.closest(DROPZONE);
+const getFileInputContext = (el: HTMLElement): { dropZoneEl: HTMLElement, inputEl: HTMLInputElement } => {
+  const dropZoneEl = el.closest(DROPZONE) as HTMLElement;
 
   if (!dropZoneEl) {
     throw new Error(`Element is missing outer ${DROPZONE}`);
   }
 
-  const inputEl = dropZoneEl.querySelector(INPUT);
+  const inputEl = dropZoneEl.querySelector(INPUT) as HTMLInputElement;
 
   return {
     dropZoneEl,
@@ -66,7 +66,7 @@ const getFileInputContext = el => {
  *
  * @param {HTMLElement} el An element within the file input component
  */
-const disable = el => {
+const disable = (el: HTMLElement): void => {
   const { dropZoneEl, inputEl } = getFileInputContext(el);
 
   inputEl.disabled = true;
@@ -78,7 +78,7 @@ const disable = el => {
  *
  * @param {HTMLElement} el An element within the file input component
  */
-const ariaDisable = el => {
+const ariaDisable = (el: HTMLElement): void => {
   const { dropZoneEl } = getFileInputContext(el);
 
   dropZoneEl.classList.add(DISABLED_CLASS);
@@ -89,7 +89,7 @@ const ariaDisable = el => {
  *
  * @param {HTMLElement} el An element within the file input component
  */
-const enable = el => {
+const enable = (el: HTMLElement): void => {
   const { dropZoneEl, inputEl } = getFileInputContext(el);
 
   inputEl.disabled = false;
@@ -102,31 +102,32 @@ const enable = el => {
  * @param {String} s special characters
  * @returns {String} replaces specified values
  */
-const replaceName = s => {
+const replaceName = (s: string): string => {
   const c = s.charCodeAt(0);
   if (c === 32) return '-';
   if (c >= 65 && c <= 90) return `img_${s.toLowerCase()}`;
   return `__000${c.toString(16).slice(-4)}`;
 };
 
+
 /**
  * Creates an ID name for each file that strips all invalid characters.
  * @param {String} name - name of the file added to file input (search value)
  * @returns {String} same characters as the name with invalid chars removed (new value)
  */
-const makeSafeForID = name => name.replace(/[^a-z0-9]/g, replaceName);
+const makeSafeForID = (name: string): string => name.replace(/[^a-z0-9]/g, replaceName);
 
 // Takes a generated safe ID and creates a unique ID.
-const createUniqueID = name => `${name}-${Math.floor(Date.now() / 1000)}`;
+const createUniqueID = (name: string): string => `${name}-${Math.floor(Date.now() / 1000)}`;
 
 /**
  * Determines if the singular or plural item label should be used
  * Determination is based on the presence of the `multiple` attribute
  *
  * @param {HTMLInputElement} fileInputEl - The input element.
- * @returns {HTMLDivElement} The singular or plural version of "item"
+ * @returns {string} The singular or plural version of "item". Either "file" or "files".
  */
-const getItemsLabel = fileInputEl => {
+const getItemsLabel = (fileInputEl: HTMLInputElement): string => {
   const acceptsMultiple = fileInputEl.hasAttribute('multiple');
   const itemsLabel = acceptsMultiple ? 'files' : 'file';
 
@@ -140,7 +141,7 @@ const getItemsLabel = fileInputEl => {
  * @param {HTMLInputElement} fileInputEl - The input element.
  * @returns {HTMLDivElement} The drag and drop target area.
  */
-const createTargetArea = fileInputEl => {
+const createTargetArea = (fileInputEl: HTMLInputElement): HTMLDivElement => {
   const fileInputParent = document.createElement('div');
   const dropTarget = document.createElement('div');
   const box = document.createElement('div');
@@ -168,7 +169,7 @@ const createTargetArea = fileInputEl => {
  * @param {HTMLInputElement} fileInputEl - The input element.
  * @returns {HTMLDivElement} The container for visible interaction instructions.
  */
-const createVisibleInstructions = fileInputEl => {
+const createVisibleInstructions = (fileInputEl: HTMLInputElement): HTMLDivElement => {
   const fileInputParent = fileInputEl.closest(DROPZONE);
   const itemsLabel = getItemsLabel(fileInputEl);
   const instructions = document.createElement('div');
@@ -208,7 +209,7 @@ const createVisibleInstructions = fileInputEl => {
  *
  * @param {HTMLInputElement} fileInputEl - The input element.
  */
-const createSROnlyStatus = fileInputEl => {
+const createSROnlyStatus = (fileInputEl: HTMLInputElement): void => {
   const statusEl = document.createElement('div');
   const itemsLabel = getItemsLabel(fileInputEl);
   const fileInputParent = fileInputEl.closest(DROPZONE);
@@ -232,7 +233,7 @@ const createSROnlyStatus = fileInputEl => {
  *
  * @param {HTMLInputElement} fileInputEl - The original input element.
  */
-const enhanceFileInput = fileInputEl => {
+const enhanceFileInput = (fileInputEl: HTMLInputElement): { instructions: HTMLDivElement, dropTarget: HTMLDivElement } => {
   const isInputDisabled =
     fileInputEl.hasAttribute('aria-disabled') ||
     fileInputEl.hasAttribute('disabled');
@@ -256,7 +257,7 @@ const enhanceFileInput = fileInputEl => {
  * @param {HTMLDivElement} dropTarget - The drag and drop target area.
  * @param {HTMLDivElement} instructions - The container for visible interaction instructions.
  */
-const removeOldPreviews = (dropTarget, instructions) => {
+const removeOldPreviews = (dropTarget: HTMLDivElement, instructions: HTMLDivElement): void => {
   const filePreviews = dropTarget.querySelectorAll(`.${PREVIEW_CLASS}`);
   const currentPreviewHeading = dropTarget.querySelector(
     `.${PREVIEW_HEADING_CLASS}`,
@@ -269,7 +270,7 @@ const removeOldPreviews = (dropTarget, instructions) => {
    * finds the parent of the passed node and removes the child
    * @param {HTMLElement} node
    */
-  const removeImages = node => {
+  const removeImages = (node: HTMLElement): void => {
     node.parentNode.removeChild(node);
   };
 
@@ -300,7 +301,7 @@ const removeOldPreviews = (dropTarget, instructions) => {
  * @param {Object} fileNames - The selected files found in the fileList object.
  * @param {Array} fileStore - The array of uploaded file names created from the fileNames object.
  */
-const updateStatusMessage = (statusElement, fileNames, fileStore) => {
+const updateStatusMessage = (statusElement: HTMLDivElement | Element, fileNames: FileList | File[], fileStore: string[]): void => {
   const statusEl = statusElement;
   let statusMessage = DEFAULT_FILE_STATUS_TEXT;
 
@@ -308,9 +309,8 @@ const updateStatusMessage = (statusElement, fileNames, fileStore) => {
   if (fileNames.length === 1) {
     statusMessage = `You have selected the file: ${fileStore}`;
   } else if (fileNames.length > 1) {
-    statusMessage = `You have selected ${
-      fileNames.length
-    } files: ${fileStore.join(', ')}`;
+    statusMessage = `You have selected ${fileNames.length
+      } files: ${fileStore.join(', ')}`;
   }
 
   // Add delay to encourage screen reader readout
@@ -324,9 +324,9 @@ const updateStatusMessage = (statusElement, fileNames, fileStore) => {
  * Update the aria-label with new instructions text
  *
  * @param {HTMLInputElement} fileInputEl - The input element.
- * @param {Object} fileNames - The selected files found in the fileList object.
+ * @param {Array} fileNames - The selected files found in the fileList object.
  */
-const addPreviewHeading = (fileInputEl, fileNames) => {
+const addPreviewHeading = (fileInputEl: HTMLInputElement, fileNames: FileList | File[]) => {
   const filePreviewsHeading = document.createElement('div');
   const dropTarget = fileInputEl.closest(`.${TARGET_CLASS}`);
   const instructions = dropTarget.querySelector(`.${INSTRUCTIONS_CLASS}`);
@@ -364,12 +364,12 @@ const addPreviewHeading = (fileInputEl, fileNames) => {
  * @param {HTMLDivElement} dropTarget - The drag and drop target area.
  */
 
-const handleChange = (e, fileInputEl, instructions, dropTarget) => {
+const handleChange = (e: Event, fileInputEl: HTMLInputElement, instructions: HTMLDivElement, dropTarget: HTMLDivElement) => {
   const multiple = fileInputEl.getAttribute('multiple'); // TODO: Double-check this works correctly when multiple is re-enabled
-  const fileNames = multiple ? e.target.files : [e.target.files[0]];
+  const fileNames = multiple ? (e.target as HTMLInputElement).files : [(e.target as HTMLInputElement).files[0]];
   const inputParent = dropTarget.closest(`.${DROPZONE_CLASS}`);
   const statusElement = inputParent.querySelector(`.${SR_ONLY_CLASS}`);
-  const fileStore = [];
+  const fileStore: string[] = [];
 
   // First, get rid of existing previews
   removeOldPreviews(dropTarget, instructions);
@@ -464,7 +464,7 @@ const handleChange = (e, fileInputEl, instructions, dropTarget) => {
  * @param {HTMLDivElement} instructions - The container for visible interaction instructions.
  * @param {HTMLDivElement} dropTarget - The drag and drop target area.
  */
-const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
+const preventInvalidFiles = (e: Event, fileInputEl: HTMLInputElement, instructions: HTMLDivElement, dropTarget: HTMLDivElement) => {
   const acceptedFilesAttr = fileInputEl.getAttribute('accept');
   dropTarget.classList.remove(INVALID_FILE_CLASS);
 
@@ -494,7 +494,7 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
 
     // If multiple files are dragged, this iterates through them and look for any files that are not accepted.
     let allFilesAllowed = true;
-    const scannedFiles = e.target.files || e.dataTransfer.files;
+    const scannedFiles = (e.target as HTMLInputElement).files || (e as DragEvent).dataTransfer.files;
     for (let i = 0; i < scannedFiles.length; i += 1) {
       const file = scannedFiles[i];
       if (allFilesAllowed) {
@@ -536,7 +536,7 @@ const preventInvalidFiles = (e, fileInputEl, instructions, dropTarget) => {
  * @param {HTMLDivElement} instructions - The container for visible interaction instructions.
  * @param {HTMLDivElement} dropTarget - The drag and drop target area.
  */
-const handleUpload = (event, fileInputEl, instructions, dropTarget) => {
+const handleUpload = (event: Event, fileInputEl: HTMLInputElement, instructions: HTMLDivElement, dropTarget: HTMLDivElement) => {
   preventInvalidFiles(event, fileInputEl, instructions, dropTarget);
   if (TYPE_IS_VALID === true) {
     handleChange(event, fileInputEl, instructions, dropTarget);
@@ -545,7 +545,7 @@ const handleUpload = (event, fileInputEl, instructions, dropTarget) => {
 
 export const fileInput = {
   init(root: HTMLElement) {
-    selectOrMatches(DROPZONE, root).forEach(fileInputEl => {
+    selectOrMatches(DROPZONE, root).forEach((fileInputEl: HTMLInputElement) => {
       const { instructions, dropTarget } = enhanceFileInput(fileInputEl);
 
       dropTarget.addEventListener(

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -12,7 +12,7 @@ import {
 } from '@stencil/core';
 import i18next from 'i18next';
 import { fileInput } from './va-file-input-upgrader';
-import { extensionToMimeType } from "./fileExtensionToMimeType";
+import { extensionToMimeType } from './fileExtensionToMimeType';
 
 /**
  * @componentName File input
@@ -111,13 +111,13 @@ export class VaFileInput {
   })
   componentLibraryAnalytics: EventEmitter;
 
-  private handleChange = (e: Event) => {
+  private handleChange = (e: Event): void => {
     const input = e.target as HTMLInputElement;
     if (input.files && input.files.length > 0) {
-      this.handleFile(input.files[0])
+      this.handleFile(input.files[0]);
     }
     input.value = '';
-  }
+  };
 
   private handleDrop = (event: DragEvent) => {
     event.preventDefault();
@@ -129,7 +129,7 @@ export class VaFileInput {
     }
   };
 
-  private handleFile = (file: File) => {
+  private handleFile = (file: File): void => {
     if (this.accept) {
       const normalizedAcceptTypes = this.normalizeAcceptProp(this.accept);
       if (!this.isAcceptedFileType(file.type, normalizedAcceptTypes)) {
@@ -156,13 +156,13 @@ export class VaFileInput {
         },
       });
     }
-  }
+  };
 
-  private handleButtonClick = () => {
+  private handleButtonClick = (): void => {
     this.el.shadowRoot.getElementById('fileInputField').click();
   };
 
-  private removeFile = (notifyParent: boolean = true) => {
+  private removeFile = (notifyParent: boolean = true): void => {
     this.closeModal();
     this.uploadStatus = 'idle';
     this.internalError = null;
@@ -174,32 +174,34 @@ export class VaFileInput {
     this.el.focus();
   };
 
-  private openModal = () => {
+  private openModal = (): void => {
     // set the status attribute here not in markup or it will have no effect
-    const modal = this.el.shadowRoot.querySelector('va-modal');
+    const modal: HTMLVaModalElement =
+      this.el.shadowRoot.querySelector('va-modal');
     modal.setAttribute('status', 'warning');
     this.showModal = true;
-  }
+  };
 
-  private closeModal = () => {
+  private closeModal = (): void => {
     this.showModal = false;
     // wait a tick for modal to close before setting focus
     setTimeout(() => {
       this.fileInputRef.focus();
     }, 0);
-  }
+  };
 
-  private changeFile = () => {
+  private changeFile = (): void => {
     if (this.fileInputRef) {
       this.fileInputRef.click();
     }
   };
 
-  private updateStatusMessage(message:string) {
+  private updateStatusMessage(message: string): void {
     // Add delay to encourage screen reader readout
     setTimeout(() => {
-      const statusMessageDiv = this.el.shadowRoot.querySelector("#statusMessage");
-      statusMessageDiv ? statusMessageDiv.textContent = message : "";
+      const statusMessageDiv =
+        this.el.shadowRoot.querySelector('#statusMessage');
+      statusMessageDiv ? (statusMessageDiv.textContent = message) : '';
     }, 1000);
   }
 
@@ -238,9 +240,12 @@ export class VaFileInput {
       item = item.trim();
       return item.startsWith('.') ? extensionToMimeType[item] : item;
     });
-  }
+  };
 
-  private isAcceptedFileType = (fileType: string, acceptedTypes: string[]): boolean => {
+  private isAcceptedFileType = (
+    fileType: string,
+    acceptedTypes: string[],
+  ): boolean => {
     for (const type of acceptedTypes) {
       if (type === fileType) {
         return true;
@@ -250,13 +255,13 @@ export class VaFileInput {
       }
     }
     return false;
-  }
+  };
 
   private renderLabelOrHeader = (
     label: string,
     required: boolean,
     headerSize?: number,
-  ) => {
+  ): HTMLElement => {
     const requiredSpan = required ? (
       <span class="required"> {i18next.t('required')}</span>
     ) : null;
@@ -286,7 +291,7 @@ export class VaFileInput {
     }
   };
 
-  private generateFileContents(file: File) {
+  private generateFileContents(file: File): void {
     if (!file) return;
 
     const reader = new FileReader();
@@ -335,7 +340,7 @@ export class VaFileInput {
       headerSize,
       fileContents,
       fileType,
-      headless
+      headless,
     } = this;
 
     const text = this.getButtonText();
@@ -366,11 +371,14 @@ export class VaFileInput {
       if (error) {
         fileThumbnail = (
           <div class="thumbnail-container">
-            <va-icon icon="error" size={3} class="thumbnail-preview thumbnail-error"/>
+            <va-icon
+              icon="error"
+              size={3}
+              class="thumbnail-preview thumbnail-error"
+            />
           </div>
         );
-      }
-      else if (fileContents) {
+      } else if (fileContents) {
         if (fileType.startsWith('image/')) {
           fileThumbnail = (
             <div class="thumbnail-container">
@@ -389,8 +397,10 @@ export class VaFileInput {
           );
         }
       }
-      let selectedFileClassName = headless ? "headless-selected-files-wrapper" : "selected-files-wrapper"
-      const hintClass = "usa-hint" + (headless ? " usa-sr-only" : "")
+      let selectedFileClassName = headless
+        ? 'headless-selected-files-wrapper'
+        : 'selected-files-wrapper';
+      const hintClass = 'usa-hint' + (headless ? ' usa-sr-only' : '');
       return (
         <Host class={{ 'has-error': !!displayError }}>
           <span class={{ 'usa-sr-only': !!headless }}>
@@ -426,7 +436,11 @@ export class VaFileInput {
                     </Fragment>
                   )}
                 </span>
-                <div class='usa-sr-only' aria-live="polite" id="statusMessage"></div>
+                <div
+                  class="usa-sr-only"
+                  aria-live="polite"
+                  id="statusMessage"
+                ></div>
                 <div class={fileInputTargetClasses}>
                   <div class="file-input-box"></div>
                   <div class="file-input-instructions">
@@ -442,10 +456,14 @@ export class VaFileInput {
             )}
             {uploadStatus !== 'idle' && (
               <div class={selectedFileClassName}>
-                {!headless &&
+                {!headless && (
                   <div class="selected-files-label">Selected files</div>
-                }
-                <div class='usa-sr-only' aria-live="polite" id="statusMessage"></div>
+                )}
+                <div
+                  class="usa-sr-only"
+                  aria-live="polite"
+                  id="statusMessage"
+                ></div>
                 <va-card class="va-card">
                   <div class="file-info-section">
                     {fileThumbnail}
@@ -454,8 +472,12 @@ export class VaFileInput {
                       <span id="input-error-message" role="alert">
                         {displayError && (
                           <Fragment>
-                            <span class="usa-sr-only">{i18next.t('error')}</span>
-                            <span class="usa-error-message">{displayError}</span>
+                            <span class="usa-sr-only">
+                              {i18next.t('error')}
+                            </span>
+                            <span class="usa-error-message">
+                              {displayError}
+                            </span>
                           </Fragment>
                         )}
                       </span>
@@ -482,15 +504,16 @@ export class VaFileInput {
                         ></va-button-icon>
                       </div>
                       <va-modal
-                        modalTitle='Delete this file?'
+                        modalTitle="Delete this file?"
                         visible={this.showModal}
-                        primaryButtonText='Yes, remove this'
-                        secondaryButtonText='No, keep this'
+                        primaryButtonText="Yes, remove this"
+                        secondaryButtonText="No, keep this"
                         onCloseEvent={this.closeModal}
                         onPrimaryButtonClick={() => this.removeFile(true)}
                         onSecondaryButtonClick={this.closeModal}
                       >
-                        We'll remove the uploaded document <span class="file-label">{file.name}</span>
+                        We'll remove the uploaded document{' '}
+                        <span class="file-label">{file.name}</span>
                       </va-modal>
                     </div>
                   )}

--- a/packages/web-components/src/components/va-header-minimal/va-header-minimal.tsx
+++ b/packages/web-components/src/components/va-header-minimal/va-header-minimal.tsx
@@ -44,8 +44,10 @@ export class VaHeaderMinimal {
   }
 
   // Redirects focus back to the modal, if the modal is open/visible
-  private trapFocus() {
-    const modal = this.el?.shadowRoot.querySelector('va-crisis-line-modal').shadowRoot.querySelector('va-modal');
+  private trapFocus(): void {
+    const modal = this.el?.shadowRoot
+      .querySelector('va-crisis-line-modal')
+      .shadowRoot.querySelector('va-modal');
     const modalVisible = modal?.getAttribute('visible');
 
     if (modalVisible !== null && modalVisible !== 'false') {
@@ -70,15 +72,25 @@ export class VaHeaderMinimal {
         <va-crisis-line-modal />
         <div onFocusin={() => this.trapFocus()} class="va-header">
           <a href="/" title="Go to VA.gov" class="va-logo-link">
-            <img class="va-logo" src={vaSeal} alt="VA logo and Seal, U.S. Department of Veterans Affairs" />
+            <img
+              class="va-logo"
+              src={vaSeal}
+              alt="VA logo and Seal, U.S. Department of Veterans Affairs"
+            />
           </a>
           <div class="header-container">
-            
-            {!disableHeadings ? <h1>{header}</h1> : <div class="header">{header}</div>}
-
-            {subheader && (
-              !disableHeadings ? <h2>{subheader}</h2> : <div class="subheader">{subheader}</div>
+            {!disableHeadings ? (
+              <h1>{header}</h1>
+            ) : (
+              <div class="header">{header}</div>
             )}
+
+            {subheader &&
+              (!disableHeadings ? (
+                <h2>{subheader}</h2>
+              ) : (
+                <div class="subheader">{subheader}</div>
+              ))}
           </div>
         </div>
       </Host>

--- a/packages/web-components/src/components/va-link-action/va-link-action.tsx
+++ b/packages/web-components/src/components/va-link-action/va-link-action.tsx
@@ -1,4 +1,13 @@
-import { Component, Event, EventEmitter, Host, h, Prop, State, Watch } from '@stencil/core';
+import {
+  Component,
+  Event,
+  EventEmitter,
+  Host,
+  h,
+  Prop,
+  State,
+  Watch,
+} from '@stencil/core';
 import classNames from 'classnames';
 
 /**
@@ -37,8 +46,8 @@ export class VaLinkAction {
    * The type of the link, which determines its style.
    * Can be 'primary', 'secondary', or 'reverse'.
    */
-  @Prop() type: "primary" | "secondary" | "reverse" = "primary";
-  
+  @Prop() type: 'primary' | 'secondary' | 'reverse' = 'primary';
+
   @State() isSingleLine: boolean = true;
 
   /**
@@ -74,7 +83,7 @@ export class VaLinkAction {
   }
 
   @Watch('text')
-  checkTextLines() {
+  checkTextLines(): void {
     if (this.linkRef) {
       const computedStyle = getComputedStyle(this.linkRef);
       const lineHeight = parseFloat(computedStyle.lineHeight);
@@ -84,30 +93,32 @@ export class VaLinkAction {
   }
 
   render() {
-    const {
-      handleClick,
-      href,
-      text,
-      messageAriaDescribedby,
-      type
-    } = this;
+    const { handleClick, href, text, messageAriaDescribedby, type } = this;
 
     const linkClass = classNames({
       'va-link--reverse': type === 'reverse',
       'va-link--primary': type === 'primary',
-      'va-link--secondary': type === 'secondary'
+      'va-link--secondary': type === 'secondary',
     });
 
     // eslint-disable-next-line i18next/no-literal-string
     const iconClass = classNames('link-icon--left', 'link-icon', {
-      'link-icon--reverse': type === 'reverse'
+      'link-icon--reverse': type === 'reverse',
     });
 
-    const ariaDescribedbyIds = messageAriaDescribedby ? 'link-description' : null;
+    const ariaDescribedbyIds = messageAriaDescribedby
+      ? 'link-description'
+      : null;
 
     return (
       <Host>
-        <a href={href} class={linkClass} aria-describedby={ariaDescribedbyIds} onClick={handleClick} ref={el => this.linkRef = el as HTMLElement}>
+        <a
+          href={href}
+          class={linkClass}
+          aria-describedby={ariaDescribedbyIds}
+          onClick={handleClick}
+          ref={el => (this.linkRef = el as HTMLElement)}
+        >
           <va-icon class={iconClass} icon="chevron_right" size={3}></va-icon>
           <span class="link-text">{text}</span>
         </a>

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -77,7 +77,7 @@ export class VaLink {
    * If 'true', will represent the link with white text instead of blue.
    */
   @Prop() reverse?: boolean = false;
- 
+
   /**
    * Adds an aria-label attribute to the link element.
    */
@@ -119,7 +119,7 @@ export class VaLink {
     }
   };
 
-  private getAbbreviationTitle = () => {
+  private getAbbreviationTitle = (): string => {
     const { abbrTitle, filetype } = this;
     if (filetype === 'PDF') return 'Portable Document Format';
     return abbrTitle;
@@ -141,19 +141,24 @@ export class VaLink {
       video,
       reverse,
       iconName,
-      iconSize
+      iconSize,
     } = this;
 
     const linkClass = classNames({
       'va-link--reverse': reverse,
-      'link--center': iconName
+      'link--center': iconName,
     });
 
     // Active link variant
     if (active) {
       return (
         <Host>
-          <a href={href} class={linkClass} onClick={handleClick} aria-label={this.label}>
+          <a
+            href={href}
+            class={linkClass}
+            onClick={handleClick}
+            aria-label={this.label}
+          >
             {text}
             <va-icon class="link-icon--active" icon="chevron_right"></va-icon>
           </a>
@@ -224,11 +229,7 @@ export class VaLink {
     if (iconName) {
       return (
         <Host>
-          <a
-            href={href}
-            class={linkClass}
-            onClick={handleClick}
-          >
+          <a href={href} class={linkClass} onClick={handleClick}>
             <va-icon icon={iconName} size={iconSize} part="icon"></va-icon>
             {text}
           </a>
@@ -239,7 +240,12 @@ export class VaLink {
     // Default
     return (
       <Host>
-        <a href={href} class={linkClass} onClick={handleClick} aria-label={this.label}>
+        <a
+          href={href}
+          class={linkClass}
+          onClick={handleClick}
+          aria-label={this.label}
+        >
           {text}
         </a>
       </Host>

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -16,6 +16,7 @@ const maxMonths = 12;
 const minMonths = 1;
 const minDays = 1;
 
+/*eslint-disable i18next/no-literal-string */
 export const months = [
   { label: 'January', value: 1 },
   { label: 'February', value: 2 },
@@ -32,7 +33,7 @@ export const months = [
 ];
 
 /* eslint-disable i18next/no-literal-string */
-const twentyNineDays = [
+const twentyNineDays: string[] = [
   '1',
   '2',
   '3',
@@ -63,7 +64,7 @@ const twentyNineDays = [
   '28',
   '29',
 ];
-const thirtyDays = [
+const thirtyDays: string[] = [
   '1',
   '2',
   '3',
@@ -95,7 +96,7 @@ const thirtyDays = [
   '29',
   '30',
 ];
-const thirtyOneDays = [
+const thirtyOneDays: string[] = [
   '1',
   '2',
   '3',
@@ -148,12 +149,12 @@ export const days = {
  * Return true if the year is a leap year.
  * (Exported for testing purposes)
  */
-export function checkLeapYear(year: number) {
+export function checkLeapYear(year: number): boolean {
   //three conditions to find out the leap year
   return (0 == year % 4 && 0 != year % 100) || 0 == year % 400;
 }
 
-export const internalErrors = [
+export const internalErrors: string[] = [
   'year-range',
   'day-range',
   'month-range',

--- a/packages/web-components/src/utils/utils.ts
+++ b/packages/web-components/src/utils/utils.ts
@@ -142,7 +142,7 @@ export const Sanitizer = {
   },
   /* eslint-enable i18next/no-literal-string */
 
-  getEntity: function (s) {
+  getEntity: function (s: string): string {
     return Sanitizer._entities[s];
   },
 


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Some of our functions contain things like return types and parameter types while others do not. Many functions also include JSDoc annotations that include parameter types and descriptions. While this is helpful, it doesn't necessarily provide the static type checking we may want from Typescript.

For example, the `replaceName` function in our instance of the file input upgrader. While the `s` parameter is given the `String` type in its JSDoc comment, it's never assigned a type in the parameter list and defaults to `any`, which introduces a potential silent failure like this: 

![Screenshot from 2024-07-29 12-54-20](https://github.com/user-attachments/assets/beb53cb1-9064-4f9f-8bb1-0eeffc88657c)

Assigning the `s` parameter an explicit type of `string` gets us the intellisense we'd expect from the typescript server: 

![Screenshot from 2024-07-29 12-54-42](https://github.com/user-attachments/assets/71ed7d05-46e8-49ea-8e7b-7987bc18f6f8)

This pull request adds types to our function type expressions that were missing them. 
