### PR TITLE
va-pagination: remove v1 code

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -937,13 +937,9 @@ export namespace Components {
          */
         "showLastPage"?: boolean;
         /**
-          * Don't show last page when the page count exceeds `maxPageListLength` (but do show the ellipsis). Only relevant if uswds is true.
+          * Don't show last page when the page count exceeds `maxPageListLength` (but do show the ellipsis).
          */
         "unbounded"?: boolean;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaPrivacyAgreement {
         /**
@@ -3156,13 +3152,9 @@ declare namespace LocalJSX {
          */
         "showLastPage"?: boolean;
         /**
-          * Don't show last page when the page count exceeds `maxPageListLength` (but do show the ellipsis). Only relevant if uswds is true.
+          * Don't show last page when the page count exceeds `maxPageListLength` (but do show the ellipsis).
          */
         "unbounded"?: boolean;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaPrivacyAgreement {
         /**

--- a/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
+++ b/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
@@ -4,252 +4,6 @@ import { axeCheck } from '../../../testing/test-helpers';
 describe('va-pagination', () => {
   it('renders', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-pagination uswds="false"></va-pagination>');
-
-    const element = await page.find('va-pagination');
-    expect(element).toEqualHtml(`
-      <va-pagination class="hydrated" role="navigation" aria-label="Pagination" uswds="false">
-        <mock:shadow-root>
-          <ul class="pagination-prev"></ul>
-          <ul class="pagination-inner"></ul>
-          <ul class="pagination-next"></ul>
-        </mock:shadow-root>
-      </va-pagination>
-    `);
-  });
-
-  it('passes an axe check', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-pagination page="3" pages="50" uswds="false">
-      </va-pagination>
-    `);
-
-    await axeCheck(page);
-  });
-
-  it('should show both "Prev" and "Next" if in a middle page', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <va-pagination page="3" pages="5" uswds="false"/>
-    `);
-
-    const element = await page.find('va-pagination');
-    expect(element).toEqualHtml(`
-      <va-pagination class="hydrated" page="3" pages="5" role="navigation" aria-label="Pagination" uswds="false">
-        <mock:shadow-root>
-          <ul class="pagination-prev">
-          <li>
-            <button aria-label="Previous page" class="button-prev" type="button">
-              Previous
-            </button>
-          </li>
-          </ul>
-          <ul class="pagination-inner">
-            <li>
-              <button aria-label="Page 1, first page" class="button-inner" type="button">
-                1
-              </button>
-            </li>
-            <li>
-              <button aria-label="Page 2" class="button-inner" type="button">
-                2
-              </button>
-            </li>
-            <li>
-              <button aria-current="true" aria-label="Page 3" class="button-active button-inner" type="button">
-                3
-              </button>
-            </li>
-            <li>
-              <button aria-label="Page 4" class="button-inner" type="button">
-                4
-              </button>
-            </li>
-            <li>
-              <button aria-label="Page 5, last page" class="button-inner" type="button">
-                5
-              </button>
-            </li>
-          </ul>
-          <ul class="pagination-next">
-            <li>
-              <button aria-label="Next page" class="button-next" type="button">
-                Next
-              </button>
-            </li>
-          </ul>
-        </mock:shadow-root>
-      </va-pagination>
-    `);
-  });
-
-  it('should show prev button but not next button if on the last page', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <va-pagination page="5" pages="5" uswds="false"/>
-    `);
-
-    const prevButton = await page.findAll('va-pagination >>> .button-prev');
-    const nextButton = await page.findAll('va-pagination >>> .button-next');
-    expect(prevButton.length).toEqual(1);
-    expect(nextButton.length).toEqual(0);
-  });
-
-  it('should select previous page when prev button is clicked', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-pagination page="3" pages="50" uswds="false"/>
-    `);
-    const onPageSelectSpy = await page.spyOnEvent('pageSelect');
-    const prevButton = await page.find('va-pagination >>> .button-prev');
-    await prevButton.click();
-    expect(onPageSelectSpy).toHaveReceivedEventDetail({ page: 2 });
-  });
-
-  it('should select next page when next button is clicked', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-pagination page="3" pages="50" uswds="false"/>
-    `);
-    const onPageSelectSpy = await page.spyOnEvent('pageSelect');
-    const nextButton = await page.find('va-pagination >>> .button-next');
-    await nextButton.click();
-    expect(onPageSelectSpy).toHaveReceivedEventDetail({ page: 4 });
-  });
-
-  it('should select page 5 when page 5 button is clicked', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-pagination page="3" pages="50" uswds="false"/>
-    `);
-    const onPageSelectSpy = await page.spyOnEvent('pageSelect');
-    const page5Button = await page.find(
-      'va-pagination >>> button[aria-label="Page 5"]',
-    );
-    await page5Button.click();
-    expect(onPageSelectSpy).toHaveReceivedEventDetail({ page: 5 });
-  });
-
-  it('should focus prev button when pressing tab inside component', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-pagination page="3" pages="50" uswds="false"/>
-    `);
-
-    const component = await page.find('va-pagination');
-    await component.press('Tab');
-
-    const focused = await page.find('va-pagination >>> button:focus');
-    expect(focused.textContent).toEqual('Previous');
-  });
-
-  it('should tab to prev button and select it using the enter key', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <va-pagination page="3" pages="50" uswds="false"/>
-    `);
-    const onPageSelectSpy = await page.spyOnEvent('pageSelect');
-    const component = await page.find('va-pagination');
-    await component.press('Tab');
-    await component.press('Enter');
-    expect(onPageSelectSpy).toHaveReceivedEventDetail({ page: 2 });
-  });
-
-  it('should set aria-current to selected page', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <va-pagination page="3" pages="50" uswds="false"/>
-    `);
-
-    const activeButton = await page.find(
-      'va-pagination >>> button[aria-current="true"]',
-    );
-
-    expect(activeButton.textContent).toEqual('3');
-  });
-
-  it('show the last page if enabled and there are more pages than max', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-    <va-pagination page="3" pages="50" show-last-page uswds="false"/>
-    `);
-
-    const lastPageButton = await page.find(
-      'va-pagination >>> button[aria-label*="Page 50"]',
-    );
-
-    expect(lastPageButton.textContent).toEqual('50');
-  });
-
-  it('fires an analytics event when a page number is clicked', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-pagination page="2" pages="5" uswds="false"/>',
-    );
-
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-
-    const buttonInner = await page.find('va-pagination >>> button.button-inner.button-active');
-    await buttonInner.click();
-
-    expect(analyticsSpy).toHaveReceivedEventDetail({
-      action: 'linkClick',
-      componentName: 'va-pagination',
-      details: {
-        event: 'nav-paginate-number',
-        'page-number': 2,
-      },
-    });
-  });
-
-  it('fires an analytics event the previous button is clicked', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-pagination page="2" pages="5" uswds="false"/>',
-    );
-
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-
-    const buttonPrev = await page.find('va-pagination >>> button.button-prev');
-    await buttonPrev.click();
-
-    expect(analyticsSpy).toHaveReceivedEventDetail({
-      action: 'linkClick',
-      componentName: 'va-pagination',
-      details: {
-        event: 'nav-paginate-previous',
-        'page-number': 1,
-      },
-    });
-  });
-
-  it('fires an analytics event the next button is clicked', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-pagination page="2" pages="5" uswds="false"/>',
-    );
-
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-
-    const buttonNext = await page.find('va-pagination >>> button.button-next');
-    await buttonNext.click();
-
-    expect(analyticsSpy).toHaveReceivedEventDetail({
-      action: 'linkClick',
-      componentName: 'va-pagination',
-      details: {
-        event: 'nav-paginate-next',
-        'page-number': 3,
-      },
-    });
-  });
-
-});
-
-describe('uswds - va-pagination', () => {
-  it('uswds renders', async () => {
-    const page = await newE2EPage();
     await page.setContent('<va-pagination page="1" pages="3" />');
 
     const element = await page.find('va-pagination');
@@ -285,7 +39,17 @@ describe('uswds - va-pagination', () => {
     `);
   });
 
-  it('uswds v3 only selected "page" has selected class', async () => {
+  it('passes an axe check', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-pagination page="3" pages="50">
+      </va-pagination>
+    `);
+
+    await axeCheck(page);
+  });
+
+  it('only selected "page" has selected class', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-pagination page="1" pages="24" max-page-list-length="7"/>`);
     const firstPage = await page.findAll('va-pagination >>> li.usa-pagination__page-no a.usa-pagination__button.usa-current');
@@ -293,7 +57,7 @@ describe('uswds - va-pagination', () => {
     expect(firstPage[0].innerHTML).toEqual("1");
   });
 
-  it('uswds v3 renders first and last page with ellipses when middle pages do not contain them', async () => {
+  it('renders first and last page with ellipses when middle pages do not contain them', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-pagination page="10" pages="24" max-page-list-length="7"/>`);
     const ellipses = await page.findAll('va-pagination >>> li.usa-pagination__overflow');
@@ -304,21 +68,21 @@ describe('uswds - va-pagination', () => {
     expect(pageNumbers[pageNumbers.length - 1].innerHTML).toEqual("24");
   });
 
-  it('uswds v3 does not render a "Next" button when on last page', async () => {
+  it('does not render a "Next" button when on last page', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-pagination page="24" pages="24" max-page-list-length="7"/>`);
     const next = await page.find('va-pagination >>> a.usa-pagination__next-page');
     expect(next).toBeNull();
   });
 
-  it('uswds v3 does not show last page number if unbounded flag is set', async () => {
+  it('does not show last page number if unbounded flag is set', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-pagination page="1" pages="24" max-page-list-length="7" unbounded/>`);
     const pageNumbers = await page.findAll('va-pagination >>> li.usa-pagination__page-no a.usa-pagination__button');
     expect(pageNumbers[pageNumbers.length - 1].innerHTML).toEqual("6");
   });
 
-  it('uswds v3 renders all page numbers if total pages is less than or equal to 7', async () => {
+  it('renders all page numbers if total pages is less than or equal to 7', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-pagination page="3" pages="7" max-page-list-length="7"/>`);
 
@@ -330,7 +94,7 @@ describe('uswds - va-pagination', () => {
     }
   });
 
-  it('uswds v3 renders an extra pagination item when the max-page-list-length is 6 and the page is 4', async () => {
+  it('renders an extra pagination item when the max-page-list-length is 6 and the page is 4', async () => {
     // this is an edge case where even though it is set to 6 items, 7 items is the minimum needed to display everything needed
     // [first page] [second page] [third/previous page] [fourth/current page] [fifth/next page] [ellipsis] [last page]
     const page = await newE2EPage();
@@ -341,7 +105,7 @@ describe('uswds - va-pagination', () => {
     expect(paginationItems).toHaveLength(9);
   });
 
-  it('uswds v3 renders an does not render an extra pagination item when the max-page-list-length is 6', async () => {
+  it('renders an does not render an extra pagination item when the max-page-list-length is 6', async () => {
     // a check to make sure the above edge case doesn't
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-pagination/va-pagination.scss
+++ b/packages/web-components/src/components/va-pagination/va-pagination.scss
@@ -9,7 +9,7 @@
   box-sizing: border-box;
 }
 
-:host(:not([uswds='false'])) {
+:host {
   a.usa-pagination__next-page > div,
   a.usa-pagination__previous-page > div {
     display: flex;
@@ -53,93 +53,4 @@ button {
   padding: 0;
   transition: all 0.3s ease-in-out;
   transition-property: color, background-color;
-}
-
-.button-next,
-.button-prev {
-  border-radius: 0;
-  margin: 0;
-}
-
-.button-next:hover,
-.button-prev:hover {
-  background-color: transparent;
-  color: var(--vads-color-link);
-  text-decoration: underline;
-}
-
-.pagination-next:hover,
-.pagination-prev:hover {
-  text-decoration: underline;
-  text-decoration-color: var(--vads-color-primary);
-}
-
-.pagination-inner {
-  overflow: hidden;
-  text-align: center;
-  white-space: nowrap;
-}
-
-.button-inner {
-  border-radius: 1000px;
-  height: 1.875rem;
-  margin: 0 0.3125rem;
-  width: 1.875rem;
-}
-
-.button-active,
-.button-inner[aria-current='true'],
-.button-inner:hover,
-.button-inner:focus {
-  background-color: var(--vads-color-primary);
-  color: var(--vads-button-color-text-primary-on-light);
-}
-
-.pagination-inner,
-.pagination-next,
-.pagination-prev {
-  padding-bottom: 4px;
-  padding-top: 4px;
-}
-
-@media (max-width: 768px) {
-  .pagination-inner {
-    width: 12.5rem;
-  }
-
-  .pagination-next {
-    margin-right: -1.875rem;
-    padding-left: .625rem;
-  }
-
-  .pagination-prev {
-    margin-left: -1.875rem;
-    padding-right: .625rem;
-  }
-}
-
-@media (min-width: 481px) {
-  .pagination-next:not(:empty) .button-next::after {
-    /* right-pointing angle quotation mark › with 2 spaces before it */
-    content: '\a0\a0\203a';
-  }
-
-  .pagination-prev:not(:empty) .button-prev::before {
-    /* left-pointing angle quotation mark ‹ with 2 spaces after it */
-    content: '\2039\a0\a0';
-  }
-}
-
-@media (min-width: 768px) {
-  .pagination-next,
-  .pagination-prev {
-    padding-left: .625rem;
-    padding-right: .625rem;
-  }
-}
-
-@media (min-width: 1201px) {
-  .pagination-inner {
-    width: 25rem;
-  }
 }

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -85,19 +85,12 @@ export class VaPagination {
   /**
    * Don't show last page when the page count exceeds
    * `maxPageListLength` (but do show the ellipsis).
-   * Only relevant if uswds is true.
    */
 
   @Prop() unbounded?: boolean = false;
 
   /**
-  * Whether or not the component will use USWDS v3 styling.
-  */
-  @Prop() uswds?: boolean = true;
-
-  /**
    * If the page total is less than or equal to this limit, show all pages.
-   * Only relevant for uswds.
    */
   SHOW_ALL_PAGES: number = 7;
 
@@ -124,7 +117,7 @@ export class VaPagination {
    * Generate a list of the continuous page numbers to render, i.e.
    * the page numbers to render not including the first and/or last page
    */
-  private pageNumbersUswds = () => {
+  private pageNumbers = () => {
     const {
       maxPageListLength,
       page: currentPage,
@@ -191,42 +184,6 @@ export class VaPagination {
     return makeArray(start, end);
   };
 
-  private pageNumbers = () => {
-    const {
-      maxPageListLength,
-      page: currentPage,
-      pages: totalPages,
-      showLastPage,
-    } = this;
-
-    // Make space for "... (last page number)" if not in range of the last page.
-    const showEllipsisAndLastPage =
-      showLastPage && currentPage < totalPages - maxPageListLength + 1;
-
-    const limit = showEllipsisAndLastPage
-      ? maxPageListLength - 2
-      : maxPageListLength;
-
-    let end;
-    let start;
-
-    // If there are more pages returned than the limit to show
-    // cap the upper range at limit + the page number.
-    if (totalPages > limit) {
-      start = currentPage;
-      end = limit + currentPage;
-      // treat the last pages specially
-      if (start >= totalPages - limit + 1) {
-        start = totalPages - limit + 1;
-        end = totalPages + 1;
-      }
-    } else {
-      start = 1;
-      end = totalPages + 1;
-    }
-    return Array.from({ length: end - start }, (_, i) => i + start);
-  };
-
   private handleKeyDown = (e, pageNumber) => {
     const keyCode = e.key;
     if (keyCode === 'Enter' || keyCode === ' ') {
@@ -287,9 +244,6 @@ export class VaPagination {
       ariaLabelSuffix,
       page,
       pages,
-      maxPageListLength,
-      showLastPage,
-      uswds,
     } = this;
 
     if (pages === 1) {
@@ -302,270 +256,160 @@ export class VaPagination {
     const nextAriaLabel = ariaLabelSuffix
       ? `Next page ${ariaLabelSuffix}`
       : 'Next page';
-    const lastPageAriaLabel = ariaLabelSuffix
-      ? `Page ${pages} ${ariaLabelSuffix}, last page`
-      : `Page ${pages}, last page`;
-    if (uswds) {
-      const pageNumbersToRender = this.pageNumbersUswds();
-      const itemClasses = classnames({
-        'usa-pagination__item': true,
-        'usa-pagination__page-no': true,
-        'va-pagination__item': true,
-      });
-      const ellipsisClasses = classnames({
-        'usa-pagination__item': true,
-        'usa-pagination__overflow': true,
-        'va-pagination__item': true,
-      });
-      const arrowClasses = classnames({
-        'usa-pagination__item': true,
-        'usa-pagination__arrow': true,
-      });
 
-      const previousButton =
-        page > 1 ? (
-          <Fragment>
-            <li class={arrowClasses} aria-label={previousAriaLabel}>
-              <a
-                onClick={() =>
-                  this.handlePageSelect(page - 1, 'nav-paginate-number')
-                }
-                onKeyDown={e => this.handleKeyDown(e, page - 1)}
-                class="usa-pagination__link usa-pagination__previous-page"
-                href="javascript:void(0)"
-              >
-                <div id="previous-arrow-icon"></div>
-                <span class="usa-pagination__link-text">
-                  {i18next.t('previous')}
-                </span>
-              </a>
-            </li>
-            {!pageNumbersToRender.includes(1) && (
-              <Fragment>
-                <li class={itemClasses}>
-                  <a
-                    onClick={() =>
-                      this.handlePageSelect(1, 'nav-paginate-number')
-                    }
-                    onKeyDown={e => this.handleKeyDown(e, 1)}
-                    href="javascript:void(0)"
-                    class="usa-pagination__button"
-                    aria-label="page 1, first page"
-                  >
-                    1
-                  </a>
-                </li>
-                <li
-                  class={ellipsisClasses}
-                  aria-label="ellipsis indicating non-visible pages"
-                >
-                  <span>…</span>
-                </li>
-              </Fragment>
-            )}
-          </Fragment>
-        ) : null;
+    const pageNumbersToRender = this.pageNumbers();
+    const itemClasses = classnames({
+      'usa-pagination__item': true,
+      'usa-pagination__page-no': true,
+      'va-pagination__item': true,
+    });
+    const ellipsisClasses = classnames({
+      'usa-pagination__item': true,
+      'usa-pagination__overflow': true,
+      'va-pagination__item': true,
+    });
+    const arrowClasses = classnames({
+      'usa-pagination__item': true,
+      'usa-pagination__arrow': true,
+    });
 
-      const renderPages = pageNumbersToRender.map(pageNumber => {
-        const anchorClasses = classnames({
-          'usa-pagination__button': true,
-          'usa-current': page === pageNumber,
-        });
-
-        let pageAriaLabel = ariaLabelSuffix
-          ? `page ${pageNumber} ${ariaLabelSuffix}`
-          : `page ${pageNumber}`;
-        if (pageNumber === 1) {
-          pageAriaLabel = `${pageAriaLabel}, first page`;
-        }
-        if (pageNumber === pages) {
-          pageAriaLabel = `${pageAriaLabel}, last page`;
-        }
-        return (
-          <li class={itemClasses}>
+    const previousButton =
+      page > 1 ? (
+        <Fragment>
+          <li class={arrowClasses} aria-label={previousAriaLabel}>
             <a
               onClick={() =>
-                this.handlePageSelect(pageNumber, 'nav-paginate-number')
+                this.handlePageSelect(page - 1, 'nav-paginate-number')
               }
-              onKeyDown={e => this.handleKeyDown(e, pageNumber)}
+              onKeyDown={e => this.handleKeyDown(e, page - 1)}
+              class="usa-pagination__link usa-pagination__previous-page"
               href="javascript:void(0)"
-              class={anchorClasses}
-              aria-current={page === pageNumber ? 'page' : null}
-              aria-label={pageAriaLabel}
             >
-              {pageNumber}
+              <div id="previous-arrow-icon"></div>
+              <span class="usa-pagination__link-text">
+                {i18next.t('previous')}
+              </span>
             </a>
           </li>
-        );
-      });
-      const endEllipsisAndLastPage =
-        pageNumbersToRender.indexOf(pages) === -1 ? (
-          <Fragment>
-            {pages > this.SHOW_ALL_PAGES && (
+          {!pageNumbersToRender.includes(1) && (
+            <Fragment>
+              <li class={itemClasses}>
+                <a
+                  onClick={() =>
+                    this.handlePageSelect(1, 'nav-paginate-number')
+                  }
+                  onKeyDown={e => this.handleKeyDown(e, 1)}
+                  href="javascript:void(0)"
+                  class="usa-pagination__button"
+                  aria-label="page 1, first page"
+                >
+                  1
+                </a>
+              </li>
               <li
                 class={ellipsisClasses}
                 aria-label="ellipsis indicating non-visible pages"
               >
                 <span>…</span>
               </li>
-            )}
-            {!this.unbounded && pages > this.SHOW_ALL_PAGES && (
-              <li class={itemClasses}>
-                <a
-                  onClick={() =>
-                    this.handlePageSelect(pages, 'nav-paginate-number')
-                  }
-                  onKeyDown={e => this.handleKeyDown(e, pages)}
-                  href="javascript:void(0)"
-                  class="usa-pagination__button"
-                  aria-label={`page ${pages}, last page`}
-                >
-                  {pages}
-                </a>
-              </li>
-            )}
-          </Fragment>
-        ) : null;
+            </Fragment>
+          )}
+        </Fragment>
+      ) : null;
 
-      const nextButton =
-        page < pages ? (
-          <Fragment>
-            <li class={arrowClasses} aria-label={nextAriaLabel}>
-              <a
-                onClick={() =>
-                  this.handlePageSelect(page + 1, 'nav-paginate-number')
-                }
-                onKeyDown={e => this.handleKeyDown(e, page + 1)}
-                class="usa-pagination__link usa-pagination__next-page"
-                href="javascript:void(0)"
-              >
-                <span class="usa-pagination__link-text">
-                  {i18next.t('next')}
-                </span>
-                <div id="next-arrow-icon"></div>
-              </a>
-            </li>
-          </Fragment>
-        ) : null;
-
-      return (
-        <Host>
-          <nav class="usa-pagination" aria-label="Pagination">
-            <ul class="usa-pagination__list">
-              {previousButton}
-              {renderPages}
-              {endEllipsisAndLastPage}
-              {nextButton}
-            </ul>
-          </nav>
-        </Host>
-      );
-    } else {
-      const renderPages = this.pageNumbers().map(pageNumber => {
-        const pageClass = classnames({
-          'button-active': page === pageNumber,
-          'button-inner': true,
-        });
-
-        let pageAriaLabel = ariaLabelSuffix
-          ? `Page ${pageNumber} ${ariaLabelSuffix}`
-          : `Page ${pageNumber}`;
-        if (pageNumber === 1) {
-          pageAriaLabel = `${pageAriaLabel}, first page`;
-        }
-        if (pageNumber === pages) {
-          pageAriaLabel = `${pageAriaLabel}, last page`;
-        }
-        return (
-          <li>
-            <button
-              aria-current={page === pageNumber ? 'true' : null}
-              aria-label={pageAriaLabel}
-              class={pageClass}
-              onClick={() =>
-                this.handlePageSelect(pageNumber, 'nav-paginate-number')
-              }
-              onKeyDown={e => this.handleKeyDown(e, pageNumber)}
-              type="button"
-            >
-              {pageNumber}
-            </button>
-          </li>
-        );
+    const renderPages = pageNumbersToRender.map(pageNumber => {
+      const anchorClasses = classnames({
+        'usa-pagination__button': true,
+        'usa-current': page === pageNumber,
       });
 
+      let pageAriaLabel = ariaLabelSuffix
+        ? `page ${pageNumber} ${ariaLabelSuffix}`
+        : `page ${pageNumber}`;
+      if (pageNumber === 1) {
+        pageAriaLabel = `${pageAriaLabel}, first page`;
+      }
+      if (pageNumber === pages) {
+        pageAriaLabel = `${pageAriaLabel}, last page`;
+      }
       return (
-        <Host role="navigation" aria-label="Pagination">
-          <ul class="pagination-prev">
-            {/* START PREV BUTTON */}
-            {this.page > 1 && (
-              <li>
-                <button
-                  aria-label={previousAriaLabel}
-                  class="button-prev"
-                  onClick={() =>
-                    this.handlePageSelect(
-                      this.page - 1,
-                      'nav-paginate-previous',
-                    )
-                  }
-                  onKeyDown={e => this.handleKeyDown(e, this.page - 1)}
-                  type="button"
-                >
-                  Previous
-                </button>
-              </li>
-            )}
-            {/* END PREV BUTTON */}
-          </ul>
-
-          <ul class="pagination-inner">
-            {renderPages}
-            {/* START ELLIPSIS AND LAST BUTTON */}
-            {showLastPage && page < pages - maxPageListLength + 1 && (
-              <Fragment>
-                <li>
-                  <span>…</span>
-                </li>
-                <li>
-                  <button
-                    aria-label={lastPageAriaLabel}
-                    class="button-inner"
-                    onClick={() =>
-                      this.handlePageSelect(pages, 'nav-paginate-number')
-                    }
-                    onKeyDown={e => this.handleKeyDown(e, pages)}
-                    type="button"
-                  >
-                    {pages}
-                  </button>
-                </li>
-              </Fragment>
-            )}
-            {/* END ELLIPSIS AND LAST BUTTON */}
-          </ul>
-
-          <ul class="pagination-next">
-            {/* START NEXT BUTTON */}
-            {this.pages > this.page && (
-              <li>
-                <button
-                  aria-label={nextAriaLabel}
-                  class="button-next"
-                  onClick={() =>
-                    this.handlePageSelect(this.page + 1, 'nav-paginate-next')
-                  }
-                  onKeyDown={e => this.handleKeyDown(e, this.page + 1)}
-                  type="button"
-                >
-                  Next
-                </button>
-              </li>
-            )}
-            {/* END NEXT BUTTON */}
-          </ul>
-        </Host>
+        <li class={itemClasses}>
+          <a
+            onClick={() =>
+              this.handlePageSelect(pageNumber, 'nav-paginate-number')
+            }
+            onKeyDown={e => this.handleKeyDown(e, pageNumber)}
+            href="javascript:void(0)"
+            class={anchorClasses}
+            aria-current={page === pageNumber ? 'page' : null}
+            aria-label={pageAriaLabel}
+          >
+            {pageNumber}
+          </a>
+        </li>
       );
-    }
+    });
+    const endEllipsisAndLastPage =
+      pageNumbersToRender.indexOf(pages) === -1 ? (
+        <Fragment>
+          {pages > this.SHOW_ALL_PAGES && (
+            <li
+              class={ellipsisClasses}
+              aria-label="ellipsis indicating non-visible pages"
+            >
+              <span>…</span>
+            </li>
+          )}
+          {!this.unbounded && pages > this.SHOW_ALL_PAGES && (
+            <li class={itemClasses}>
+              <a
+                onClick={() =>
+                  this.handlePageSelect(pages, 'nav-paginate-number')
+                }
+                onKeyDown={e => this.handleKeyDown(e, pages)}
+                href="javascript:void(0)"
+                class="usa-pagination__button"
+                aria-label={`page ${pages}, last page`}
+              >
+                {pages}
+              </a>
+            </li>
+          )}
+        </Fragment>
+      ) : null;
+
+    const nextButton =
+      page < pages ? (
+        <Fragment>
+          <li class={arrowClasses} aria-label={nextAriaLabel}>
+            <a
+              onClick={() =>
+                this.handlePageSelect(page + 1, 'nav-paginate-number')
+              }
+              onKeyDown={e => this.handleKeyDown(e, page + 1)}
+              class="usa-pagination__link usa-pagination__next-page"
+              href="javascript:void(0)"
+            >
+              <span class="usa-pagination__link-text">
+                {i18next.t('next')}
+              </span>
+              <div id="next-arrow-icon"></div>
+            </a>
+          </li>
+        </Fragment>
+      ) : null;
+
+    return (
+      <Host>
+        <nav class="usa-pagination" aria-label="Pagination">
+          <ul class="usa-pagination__list">
+            {previousButton}
+            {renderPages}
+            {endEllipsisAndLastPage}
+            {nextButton}
+          </ul>
+        </nav>
+      </Host>
+    );
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `pagination-remove-v1` is a placeholder for a CI job - it will be updated automatically -->
https://pagination-remove-v1--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR removes v1 code from va-pagination.
Closes [3019](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3019)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
