### PR TITLE
va-additional-info: v1 variation removal

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -56,10 +56,6 @@ export namespace Components {
           * The text to trigger the expansion
          */
         "trigger": string;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaAlert {
         /**
@@ -2115,10 +2111,6 @@ declare namespace LocalJSX {
           * The text to trigger the expansion
          */
         "trigger": string;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaAlert {
         /**

--- a/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
+++ b/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
@@ -5,13 +5,13 @@ describe('va-additional-info', () => {
   it('renders', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-additional-info trigger="More info" uswds="false"></va-additional-info>',
+      '<va-additional-info trigger="More info"></va-additional-info>',
     );
 
     const element = await page.find('va-additional-info');
 
     expect(element).toEqualHtml(`
-      <va-additional-info trigger="More info" class="hydrated" uswds="false">
+      <va-additional-info trigger="More info" class="hydrated">
         <mock:shadow-root>
           <a aria-controls="info" aria-expanded="false" role="button" tabindex="0">
             <div>
@@ -32,7 +32,7 @@ describe('va-additional-info', () => {
   it('passes an axe check', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<va-additional-info trigger="Additional information" uswds="false">
+      `<va-additional-info trigger="Additional information">
         <div>
           Additional content
         </div>
@@ -45,7 +45,7 @@ describe('va-additional-info', () => {
   it('passes an axe check when opened', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<va-additional-info trigger="Additional information" uswds="false">
+      `<va-additional-info trigger="Additional information">
         <div>
           Additional content
         </div>
@@ -61,7 +61,7 @@ describe('va-additional-info', () => {
   it('expands when clicked', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<va-additional-info trigger="Additional information" uswds="false">
+      `<va-additional-info trigger="Additional information">
         <div id="content">
           Additional content
         </div>
@@ -96,7 +96,7 @@ describe('va-additional-info', () => {
   it('has keyboard control for expanding & collapsing on spacebar', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<va-additional-info trigger="Additional information" uswds="false">
+      `<va-additional-info trigger="Additional information">
         <div id="content">
           Additional content
         </div>
@@ -117,6 +117,7 @@ describe('va-additional-info', () => {
     const postOpacity = await handle.evaluate(
       (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
     );
+
     const preOpacityToNumber = parseFloat(preOpacity);
     const postOpacityToNumber = parseFloat(postOpacity);
 
@@ -127,7 +128,7 @@ describe('va-additional-info', () => {
   it('has keyboard control for expanding & collapsing on enter', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<va-additional-info trigger="Additional information" uswds="false">
+      `<va-additional-info trigger="Additional information">
         <div id="content">
           Additional content
         </div>
@@ -160,7 +161,7 @@ describe('va-additional-info', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <va-additional-info trigger="Whatever" uswds="false">
+      <va-additional-info trigger="Whatever">
         <div>More content</div>
       </va-additional-info>
     `);
@@ -183,7 +184,7 @@ describe('va-additional-info', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <va-additional-info trigger="Whatever" uswds="false">
+      <va-additional-info trigger="Whatever">
         <div>More content</div>
       </va-additional-info>
     `);
@@ -204,242 +205,6 @@ describe('va-additional-info', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <va-additional-info trigger="Whatever" disable-analytics uswds="false">
-        <div>More content</div>
-      </va-additional-info>
-    `);
-
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.click();
-
-    expect(analyticsSpy).toHaveReceivedEventTimes(0);
-  });
-
-  it('sets the correct max-height value for the content given', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-additional-info trigger="Click here for a treat!" disable-analytics uswds="false">
-        <div style="height:50px;padding:10px 0;margin:5px 0;">We're out of treats! Try again later.</div>
-      </va-additional-info>
-    `);
-    const handle = await page.waitForSelector('pierce/#info');
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.click();
-    await page.waitForSelector('pierce/#info.open');
-    const calcMaxHeight = await handle.evaluate((domElement: HTMLElement) =>
-      domElement.style.getPropertyValue('--calc-max-height'),
-    );
-    // 50px from height + 20px from padding
-    // margin-bottom and margin-top is set to 0 for first slotted child
-    expect(calcMaxHeight).toEqual('calc(70px + 1.125rem)');
-  });
-
-  // Begin USWDS v3 test
-  it('uswds v3 renders', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-additional-info trigger="More info" uswds></va-additional-info>',
-    );
-
-    const element = await page.find('va-additional-info');
-
-    expect(element).toEqualHtml(`
-      <va-additional-info trigger="More info" class="hydrated" uswds="">
-        <mock:shadow-root>
-          <a aria-controls="info" aria-expanded="false" role="button" tabindex="0">
-            <div>
-              <span class="additional-info-title">
-                More info
-              </span>
-              <va-icon class="additional-info-icon hydrated"></va-icon>
-            </div>
-          </a>
-          <div class="closed" id="info" style="--calc-max-height:calc(0px + 1.125rem);">
-            <slot></slot>
-          </div>
-        </mock:shadow-root>
-      </va-additional-info>
-    `);
-  });
-
-  it('uswds v3 passes an axe check', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<va-additional-info trigger="Additional information" uswds>
-        <div>
-          Additional content
-        </div>
-      </va-additional-info>`,
-    );
-
-    await axeCheck(page);
-  });
-
-  it('uswds v3 passes an axe check when opened', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<va-additional-info trigger="Additional information" uswds>
-        <div>
-          Additional content
-        </div>
-      </va-additional-info>`,
-    );
-
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.click();
-
-    await axeCheck(page);
-  });
-
-  it('uswds v3 expands when clicked', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<va-additional-info trigger="Additional information" uswds>
-        <div id="content">
-          Additional content
-        </div>
-      </va-additional-info>`,
-    );
-    const handle = await page.waitForSelector('pierce/#info');
-
-    const preOpacity = await handle.evaluate(
-      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
-    );
-
-    // Use click to expand
-    const anchorEl = await page.find('va-additional-info >>> a');
-    expect(anchorEl.getAttribute('aria-expanded')).toEqual('false');
-
-    await anchorEl.click();
-    // Allow the transition to complete
-    await page.waitForTimeout(600);
-    expect(anchorEl.getAttribute('aria-expanded')).toEqual('true');
-
-    const postOpacity = await handle.evaluate(
-      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
-    );
-
-    const preOpacityToNumber = parseFloat(preOpacity);
-    const postOpacityToNumber = parseFloat(postOpacity);
-
-    expect(preOpacityToNumber).toEqual(0);
-    expect(postOpacityToNumber).toBeGreaterThan(0);
-  });
-
-  it('uswds v3 has keyboard control for expanding & collapsing on spacebar', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<va-additional-info trigger="Additional information" uswds>
-        <div id="content">
-          Additional content
-        </div>
-      </va-additional-info>`,
-    );
-    const handle = await page.waitForSelector('pierce/#info');
-
-    const preOpacity = await handle.evaluate(
-      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
-    );
-
-    // Use keyboard to expand
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.press(' ');
-    // Allow the transition to complete
-    await page.waitForTimeout(600);
-
-    const postOpacity = await handle.evaluate(
-      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
-    );
-
-    const preOpacityToNumber = parseFloat(preOpacity);
-    const postOpacityToNumber = parseFloat(postOpacity);
-
-    expect(preOpacityToNumber).toEqual(0);
-    expect(postOpacityToNumber).toBeGreaterThan(0);
-  });
-
-  it('uswds v3 has keyboard control for expanding & collapsing on enter', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<va-additional-info trigger="Additional information">
-        <div id="content">
-          Additional content
-        </div>
-      </va-additional-info>`,
-    );
-    const handle = await page.waitForSelector('pierce/#info');
-
-    const preOpacity = await handle.evaluate(
-      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
-    );
-
-    // Use keyboard to expand
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.press('Enter');
-    // Allow the transition to complete
-    await page.waitForTimeout(600);
-
-    const postOpacity = await handle.evaluate(
-      (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
-    );
-
-    const preOpacityToNumber = parseFloat(preOpacity);
-    const postOpacityToNumber = parseFloat(postOpacity);
-
-    expect(preOpacityToNumber).toEqual(0);
-    expect(postOpacityToNumber).toBeGreaterThan(0);
-  });
-
-  it('uswds v3 fires an analytics event by default', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`
-      <va-additional-info trigger="Whatever">
-        <div>More content</div>
-      </va-additional-info>
-    `);
-
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.click();
-
-    expect(analyticsSpy).toHaveReceivedEventDetail({
-      action: 'expand',
-      componentName: 'va-additional-info',
-      details: {
-        triggerText: 'Whatever',
-      },
-    });
-  });
-
-  it('uswds v3 has the collapse action in analytics event', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`
-      <va-additional-info trigger="Whatever">
-        <div>More content</div>
-      </va-additional-info>
-    `);
-
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-
-    const anchorEl = await page.find('va-additional-info >>> a');
-
-    // Click once to expand, again to collapse
-    await anchorEl.click();
-    await anchorEl.click();
-
-    const secondEvent = analyticsSpy.events[1];
-    expect(secondEvent.detail.action).toEqual('collapse');
-  });
-
-  it('uswds v3 does not fire an analytics event when disableAnalytics is set', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`
       <va-additional-info trigger="Whatever" disable-analytics>
         <div>More content</div>
       </va-additional-info>
@@ -453,7 +218,7 @@ describe('va-additional-info', () => {
     expect(analyticsSpy).toHaveReceivedEventTimes(0);
   });
 
-  it('uswds v3 sets the correct max-height value for the content given', async () => {
+  it('sets the correct max-height value for the content given', async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-additional-info trigger="Click here for a treat!" disable-analytics>

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
@@ -30,10 +30,7 @@ export class VaAdditionalInfo {
    * The text to trigger the expansion
    */
   @Prop() trigger!: string;
-  /**
-   * Whether or not the component will use USWDS v3 styling.
-   */
-  @Prop() uswds?: boolean = true;
+
   /**
    * If `true`, doesn't fire the CustomEvent which can be used for analytics tracking.
    */
@@ -100,60 +97,33 @@ export class VaAdditionalInfo {
   }
 
   render() {
-    if (this.uswds) {
-      const infoClass = classnames({
-        'open': this.open,
-        'closed': !this.open
-      });
-      return (
-        <Host>
-          <a
-            role="button"
-            aria-controls="info"
-            aria-expanded={this.open ? 'true' : 'false'}
-            tabIndex={0}
-            onClick={this.toggleOpen.bind(this)}
-            onKeyDown={this.handleKeydown.bind(this)}
-          >
-            <div>
-              <span class="additional-info-title">{this.trigger}</span>
-              <va-icon
-                class="additional-info-icon"
-                icon="chevron_right"
-                size={3}
-              ></va-icon>
-            </div>
-          </a>
-          <div id="info" class={infoClass}>
-            <slot></slot>
+    const infoClass = classnames({
+      'open': this.open,
+      'closed': !this.open
+    });
+    return (
+      <Host>
+        <a
+          role="button"
+          aria-controls="info"
+          aria-expanded={this.open ? 'true' : 'false'}
+          tabIndex={0}
+          onClick={this.toggleOpen.bind(this)}
+          onKeyDown={this.handleKeydown.bind(this)}
+        >
+          <div>
+            <span class="additional-info-title">{this.trigger}</span>
+            <va-icon
+              class="additional-info-icon"
+              icon="chevron_right"
+              size={3}
+            ></va-icon>
           </div>
-        </Host>
-      );
-    } else {
-      return (
-        <Host>
-          <a
-            role="button"
-            aria-controls="info"
-            aria-expanded={this.open ? 'true' : 'false'}
-            tabIndex={0}
-            onClick={this.toggleOpen.bind(this)}
-            onKeyDown={this.handleKeydown.bind(this)}
-          >
-            <div>
-              <span class="additional-info-title">{this.trigger}</span>
-              <va-icon
-                class="additional-info-icon"
-                icon="chevron_right"
-                size={3}
-              ></va-icon>
-            </div>
-          </a>
-          <div id="info" class={this.open ? 'open' : 'closed'}>
-            <slot></slot>
-          </div>
-        </Host>
-      );
-    }
+        </a>
+        <div id="info" class={infoClass}>
+          <slot></slot>
+        </div>
+      </Host>
+    );
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `3011-additional-info-v1-removal` is a placeholder for a CI job - it will be updated automatically -->
https://3011-additional-info-v1-removal--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Removes v1 code for additional-info. There are no changes to the css file for this component as all classes still seem relevant to code for v3.

Closes [3011](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3011)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes-
Original:
![Screenshot 2024-08-09 at 1 46 19 PM](https://github.com/user-attachments/assets/14eb400e-cbb7-4582-8582-cdc6976a6b06)

New:
![Screenshot 2024-08-09 at 1 46 40 PM](https://github.com/user-attachments/assets/68350a8a-a224-401a-884a-06e405a4b2ed)


## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
