### PR TITLE
va-button-pair: add support for custom button text

### DIFF
--- a/packages/storybook/stories/va-button-pair-uswds.stories.jsx
+++ b/packages/storybook/stories/va-button-pair-uswds.stories.jsx
@@ -25,6 +25,8 @@ const defaultArgs = {
   'secondary-label': undefined,
   'submit': undefined,
   'update': undefined,
+  'left-button-text': undefined,
+  'right-button-text': undefined
 };
 
 const Template = ({
@@ -34,6 +36,8 @@ const Template = ({
   'secondary-label': secondaryLabel,
   submit,
   update,
+  'left-button-text': lbText,
+  'right-button-text': rbText
 }) => {
   return (
     <div style={{ paddingLeft: '8px' }}>
@@ -46,6 +50,8 @@ const Template = ({
         onPrimaryClick={e => console.log(e)}
         onSecondaryClick={e => console.log(e)}
         update={update}
+        leftButtonText={lbText}
+        rightButtonText={rbText}
       />
     </div>
   );
@@ -68,3 +74,10 @@ Continue.args = {
   ...defaultArgs,
   continue: true,
 };
+
+export const CustomButtonText = Template.bind(null);
+CustomButtonText.args = {
+  ...defaultArgs,
+  'left-button-text': 'Start',
+  'right-button-text': 'Stop'
+}

--- a/packages/storybook/stories/va-button-pair-uswds.stories.jsx
+++ b/packages/storybook/stories/va-button-pair-uswds.stories.jsx
@@ -78,6 +78,6 @@ Continue.args = {
 export const CustomButtonText = Template.bind(null);
 CustomButtonText.args = {
   ...defaultArgs,
-  'left-button-text': 'Start',
-  'right-button-text': 'Stop'
+  'left-button-text': 'Agree to these terms',
+  'right-button-text': 'File later'
 }

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -229,11 +229,17 @@ export namespace Components {
           * If `true`, the component-library-analytics event is disabled.
          */
         "disableAnalytics"?: boolean;
+        /**
+          * Custom text that will be applied to the left va-button inside the component. If set will override text controlled by the 'update' prop.
+         */
         "leftButtonText"?: string;
         /**
           * Applies to the primary button aria-label.
          */
         "primaryLabel"?: string;
+        /**
+          * Custom text that will be applied to the right va-button inside the component. If set will override text controlled by the 'update' prop,
+         */
         "rightButtonText"?: string;
         /**
           * Applies to the secondary button aria-label.
@@ -2197,6 +2203,9 @@ declare namespace LocalJSX {
           * If `true`, the component-library-analytics event is disabled.
          */
         "disableAnalytics"?: boolean;
+        /**
+          * Custom text that will be applied to the left va-button inside the component. If set will override text controlled by the 'update' prop.
+         */
         "leftButtonText"?: string;
         /**
           * The event used to track usage of the component.
@@ -2214,6 +2223,9 @@ declare namespace LocalJSX {
           * Applies to the primary button aria-label.
          */
         "primaryLabel"?: string;
+        /**
+          * Custom text that will be applied to the right va-button inside the component. If set will override text controlled by the 'update' prop,
+         */
         "rightButtonText"?: string;
         /**
           * Applies to the secondary button aria-label.

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -229,10 +229,12 @@ export namespace Components {
           * If `true`, the component-library-analytics event is disabled.
          */
         "disableAnalytics"?: boolean;
+        "leftButtonText"?: string;
         /**
           * Applies to the primary button aria-label.
          */
         "primaryLabel"?: string;
+        "rightButtonText"?: string;
         /**
           * Applies to the secondary button aria-label.
          */
@@ -2187,6 +2189,7 @@ declare namespace LocalJSX {
           * If `true`, the component-library-analytics event is disabled.
          */
         "disableAnalytics"?: boolean;
+        "leftButtonText"?: string;
         /**
           * The event used to track usage of the component.
          */
@@ -2203,6 +2206,7 @@ declare namespace LocalJSX {
           * Applies to the primary button aria-label.
          */
         "primaryLabel"?: string;
+        "rightButtonText"?: string;
         /**
           * Applies to the secondary button aria-label.
          */

--- a/packages/web-components/src/components/va-button-pair/test/va-button-pair.e2e.ts
+++ b/packages/web-components/src/components/va-button-pair/test/va-button-pair.e2e.ts
@@ -88,4 +88,28 @@ describe('va-button-pair', () => {
     await buttons[1].click();
     expect(secondaryClickEvent).toHaveReceivedEventTimes(1);
   });
+
+  it('renders custom button text when left- and right-button-text props are set', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-button-pair left-button-text="hello" right-button-text="world"></va-button-pair>')
+   
+    const leftButton = (
+      await page.waitForFunction(() =>
+        document.querySelector('va-button-pair').shadowRoot.querySelector('va-button').shadowRoot.querySelector('button')
+      )
+    ).asElement();
+
+    const leftText = await leftButton.evaluate(element => element.innerHTML);
+    expect(leftText).toEqual('hello');
+
+    const rightButton = (
+      await page.waitForFunction(() => {
+        const vaButtons = document.querySelector('va-button-pair').shadowRoot.querySelectorAll('va-button');
+        return vaButtons[1].shadowRoot.querySelector('button');
+      })
+    ).asElement();
+
+    const rightText = await rightButton.evaluate(element => element.innerHTML);
+    expect(rightText).toEqual('world');
+  })
 });

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
@@ -55,6 +55,18 @@ export class VaButtonPair {
   @Prop() update?: boolean = false;
 
   /**
+   * Custom text that will be applied to the left va-button inside the component.
+   * If set will override text controlled by the 'update' prop.
+   */
+  @Prop() leftButtonText?: string;
+
+  /**
+   * Custom text that will be applied to the right va-button inside the component.
+   * If set will override text controlled by the 'update' prop,
+   */
+  @Prop() rightButtonText?: string
+
+  /**
    * Fires when the primary button is clicked.
    */
   @Event({
@@ -117,6 +129,28 @@ export class VaButtonPair {
     this.secondaryClick.emit(e);
   };
 
+
+  private getLeftButtonText = () => {
+    let text: string;
+    if (this.leftButtonText) {
+      text = this.leftButtonText;
+    } else {
+      text = this.update ? 'Update' : 'Yes';
+    }
+    return text;
+  }
+
+
+  private getRightButtonText = () => {
+    let text: string;
+    if (this.rightButtonText) {
+      text = this.rightButtonText;
+    } else {
+      text = this.update ? 'Cancel' : 'No';
+    }
+    return text;
+  }
+
   render() {
     const {
       continue: _continue,
@@ -126,7 +160,6 @@ export class VaButtonPair {
       primaryLabel,
       secondaryLabel,
       submit,
-      update,
     } = this;
 
     if (_continue) {
@@ -155,31 +188,29 @@ export class VaButtonPair {
       );
     }
 
-    if (update || !_continue) {
-      return (
-        <Host>
-          <ul class="usa-button-group">
-            <li class="usa-button-group__item">
-              <va-button
-                disable-analytics={disableAnalytics}
-                label={primaryLabel}
-                onClick={handlePrimaryClick}
-                text={update ? 'Update' : 'Yes'}
-                submit={submit}
-              />
-            </li>
-            <li class="usa-button-group__item">
-              <va-button
-                disable-analytics={disableAnalytics}
-                label={secondaryLabel}
-                onClick={handleSecondaryClick}
-                secondary
-                text={update ? 'Cancel' : 'No'}
-              />
-            </li>
-          </ul>
-        </Host>
-      );
-    }
+    return (
+      <Host>
+        <ul class="usa-button-group">
+          <li class="usa-button-group__item">
+            <va-button
+              disable-analytics={disableAnalytics}
+              label={primaryLabel}
+              onClick={handlePrimaryClick}
+              text={this.getLeftButtonText()}
+              submit={submit}
+            />
+          </li>
+          <li class="usa-button-group__item">
+            <va-button
+              disable-analytics={disableAnalytics}
+              label={secondaryLabel}
+              onClick={handleSecondaryClick}
+              secondary
+              text={this.getRightButtonText()}
+            />
+          </li>
+        </ul>
+      </Host>
+    );
   }
 }

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
@@ -130,6 +130,7 @@ export class VaButtonPair {
   };
 
 
+  // get text for the left button; custom text takes precedence
   private getLeftButtonText = () => {
     let text: string;
     if (this.leftButtonText) {
@@ -141,6 +142,7 @@ export class VaButtonPair {
   }
 
 
+  // get text for the right button; custom text takes precedence
   private getRightButtonText = () => {
     let text: string;
     if (this.rightButtonText) {


### PR DESCRIPTION
## Chromatic
<!-- This `va-button-pair-custom-text` is a placeholder for a CI job - it will be updated automatically -->
https://va-button-pair-custom-text--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR adds support for custom text for the buttons in va-button-pair.
Closes [3167](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3167)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<img width="241" alt="Screenshot 2024-08-22 at 4 25 16 PM" src="https://github.com/user-attachments/assets/3f135d69-f1cb-4c2e-b04c-b76920a73b4b">


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
