### PR TITLE
va-file-input | story: replace 'Label Header' with 'Header label'

### DIFF
--- a/packages/storybook/stories/va-file-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.jsx
@@ -97,7 +97,7 @@ ErrorMessage.args = {
 export const HeaderLabel = Template.bind(null);
 HeaderLabel.args = {
   ...defaultArgs,
-  label: 'Label Header',
+  label: 'Header label',
   headerSize: 3,
   required: true
 }
@@ -113,7 +113,7 @@ const additionalFormInputsContent = (
 export const AdditionalFormInputs = Template.bind(null);
 AdditionalFormInputs.args = {
   ...defaultArgs,
-  label: 'Label Header',
+  label: 'Header label',
   children: additionalFormInputsContent
 }
 


### PR DESCRIPTION
## Chromatic
<!-- This `3080-file-input-title-case` is a placeholder for a CI job - it will be updated automatically -->
https://3080-file-input-title-case--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Replace 'Label Header' story title with 'Header Label' to avoid using title case and to be consistent with the title in the storybook example.

Closes [3080](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3080)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
Before:
![Screenshot 2024-08-02 at 1 13 24 PM](https://github.com/user-attachments/assets/34ef4a93-828d-4d81-b044-e517c06447ba)

After:
![Screenshot 2024-08-02 at 1 14 25 PM](https://github.com/user-attachments/assets/8df5fa91-821a-4fca-a291-c456c5f8eb1c)

## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
