### PR TITLE
va-text-input: add suffix icon support

### DIFF
--- a/packages/storybook/stories/va-text-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.jsx
@@ -72,6 +72,7 @@ const defaultArgs = {
   'input-prefix': undefined,
   'input-icon-prefix': undefined,
   'input-suffix': undefined,
+  'input-icon-suffix': undefined
 };
 
 const Template = ({
@@ -96,6 +97,7 @@ const Template = ({
   'input-prefix': inputPrefix,
   'input-icon-prefix': inputIconPrefix,
   'input-suffix': inputSuffix,
+  'input-icon-suffix': inputIconSuffix
 }) => {
   return (
     <va-text-input
@@ -122,6 +124,7 @@ const Template = ({
       input-prefix={inputPrefix}
       input-icon-prefix={inputIconPrefix}
       input-suffix={inputSuffix}
+      input-icon-suffix={inputIconSuffix}
     />
   );
 };
@@ -449,6 +452,12 @@ WithSuffix.args = {
   'input-suffix': 'lbs.',
 };
 
+export const WithIconSuffix = Template.bind(null);
+WithIconSuffix.args = {
+  ...defaultArgs,
+  'input-icon-suffix': 'comment',
+}
+
 export const WithIconAndSuffix = Template.bind(null);
 WithIconAndSuffix.args = {
   ...defaultArgs,
@@ -457,6 +466,13 @@ WithIconAndSuffix.args = {
   'input-icon-prefix': 'attach_money',
   'input-suffix': 'per year',
 };
+
+export const WithPrefixAndIconSuffix = Template.bind(null);
+WithPrefixAndIconSuffix.args = {
+  ...defaultArgs,
+  'input-icon-suffix': 'comment',
+  'input-prefix': 'Pre'
+}
 
 export const Widths = WidthsTemplate.bind(null);
 Widths.args = {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1356,6 +1356,10 @@ export namespace Components {
          */
         "inputIconPrefix"?: string;
         /**
+          * A string that represents the name of an icon passed to va-icon, which will be applied as a suffix to the input.
+         */
+        "inputIconSuffix"?: string;
+        /**
           * Displays a fixed prefix string at the start of the input field.
          */
         "inputPrefix"?: string;
@@ -3610,6 +3614,10 @@ declare namespace LocalJSX {
           * This property displays a prefix that accepts a string which represents icon name.
          */
         "inputIconPrefix"?: string;
+        /**
+          * A string that represents the name of an icon passed to va-icon, which will be applied as a suffix to the input.
+         */
+        "inputIconSuffix"?: string;
         /**
           * Displays a fixed prefix string at the start of the input field.
          */

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -455,7 +455,8 @@ describe('va-text-input', () => {
     const page = await newE2EPage();
     await page.setContent('<va-text-input input-icon-suffix=\'credit_card\'></va-text-input>');
     const vaIconEl = await page.find('va-text-input >>> va-icon');
-    expect(vaIconEl).toHaveClass('hydrated');
+    const iconProp = await vaIconEl.getProperty('icon');
+    expect(iconProp).toMatch('credit_card');
   })
 
   it('sets the input mode to a default pattern if inputmode is numerical or decimal', async () => {

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -451,6 +451,12 @@ describe('va-text-input', () => {
     expect(el).toHaveClass('usa-input-suffix');
   });
   
+  it('renders an icon if input-icon-suffix is set', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-text-input input-icon-suffix=\'credit_card\'></va-text-input>');
+    const vaIconEl = await page.find('va-text-input >>> va-icon');
+    expect(vaIconEl).toHaveClass('hydrated');
+  })
 
   it('sets the input mode to a default pattern if inputmode is numerical or decimal', async () => {
     for (const inputMode of ['numeric', 'decimal']) {

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -180,7 +180,13 @@ export class VaTextInput {
    /**
    * Displays a fixed suffix string at the end of the input field.
    */
-   @Prop() inputSuffix?: string;
+  @Prop() inputSuffix?: string;
+  
+
+   /**
+   * A string that represents the name of an icon passed to va-icon, which will be applied as a suffix to the input.
+   */
+   @Prop() inputIconSuffix?: string;
 
   /**
    * The min attribute specifies the minimum value for an input element
@@ -349,7 +355,8 @@ export class VaTextInput {
       currency,
       inputPrefix,
       inputIconPrefix,
-      inputSuffix
+      inputSuffix,
+      inputIconSuffix
     } = this;
 
     const type = this.getInputType();
@@ -370,7 +377,7 @@ export class VaTextInput {
 
     const currencyWrapper = classnames({
       'currency-wrapper': currency,
-      'usa-input-group': inputSuffix || inputPrefix || inputIconPrefix
+      'usa-input-group': inputSuffix || inputPrefix || inputIconPrefix || inputIconSuffix
     });
 
     const getInputStyle = () => {
@@ -479,6 +486,7 @@ export class VaTextInput {
               max={max}
             />
             {inputSuffix && <div class="usa-input-suffix" part="suffix" aria-hidden="true">{inputSuffix.substring(0, 25)}</div>}
+            {inputIconSuffix && <div class="usa-input-suffix" part="input-suffix"><va-icon icon={inputIconSuffix} size={3} part="icon"></va-icon></div>}
           </div>
           {messageAriaDescribedby && (
             <span id="input-message" class="usa-sr-only dd-privacy-hidden">


### PR DESCRIPTION
## Chromatic
<!-- This `suffix-icon-va-text-input` is a placeholder for a CI job - it will be updated automatically -->
https://suffix-icon-va-text-input--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR adds support for an icon as a suffix for va-text-input.
Closes [3063](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3063)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<img width="1040" alt="Screenshot 2024-08-15 at 1 42 37 PM" src="https://github.com/user-attachments/assets/f43e3bae-38fa-4890-9a0d-92b3ae8a6db7">


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
