### PR TITLE
Revert "update web-components to always use configured instance of i1…

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -11,7 +11,7 @@ import {
   forceUpdate,
 } from '@stencil/core';
 import { getSlottedNodes } from '../../utils/utils';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { Build } from '@stencil/core';
 import classNames from 'classnames';
 

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
@@ -11,7 +11,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { Build } from '@stencil/core';
 import { getHeaderLevel } from '../../utils/utils';
 

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -10,7 +10,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { Build } from '@stencil/core';
 
 if (Build.isTesting) {

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -8,7 +8,7 @@ import {
   Element,
   Fragment,
 } from '@stencil/core';
-import { i18next } from '../..';
+import i18next from 'i18next';
 
 import {
   months,

--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -8,7 +8,7 @@ import {
   Event,
   EventEmitter,
 } from '@stencil/core';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { FileIndex } from "./FileIndex";
 
 /**

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -10,7 +10,7 @@ import {
   EventEmitter,
   State,
 } from '@stencil/core';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { fileInput } from './va-file-input-upgrader';
 import { extensionToMimeType } from "./fileExtensionToMimeType";
 

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../utils/date-utils';
 import { getHeaderLevel } from '../../utils/utils';
 
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { Build } from '@stencil/core';
 import classnames from 'classnames';
 

--- a/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
+++ b/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
@@ -8,7 +8,7 @@ import {
   Element,
   forceUpdate
 } from '@stencil/core';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { Build } from '@stencil/core';
 
 import iconHttpsSvg from '../../assets/icon-https.svg';

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
@@ -7,7 +7,7 @@ import {
   h,
   Prop
 } from '@stencil/core';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { Build } from '@stencil/core';
 import { consoleDevError } from '../../utils/utils';
 

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -11,7 +11,7 @@ import {
   getAssetPath,
 } from '@stencil/core';
 import classnames from 'classnames';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { Build } from '@stencil/core';
 
 import { makeArray } from '../../utils/utils';

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -12,7 +12,7 @@ import {
 } from '@stencil/core';
 import classnames from 'classnames';
 import { getSlottedNodes } from '../../utils/utils';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { Build } from '@stencil/core';
 import { getHeaderLevel } from '../../utils/utils';
 

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -22,7 +22,7 @@ describe('va-select', () => {
           <span id="input-error-message" role="alert"></span>
           <slot></slot>
           <select id="options" part="select" aria-invalid="false" class="usa-select">
-            <option value="">- Select -</option>
+            <option value=""></option>
             <option value="">Please choose an option</option>
             <option value="foo">Foo</option>
             <option value="bar">Bar</option>

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -12,7 +12,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { getSlottedNodes } from '../../utils/utils';
 
 /**

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -12,7 +12,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { consoleDevError, getCharacterMessage, getHeaderLevel } from '../../utils/utils';
 
 if (Build.isTesting) {

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -11,7 +11,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import { i18next } from '../..';
+import i18next from 'i18next';
 import { consoleDevError, getCharacterMessage, getHeaderLevel } from '../../utils/utils';
 
 if (Build.isTesting) {

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,7 +1,5 @@
 import '../../core/src/i18n/i18n-setup';
 
-export { i18next } from '../../core/src/i18n/i18n-setup';
-
 export { Components, JSX } from './components';
 
 export { CONTACTS, contactsMap } from './contacts';


### PR DESCRIPTION
…8n (#1290)"

This reverts commit 9d77821ae7be3bb1b7fe1b0b4bc538483b65ee21.

## Chromatic
<!-- This `revert-i18n` is a placeholder for a CI job - it will be updated automatically -->
https://revert-i18n--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR is a reversion due to a problem building react bindings in /web-components.

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
