### PR TITLE
va-search-input: remove v1 code

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1085,7 +1085,7 @@ export namespace Components {
     }
     interface VaSearchInput {
         /**
-          * If `true`, the component will use the big variant. Only available when `uswds` is `true`.
+          * If `true`, the component will use the big variant.
          */
         "big"?: boolean;
         /**
@@ -1101,17 +1101,13 @@ export namespace Components {
          */
         "label"?: string;
         /**
-          * If `true`, the component will use the small variant. Only available when `uswds` is `true`.
+          * If `true`, the component will use the small variant.
          */
         "small"?: boolean;
         /**
           * An array of strings containing suggestions to be displayed in listbox. This component displays up to 5 suggestions.
          */
         "suggestions"?: any;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
         /**
           * The value of the input field
          */
@@ -3324,7 +3320,7 @@ declare namespace LocalJSX {
     }
     interface VaSearchInput {
         /**
-          * If `true`, the component will use the big variant. Only available when `uswds` is `true`.
+          * If `true`, the component will use the big variant.
          */
         "big"?: boolean;
         /**
@@ -3344,17 +3340,13 @@ declare namespace LocalJSX {
          */
         "onComponent-library-analytics"?: (event: VaSearchInputCustomEvent<any>) => void;
         /**
-          * If `true`, the component will use the small variant. Only available when `uswds` is `true`.
+          * If `true`, the component will use the small variant.
          */
         "small"?: boolean;
         /**
           * An array of strings containing suggestions to be displayed in listbox. This component displays up to 5 suggestions.
          */
         "suggestions"?: any;
-        /**
-          * Whether or not the component will use USWDS v3 styling.
-         */
-        "uswds"?: boolean;
         /**
           * The value of the input field
          */

--- a/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
+++ b/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
@@ -4,7 +4,7 @@ import { axeCheck } from '../../../testing/test-helpers';
 describe('va-search-input', () => {
   it('renders', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     const element = await page.find('va-search-input');
     expect(element).toHaveClass('hydrated');
@@ -12,14 +12,14 @@ describe('va-search-input', () => {
 
   it('passes an axe check', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     await axeCheck(page);
   });
 
   it('passes an axe check with suggestions visible', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-search-input uswds="false"></va-search-input>`);
+    await page.setContent(`<va-search-input></va-search-input>`);
 
     await page.$eval('va-search-input', (elm: any) => {
       elm.value = 'benefits';
@@ -38,20 +38,21 @@ describe('va-search-input', () => {
   it('renders with button with text', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-search-input button-text="Search VA.gov" uswds="false"></va-search-input>',
+      '<va-search-input button-text="Search VA.gov"></va-search-input>',
     );
 
     const element = await page.find('va-search-input');
     expect(element).toEqualHtml(`
-      <va-search-input button-text="Search VA.gov" class="hydrated" value="" uswds="false">
+      <va-search-input button-text="Search VA.gov" class="hydrated" value="">
         <mock:shadow-root>
-          <input aria-autocomplete="none" aria-label="Search" autocomplete="off" id="va-search-input" type="text">
-          <button aria-label="Search" id="va-search-button" type="submit">
-            <va-icon class="hydrated"></va-icon>
-            <span id="va-search-button-text">
-              Search VA.gov
-            </span>
+        <form class="usa-search" role="search">
+          <label class="usa-sr-only" for="search-field">Search</label>
+          <input class="usa-input" id="search-field" name="search" type="search" aria-autocomplete="none" aria-label="Search" autocomplete="off">
+          <button class="usa-button" type="submit">
+          <span class="usa-search__submit-text">Search VA.gov</span>
+          <va-icon class="hydrated usa-search__submit-icon"></va-icon>
           </button>
+        </form>
         </mock:shadow-root>
       </va-search-input>
     `);
@@ -59,7 +60,7 @@ describe('va-search-input', () => {
 
   it('fires input event on key press', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     const inputSpy = await page.spyOnEvent('input');
     const input = await page.find('va-search-input >>> input');
@@ -76,7 +77,7 @@ describe('va-search-input', () => {
 
   it('fires submit event on search button click when input has a value', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     await page.$eval('va-search-input', (elm: any) => {
       elm.value = 'benefits';
@@ -91,7 +92,7 @@ describe('va-search-input', () => {
 
   it('focuses first suggestion when pressing ArrowDown inside input field', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     await page.$eval('va-search-input', (elm: any) => {
       elm.value = 'benefits';
@@ -120,7 +121,7 @@ describe('va-search-input', () => {
 
   it('focuses last suggestion when pressing ArrowUp inside input field', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     await page.$eval('va-search-input', (elm: any) => {
       elm.value = 'benefits';
@@ -147,7 +148,7 @@ describe('va-search-input', () => {
 
   it('clears input value when pressing Escape key inside input field', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     await page.$eval('va-search-input', (elm: any) => {
       elm.value = 'benefits';
@@ -172,7 +173,7 @@ describe('va-search-input', () => {
 
   it('focuses next suggestion when pressing ArrowDown when suggestions are visible', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     await page.$eval('va-search-input', (elm: any) => {
       elm.value = 'benefits';
@@ -203,7 +204,7 @@ describe('va-search-input', () => {
 
   it('focuses last suggestion when pressing ArrowUp with first suggestion selected', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     await page.$eval('va-search-input', (elm: any) => {
       elm.value = 'benefits';
@@ -234,7 +235,7 @@ describe('va-search-input', () => {
 
   it('sets input value to suggestion when pressing Enter key with suggestion focused', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     await page.$eval('va-search-input', (elm: any) => {
       elm.value = 'benefits';
@@ -263,7 +264,7 @@ describe('va-search-input', () => {
 
   it('clears input value when pressing Escape key with a suggestion focused', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     await page.$eval('va-search-input', (elm: any) => {
       elm.value = 'benefits';
@@ -292,7 +293,7 @@ describe('va-search-input', () => {
 
   it('fires submit event when enter key is pressed', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
 
     const submitSpy = await page.spyOnEvent('submit');
     const input = await page.find('va-search-input >>> input');
@@ -310,7 +311,7 @@ describe('va-search-input', () => {
 
   it('fires submit event when a suggestion is clicked', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
     const inputEl = await page.find('va-search-input >>> input');
     await inputEl.click(); // Focus on the element
 
@@ -330,6 +331,7 @@ describe('va-search-input', () => {
     const firstSuggestion = await page.find(
       'va-search-input >>> [role="option"]',
     );
+
     await firstSuggestion.click();
 
     expect(submitSpy).toHaveReceivedEvent();
@@ -337,7 +339,7 @@ describe('va-search-input', () => {
 
   it('displays up to 5 suggestions but not more', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
+    await page.setContent('<va-search-input></va-search-input>');
     const inputEl = await page.find('va-search-input >>> input');
     await inputEl.click(); // Focus on the element
 
@@ -364,37 +366,10 @@ describe('va-search-input', () => {
     expect(suggestions.length).toEqual(5);
   });
 
-  it('displays 0 suggestions when the element has not recieved focus', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds="false"></va-search-input>');
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits delivery at discharge',
-        'benefits for surviving spouse',
-        'benefits for spouses',
-        'benefits for assisted living',
-        'benefits for family',
-        'x',
-        'y',
-        'z',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const suggestions = await page.findAll(
-      'va-search-input >>> [role="option"]',
-    );
-
-    expect(suggestions.length).toEqual(0);
-  });
-
   it('fires an analytics event when button is clicked', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-search-input label="Search" value="benefits"" uswds="false"></va-search-input>',
+      '<va-search-input label="Search" value="benefits""></va-search-input>',
     );
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
@@ -414,415 +389,7 @@ describe('va-search-input', () => {
   it('fires an analytics event on blur', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-search-input label="Search" value="benefits"" uswds="false"></va-search-input>',
-    );
-
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-
-    const component = await page.find('va-search-input');
-    await component.press('Tab'); // on the input
-    await component.press('Tab'); // on the button
-    await component.press('Tab'); // off the component
-
-    expect(analyticsSpy).toHaveReceivedEventDetail({
-      action: 'blur',
-      componentName: 'va-search-input',
-      details: {
-        value: 'benefits',
-      },
-    });
-  });
-
-  // Begin USWDS tests
-
-  it('uswds renders', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    const element = await page.find('va-search-input');
-    expect(element).toHaveClass('hydrated');
-  });
-
-  it('uswds passes an axe check', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    await axeCheck(page);
-  });
-
-  it('uswds passes an axe check with suggestions visible', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`<va-search-input uswds></va-search-input>`);
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits for spouses',
-        'benefits for assisted living',
-        'benefits for family',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    await axeCheck(page);
-  });
-
-  it('uswds renders with button with text', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-search-input uswds button-text="Search VA.gov"></va-search-input>',
-    );
-
-    const element = await page.find('va-search-input');
-    expect(element).toEqualHtml(`
-      <va-search-input button-text="Search VA.gov" class="hydrated" value="" uswds="">
-        <mock:shadow-root>
-        <form class="usa-search" role="search">
-          <label class="usa-sr-only" for="search-field">Search</label>
-          <input class="usa-input" id="search-field" name="search" type="search" aria-autocomplete="none" aria-label="Search" autocomplete="off">
-          <button class="usa-button" type="submit">
-          <span class="usa-search__submit-text">Search VA.gov</span>
-          <va-icon class="hydrated usa-search__submit-icon"></va-icon>
-          </button>
-        </form>
-        </mock:shadow-root>
-      </va-search-input>
-    `);
-  });
-
-  it('uswds fires input event on key press', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    const inputSpy = await page.spyOnEvent('input');
-    const input = await page.find('va-search-input >>> input');
-    await input.focus();
-
-    await input.press('F');
-    await input.press('o');
-    await input.press('r');
-    await input.press('m');
-    await input.press('s');
-
-    expect(inputSpy).toHaveReceivedEventTimes(5);
-  });
-
-  it('uswds fires submit event on search button click when input has a value', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-    });
-
-    const submitSpy = await page.spyOnEvent('submit');
-    const button = await page.find('va-search-input >>> button');
-    await button.click();
-
-    expect(submitSpy).toHaveReceivedEventTimes(1);
-  });
-
-  it('uswds focuses first suggestion when pressing ArrowDown inside input field', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits for assisted living',
-        'benefits for family',
-        'benefits for spouses',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const input = await page.find('va-search-input >>> input');
-    await input.focus();
-
-    await input.press('ArrowDown');
-
-    const selectedSuggestion = await page.find(
-      'va-search-input >>> [aria-selected="true"]',
-    );
-
-    expect(selectedSuggestion.innerText).toContain(
-      'benefits for assisted living',
-    );
-  });
-
-  it('uswds focuses last suggestion when pressing ArrowUp inside input field', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits for assisted living',
-        'benefits for family',
-        'benefits for spouses',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const input = await page.find('va-search-input >>> input');
-    await input.focus();
-
-    await input.press('ArrowUp');
-
-    const selectedSuggestion = await page.find(
-      'va-search-input >>> [aria-selected="true"]',
-    );
-
-    expect(selectedSuggestion.innerText).toContain('benefits for spouses');
-  });
-
-  it('uswds clears input value when pressing Escape key inside input field', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits for assisted living',
-        'benefits for family',
-        'benefits for spouses',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const input = await page.find('va-search-input >>> input');
-    await input.focus();
-
-    await input.press('Escape');
-
-    const inputValue = await input.getProperty('value');
-
-    expect(inputValue).toContain('');
-  });
-
-  it('uswds focuses next suggestion when pressing ArrowDown when suggestions are visible', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits for assisted living',
-        'benefits for family',
-        'benefits for spouses',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const input = await page.find('va-search-input >>> input');
-    await input.focus();
-    await input.press('ArrowDown');
-
-    const currentSuggestion = await page.find(
-      'va-search-input >>> [aria-selected="true"]',
-    );
-    await currentSuggestion.press('ArrowDown');
-
-    const selectedSuggestion = await page.find(
-      'va-search-input >>> [aria-selected="true"]',
-    );
-
-    expect(selectedSuggestion.innerText).toContain('benefits for family');
-  });
-
-  it('uswds focuses last suggestion when pressing ArrowUp with first suggestion selected', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits for assisted living',
-        'benefits for family',
-        'benefits for spouses',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const input = await page.find('va-search-input >>> input');
-    await input.focus();
-    await input.press('ArrowDown');
-
-    const currentSuggestion = await page.find(
-      'va-search-input >>> [aria-selected="true"]',
-    );
-    await currentSuggestion.press('ArrowUp');
-
-    const selectedSuggestion = await page.find(
-      'va-search-input >>> [aria-selected="true"]',
-    );
-
-    expect(selectedSuggestion.innerText).toContain('benefits for spouses');
-  });
-
-  it('uswds sets input value to suggestion when pressing Enter key with suggestion focused', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits for assisted living',
-        'benefits for family',
-        'benefits for spouses',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const input = await page.find('va-search-input >>> input');
-    await input.focus();
-    await input.press('ArrowDown');
-
-    const selectedSuggestion = await page.find(
-      'va-search-input >>> [aria-selected="true"]',
-    );
-    await selectedSuggestion.press('Enter');
-
-    const inputValue = await input.getProperty('value');
-
-    expect(inputValue).toContain('benefits for assisted living');
-  });
-
-  it('uswds clears input value when pressing Escape key with a suggestion focused', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits for assisted living',
-        'benefits for family',
-        'benefits for spouses',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const input = await page.find('va-search-input >>> input');
-    await input.focus();
-    await input.press('ArrowDown');
-
-    const selectedSuggestion = await page.find(
-      'va-search-input >>> [aria-selected="true"]',
-    );
-    await selectedSuggestion.press('Escape');
-
-    const inputValue = await input.getProperty('value');
-
-    expect(inputValue).toContain('');
-  });
-
-  it('uswds fires submit event when enter key is pressed', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-
-    const submitSpy = await page.spyOnEvent('submit');
-    const input = await page.find('va-search-input >>> input');
-    await input.focus();
-
-    await input.press('F');
-    await input.press('o');
-    await input.press('r');
-    await input.press('m');
-    await input.press('s');
-    await input.press('Enter');
-
-    expect(submitSpy).toHaveReceivedEvent();
-  });
-
-  it('uswds fires submit event when a suggestion is clicked', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-    const inputEl = await page.find('va-search-input >>> input');
-    await inputEl.click(); // Focus on the element
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits for assisted living',
-        'benefits for family',
-        'benefits for spouses',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const submitSpy = await page.spyOnEvent('submit');
-
-    const firstSuggestion = await page.find(
-      'va-search-input >>> [role="option"]',
-    );
-
-    await firstSuggestion.click();
-
-    expect(submitSpy).toHaveReceivedEvent();
-  });
-
-  it('uswds displays up to 5 suggestions but not more', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds></va-search-input>');
-    const inputEl = await page.find('va-search-input >>> input');
-    await inputEl.click(); // Focus on the element
-
-    await page.$eval('va-search-input', (elm: any) => {
-      elm.value = 'benefits';
-      elm.suggestions = [
-        'benefits delivery at discharge',
-        'benefits for surviving spouse',
-        'benefits for spouses',
-        'benefits for assisted living',
-        'benefits for family',
-        'x',
-        'y',
-        'z',
-      ];
-    });
-
-    await page.waitForChanges();
-
-    const suggestions = await page.findAll(
-      'va-search-input >>> [role="option"]',
-    );
-
-    expect(suggestions.length).toEqual(5);
-  });
-
-  it('uswds fires an analytics event when button is clicked', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-search-input uswds label="Search" value="benefits""></va-search-input>',
-    );
-
-    const analyticsSpy = await page.spyOnEvent('component-library-analytics');
-
-    const button = await page.find('va-search-input >>> button');
-    await button.click();
-
-    expect(analyticsSpy).toHaveReceivedEventDetail({
-      action: 'click',
-      componentName: 'va-search-input',
-      details: {
-        value: 'benefits',
-      },
-    });
-  });
-
-  it('uswds fires an analytics event on blur', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-search-input uswds label="Search" value="benefits""></va-search-input>',
+      '<va-search-input label="Search" value="benefits""></va-search-input>',
     );
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
@@ -903,7 +470,7 @@ describe('va-search-input', () => {
 
   it('uswds displays as the small variation', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds small></va-search-input>');
+    await page.setContent('<va-search-input small></va-search-input>');
 
     const form = await page.find('va-search-input >>> form');
     expect(form).toHaveClass('usa-search--small');
@@ -911,7 +478,7 @@ describe('va-search-input', () => {
 
   it('uswds displays as the big variation', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-search-input uswds big></va-search-input>');
+    await page.setContent('<va-search-input big></va-search-input>');
 
     const form = await page.find('va-search-input >>> form');
     expect(form).toHaveClass('usa-search--big');

--- a/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
+++ b/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
@@ -468,7 +468,7 @@ describe('va-search-input', () => {
     expect(analyticsSpy).not.toHaveReceivedEvent();
   });
 
-  it('uswds displays as the small variation', async () => {
+  it('displays as the small variation', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-search-input small></va-search-input>');
 
@@ -476,7 +476,7 @@ describe('va-search-input', () => {
     expect(form).toHaveClass('usa-search--small');
   });
 
-  it('uswds displays as the big variation', async () => {
+  it('displays as the big variation', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-search-input big></va-search-input>');
 

--- a/packages/web-components/src/components/va-search-input/va-search-input.scss
+++ b/packages/web-components/src/components/va-search-input/va-search-input.scss
@@ -5,6 +5,7 @@
 @use 'usa-button/src/styles/usa-button';
 
 @import '../../mixins/uswds-error-border.scss';
+@import '../../mixins/inputs.css';
 
 :host {
   display: block;
@@ -34,3 +35,4 @@
     width: auto;
   }
 }
+

--- a/packages/web-components/src/components/va-search-input/va-search-input.scss
+++ b/packages/web-components/src/components/va-search-input/va-search-input.scss
@@ -12,16 +12,16 @@
   padding: 0;
 }
 
-:host(:not([uswds='false'])) .usa-input {
+.usa-input {
   margin-top: 0;
 }
 
-:host(:not([uswds='false'])) #va-search-listbox {
+#va-search-listbox {
   top: 37px;
   z-index: 1;
 }
 
-:host(:not([uswds='false'])[big="true"]) #va-search-listbox  {
+:host([big="true"]) #va-search-listbox  {
   top: 52px;
 }
 
@@ -33,77 +33,4 @@
   :host .usa-search [type=submit] {
     width: auto;
   }
-}
-
-/* Original Component Styles. */
-
-@import '../../mixins/inputs.css';
-@import '../../mixins/buttons.css';
-
-:host([uswds='false']) {
-  display: block;
-  align-items: center;
-  display: flex;
-  position: relative;
-}
-
-#va-search-input {
-  border-color: var(--vads-color-base-dark);
-  display: inline-block;
-  height: 48px;
-  margin: 0;
-  max-width: none;
-  min-width: 248px;
-  padding: 12px 8px;
-}
-
-#va-search-input:focus {
-  z-index: 1;
-}
-
-#va-search-button {
-  align-items: center;
-  background-color: var(--vads-color-primary);
-  border-radius: 0 3px 3px 0;
-  display: flex;
-  height: 48px;
-}
-
-#va-search-button:focus {
-  z-index: 1;
-}
-
-#va-search-button:active,
-#va-search-button:hover {
-  background-color: var(--vads-color-primary-dark);
-}
-
-#va-search-button-text {
-  margin-left: 4px;
-}
-
-#va-search-listbox {
-  background-color: var(--vads-color-white);
-  box-shadow: 0px 2px 6px 1px rgba(20, 20, 20, 0.14);
-  display: block;
-  left: 0;
-  line-height: 24px;
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  position: absolute;
-  right: 0;
-  top: 48px;
-}
-
-.va-search-suggestion {
-  cursor: pointer;
-  padding: 8px;
-}
-
-.va-search-suggestion[aria-selected='true'],
-.va-search-suggestion:focus,
-.va-search-suggestion:hover {
-  background-color: var(--vads-color-primary);
-  color: var(--vads-color-white);
 }

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -77,17 +77,12 @@ export class VaSearchInput {
   // $('va-search-input').getAttribute('value') will be incorrect
 
   /**
-   * Whether or not the component will use USWDS v3 styling.
-   */
-  @Prop() uswds?: boolean = true;
-
-  /**
-   * If `true`, the component will use the big variant. Only available when `uswds` is `true`.
+   * If `true`, the component will use the big variant.
    */
   @Prop() big?: boolean = false;
 
   /**
-   * If `true`, the component will use the small variant. Only available when `uswds` is `true`.
+   * If `true`, the component will use the small variant.
    */
   @Prop() small?: boolean = false;
 
@@ -418,7 +413,6 @@ export class VaSearchInput {
       isListboxOpen,
       label,
       value,
-      uswds,
       big,
       small,
     } = this;
@@ -444,133 +438,76 @@ export class VaSearchInput {
     /* eslint-disable i18next/no-literal-string */
     const ariaHasPopup = isCombobox ? 'listbox' : undefined;
     const role = isCombobox ? 'combobox' : undefined;
-    const type = this.el.getAttribute('type') || 'text';
     /* eslint-enable i18next/no-literal-string */
 
-    if (uswds) {
-      const formClasses = classnames({
-        'usa-search': true,
-        'usa-search--big': big && !small,
-        'usa-search--small': small && !big,
-      });
-      return (
-        <Host onBlur={handleBlur}>
-          <form class={formClasses} role="search">
-            <label class="usa-sr-only" htmlFor="search-field">
-              {label}
-            </label>
-            <input
-              class="usa-input"
-              id="search-field"
-              name="search"
-              type="search"
-              ref={el => (this.inputRef = el as HTMLInputElement)}
-              aria-autocomplete={ariaAutoComplete}
-              aria-controls={ariaControls}
-              aria-expanded={ariaExpanded}
-              aria-haspopup={ariaHasPopup}
-              aria-label={label}
-              autocomplete="off"
-              onFocus={handleInputFocus}
-              onInput={handleInput}
-              onKeyDown={handleInputKeyDown}
-              role={role}
-              value={value}
-            />
-            <button
-              class="usa-button"
-              type="submit"
-              onClick={handleButtonClick}
-            >
-              {!small && (
-                <span class="usa-search__submit-text">{buttonText}</span>
-              )}
-              <va-icon
-                class="usa-search__submit-icon"
-                icon="search"
-                size={3}
-              ></va-icon>
-            </button>
-            {isListboxOpen && (
-              <ul
-                id="va-search-listbox"
-                aria-label="Search Suggestions"
-                role="listbox"
-              >
-                {formattedSuggestions.map(
-                  (suggestion: string | HTMLElement, index: number) => {
-                    return (
-                      <li
-                        id={`listbox-option-${index}`}
-                        class="va-search-suggestion"
-                        onClick={() => handleListboxClick(index)}
-                        onKeyDown={e => handleListboxKeyDown(e, index)}
-                        role="option"
-                        tabIndex={-1}
-                      >
-                        {suggestion}
-                      </li>
-                    );
-                  },
-                )}
-              </ul>
-            )}
-          </form>
-        </Host>
-      );
-    }
-
+    const formClasses = classnames({
+      'usa-search': true,
+      'usa-search--big': big && !small,
+      'usa-search--small': small && !big,
+    });
     return (
       <Host onBlur={handleBlur}>
-        <input
-          ref={el => (this.inputRef = el as HTMLInputElement)}
-          id="va-search-input"
-          aria-autocomplete={ariaAutoComplete}
-          aria-controls={ariaControls}
-          aria-expanded={ariaExpanded}
-          aria-haspopup={ariaHasPopup}
-          aria-label={label}
-          autocomplete="off"
-          onFocus={handleInputFocus}
-          onInput={handleInput}
-          onKeyDown={handleInputKeyDown}
-          role={role}
-          type={type}
-          value={value}
-        />
-        <button
-          id="va-search-button"
-          type="submit"
-          aria-label={label}
-          onClick={handleButtonClick}
-        >
-          <va-icon icon="search" size={3}></va-icon>
-          {buttonText && <span id="va-search-button-text">{buttonText}</span>}
-        </button>
-        {isListboxOpen && (
-          <ul
-            id="va-search-listbox"
-            aria-label="Search Suggestions"
-            role="listbox"
+        <form class={formClasses} role="search">
+          <label class="usa-sr-only" htmlFor="search-field">
+            {label}
+          </label>
+          <input
+            class="usa-input"
+            id="search-field"
+            name="search"
+            type="search"
+            ref={el => (this.inputRef = el as HTMLInputElement)}
+            aria-autocomplete={ariaAutoComplete}
+            aria-controls={ariaControls}
+            aria-expanded={ariaExpanded}
+            aria-haspopup={ariaHasPopup}
+            aria-label={label}
+            autocomplete="off"
+            onFocus={handleInputFocus}
+            onInput={handleInput}
+            onKeyDown={handleInputKeyDown}
+            role={role}
+            value={value}
+          />
+          <button
+            class="usa-button"
+            type="submit"
+            onClick={handleButtonClick}
           >
-            {formattedSuggestions.map(
-              (suggestion: string | HTMLElement, index: number) => {
-                return (
-                  <li
-                    id={`listbox-option-${index}`}
-                    class="va-search-suggestion"
-                    onClick={() => handleListboxClick(index)}
-                    onKeyDown={e => handleListboxKeyDown(e, index)}
-                    role="option"
-                    tabIndex={-1}
-                  >
-                    {suggestion}
-                  </li>
-                );
-              },
+            {!small && (
+              <span class="usa-search__submit-text">{buttonText}</span>
             )}
-          </ul>
-        )}
+            <va-icon
+              class="usa-search__submit-icon"
+              icon="search"
+              size={3}
+            ></va-icon>
+          </button>
+          {isListboxOpen && (
+            <ul
+              id="va-search-listbox"
+              aria-label="Search Suggestions"
+              role="listbox"
+            >
+              {formattedSuggestions.map(
+                (suggestion: string | HTMLElement, index: number) => {
+                  return (
+                    <li
+                      id={`listbox-option-${index}`}
+                      class="va-search-suggestion"
+                      onClick={() => handleListboxClick(index)}
+                      onKeyDown={e => handleListboxKeyDown(e, index)}
+                      role="option"
+                      tabIndex={-1}
+                    >
+                      {suggestion}
+                    </li>
+                  );
+                },
+              )}
+            </ul>
+          )}
+        </form>
       </Host>
     );
   }


### PR DESCRIPTION
## Chromatic
<!-- This `search-input-v1-removal` is a placeholder for a CI job - it will be updated automatically -->
https://search-input-v1-removal--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR removes v1 code from `va-search-input`
Closes [3023](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3023)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
