### PR TITLE
va-link: Adding a 'back' variant

### DIFF
--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const linkDocs = getWebComponentDocs('va-link');
@@ -17,6 +17,7 @@ export default {
 const defaultArgs = {
   'abbr-title': undefined,
   'active': undefined,
+  'back': undefined,
   'calendar': undefined,
   'channel': undefined,
   'disable-analytics': undefined,
@@ -36,6 +37,7 @@ const defaultArgs = {
 const Template = ({
   'abbr-title': abbrTitle,
   active,
+  back,
   calendar,
   channel,
   'disable-analytics': disableAnalytics,
@@ -50,13 +52,13 @@ const Template = ({
   label,
 }) => {
   return (
-    <Fragment>
     <p>
       If you need help to gather your information or fill out your
       application/form,{' '}
       <va-link
         abbr-title={abbrTitle}
         active={active}
+        back={back}
         calendar={calendar}
         channel={channel}
         disable-analytics={disableAnalytics}
@@ -71,7 +73,6 @@ const Template = ({
         label={label}
       />
     </p>
-    </Fragment>
   );
 };
 
@@ -86,6 +87,7 @@ Default.argTypes = propStructure(linkDocs);
 const VariantTemplate = ({
   'abbr-title': abbrTitle,
   active,
+  back,
   calendar,
   channel,
   'disable-analytics': disableAnalytics,
@@ -105,6 +107,7 @@ const VariantTemplate = ({
     <va-link
       abbr-title={abbrTitle}
       active={active}
+      back={back}
       calendar={calendar}
       channel={channel}
       disable-analytics={disableAnalytics}
@@ -130,27 +133,11 @@ Active.args = {
   text: 'Share your VA medical records',
 };
 
-export const Download = VariantTemplate.bind(null);
-Download.args = {
+export const Back = VariantTemplate.bind(null);
+Back.args = {
   ...defaultArgs,
-  download: true,
-  text: 'Download VA form 10-10EZ',
-  filetype: 'PDF',
-  pages: 5,
-};
-
-export const Video = VariantTemplate.bind(null);
-Video.args = {
-  ...defaultArgs,
-  video: true,
-  text: 'Go to the video about VA disability compensation',
-};
-
-export const Channel = VariantTemplate.bind(null);
-Channel.args = {
-  ...defaultArgs,
-  channel: true,
-  text: `Veteran's Affairs`,
+  back: true,
+  text: 'Back to previous page',
 };
 
 export const Calendar = VariantTemplate.bind(null);
@@ -161,6 +148,22 @@ Calendar.args = {
   text: `Add to calendar`,
 };
 
+export const Channel = VariantTemplate.bind(null);
+Channel.args = {
+  ...defaultArgs,
+  channel: true,
+  text: `Veteran's Affairs`,
+};
+
+export const Download = VariantTemplate.bind(null);
+Download.args = {
+  ...defaultArgs,
+  download: true,
+  text: 'Download VA form 10-10EZ',
+  filetype: 'PDF',
+  pages: 5,
+};
+
 export const Icon = VariantTemplate.bind(null);
 Icon.args = {
   ...defaultArgs,
@@ -168,6 +171,13 @@ Icon.args = {
   'text': `National Cemetery Administration`,
   'icon-name': 'mail',
   'icon-size': 3,
+};
+
+export const Video = VariantTemplate.bind(null);
+Video.args = {
+  ...defaultArgs,
+  video: true,
+  text: 'Go to the video about VA disability compensation',
 };
 
 const ReverseTemplate = ({ filename, filetype, href, reverse, text }) => {
@@ -194,12 +204,28 @@ const ReverseTemplate = ({ filename, filetype, href, reverse, text }) => {
         text="Share your VA medical records"
       />
 
-      <h4 className="vads-u-color--white">Icon</h4>
+      <h4 className="vads-u-color--white">Back Link</h4>
       <va-link
+        back
         href={href}
         reverse={reverse}
-        text="National Cemetery Administration"
-        icon-name="mail"
+        text="Back to previous page"
+      />
+
+      <h4 className="vads-u-color--white">Calendar Link</h4>
+      <va-link
+        calendar
+        href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR"
+        text="Add to calendar"
+        reverse
+      />
+
+      <h4 className="vads-u-color--white">Channel Link</h4>
+      <va-link
+        channel
+        href="https://www.va.gov"
+        text="Veteran's Affairs"
+        reverse
       />
 
       <h4 className="vads-u-color--white">Download Link</h4>
@@ -212,27 +238,19 @@ const ReverseTemplate = ({ filename, filetype, href, reverse, text }) => {
         text="Download VA form 10-10EZ"
       />
 
+      <h4 className="vads-u-color--white">Icon</h4>
+      <va-link
+        href={href}
+        reverse={reverse}
+        text="National Cemetery Administration"
+        icon-name="mail"
+      />
+
       <h4 className="vads-u-color--white">Video Link</h4>
       <va-link
         href="https://www.va.gov"
         text="Go to the video about VA disability compensation"
         video
-        reverse
-      />
-
-      <h4 className="vads-u-color--white">Channel Link</h4>
-      <va-link
-        channel
-        href="https://www.va.gov"
-        text="Veteran's Affairs"
-        reverse
-      />
-
-      <h4 className="vads-u-color--white">Calendar Link</h4>
-      <va-link
-        calendar
-        href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR"
-        text="Add to calendar"
         reverse
       />
     </div>

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -491,6 +491,10 @@ export namespace Components {
          */
         "active"?: boolean;
         /**
+          * If 'true', renders a "back arrow" in front of the link text
+         */
+        "back"?: boolean;
+        /**
           * If `true`, a calendar icon will be displayed before the anchor text.
          */
         "calendar"?: boolean;
@@ -2597,6 +2601,10 @@ declare namespace LocalJSX {
           * If `true`, the anchor text will be bolded and include a right arrow icon.
          */
         "active"?: boolean;
+        /**
+          * If 'true', renders a "back arrow" in front of the link text
+         */
+        "back"?: boolean;
         /**
           * If `true`, a calendar icon will be displayed before the anchor text.
          */

--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -132,6 +132,33 @@ describe('va-link', () => {
       </mock:shadow-root>
     </va-link>
     `);
+
+    const iconEl = await page.find('va-link >>> va-icon');
+    const iconName = await iconEl.getProperty('icon');
+    expect(iconName).toBe('chevron_right');
+  });
+
+  it('renders back link', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-link href="https://www.va.gov" text="Veteran's Affairs" back/>`,
+    );
+
+    const element = await page.find('va-link');
+    expect(element).toEqualHtml(`
+    <va-link class="hydrated" href="https://www.va.gov" text="Veteran's Affairs" back>
+      <mock:shadow-root>
+        <a href="https://www.va.gov">
+          <va-icon class="hydrated link-icon--back link-icon--left"></va-icon>
+          Veteran's Affairs
+        </a>
+      </mock:shadow-root>
+    </va-link>
+    `);
+
+    const iconEl = await page.find('va-link >>> va-icon');
+    const iconName = await iconEl.getProperty('icon');
+    expect(iconName).toBe('arrow_back');
   });
 
   it('renders a link with a screen reader label', async () => {

--- a/packages/web-components/src/components/va-link/va-link.css
+++ b/packages/web-components/src/components/va-link/va-link.css
@@ -11,7 +11,7 @@
   font: inherit;
 }
 
-:host a.va-link--reverse {
+:host a.va-link--reverse, :host a.va-link--reverse .link-icon--back {
   color: var(--vads-color-white);
 
   &:hover, &:active {
@@ -37,8 +37,12 @@
 .link-icon--left {
   margin-right: 4px;
   vertical-align: baseline;
-  position: relative; 
+  position: relative;
   top: 3px;
+}
+
+.link-icon--back {
+  color: var(--vads-color-gray-medium);
 }
 
 .link--center {

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -24,6 +24,11 @@ export class VaLink {
   @Prop({ reflect: true }) active?: boolean = false;
 
   /**
+   * If 'true', renders a "back arrow" in front of the link text
+   */
+  @Prop() back?: boolean = false;
+
+  /**
    * If `true`, a calendar icon will be displayed before the anchor text.
    */
   @Prop() calendar?: boolean = false;
@@ -77,7 +82,7 @@ export class VaLink {
    * If 'true', will represent the link with white text instead of blue.
    */
   @Prop() reverse?: boolean = false;
- 
+
   /**
    * Adds an aria-label attribute to the link element.
    */
@@ -128,6 +133,7 @@ export class VaLink {
   render() {
     const {
       active,
+      back,
       calendar,
       channel,
       download,
@@ -141,19 +147,31 @@ export class VaLink {
       video,
       reverse,
       iconName,
-      iconSize
+      iconSize,
     } = this;
 
     const linkClass = classNames({
       'va-link--reverse': reverse,
-      'link--center': iconName
+      'link--center': iconName,
     });
+
+    const backArrow = (
+      <va-icon
+        icon="arrow_back"
+        class="link-icon--left link-icon--back"
+      ></va-icon>
+    );
 
     // Active link variant
     if (active) {
       return (
         <Host>
-          <a href={href} class={linkClass} onClick={handleClick} aria-label={this.label}>
+          <a
+            href={href}
+            class={linkClass}
+            onClick={handleClick}
+            aria-label={this.label}
+          >
             {text}
             <va-icon class="link-icon--active" icon="chevron_right"></va-icon>
           </a>
@@ -224,11 +242,7 @@ export class VaLink {
     if (iconName) {
       return (
         <Host>
-          <a
-            href={href}
-            class={linkClass}
-            onClick={handleClick}
-          >
+          <a href={href} class={linkClass} onClick={handleClick}>
             <va-icon icon={iconName} size={iconSize} part="icon"></va-icon>
             {text}
           </a>
@@ -239,7 +253,13 @@ export class VaLink {
     // Default
     return (
       <Host>
-        <a href={href} class={linkClass} onClick={handleClick} aria-label={this.label}>
+        <a
+          href={href}
+          class={linkClass}
+          onClick={handleClick}
+          aria-label={this.label}
+        >
+          {back && backArrow}
           {text}
         </a>
       </Host>


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#2797](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2797)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2024-08-16 at 9 58 00 AM](https://github.com/user-attachments/assets/f9057c3b-d9af-4546-b878-13c5a612a7f1)

## Acceptance criteria
- [ ] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
