### PR TITLE
va-statement-of-truth: reflect error prop in va-text-input for styling

### DIFF
--- a/packages/web-components/src/components/va-statement-of-truth/va-statement-of-truth.tsx
+++ b/packages/web-components/src/components/va-statement-of-truth/va-statement-of-truth.tsx
@@ -20,9 +20,6 @@ import {
   shadow: true,
 })
 export class VaStatementOfTruth {
-  private inputField: HTMLElement;
-  private checkboxField: HTMLElement;
-
   /**
    * An optional custom header for the component
    */
@@ -110,19 +107,6 @@ export class VaStatementOfTruth {
     this.vaCheckboxChange.emit({ checked });
   };
 
-  /**
-  without this step the va-text-input and va-checkbox components will not
-  have an error attribute, which is used for styling.
-  */
-  componentDidRender() {
-    if (this.inputError) {
-      this.inputField.setAttribute('error', this.inputError);
-    }
-    if (this.checkboxError) {
-      this.checkboxField.setAttribute('error', this.checkboxError);
-    }
-  }
-
   render() {
     const {
       heading,
@@ -131,6 +115,8 @@ export class VaStatementOfTruth {
       inputMessageAriaDescribedby,
       checked,
       inputValue,
+      inputError,
+      checkboxError,
     } = this;
     return (
       <Host>
@@ -150,7 +136,6 @@ export class VaStatementOfTruth {
               <va-icon
                 class="privacy-policy-icon"
                 icon="launch"
-                size={2}
               ></va-icon>
               <span class="usa-sr-only">opens in a new window</span>
             </a>
@@ -163,9 +148,9 @@ export class VaStatementOfTruth {
             value={inputValue}
             message-aria-describedby={inputMessageAriaDescribedby}
             required
+            error={inputError}
             onInput={this.handleInputChange}
             onBlur={this.handleInputBlur}
-            ref={field => (this.inputField = field)}
           />
           <va-checkbox
             id="veteran-certify"
@@ -173,8 +158,8 @@ export class VaStatementOfTruth {
             label={checkboxLabel}
             required
             checked={checked}
+            error={checkboxError}
             onVaChange={this.handleCheckboxChange}
-            ref={field => (this.checkboxField = field)}
           />
         </article>
       </Host>

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -54,7 +54,7 @@ export class VaTextInput {
   /**
    * The error message to render.
    */
-  @Prop() error?: string;
+  @Prop({ reflect: true }) error?: string;
 
   /**
    * Whether or not to add usa-input--error as class if error message is outside of component
@@ -310,7 +310,7 @@ export class VaTextInput {
   private getInputmode(): string {
     if (this.currency) {
       return 'numeric';
-    } 
+    }
     return this.inputmode ? this.inputmode : undefined
   }
 
@@ -454,7 +454,7 @@ export class VaTextInput {
             {currency && <div id="symbol">$</div>}
             {inputPrefix && <div class="usa-input-prefix" part="input-prefix">{inputPrefix.substring(0, 25)}</div>}
             {inputIconPrefix && <div class="usa-input-prefix" part="input-prefix"><va-icon icon={inputIconPrefix} size={3} part="icon"></va-icon></div>}
-            
+
             <input
               class={inputClass}
               id="inputField"


### PR DESCRIPTION
## Chromatic
<!-- This `3065-statement-of-truth` is a placeholder for a CI job - it will be updated automatically -->
https://3065-statement-of-truth--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This update will make sure that the `error` prop is being reflected on to the `va-text-input` markup element in the DOM so that error styling will apply to it. It also cleans up the previous solution that is no longer necessary because of that update. 

This will fix error styling inconsistencies reported in the issue below.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3065

## Screenshots

<img width="1035" alt="Screenshot 2024-08-05 at 4 00 25 PM" src="https://github.com/user-attachments/assets/be4c6171-6c70-4b7d-b187-99d5f0bebf16">

<img width="814" alt="Screenshot 2024-08-05 at 4 01 03 PM" src="https://github.com/user-attachments/assets/f8fed93b-851e-464e-8fdd-3ac69bec55a8">


## QA Checklist

- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
