### PR TITLE
va-text-input: add autofill Safari documentation to storybook

### DIFF
--- a/packages/storybook/stories/va-text-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.jsx
@@ -7,6 +7,9 @@ import {
   applyFocus,
 } from './wc-helpers';
 
+import { VaTextInput } from '@department-of-veterans-affairs/web-components/react-bindings';
+
+
 const textInputDocs = getWebComponentDocs('va-text-input');
 
 export default {
@@ -336,12 +339,50 @@ ValidRange.args = {
   hint: 'The valid range is 0 to 4',
 };
 
-export const Autocomplete = Template.bind(null);
+export const Autocomplete = ({ name, label, autocomplete }) => {
+  function handleSubmit() { };
+  function handleKeyPress() { }
+  return (
+    <>
+      <form onSubmit={handleSubmit} >
+        <VaTextInput label={label} onKeyPress={handleKeyPress} name={name} autocomplete={autocomplete} />
+      </form>
+      <div className='vads-u-margin-top--2'>
+        Note: on Safari (Mac or iOS), when using "Shift + Command + A" to autofill a field,
+        no <code>input</code>&nbsp;event is fired, which means that any handler passed to <code>onInput</code> will not fire. This can result in
+        errors on form submission, because from the component's perspective the autofilled field is empty. A suggested
+        workaround is to synchronize field state with component state on submit by passing handlers
+        to <code>VaTextInput</code>&nbsp;such as:
+
+        <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
+          <code>
+            function onSubmit(e) &#x7b;<br/>
+            &nbsp;&nbsp;e.preventDefault()<br/>
+            &nbsp;&nbsp;// check if the "value" passed to VaTextInput is <br/>
+            &nbsp;&nbsp;// the same as e.target.value, <br />
+            &nbsp;&nbsp;// then proceed with submission <br />
+            &#x7d;<br/><br/>
+
+            function handleKeyPress(e) &#x7b;<br/>
+              &nbsp;&nbsp;if (e.key === 'Enter') &#x7b;<br/>
+              &nbsp;&nbsp;// the user wants to submit the form<br/>
+              &nbsp;&nbsp;// synchronize element and component state before<br/>
+              &nbsp;&nbsp;// continuing with submission<br/>
+              &nbsp;&#x7d;<br/>
+            &#x7d;<br />
+        </code>
+      </pre>
+      </div>
+    </>
+  )
+}
+
 Autocomplete.args = {
   ...defaultArgs,
   name: 'email',
   autocomplete: 'email',
-};
+  label: 'This va-text-input is configured for email autocompletion'
+}
 
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };


### PR DESCRIPTION
## Chromatic
<!-- This `va-text-input-safari-docs` is a placeholder for a CI job - it will be updated automatically -->
https://va-text-input-safari-docs--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description

This PR elaborates the storybook "autocomplete" option for `va-text-input` to explain to users the limitations with using this component with Safari autofill.

Closes [2688](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2668)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

<img width="1044" alt="Screenshot 2024-08-05 at 3 36 24 PM" src="https://github.com/user-attachments/assets/bce19120-33de-4240-8adb-121d51a54182">

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
