### PR TITLE
Tool for getting codeowner team member names

### DIFF
--- a/codeowner-scan.sh
+++ b/codeowner-scan.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+RETJSON=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  /orgs/department-of-veterans-affairs/teams/$1/members)
+
+echo $RETJSON | jq '.[].id' | while read -r userid; do
+  USERINFO=$(gh api \
+    -H "Accept: application/vnd.github+json" \
+    /user/$userid)
+  USERNAME=$(echo $USERINFO | jq '.name')
+  echo $USERNAME
+done

--- a/codeowner-scan.sh
+++ b/codeowner-scan.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# Takes a codeowner team_name and provides the names of members of that team
+# Call like this: ./codeowner-scan.sh <team_name>
+# e.g. ./codeowner-scan.sh platform_design_system_team
+
+if [ $# -eq 0 ]; then
+  echo >&2 "No team name provided, please call as './codeowner-scan.sh <team_name>'"
+  exit 1
+fi
+
 RETJSON=$(gh api \
   -H "Accept: application/vnd.github+json" \
   /orgs/department-of-veterans-affairs/teams/$1/members)


### PR DESCRIPTION
## Chromatic
<!-- This `9999-codeowner-scanner-tool` is a placeholder for a CI job - it will be updated automatically -->
https://9999-codeowner-scanner-tool--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Tool that takes a codeowner team name and spits out names of that team's members.
