### PR TITLE
va-summary-box: v1 variation code removal

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1244,10 +1244,6 @@ export namespace Components {
         "inputValue": string;
     }
     interface VaSummaryBox {
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaTable {
         /**
@@ -3523,10 +3519,6 @@ declare namespace LocalJSX {
         "onVaInputChange"?: (event: VaStatementOfTruthCustomEvent<any>) => void;
     }
     interface VaSummaryBox {
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaTable {
         /**

--- a/packages/web-components/src/components/va-summary-box/test/va-summary-box.e2e.ts
+++ b/packages/web-components/src/components/va-summary-box/test/va-summary-box.e2e.ts
@@ -2,78 +2,7 @@ import { newE2EPage } from '@stencil/core/testing';
 import { axeCheck } from '../../../testing/test-helpers';
 
 describe('va-summary-box', () => {
-  it('renders v1', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-summary-box uswds="false">
-        <h3 slot="headline">
-          If I'm a Veteran, can I get VR&E benefits and services?
-        </h3>
-        <p>You may be eligible for VR&amp;E benefits and services if you're a Veteran, and you meet all of the requirements listed below.</p>
-        <p><strong>All of these must be true. You:</strong></p>
-        <ul>
-          <li>Didn't receive a dishonorable discharge, <strong>and</strong></li>
-          <li>Have a service-connected disability rating of at least 10% from VA, <strong>and</strong></li>
-          <li><a href="#">Apply for VR&amp;E services</a></li>
-        </ul>
-      </va-summary-box>
-    `);
-    const element = await page.find('va-summary-box');
-
-    expect(element).toEqualHtml(`
-      <va-summary-box class="hydrated" uswds="false">
-        <mock:shadow-root>
-          <div class="feature">
-            <slot name="headline"></slot>
-            <slot></slot>
-          </div>
-        </mock:shadow-root>
-        <h3 slot="headline">If I'm a Veteran, can I get VR&amp;E benefits and services?</h3>
-        <p>You may be eligible for VR&amp;E benefits and services if you're a Veteran, and you meet all of the requirements listed below.</p>
-        <p><strong>All of these must be true. You:</strong></p>
-        <ul>
-          <li>Didn't receive a dishonorable discharge, <strong>and</strong></li>
-          <li>Have a service-connected disability rating of at least 10% from VA, <strong>and</strong></li>
-          <li><a href="#">Apply for VR&amp;E services</a></li>
-        </ul>
-      </va-summary-box>
-    `);
-  });
-
-  it("renders the heading passed to the 'headline' slot", async () => {
-    const heading = "If I'm a Veteran, can I get VR&E benefits and services?";
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-summary-box uswds="false">
-        <h3 slot="headline">${heading}</h3>
-      </va-summary-box>
-    `);
-    const element = await page.find('h3');
-    expect(element).not.toBeNull();
-    expect(element).toEqualText(heading);
-  });
-
-  it('passes an axe check', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-summary-box uswds="false">
-        <h3 slot="headline">
-          If I'm a Veteran, can I get VR&E benefits and services?
-        </h3>
-        <p>You may be eligible for VR&amp;E benefits and services if you're a Veteran, and you meet all of the requirements listed below.</p>
-        <p><strong>All of these must be true. You:</strong></p>
-        <ul>
-          <li>Didn't receive a dishonorable discharge, <strong>and</strong></li>
-          <li>Have a service-connected disability rating of at least 10% from VA, <strong>and</strong></li>
-          <li><a href="#">Apply for VR&amp;E services</a></li>
-        </ul>
-      </va-summary-box>
-    `);
-
-    await axeCheck(page);
-  });
-
-  it('renders v3', async () => {
+  it('renders', async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-summary-box>

--- a/packages/web-components/src/components/va-summary-box/va-summary-box.scss
+++ b/packages/web-components/src/components/va-summary-box/va-summary-box.scss
@@ -11,13 +11,6 @@
   display: block;
 }
 
-.feature {
-  background: var(--vads-color-primary-alt-lightest);
-  padding: 1em;
-  clear: both;
-  margin: 1.5em 0 1.5em 0;
-}
-
 ::slotted([slot='headline']) {
   font-family: var(--font-serif);
   margin-top: 0 !important;

--- a/packages/web-components/src/components/va-summary-box/va-summary-box.scss
+++ b/packages/web-components/src/components/va-summary-box/va-summary-box.scss
@@ -2,11 +2,6 @@
 
 @use 'usa-summary-box/src/styles/usa-summary-box';
 
-.usa-summary-box {
-  font-size: 16px;
-  border-radius: 4px;
-}
-
 :host {
   display: block;
 }

--- a/packages/web-components/src/components/va-summary-box/va-summary-box.tsx
+++ b/packages/web-components/src/components/va-summary-box/va-summary-box.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element, State } from '@stencil/core';
+import { Component, Host, h, Element, State } from '@stencil/core';
 
 /**
  * @componentName Summary box
@@ -11,11 +11,7 @@ import { Component, Host, h, Prop, Element, State } from '@stencil/core';
   shadow: true,
 })
 export class VaSummaryBox {
-  /**
-   * Whether or not the component will use USWDS v3 styling.
-   */
-  @Prop() uswds?: boolean = true;
-
+  
   /**
    * Local state for slot=headline's text.
    * Used to place an aria-label for role="region" with the same text as the heading.
@@ -30,10 +26,7 @@ export class VaSummaryBox {
   }
 
   componentDidLoad() {
-    if (!this.uswds) {
-      return
-    }
-    // add uswds classes
+       // add uswds classes
     const nodes = this.el.shadowRoot
       .querySelectorAll('slot')
     const headline = nodes[0];
@@ -47,27 +40,15 @@ export class VaSummaryBox {
   }
 
   render() {
-    const { uswds } = this;
-    if (uswds) {
-      return (
-        <Host>
-          <div class="usa-summary-box" role="region" aria-label={this.headlineText}>
-            <div class="usa-summary-box__body">
-              <slot name="headline"></slot>
-              <slot />
-            </div>
-          </div>
-        </Host>
-      );
-    } else {
-      return (
-        <Host>
-          <div class="feature">
+    return (
+      <Host>
+        <div class="usa-summary-box" role="region" aria-label={this.headlineText}>
+          <div class="usa-summary-box__body">
             <slot name="headline"></slot>
             <slot />
           </div>
-        </Host>
-      );
-    }
-  }
+        </div>
+      </Host>
+    );
+  } 
 }


### PR DESCRIPTION
## Chromatic
<!-- This `3026-va-summary-box-v1-removal` is a placeholder for a CI job - it will be updated automatically -->
https://3026-va-summary-box-v1-removal--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
va-summary-box v1 removal
Closes [3026](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3026)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes:

Before:
![Screenshot 2024-08-12 at 10 36 58 AM](https://github.com/user-attachments/assets/82f932ca-5576-4aec-b33b-b166ee75dbd5)

After:
![Screenshot 2024-08-12 at 10 36 41 AM](https://github.com/user-attachments/assets/250ec608-b922-42ec-888c-3532b6f0e302)



## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
