### PR TITLE
va-modal: fix focus state bug when va-radio-option is in modal contents

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -155,7 +155,7 @@ export namespace Components {
     }
     interface VaBreadcrumbs {
         /**
-          * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`. This prop is available when `uswds` is set to `true`.
+          * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`.
          */
         "breadcrumbList"?: Breadcrumb[] | string;
         /**
@@ -171,7 +171,7 @@ export namespace Components {
          */
         "label"?: string;
         /**
-          * Whether or not the component will wrap the breadcrumbs. This prop is available when `uswds` is set to `true`.
+          * Whether or not the component will wrap the breadcrumbs.
          */
         "wrapping"?: boolean;
     }
@@ -2234,7 +2234,7 @@ declare namespace LocalJSX {
     }
     interface VaBreadcrumbs {
         /**
-          * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`. This prop is available when `uswds` is set to `true`.
+          * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`.
          */
         "breadcrumbList"?: Breadcrumb[] | string;
         /**
@@ -2254,11 +2254,11 @@ declare namespace LocalJSX {
          */
         "onComponent-library-analytics"?: (event: VaBreadcrumbsCustomEvent<any>) => void;
         /**
-          * Fires when user clicks on breadcrumb anchor tag. Has no effect unless uswds is true and the href of anchor tag is part of breadcrumb object that also has isRouterLink: true
+          * Fires when user clicks on breadcrumb anchor tag. Has no effect unless the href of anchor tag is part of breadcrumb object that also has isRouterLink: true
          */
         "onRouteChange"?: (event: VaBreadcrumbsCustomEvent<{ href: string }>) => void;
         /**
-          * Whether or not the component will wrap the breadcrumbs. This prop is available when `uswds` is set to `true`.
+          * Whether or not the component will wrap the breadcrumbs.
          */
         "wrapping"?: boolean;
     }

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -306,7 +306,6 @@ export class VaModal {
     const actionButtons = Array.from(
       this.alertActions?.querySelectorAll(focusableQueryString) || [],
     );
-
     // maintain tab order
     return [
       this.closeButton, // close button first
@@ -317,15 +316,23 @@ export class VaModal {
       if (elm && (elm.offsetWidth || elm.offsetHeight)) {
         // hydrated class likely on web components
         if (elm.classList.contains('hydrated')) {
-          const shadowElms = Array.from(
-            elm.shadowRoot.querySelectorAll(focusableQueryString) || [],
-          );
-          if (shadowElms.length) {
+          let focusElms = [];
+          // va-radio-option does not have a shadow root, but should still be included in the focusable elements
+          if (elm.shadowRoot) {
+            focusElms = Array.from(
+              elm.shadowRoot.querySelectorAll(focusableQueryString) || [],
+            );
+          } else {
+            focusElms = Array.from(
+              elm.querySelectorAll(focusableQueryString) || [],
+            );
+          }
+          if (focusElms.length) {
             // add the web component and focusable shadow elements
             // document.activeElement targets the web component but the event
             // is composed, so crosses shadow DOM and shows up in composedPath
             focusableElms.push(elm);
-            return focusableElms.concat(shadowElms);
+            return focusableElms.concat(focusElms);
           }
         } else {
           focusableElms.push(elm);

--- a/packages/web-components/src/utils/modal.ts
+++ b/packages/web-components/src/utils/modal.ts
@@ -7,7 +7,7 @@
  */
  export const focusableQueryString = [
   'a[href]:not([tabindex^="-"])',
-  '.hydrated:not([tabindex^="-"])',
+  '.hydrated:not([tabindex^="-"]):not(va-radio-option)', // This was selecting the component wrapper for va-radio-option, we only want to select the input
   '[tabindex]:not([tabindex^="-"])',
   'input:not([type=hidden]):not([tabindex^="-"])',
   'textarea:not([tabindex^="-"])',


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
A bug was found in va-modal where focus was not working as expected when using the keyboard to navigate. A JS error was also being thrown when the modal was activated. Both of these were caused when va-radio-option was included in the contents of the modal. va-radio-option does not utilize the shadow-dom, which caused issues in the modal focus logic.

Closes [3161](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3161)

## QA Checklist
- [x ] Component maintains 1:1 parity with design mocks
- [x ] Text is consistent with what's been provided in the mocks
- [x ] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x ] Tab order and focus state work as expected
- [x ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes

## Acceptance criteria
- [x ] QA checklist has been completed
- [x ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
