### PR TITLE
fix: file input action buttons accessibility

### DIFF
--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -474,10 +474,12 @@ export class VaFileInput {
                           buttonType="change-file"
                           onClick={this.changeFile}
                           label="Change file"
+                          aria-label={'change file ' + file.name}
                         ></va-button-icon>
                         <va-button-icon
                           buttonType="delete"
                           onClick={this.openModal}
+                          aria-label={'delete file ' + file.name}
                           label="Delete"
                         ></va-button-icon>
                       </div>


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
This PR adds ARIA labels to the action buttons(Change and Delete) for the file input component.
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3083

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<img width="859" alt="Screenshot 2024-08-06 at 3 56 29 PM" src="https://github.com/user-attachments/assets/9330b72e-b7d7-44b8-a785-e70b7b401413">


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
