### PR TITLE
va-back-to-top: set display none to link when it should not be visible

### DIFF
--- a/packages/storybook/stories/va-back-to-top.stories.jsx
+++ b/packages/storybook/stories/va-back-to-top.stories.jsx
@@ -6,6 +6,7 @@ const bttDocs = getWebComponentDocs('va-back-to-top');
 export default {
   title: 'Components/Back to top',
   id: 'components/va-back-to-top',
+  displayAmount: 10,
   parameters: {
     componentSubtitle: 'va-back-to-top web component',
     docs: {
@@ -16,13 +17,15 @@ export default {
 
 const defaultArgs = {};
 
-const Template = (defaultArgs) => {
+const Template = ({
+  displayAmount
+}) => {
   return (
     <>
       <div className="usa-grid usa-grid-full">
         <div className="usa-width-three-fourths">
           <h1>The top</h1>
-          {[...Array(10)].map(i => (
+          {[...Array(displayAmount)].map(i => (
             <div
               key={i}
               style={{
@@ -34,6 +37,7 @@ const Template = (defaultArgs) => {
                 justifyContent: 'center',
               }}
             >
+              <a href="">Link</a>
               Scroll down
             </div>
           ))}
@@ -56,4 +60,15 @@ const Template = (defaultArgs) => {
 };
 
 export const Default = Template.bind(null);
+Default.args = {
+  ...defaultArgs,
+  displayAmount: 10
+}
+Default.argTypes = propStructure(bttDocs);
+
+export const ShortExample = Template.bind(null);
+ShortExample.args = {
+  ...defaultArgs,
+  displayAmount: 2
+}
 Default.argTypes = propStructure(bttDocs);

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.css
@@ -56,7 +56,13 @@ a:not([disabled]):hover {
   color: var(--vads-color-primary-darker);
   outline: none;
 }
+
+div a {
+  display: none;
+}
+  
 div.reveal a {
+  display: inherit;
   border-bottom-left-radius: 5px;
   border-top-left-radius: 5px;
   text-decoration: none;

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
@@ -87,7 +87,7 @@ export class VaBackToTop {
           <div
             class={classnames({ docked: this.isDocked, reveal: this.revealed })}
           >
-            <a href="#ds-back-to-top" onClick={this.navigateToTop.bind(this)} aria-hidden={`${!this.revealed}`}>
+            <a href="#ds-back-to-top" onClick={this.navigateToTop.bind(this)}>
               <span>
                 <va-icon icon="arrow_upward" size={3}></va-icon>
                 <span class="sr-only">Back to top</span>{' '}

--- a/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
+++ b/packages/web-components/src/components/va-back-to-top/va-back-to-top.tsx
@@ -87,7 +87,7 @@ export class VaBackToTop {
           <div
             class={classnames({ docked: this.isDocked, reveal: this.revealed })}
           >
-            <a href="#ds-back-to-top" onClick={this.navigateToTop.bind(this)}>
+            <a href="#ds-back-to-top" onClick={this.navigateToTop.bind(this)} aria-hidden={`${!this.revealed}`}>
               <span>
                 <va-icon icon="arrow_upward" size={3}></va-icon>
                 <span class="sr-only">Back to top</span>{' '}


### PR DESCRIPTION
## Chromatic
<!-- This `3162-back-to-top-sr-bug` is a placeholder for a CI job - it will be updated automatically -->
https://3162-back-to-top-sr-bug--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Screen readers were still reading and focusing on the link even when it was hidden. This change to set the display to none when the link is not revealed fixes this issue.

Closes [3162](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3162)

## QA Checklist
- [x ] Component maintains 1:1 parity with design mocks
- [x ] Text is consistent with what's been provided in the mocks
- [x ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x ] Tab order and focus state work as expected
- [x ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes

## Acceptance criteria
- [x ] QA checklist has been completed
- [x ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x ] Documentation has been updated, if applicable
- [x ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
