### PR TITLE
va-file-input-multiple: add deleted file info to event payload

### DIFF
--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -135,7 +135,7 @@ export class VaFileInputMultiple {
    */
   private handleChange(event: any, fileKey: number, pageIndex: number) {
     const newFile = event.detail.files[0];
-
+    let deletedFile = null;
     if (newFile) {
       const fileObject = this.findFileByKey(fileKey);
 
@@ -155,7 +155,7 @@ export class VaFileInputMultiple {
       }
     } else {
       // Deleted file
-      this.files.splice(pageIndex, 1);
+      [{ file: deletedFile }] = this.files.splice(pageIndex, 1);
       const statusMessageDiv = this.el.shadowRoot.querySelector("#statusMessage");
       // empty status message so it is read when updated
       statusMessageDiv.textContent = ""
@@ -164,7 +164,7 @@ export class VaFileInputMultiple {
       }, 1000);
     }
 
-    this.vaMultipleChange.emit({ files: this.files.map(fileObj => fileObj.file) });
+    this.vaMultipleChange.emit({ files: this.files.map(fileObj => fileObj.file), deletedFile });
     this.files = Array.of(...this.files);
   }
 


### PR DESCRIPTION
## Chromatic
<!-- This `3031-file-input-multiple-event` is a placeholder for a CI job - it will be updated automatically -->
https://3031-file-input-multiple-event--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
This PR adds information of a deleted file to an event payload so that application code can more easily keep track of which files are ready for upload and which have been deleted. The deletedFile value will be `null` if no file was deleted or a `File` if a file was deleted.

Closes [3031](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3031)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

Event payload after adding second of two files. `deletedFile` is `null`
<img width="677" alt="Screenshot 2024-08-05 at 5 31 50 PM" src="https://github.com/user-attachments/assets/a51f09a5-7ec5-4a9c-b2a0-48965ec69788">

Event payload after deleting second file: `deletedFile` contains information on deleted file

<img width="628" alt="Screenshot 2024-08-05 at 5 32 59 PM" src="https://github.com/user-attachments/assets/de87b707-2848-4321-969b-10de0983885c">



## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
