### PR TITLE
va-breadcrumb: mobile view padding fix

### DIFF
--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.scss
@@ -61,6 +61,14 @@
   .usa-breadcrumb__list-item:not(:last-child)::after {
     background: var(--vads-color-gray-medium);
   }
+
+  @media (max-width: 29.99em) {
+    .usa-breadcrumb__list-item:nth-last-child(2) .usa-breadcrumb__link {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+  }
+
 }
 
 .usa-current a {


### PR DESCRIPTION
## Chromatic
<!-- This `2970-breadcrumb-padding-fix` is a placeholder for a CI job - it will be updated automatically -->
https://2970-breadcrumb-padding-fix--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR fixes the breadcrumb padding on mobile view.

Closes 2970

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<img width="998" alt="Screenshot 2024-08-02 at 2 00 41 PM" src="https://github.com/user-attachments/assets/69a37753-958c-40ef-a414-d903a95d7f27">


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
