### PR TITLE
va-process-list: v1 variation removal

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -952,10 +952,6 @@ export namespace Components {
         "showError"?: boolean;
     }
     interface VaProcessList {
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaProcessListItem {
         /**
@@ -3167,10 +3163,6 @@ declare namespace LocalJSX {
         "showError"?: boolean;
     }
     interface VaProcessList {
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaProcessListItem {
         /**

--- a/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
@@ -2,66 +2,10 @@ import { newE2EPage } from '@stencil/core/testing';
 import { axeCheck } from '../../../testing/test-helpers';
 
 describe('va-process-list', () => {
-  it('renders slotted nodes into an ordered list', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-process-list uswds="false">
-        <li>
-          <h2>Step one</h2>
-          <p>Some content</p>
-        </li>
-        <li>
-          <h2>Step two</h2>
-          <p>Additional content</p>
-          <ul>
-            <li>Item one</li>
-            <li>Item two</li>
-          </ul>
-        </li>
-      </va-process-list>
-    `);
-
-    const element = await page.find('va-process-list');
-    expect(element).toEqualHtml(`
-      <va-process-list class="hydrated" uswds="false">
-        <mock:shadow-root>
-          <ol role="list">
-            <slot></slot>
-          </ol>
-        </mock:shadow-root>
-        <li>
-          <h2>Step one</h2>
-          <p>Some content</p>
-        </li>
-        <li>
-          <h2>Step two</h2>
-          <p>Additional content</p>
-          <ul>
-            <li>Item one</li>
-            <li>Item two</li>
-          </ul>
-        </li>
-      </va-process-list>
-    `);
-  });
-
   it('passes an axe check', async () => {
     const page = await newE2EPage();
     await page.setContent(`
-        <va-process-list uswds="false">
-          <li>One</li>
-          <li>Two</li>
-          <li>Three</li>
-        </va-process-list>
-      `);
-
-    await axeCheck(page);
-  });
-
-  it('v3 passes an axe check', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-process-list uswds>
+      <va-process-list>
         <va-process-list-item header="Step one">
           <p>Some content</p>
         </va-process-list-item>
@@ -78,7 +22,7 @@ describe('va-process-list', () => {
     await axeCheck(page);
   });
 
-  it('v3 uswds renders slotted nodes into an ordered list', async () => {
+  it('renders slotted nodes into an ordered list', async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-process-list>

--- a/packages/web-components/src/components/va-process-list/va-process-list.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list.scss
@@ -7,7 +7,7 @@
   box-sizing: border-box;
 }
 
-:host(:not([uswds='false'])) {
+:host {
   counter-reset: usa-numbered-list;
 }
 
@@ -34,53 +34,4 @@
 
 ::slotted(va-process-list-item) {
   border-left: 8px solid var(--vads-color-gray-cool-light);
-}
-
-/** Original Component Style **/
-
-:host {
-  display: block;
-  list-style: none;
-  padding: 1rem 0;
-  position: relative;
-}
-
-ol {
-  margin: 0 0 0 1.25rem;
-  list-style-position: outside;
-}
-
-::slotted(li:first-child) {
-  counter-reset: listCounter;
-}
-
-::slotted(li) {
-  counter-increment: listCounter;
-  border-left: 8px solid var(--vads-color-base-light);
-  padding: 0 0 2rem 2rem;
-  list-style: none;
-  margin: 0 !important;
-}
-
-::slotted(li):before {
-  color: var(--vads-color-white);
-  content: counter(listCounter);
-  float: left;
-  font-size: 1.3rem;
-  font-weight: 700;
-  text-align: center;
-  width: 2.5rem;
-  top: -0.25rem;
-  margin-left: -3.5rem;
-  display: block;
-  border: 4px solid var(--vads-color-white);
-  background: var(--vads-color-base-dark);
-  border-radius: 2.5rem;
-  position: relative;
-  box-sizing: border-box !important;
-}
-
-::slotted(li:last-child) {
-  border-left: 0;
-  padding-left: calc(1.9375rem + 8px);
 }

--- a/packages/web-components/src/components/va-process-list/va-process-list.tsx
+++ b/packages/web-components/src/components/va-process-list/va-process-list.tsx
@@ -1,9 +1,4 @@
-import { Component, h, Prop } from '@stencil/core';
-
-/**
- * For v3/uswds this component expects `<va-process-list-item>` elements as its children.
- * For v1 this component expects `<li>` elements as its children.
- */
+import { Component, h } from '@stencil/core';
 
 /**
  * @componentName Process list
@@ -16,26 +11,12 @@ import { Component, h, Prop } from '@stencil/core';
   shadow: true,
 })
 export class VaProcessList {
-  /**
-   * Whether or not the component will use USWDS v3 styling.
-   */
-  @Prop() uswds?: boolean = true
 
   render() {
-    const { uswds } = this;
-    
-    if (uswds) {
-      return (
-        <ol role="list" class={'usa-process-list'}>
-          <slot></slot>
-        </ol>
-      );
-    } else {
-      return (
-        <ol role="list">
-          <slot></slot>
-        </ol>
-      );
-    }
+    return (
+      <ol role="list" class={'usa-process-list'}>
+        <slot></slot>
+      </ol>
+    );
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `3021-v1-process-list-removal` is a placeholder for a CI job - it will be updated automatically -->
https://3021-v1-process-list-removal--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Process-list v1 code removal
Closes [3021](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3021)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes:

Before:
![Screenshot 2024-08-13 at 10 30 42 AM](https://github.com/user-attachments/assets/22bdc546-a05e-4975-a6bc-eb3d9801192f)


After:
![Screenshot 2024-08-13 at 10 31 08 AM](https://github.com/user-attachments/assets/f3c1843f-23e0-4805-8c39-e6d0a246c7bd)


## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
