### PR TITLE
va-file-input/va-file-input-multiple: v1 variation removal

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -432,10 +432,6 @@ export namespace Components {
           * Sets the input to required and renders the (*Required) text.
          */
         "required"?: boolean;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaFileInputMultiple {
         /**
@@ -2547,10 +2543,6 @@ declare namespace LocalJSX {
           * Sets the input to required and renders the (*Required) text.
          */
         "required"?: boolean;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
     }
     interface VaFileInputMultiple {
         /**

--- a/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.e2e.ts
+++ b/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.e2e.ts
@@ -7,7 +7,7 @@ describe('va-file-input-multiple', () => {
   it('renders', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-file-input-multiple label="This is the file upload label" required="false" class="hydrated" uswds></va-file-input-multiple>',
+      '<va-file-input-multiple label="This is the file upload label" required="false" class="hydrated"></va-file-input-multiple>',
     );
 
     const multiElement = await page.find('va-file-input-multiple');

--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -266,7 +266,6 @@ export class VaFileInputMultiple {
             return (
               <va-file-input
                 key={fileEntry.key}
-                uswds
                 headless
                 label={label}
                 hint={hint}

--- a/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
+++ b/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
@@ -6,7 +6,7 @@ describe('va-file-input', () => {
   it('renders', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-file-input label="This is the file upload label" buttonText="Upload a file" required="false" class="hydrated" uswds></va-file-input>',
+      '<va-file-input label="This is the file upload label" buttonText="Upload a file" required="false" class="hydrated"></va-file-input>',
     );
 
     const element = await page.find('va-file-input');
@@ -15,7 +15,7 @@ describe('va-file-input', () => {
 
   it('renders hint text', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-file-input hint="This is hint text" uswds />');
+    await page.setContent('<va-file-input hint="This is hint text" />');
 
     // Render the hint text
     const hintTextElement = await page.find('va-file-input >>> div.usa-hint');
@@ -25,7 +25,7 @@ describe('va-file-input', () => {
   it('renders a required span', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<va-file-input required label="Example file input." buttonText="Upload a file" uswds />`,
+      `<va-file-input required label="Example file input." buttonText="Upload a file" />`,
     );
 
     const requiredSpan = await page.find(
@@ -37,7 +37,7 @@ describe('va-file-input', () => {
   it('the `accept` attribute exists if set', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<va-file-input buttonText="Upload a file" accept=".png" uswds />`,
+      `<va-file-input buttonText="Upload a file" accept=".png" />`,
     );
 
     const fileInput = await page.find('va-file-input >>> input');
@@ -46,7 +46,7 @@ describe('va-file-input', () => {
 
   it('the `accept` attribute does not apply if omitted', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-file-input buttonText="Upload a file" uswds />`);
+    await page.setContent(`<va-file-input buttonText="Upload a file" />`);
 
     const fileInput = await page.find('va-file-input >>> input');
     expect(fileInput.getAttribute('accept')).toBeFalsy();
@@ -54,7 +54,7 @@ describe('va-file-input', () => {
 
   it('emits the vaChange event only once', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-file-input buttonText="Upload a file" uswds />`);
+    await page.setContent(`<va-file-input buttonText="Upload a file" />`);
 
     const fileUploadSpy = await page.spyOnEvent('vaChange');
     const filePath = path.relative(process.cwd(), __dirname + '/1x1.png');
@@ -73,7 +73,7 @@ describe('va-file-input', () => {
     const page = await newE2EPage();
 
     await page.setContent(
-      '<va-file-input required label="This is a test" buttonText="Upload a file" error="With an error message" uswds />',
+      '<va-file-input required label="This is a test" buttonText="Upload a file" error="With an error message" />',
     );
 
     await axeCheck(page);
@@ -82,7 +82,7 @@ describe('va-file-input', () => {
   // this test usually passes but it is too flaky to enable
   it.skip('opens a modal when delete button clicked and lets user remove or keep file', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-file-input buttonText="Upload a file" uswds />`);
+    await page.setContent(`<va-file-input buttonText="Upload a file" />`);
 
     const filePath = path.relative(process.cwd(), __dirname + '/1x1.png');
 
@@ -136,7 +136,7 @@ describe('va-file-input', () => {
   // this test usually passes but it is too flaky to enable
   it.skip('opens a modal when delete button clicked and lets user remove the file', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-file-input buttonText="Upload a file" uswds />`);
+    await page.setContent(`<va-file-input buttonText="Upload a file" />`);
 
     const filePath = path.relative(process.cwd(), __dirname + '/1x1.png');
 

--- a/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
+++ b/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
@@ -6,113 +6,6 @@ describe('va-file-input', () => {
   it('renders', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-file-input label="This is the file upload label" buttonText="Upload a file" required="false" class="hydrated"></va-file-input>',
-    );
-
-    const element = await page.find('va-file-input');
-    expect(element).toEqualHtml(`
-    <va-file-input label="This is the file upload label" buttonText="Upload a file" required="false" class="hydrated">
-        <mock:shadow-root>
-          <label for="fileInputButton">This is the file upload label</label>
-          <slot></slot>
-          <span id="error-message" role="alert"></span>
-          <va-button id="fileInputButton" aria-label="This is the file upload label" secondary="" class="hydrated"></va-button>
-          <input type="file" id="fileInputField" hidden>
-        </mock:shadow-root>
-      </va-text-input>
-    `);
-  });
-
-  it('displays an error message when `error` is defined', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<va-file-input error="This is an error" buttonText="Upload a file" />`,
-    );
-
-    const errorSpan = await page.find('va-file-input >>> #error-message');
-    expect(errorSpan.innerText.includes('This is an error')).toBe(true);
-  });
-
-  it('no error message when `error` is not defined', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`<va-file-input />`);
-
-    const errorSpan = await page.find('va-file-input >>> #error-message');
-    expect(errorSpan.innerText).toBeNull;
-  });
-
-  it('renders hint text', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-file-input hint="This is hint text" />');
-
-    // Render the hint text
-    const hintTextElement = await page.find('va-file-input >>> span.hint-text');
-    expect(hintTextElement.innerText).toContain('This is hint text');
-  });
-
-  it('renders a required span', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<va-file-input required label="Example file input." buttonText="Upload a file"/>`,
-    );
-
-    const requiredSpan = await page.find('va-file-input >>> .required');
-    expect(requiredSpan).not.toBeNull();
-  });
-
-  it('the `accept` attribute exists if set', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<va-file-input buttonText="Upload a file" accept=".png" />`,
-    );
-
-    const fileInput = await page.find('va-file-input >>> input');
-    expect(fileInput.getAttribute('accept')).toBeTruthy();
-  });
-
-  it('the `accept` attribute does not apply if omitted', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`<va-file-input buttonText="Upload a file" />`);
-
-    const fileInput = await page.find('va-file-input >>> input');
-    expect(fileInput.getAttribute('accept')).toBeFalsy();
-  });
-
-  it('emits the vaChange event only once', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`<va-file-input button-text="Upload a file" />`);
-
-    const fileUploadSpy = await page.spyOnEvent('vaChange');
-    const filePath = path.relative(process.cwd(), __dirname + '/1x1.png');
-    const input = (
-      await page.waitForFunction(() =>
-        document
-          .querySelector('va-file-input')
-          .shadowRoot.querySelector('input[type=file]'),
-      )
-    ).asElement();
-
-    await input.uploadFile(filePath);
-    await page.waitForChanges();
-
-    expect(fileUploadSpy).toHaveReceivedEventTimes(1);
-  });
-
-  it('passes an aXe check', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(
-      '<va-file-input required label="This is a test" buttonText="Upload a file" error="With an error message"/>',
-    );
-
-    await axeCheck(page);
-  });
-
-  /** USWDS v3 mode tests */
-
-  it('v3 renders', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
       '<va-file-input label="This is the file upload label" buttonText="Upload a file" required="false" class="hydrated" uswds></va-file-input>',
     );
 
@@ -120,7 +13,7 @@ describe('va-file-input', () => {
     expect(element).not.toBeNull();
   });
 
-  it('v3 renders hint text', async () => {
+  it('renders hint text', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-file-input hint="This is hint text" uswds />');
 
@@ -129,7 +22,7 @@ describe('va-file-input', () => {
     expect(hintTextElement.innerText).toContain('This is hint text');
   });
 
-  it('v3 renders a required span', async () => {
+  it('renders a required span', async () => {
     const page = await newE2EPage();
     await page.setContent(
       `<va-file-input required label="Example file input." buttonText="Upload a file" uswds />`,
@@ -141,7 +34,7 @@ describe('va-file-input', () => {
     expect(requiredSpan).not.toBeNull();
   });
 
-  it('v3 the `accept` attribute exists if set', async () => {
+  it('the `accept` attribute exists if set', async () => {
     const page = await newE2EPage();
     await page.setContent(
       `<va-file-input buttonText="Upload a file" accept=".png" uswds />`,
@@ -151,7 +44,7 @@ describe('va-file-input', () => {
     expect(fileInput.getAttribute('accept')).toBeTruthy();
   });
 
-  it('v3 the `accept` attribute does not apply if omitted', async () => {
+  it('the `accept` attribute does not apply if omitted', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-file-input buttonText="Upload a file" uswds />`);
 
@@ -159,7 +52,7 @@ describe('va-file-input', () => {
     expect(fileInput.getAttribute('accept')).toBeFalsy();
   });
 
-  it('v3 emits the vaChange event only once', async () => {
+  it('emits the vaChange event only once', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-file-input buttonText="Upload a file" uswds />`);
 
@@ -176,7 +69,7 @@ describe('va-file-input', () => {
     expect(fileUploadSpy).toHaveReceivedEventTimes(1);
   });
 
-  it('v3 passes an aXe check', async () => {
+  it('passes an aXe check', async () => {
     const page = await newE2EPage();
 
     await page.setContent(
@@ -187,7 +80,7 @@ describe('va-file-input', () => {
   });
 
   // this test usually passes but it is too flaky to enable
-  it.skip('v3 opens a modal when delete button clicked and lets user remove or keep file', async () => {
+  it.skip('opens a modal when delete button clicked and lets user remove or keep file', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-file-input buttonText="Upload a file" uswds />`);
 
@@ -241,7 +134,7 @@ describe('va-file-input', () => {
   });
 
   // this test usually passes but it is too flaky to enable
-  it.skip('v3 opens a modal when delete button clicked and lets user remove the file', async () => {
+  it.skip('opens a modal when delete button clicked and lets user remove the file', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-file-input buttonText="Upload a file" uswds />`);
 

--- a/packages/web-components/src/components/va-file-input/va-file-input.scss
+++ b/packages/web-components/src/components/va-file-input/va-file-input.scss
@@ -13,41 +13,10 @@
   display: none;
 }
 
-/** Original Component Style **/
-@import '../../mixins/accessibility.css';
-@import '../../mixins/form-field-error.css';
-@import '../../mixins/hint-text.css';
-
 :host {
   display: block;
   font-family: var(--font-source-sans);
   font-size: 16.96px;
-}
-
-:host(.has-error) {
-  border-left: 0.25rem solid $vads-color-secondary-dark;
-  padding-left: 1rem;
-  position: relative;
-
-  @media screen and (min-width: 1008px) {
-    margin-left: -0.9rem;
-  }
-}
-
-#error-message {
-  margin-bottom: 0.188rem;
-}
-
-va-button {
-  margin-bottom: -0.5rem;
-}
-
-.required {
-  color: var(--vads-color-secondary-dark);
-  margin-left: 0.25rem;
-}
-
-:host(:not([uswds=false])) {
 
   .label-header {
     color: var(--vads-color-base);
@@ -219,4 +188,19 @@ va-button {
   .thumbnail-error {
     color: $vads-color-error-dark;
   }
+}
+
+:host(.has-error) {
+  border-left: 0.25rem solid $vads-color-secondary-dark;
+  padding-left: 1rem;
+  position: relative;
+
+  @media screen and (min-width: 1008px) {
+    margin-left: -0.9rem;
+  }
+}
+
+.required {
+  color: var(--vads-color-secondary-dark);
+  margin-left: 0.25rem;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `3017-file-input-v1-removal` is a placeholder for a CI job - it will be updated automatically -->
https://3017-file-input-v1-removal--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
- Remove v1 code from va-file-input
- Update va-file-input-multiple to remove uswds attributes

Closes [3017](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3017)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes

Before: 
![Screenshot 2024-08-13 at 2 37 34 PM](https://github.com/user-attachments/assets/56550161-966c-493b-b8f9-1495c2708d91)


After:
![Screenshot 2024-08-13 at 2 37 07 PM](https://github.com/user-attachments/assets/77ad31bf-50fb-464d-8bfd-f74c09eb0afa)



## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
