### PR TITLE
va-segmented-progress-bar: v1 variation code removal

### DIFF
--- a/packages/storybook/stories/va-back-to-top.stories.jsx
+++ b/packages/storybook/stories/va-back-to-top.stories.jsx
@@ -37,7 +37,6 @@ const Template = ({
                 justifyContent: 'center',
               }}
             >
-              <a href="">Link</a>
               Scroll down
             </div>
           ))}

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -155,7 +155,7 @@ export namespace Components {
     }
     interface VaBreadcrumbs {
         /**
-          * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`. This prop is available when `uswds` is set to `true`.
+          * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`.
          */
         "breadcrumbList"?: Breadcrumb[] | string;
         /**
@@ -171,7 +171,7 @@ export namespace Components {
          */
         "label"?: string;
         /**
-          * Whether or not the component will wrap the breadcrumbs. This prop is available when `uswds` is set to `true`.
+          * Whether or not the component will wrap the breadcrumbs.
          */
         "wrapping"?: boolean;
     }
@@ -1170,10 +1170,6 @@ export namespace Components {
           * When true, this makes the segmented-progress-bar use a div instead of a heading (v3 only)
          */
         "useDiv"?: boolean;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaSelect {
         /**
@@ -2238,7 +2234,7 @@ declare namespace LocalJSX {
     }
     interface VaBreadcrumbs {
         /**
-          * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`. This prop is available when `uswds` is set to `true`.
+          * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`.
          */
         "breadcrumbList"?: Breadcrumb[] | string;
         /**
@@ -2258,11 +2254,11 @@ declare namespace LocalJSX {
          */
         "onComponent-library-analytics"?: (event: VaBreadcrumbsCustomEvent<any>) => void;
         /**
-          * Fires when user clicks on breadcrumb anchor tag. Has no effect unless uswds is true and the href of anchor tag is part of breadcrumb object that also has isRouterLink: true
+          * Fires when user clicks on breadcrumb anchor tag. Has no effect unless the href of anchor tag is part of breadcrumb object that also has isRouterLink: true
          */
         "onRouteChange"?: (event: VaBreadcrumbsCustomEvent<{ href: string }>) => void;
         /**
-          * Whether or not the component will wrap the breadcrumbs. This prop is available when `uswds` is set to `true`.
+          * Whether or not the component will wrap the breadcrumbs.
          */
         "wrapping"?: boolean;
     }
@@ -3433,10 +3429,6 @@ declare namespace LocalJSX {
           * When true, this makes the segmented-progress-bar use a div instead of a heading (v3 only)
          */
         "useDiv"?: boolean;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaSelect {
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1127,11 +1127,11 @@ export namespace Components {
     }
     interface VaSegmentedProgressBar {
         /**
-          * Whether or not to center the step labels (v3 only)
+          * Whether or not to center the step labels
          */
         "centeredLabels"?: boolean;
         /**
-          * Show number counters for each step (v3 only)
+          * Show number counters for each step
          */
         "counters"?: "default" | "small";
         /**
@@ -1143,11 +1143,11 @@ export namespace Components {
          */
         "enableAnalytics"?: boolean;
         /**
-          * Header level for button wrapper. Must be between 1 and 6 (v3 only)
+          * Header level for button wrapper. Must be between 1 and 6
          */
         "headerLevel"?: number;
         /**
-          * Text of current step (v3 only)
+          * Text of current step
          */
         "headingText"?: string;
         /**
@@ -1155,7 +1155,7 @@ export namespace Components {
          */
         "label"?: string;
         /**
-          * String containing a list of step labels delimited by a semi-colon (v3 only) Example: `"Step 1;Step 2;Step 3"`
+          * String containing a list of step labels delimited by a semi-colon. Example: `"Step 1;Step 2;Step 3"`
          */
         "labels"?: string;
         /**
@@ -1167,7 +1167,7 @@ export namespace Components {
          */
         "total": number;
         /**
-          * When true, this makes the segmented-progress-bar use a div instead of a heading (v3 only)
+          * When true, this makes the segmented-progress-bar use a div instead of a heading
          */
         "useDiv"?: boolean;
     }
@@ -3382,11 +3382,11 @@ declare namespace LocalJSX {
     }
     interface VaSegmentedProgressBar {
         /**
-          * Whether or not to center the step labels (v3 only)
+          * Whether or not to center the step labels
          */
         "centeredLabels"?: boolean;
         /**
-          * Show number counters for each step (v3 only)
+          * Show number counters for each step
          */
         "counters"?: "default" | "small";
         /**
@@ -3398,11 +3398,11 @@ declare namespace LocalJSX {
          */
         "enableAnalytics"?: boolean;
         /**
-          * Header level for button wrapper. Must be between 1 and 6 (v3 only)
+          * Header level for button wrapper. Must be between 1 and 6
          */
         "headerLevel"?: number;
         /**
-          * Text of current step (v3 only)
+          * Text of current step
          */
         "headingText"?: string;
         /**
@@ -3410,7 +3410,7 @@ declare namespace LocalJSX {
          */
         "label"?: string;
         /**
-          * String containing a list of step labels delimited by a semi-colon (v3 only) Example: `"Step 1;Step 2;Step 3"`
+          * String containing a list of step labels delimited by a semi-colon. Example: `"Step 1;Step 2;Step 3"`
          */
         "labels"?: string;
         /**
@@ -3426,7 +3426,7 @@ declare namespace LocalJSX {
          */
         "total": number;
         /**
-          * When true, this makes the segmented-progress-bar use a div instead of a heading (v3 only)
+          * When true, this makes the segmented-progress-bar use a div instead of a heading
          */
         "useDiv"?: boolean;
     }

--- a/packages/web-components/src/components/va-segmented-progress-bar/test/va-segmented-progress-bar.e2e.ts
+++ b/packages/web-components/src/components/va-segmented-progress-bar/test/va-segmented-progress-bar.e2e.ts
@@ -1,92 +1,8 @@
 import { newE2EPage } from '@stencil/core/testing';
 import { axeCheck } from '../../../testing/test-helpers';
 
-describe('v1 va-segmented-progress-bar', () => {
+describe('va-segmented-progress-bar', () => {
   it('renders', async () => {
-    const page = await newE2EPage({
-      html: '<va-segmented-progress-bar current="3" total="6" uswds="false"></va-segmented-progress-bar>',
-    });
-    const element = await page.find('va-segmented-progress-bar');
-    expect(element).toEqualHtml(`
-      <va-segmented-progress-bar class="hydrated" current="3" total="6" uswds="false">
-        <mock:shadow-root>
-          <div>
-            <div
-              class="progress-bar-segmented"
-              role="progressbar"
-              aria-valuenow="3"
-              aria-valuemin="0"
-              aria-valuemax="6"
-              aria-valuetext="Step 3 of 6"
-              aria-label="Step 3 of 6"
-            >
-              <div class="progress-segment progress-segment-complete"></div>
-              <div class="progress-segment progress-segment-complete"></div>
-              <div class="progress-segment progress-segment-complete"></div>
-              <div class="progress-segment"></div>
-              <div class="progress-segment"></div>
-              <div class="progress-segment"></div>
-            </div>
-          </div>
-        </mock:shadow-root>
-      </va-segmented-progress-bar>
-    `);
-  });
-
-  it('passes an axe check', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-segmented-progress-bar current="3" total="6" uswds="false"></va-segmented-progress-bar>',
-    );
-    await axeCheck(page);
-  });
-
-  it('it should update the aria label based on changed ariaLabel prop', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-segmented-progress-bar current="3" total="6" label="E2E Test" uswds="false"></va-segmented-progress-bar>',
-    );
-    const label = await page.find(
-      'va-segmented-progress-bar >>> div.progress-bar-segmented',
-    );
-    expect(label.getAttribute('aria-label')).toContain('E2E Test');
-  });
-
-  it('fires an analytics event when the component is mounted', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-segmented-progress-bar enable-analytics uswds="false"></va-segmented-progress-bar>',
-    );
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-    await page.$eval('va-segmented-progress-bar', (element: any) => {
-      element.current = 3;
-      element.total = 6;
-    });
-    await page.waitForChanges();
-    expect(analyticsSpy).toHaveReceivedEventDetail({
-      action: 'change',
-      componentName: 'va-segmented-progress-bar',
-      details: {
-        current: 3,
-        total: 6,
-      },
-    });
-  });
-
-  it("doesn't fire an analytics event when enable-analytics is false", async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-segmented-progress-bar current="3" total="6" aria-label="E2E Test" uswds="false"></va-segmented-progress-bar>',
-    );
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-    expect(analyticsSpy).not.toHaveReceivedEvent();
-  });
-});
-
-
-
-describe('v3 va-segmented-progress-bar', () => {
-  it('uswds - renders', async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6"></va-segmented-progress-bar>',
     });
@@ -125,7 +41,7 @@ describe('v3 va-segmented-progress-bar', () => {
     `);
   });
 
-  it('uswds - passes an axe check', async () => {
+  it('passes an axe check', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-segmented-progress-bar current="3" total="6"></va-segmented-progress-bar>',
@@ -133,7 +49,7 @@ describe('v3 va-segmented-progress-bar', () => {
     await axeCheck(page);
   });
 
-  it('uswds - fires an analytics event when the component is mounted', async () => {
+  it('fires an analytics event when the component is mounted', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-segmented-progress-bar enable-analytics></va-segmented-progress-bar>',
@@ -154,7 +70,7 @@ describe('v3 va-segmented-progress-bar', () => {
     });
   });
 
-  it("uswds - doesn't fire an analytics event when enable-analytics is false", async () => {
+  it("doesn't fire an analytics event when enable-analytics is false", async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-segmented-progress-bar current="3" total="6" aria-label="E2E Test"></va-segmented-progress-bar>',
@@ -163,7 +79,7 @@ describe('v3 va-segmented-progress-bar', () => {
     expect(analyticsSpy).not.toHaveReceivedEvent();
   });
 
-  it("uswds - should render heading-text when labels are not provided", async () => {
+  it("should render heading-text when labels are not provided", async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6" heading-text="My Header"></va-segmented-progress-bar>',
     });
@@ -172,7 +88,7 @@ describe('v3 va-segmented-progress-bar', () => {
     expect(headerElement.innerHTML).toEqual("My Header");
   })
 
-  it("uswds - should render label text for header when labels are provided", async () => {
+  it("should render label text for header when labels are provided", async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6" heading-text="My Header" labels="Personal Information;Household Status;Supporting Documents;Signature;Review and Submit"></va-segmented-progress-bar>',
     });
@@ -181,7 +97,7 @@ describe('v3 va-segmented-progress-bar', () => {
     expect(headerElement.innerHTML).toEqual("Supporting Documents");
   })
 
-  it("uswds - should render labels when labels are provided", async () => {
+  it("should render labels when labels are provided", async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6" heading-text="My Header" labels="Personal Information;Household Status;Supporting Documents;Signature;Review and Submit"></va-segmented-progress-bar>',
     });
@@ -190,7 +106,7 @@ describe('v3 va-segmented-progress-bar', () => {
     expect(segments.querySelectorAll('.usa-step-indicator__segment-label').length).toBe(6);
   })
 
-  it("uswds - should render counter numbers when counters = 'default'", async () => {
+  it("should render counter numbers when counters = 'default'", async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6" labels="Personal Information;Household Status;Supporting Documents;Signature;Review and Submit" counters="default"></va-segmented-progress-bar>',
     });
@@ -199,7 +115,7 @@ describe('v3 va-segmented-progress-bar', () => {
     expect(indicator.classList.contains('usa-step-indicator--counters')).toBe(true);
   })
 
-  it("uswds - should render counter numbers when counters = 'small'", async () => {
+  it("should render counter numbers when counters = 'small'", async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6" labels="Personal Information;Household Status;Supporting Documents;Signature;Review and Submit" counters="small"></va-segmented-progress-bar>',
     });
@@ -208,7 +124,7 @@ describe('v3 va-segmented-progress-bar', () => {
     expect(indicator.classList.contains('usa-step-indicator--counters-sm')).toBe(true);
   })
 
-  it("uswds - should render centered labels when 'centered-labels' is true", async () => {
+  it("should render centered labels when 'centered-labels' is true", async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6" centered-labels="true" labels="Personal Information;Household Status;Supporting Documents;Signature;Review and Submit"></va-segmented-progress-bar>',
     });
@@ -217,7 +133,7 @@ describe('v3 va-segmented-progress-bar', () => {
     expect(indicator.classList.contains('usa-step-indicator--center')).toBe(true);
   })
 
-  it("uswds - should render correct header level when prop defined", async () => {
+  it("should render correct header level when prop defined", async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6" centered-labels="true" labels="Personal Information;Household Status;Supporting Documents;Signature;Review and Submit" header-level="2"></va-segmented-progress-bar>',
     });
@@ -226,7 +142,7 @@ describe('v3 va-segmented-progress-bar', () => {
     expect(header.tagName).toBe('H2');
   })
 
-  it("uswds - should render correct progress text", async () => {
+  it("should render correct progress text", async () => {
     const page = await newE2EPage({
       html: '<va-segmented-progress-bar current="3" total="6" centered-labels="true" labels="Personal Information;Household Status;Supporting Documents;Signature;Review and Submit" progress-term="Chapter"></va-segmented-progress-bar>',
     });

--- a/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.scss
+++ b/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.scss
@@ -8,31 +8,3 @@
 *, ::after, ::before {
   box-sizing: border-box;
 }
-
-/** V1 Styles **/
-
-.progress-bar-segmented {
-  display: flex;
-  width: 100%;
-  height: 6px;
-}
-
-.progress-segment {
-  content: '&nbsp;';
-  flex: 1;
-  margin-left: 2px;
-  margin-right: 2px;
-  background-color: var(--vads-color-base-lighter);
-}
-
-.progress-segment:first-child {
-  margin-left: 0;
-}
-
-.progress-segment:last-child {
-  margin-right: 0;
-}
-
-.progress-segment-complete {
-  background-color: var(--vads-color-primary);
-}

--- a/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
+++ b/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
@@ -35,7 +35,7 @@ export class VaSegmentedProgressBar {
   @Prop() label?: string;
 
   /**
-  * Header level for button wrapper. Must be between 1 and 6 (v3 only)
+  * Header level for button wrapper. Must be between 1 and 6
   */
   @Prop() headerLevel?: number = 4;
 
@@ -45,27 +45,27 @@ export class VaSegmentedProgressBar {
   @Prop() progressTerm?: string = 'Step';
 
   /**
-  * String containing a list of step labels delimited by a semi-colon (v3 only) Example: `"Step 1;Step 2;Step 3"`
+  * String containing a list of step labels delimited by a semi-colon. Example: `"Step 1;Step 2;Step 3"`
   */
   @Prop() labels?: string;
 
   /**
-  * Whether or not to center the step labels (v3 only)
+  * Whether or not to center the step labels
   */
   @Prop() centeredLabels?: boolean;
 
   /**
-  * Show number counters for each step (v3 only)
+  * Show number counters for each step
   */
   @Prop() counters?: "default" | "small";
 
   /**
-  * Text of current step (v3 only)
+  * Text of current step
   */
   @Prop() headingText?: string;
 
   /**
-   * When true, this makes the segmented-progress-bar use a div instead of a heading (v3 only)
+   * When true, this makes the segmented-progress-bar use a div instead of a heading
    */
   @Prop() useDiv?: boolean;
 

--- a/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
+++ b/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx
@@ -35,11 +35,6 @@ export class VaSegmentedProgressBar {
   @Prop() label?: string;
 
   /**
-  * Whether or not the component will use USWDS v3 styling.
-  */
-  @Prop() uswds?: boolean = true;
-
-  /**
   * Header level for button wrapper. Must be between 1 and 6 (v3 only)
   */
   @Prop() headerLevel?: number = 4;
@@ -102,8 +97,6 @@ export class VaSegmentedProgressBar {
     const {
       current,
       total,
-      label = `Step ${current} of ${total}`,
-      uswds,
       labels,
       centeredLabels,
       counters,
@@ -118,86 +111,59 @@ export class VaSegmentedProgressBar {
     }
     const range = Array.from({ length: total }, (_, i) => i);
 
-    if (uswds) {
 
-      // eslint-disable-next-line i18next/no-literal-string
-      const Tag = useDiv ? `div` : `h${headerLevel}`;
+    // eslint-disable-next-line i18next/no-literal-string
+    const Tag = useDiv ? `div` : `h${headerLevel}`;
 
-      const indicatorClass = classNames({
-        'usa-step-indicator': true,
-        'usa-step-indicator--center': centeredLabels,
-        'usa-step-indicator--counters': counters === 'default',
-        'usa-step-indicator--counters-sm': counters === 'small'
-      })
+    const indicatorClass = classNames({
+      'usa-step-indicator': true,
+      'usa-step-indicator--center': centeredLabels,
+      'usa-step-indicator--counters': counters === 'default',
+      'usa-step-indicator--counters-sm': counters === 'small'
+    })
 
-      const computeSegmentClass = (step) => {
-        return classNames({
-          'usa-step-indicator__segment': true,
-          'usa-step-indicator__segment--complete': current > step + 1,
-          'usa-step-indicator__segment--current': current === step + 1
-        });
-      }
-
-      return (
-        <Host>
-          <div class={indicatorClass}>
-                <ol class="usa-step-indicator__segments" aria-hidden={labels ? null : 'true'}>
-                  {range.map(step => (
-                    <li class={computeSegmentClass(step)} aria-current={current===step + 1 ? 'step' : null}>
-                      {
-                        labels ? (
-                          <span class="usa-step-indicator__segment-label">{labelsArray[step]}
-                            {
-                              current !== step + 1 ? (
-                                <span class="usa-sr-only">{current > step + 1 ? 'completed' : 'not completed'}</span>
-                              ) : null
-                            }
-                          </span>
-                        ) : null
-                      }
-                    </li>
-                  ))}
-                </ol>
-                {
-                  <div class="usa-step-indicator__header">
-                    <Tag class="usa-step-indicator__heading">
-                      <span class="usa-step-indicator__heading-counter">
-                        <span class="usa-sr-only">{progressTerm}</span>
-                        <span class="usa-step-indicator__current-step">{current}</span>
-                        <span class="usa-step-indicator__total-steps"> of {total}</span>
-                      </span>
-                      <span class="usa-step-indicator__heading-text">{labels ? labelsArray[current - 1] : headingText}</span>
-                    </Tag>
-                  </div>
-                }
-              </div>
-        </Host>
-      )
-    } else {
-      return (
-        <Host>
-          <div>
-            <div
-              class="progress-bar-segmented"
-              role="progressbar"
-              aria-label={label}
-              aria-valuenow={current}
-              aria-valuemin="0"
-              aria-valuemax={total}
-              aria-valuetext={label}
-            >
-              {range.map(step => (
-                <div
-                  key={step}
-                  class={`progress-segment ${
-                    current > step ? 'progress-segment-complete' : ''
-                  }`}
-                />
-              ))}
-            </div>
-          </div>
-        </Host>
-      )
+    const computeSegmentClass = (step) => {
+      return classNames({
+        'usa-step-indicator__segment': true,
+        'usa-step-indicator__segment--complete': current > step + 1,
+        'usa-step-indicator__segment--current': current === step + 1
+      });
     }
-  }
+
+    return (
+      <Host>
+        <div class={indicatorClass}>
+              <ol class="usa-step-indicator__segments" aria-hidden={labels ? null : 'true'}>
+                {range.map(step => (
+                  <li class={computeSegmentClass(step)} aria-current={current===step + 1 ? 'step' : null}>
+                    {
+                      labels ? (
+                        <span class="usa-step-indicator__segment-label">{labelsArray[step]}
+                          {
+                            current !== step + 1 ? (
+                              <span class="usa-sr-only">{current > step + 1 ? 'completed' : 'not completed'}</span>
+                            ) : null
+                          }
+                        </span>
+                      ) : null
+                    }
+                  </li>
+                ))}
+              </ol>
+              {
+                <div class="usa-step-indicator__header">
+                  <Tag class="usa-step-indicator__heading">
+                    <span class="usa-step-indicator__heading-counter">
+                      <span class="usa-sr-only">{progressTerm}</span>
+                      <span class="usa-step-indicator__current-step">{current}</span>
+                      <span class="usa-step-indicator__total-steps"> of {total}</span>
+                    </span>
+                    <span class="usa-step-indicator__heading-text">{labels ? labelsArray[current - 1] : headingText}</span>
+                  </Tag>
+                </div>
+              }
+            </div>
+      </Host>
+    )
+  } 
 }


### PR DESCRIPTION
## Chromatic
<!-- This `3024-seg-prog-bar-v1-removal` is a placeholder for a CI job - it will be updated automatically -->
https://3024-seg-prog-bar-v1-removal--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
V1 code removal for va-segmented-progress-bar
Closes [3024](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3024)

## QA Checklist
- [x ] Component maintains 1:1 parity with design mocks
- [x ] Text is consistent with what's been provided in the mocks
- [x ] Component behaves as expected across breakpoints
- [x ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x ] Tab order and focus state work as expected
- [x ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes

Before:
![Screenshot 2024-08-09 at 10 12 25 AM](https://github.com/user-attachments/assets/75091831-bbed-4fc3-b8b7-56643635fb65)

After:
![Screenshot 2024-08-09 at 10 13 15 AM](https://github.com/user-attachments/assets/e0f43e71-9c29-4dbf-ae17-020dd1064029)

## Acceptance criteria
- [x ] QA checklist has been completed
- [x ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x ] Documentation has been updated, if applicable
- [x ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
