### PR TITLE
web-components: update i18n configuration

### DIFF
--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const linkDocs = getWebComponentDocs('va-link');
@@ -17,7 +17,6 @@ export default {
 const defaultArgs = {
   'abbr-title': undefined,
   'active': undefined,
-  'back': undefined,
   'calendar': undefined,
   'channel': undefined,
   'disable-analytics': undefined,
@@ -38,7 +37,6 @@ const defaultArgs = {
 const Template = ({
   'abbr-title': abbrTitle,
   active,
-  back,
   calendar,
   channel,
   'disable-analytics': disableAnalytics,
@@ -53,13 +51,13 @@ const Template = ({
   label,
 }) => {
   return (
+    <Fragment>
     <p>
       If you need help to gather your information or fill out your
       application/form,{' '}
       <va-link
         abbr-title={abbrTitle}
         active={active}
-        back={back}
         calendar={calendar}
         channel={channel}
         disable-analytics={disableAnalytics}
@@ -74,6 +72,7 @@ const Template = ({
         label={label}
       />
     </p>
+    </Fragment>
   );
 };
 
@@ -88,7 +87,6 @@ Default.argTypes = propStructure(linkDocs);
 const VariantTemplate = ({
   'abbr-title': abbrTitle,
   active,
-  back,
   calendar,
   channel,
   'disable-analytics': disableAnalytics,
@@ -109,7 +107,6 @@ const VariantTemplate = ({
     <va-link
       abbr-title={abbrTitle}
       active={active}
-      back={back}
       calendar={calendar}
       channel={channel}
       disable-analytics={disableAnalytics}
@@ -136,11 +133,27 @@ Active.args = {
   text: 'Share your VA medical records',
 };
 
-export const Back = VariantTemplate.bind(null);
-Back.args = {
+export const Download = VariantTemplate.bind(null);
+Download.args = {
   ...defaultArgs,
-  back: true,
-  text: 'Back to previous page',
+  download: true,
+  text: 'Download VA form 10-10EZ',
+  filetype: 'PDF',
+  pages: 5,
+};
+
+export const Video = VariantTemplate.bind(null);
+Video.args = {
+  ...defaultArgs,
+  video: true,
+  text: 'Go to the video about VA disability compensation',
+};
+
+export const Channel = VariantTemplate.bind(null);
+Channel.args = {
+  ...defaultArgs,
+  channel: true,
+  text: `Veteran's Affairs`,
 };
 
 export const Calendar = VariantTemplate.bind(null);
@@ -151,28 +164,12 @@ Calendar.args = {
   text: `Add to calendar`,
 };
 
-export const Channel = VariantTemplate.bind(null);
-Channel.args = {
-  ...defaultArgs,
-  channel: true,
-  text: `Veteran's Affairs`,
-};
-
-export const Download = VariantTemplate.bind(null);
-Download.args = {
-  ...defaultArgs,
-  download: true,
-  text: 'Download VA form 10-10EZ',
-  filetype: 'PDF',
-  pages: 5,
-};
-
 export const External = VariantTemplate.bind(null);
 External.args = {
   ...defaultArgs,
   external: true,
   text: `Leave VA.gov`,
-  href: 'https://design.va.gov/content-style-guide/links#linking-to-external-sites',
+  href: 'https://design.va.gov/content-style-guide/links#linking-to-external-sites'
 };
 
 export const Icon = VariantTemplate.bind(null);
@@ -182,13 +179,6 @@ Icon.args = {
   'text': `National Cemetery Administration`,
   'icon-name': 'mail',
   'icon-size': 3,
-};
-
-export const Video = VariantTemplate.bind(null);
-Video.args = {
-  ...defaultArgs,
-  video: true,
-  text: 'Go to the video about VA disability compensation',
 };
 
 const ReverseTemplate = ({ filename, filetype, href, reverse, text }) => {
@@ -215,28 +205,12 @@ const ReverseTemplate = ({ filename, filetype, href, reverse, text }) => {
         text="Share your VA medical records"
       />
 
-      <h4 className="vads-u-color--white">Back Link</h4>
+      <h4 className="vads-u-color--white">Icon</h4>
       <va-link
-        back
         href={href}
         reverse={reverse}
-        text="Back to previous page"
-      />
-
-      <h4 className="vads-u-color--white">Calendar Link</h4>
-      <va-link
-        calendar
-        href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR"
-        text="Add to calendar"
-        reverse
-      />
-
-      <h4 className="vads-u-color--white">Channel Link</h4>
-      <va-link
-        channel
-        href="https://www.va.gov"
-        text="Veteran's Affairs"
-        reverse
+        text="National Cemetery Administration"
+        icon-name="mail"
       />
 
       <h4 className="vads-u-color--white">Download Link</h4>
@@ -249,27 +223,35 @@ const ReverseTemplate = ({ filename, filetype, href, reverse, text }) => {
         text="Download VA form 10-10EZ"
       />
 
-      <h4 className="vads-u-color--white">External</h4>
-      <va-link
-        external
-        href="https://design.va.gov/content-style-guide/links#linking-to-external-sites"
-        text="Leave VA.gov"
-        reverse
-      />
-
-      <h4 className="vads-u-color--white">Icon</h4>
-      <va-link
-        href={href}
-        reverse={reverse}
-        text="National Cemetery Administration"
-        icon-name="mail"
-      />
-
       <h4 className="vads-u-color--white">Video Link</h4>
       <va-link
         href="https://www.va.gov"
         text="Go to the video about VA disability compensation"
         video
+        reverse
+      />
+
+      <h4 className="vads-u-color--white">Channel Link</h4>
+      <va-link
+        channel
+        href="https://www.va.gov"
+        text="Veteran's Affairs"
+        reverse
+      />
+
+      <h4 className="vads-u-color--white">Calendar Link</h4>
+      <va-link
+        calendar
+        href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR"
+        text="Add to calendar"
+        reverse
+      />
+
+      <h4 className="vads-u-color--white">External</h4>
+      <va-link
+        external
+        href='https://design.va.gov/content-style-guide/links#linking-to-external-sites'
+        text="Leave VA.gov"
         reverse
       />
     </div>

--- a/packages/storybook/stories/va-text-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.jsx
@@ -73,8 +73,7 @@ const defaultArgs = {
   'input-prefix': undefined,
   'input-icon-prefix': undefined,
   'input-suffix': undefined,
-  'input-icon-suffix': undefined,
-  'show-input-error': true,
+  'input-icon-suffix': undefined
 };
 
 const Template = ({
@@ -100,8 +99,7 @@ const Template = ({
   'input-prefix': inputPrefix,
   'input-icon-prefix': inputIconPrefix,
   'input-suffix': inputSuffix,
-  'input-icon-suffix': inputIconSuffix,
-  'show-input-error': showInputError,
+  'input-icon-suffix': inputIconSuffix
 }) => {
   return (
     <va-text-input
@@ -130,7 +128,6 @@ const Template = ({
       input-icon-prefix={inputIconPrefix}
       input-suffix={inputSuffix}
       input-icon-suffix={inputIconSuffix}
-      show-input-error={showInputError}
     />
   );
 };
@@ -487,14 +484,6 @@ export const Widths = WidthsTemplate.bind(null);
 Widths.args = {
   ...defaultArgs,
 };
-
-export const hideInputError = Template.bind(null);
-hideInputError.args = {
-  ...defaultArgs,
-  'show-input-error': false,
-  'error': 'This is an error message',
-};
-
 
 export const FormsPatternSingle = FormsPatternSingleTemplate.bind(null);
 FormsPatternSingle.args = {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -491,10 +491,6 @@ export namespace Components {
          */
         "active"?: boolean;
         /**
-          * If 'true', renders a "back arrow" in front of the link text
-         */
-        "back"?: boolean;
-        /**
           * If `true`, a calendar icon will be displayed before the anchor text.
          */
         "calendar"?: boolean;
@@ -1319,10 +1315,6 @@ export namespace Components {
           * Set the input to required and render the (Required) text.
          */
         "required"?: boolean;
-        /**
-          * When `false`, hides the error message from view, but not from the screen reader. Should only be used if error is being displayed elsewhere. Must use kebab-case on this attribute for it to work properly.
-         */
-        "showInputError"?: boolean;
         /**
           * The step attribute is a number, or the string 'any', that specifies the granularity of the value. For example: `<va-text-input type="number" step=".1"/>` enables float/decimal values to be valid and increment by one-tenth. <br/> Defaults to 1 for every field type except for time and datetime-local which default to 60 (seconds). View more documentation on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/step)
          */
@@ -2505,10 +2497,6 @@ declare namespace LocalJSX {
          */
         "active"?: boolean;
         /**
-          * If 'true', renders a "back arrow" in front of the link text
-         */
-        "back"?: boolean;
-        /**
           * If `true`, a calendar icon will be displayed before the anchor text.
          */
         "calendar"?: boolean;
@@ -3477,10 +3465,6 @@ declare namespace LocalJSX {
           * Set the input to required and render the (Required) text.
          */
         "required"?: boolean;
-        /**
-          * When `false`, hides the error message from view, but not from the screen reader. Should only be used if error is being displayed elsewhere. Must use kebab-case on this attribute for it to work properly.
-         */
-        "showInputError"?: boolean;
         /**
           * The step attribute is a number, or the string 'any', that specifies the granularity of the value. For example: `<va-text-input type="number" step=".1"/>` enables float/decimal values to be valid and increment by one-tenth. <br/> Defaults to 1 for every field type except for time and datetime-local which default to 60 (seconds). View more documentation on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/step)
          */

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -11,7 +11,7 @@ import {
   forceUpdate,
 } from '@stencil/core';
 import { getSlottedNodes } from '../../utils/utils';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { Build } from '@stencil/core';
 import classNames from 'classnames';
 

--- a/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
+++ b/packages/web-components/src/components/va-checkbox-group/va-checkbox-group.tsx
@@ -11,7 +11,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { Build } from '@stencil/core';
 import { getHeaderLevel } from '../../utils/utils';
 

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -10,7 +10,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { Build } from '@stencil/core';
 
 if (Build.isTesting) {

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -8,7 +8,7 @@ import {
   Element,
   Fragment,
 } from '@stencil/core';
-import i18next from 'i18next';
+import { i18next } from '../..';
 
 import {
   months,
@@ -302,7 +302,6 @@ export class VaDate {
               invalid={this.invalidYear}
               onInput={handleDateChange}
               onBlur={this.handleYearBlur}
-              show-input-error="false"
               class="input-year"
               inputmode="numeric"
               type="text"

--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -8,7 +8,7 @@ import {
   Event,
   EventEmitter,
 } from '@stencil/core';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { FileIndex } from "./FileIndex";
 
 /**
@@ -164,7 +164,7 @@ export class VaFileInputMultiple {
       }, 1000);
     }
 
-    this.vaMultipleChange.emit({ files: this.files.map(fileObj => fileObj.file).filter((file =>{ return !!file})) });
+    this.vaMultipleChange.emit({ files: this.files.map(fileObj => fileObj.file) });
     this.files = Array.of(...this.files);
   }
 

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -10,7 +10,7 @@ import {
   EventEmitter,
   State,
 } from '@stencil/core';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { fileInput } from './va-file-input-upgrader';
 import { extensionToMimeType } from "./fileExtensionToMimeType";
 

--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -132,35 +132,6 @@ describe('va-link', () => {
       </mock:shadow-root>
     </va-link>
     `);
-
-    const iconEl = await page.find('va-link >>> va-icon');
-    const iconName = await iconEl.getProperty('icon');
-    expect(iconName).toBe('chevron_right');
-  });
-
-  it('renders back link', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<va-link href="https://www.va.gov" text="Veteran's Affairs" back/>`,
-    );
-
-    const element = await page.find('va-link');
-    expect(element).toEqualHtml(`
-    <va-link class="hydrated" href="https://www.va.gov" text="Veteran's Affairs" back>
-      <mock:shadow-root>
-        <div class="link-container">
-          <va-icon class="hydrated link-icon--back link-icon--left"></va-icon>
-          <a href="https://www.va.gov">
-            Veteran's Affairs
-          </a>
-        </div>
-      </mock:shadow-root>
-    </va-link>
-    `);
-
-    const iconEl = await page.find('va-link >>> va-icon');
-    const iconName = await iconEl.getProperty('icon');
-    expect(iconName).toBe('arrow_back');
   });
 
   it('renders external link', async () => {

--- a/packages/web-components/src/components/va-link/va-link.scss
+++ b/packages/web-components/src/components/va-link/va-link.scss
@@ -1,6 +1,7 @@
 @use 'uswds-helpers/src/styles/usa-sr-only';
-@import '~@department-of-veterans-affairs/css-library/dist/stylesheets/uswds-typography.css';
+@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/uswds-typography.css";
 @import '../../mixins/links.css';
+
 
 :host {
   display: inline;
@@ -11,14 +12,10 @@
   text-decoration: underline;
 }
 
-:host a.va-link--reverse,
-:host a.va-link--reverse .link-icon--back {
+:host a.va-link--reverse {
   color: var(--vads-color-white);
 
-  &:hover,
-  &:active,
-  &:hover .link-icon--back,
-  &:active .link-icon--back {
+  &:hover, &:active {
     color: var(--vads-color-action-focus-on-light);
     background-color: transparent;
   }
@@ -41,21 +38,8 @@
 .link-icon--left {
   margin-right: 4px;
   vertical-align: baseline;
-  position: relative;
+  position: relative; 
   top: 3px;
-}
-
-// Needed by the back link variant for text alignment
-.link-container {
-  display: flex;
-  flex-direction: row;
-}
-
-.link-icon--back {
-  color: var(--vads-color-gray-medium);
-  transition-duration: 0.3s;
-  transition-timing-function: ease-in-out;
-  transition-property: color, background-color, border-color;
 }
 
 .link--center {

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -24,11 +24,6 @@ export class VaLink {
   @Prop({ reflect: true }) active?: boolean = false;
 
   /**
-   * If 'true', renders a "back arrow" in front of the link text
-   */
-  @Prop() back?: boolean = false;
-
-  /**
    * If `true`, a calendar icon will be displayed before the anchor text.
    */
   @Prop() calendar?: boolean = false;
@@ -87,7 +82,7 @@ export class VaLink {
    * If 'true', will open in a new tab and have icon denoting that. Will also have the text "opens in a new tab" appended to the link text in screen reader only span
    */
   @Prop() external?: boolean = false;
-
+ 
   /**
    * Adds an aria-label attribute to the link element.
    */
@@ -138,7 +133,6 @@ export class VaLink {
   render() {
     const {
       active,
-      back,
       calendar,
       channel,
       download,
@@ -153,53 +147,22 @@ export class VaLink {
       reverse,
       external,
       iconName,
-      iconSize,
+      iconSize
     } = this;
 
     const linkClass = classNames({
       'va-link--reverse': reverse,
-      'link--center': iconName || external,
+      'link--center': iconName || external
     });
 
     // Active link variant
     if (active) {
       return (
         <Host>
-          <a
-            href={href}
-            class={linkClass}
-            onClick={handleClick}
-            aria-label={this.label}
-          >
+          <a href={href} class={linkClass} onClick={handleClick} aria-label={this.label}>
             {text}
             <va-icon class="link-icon--active" icon="chevron_right"></va-icon>
           </a>
-        </Host>
-      );
-    }
-
-    // Back link variant
-    if (back) {
-      const backArrow = (
-        <va-icon
-          icon="arrow_back"
-          class="link-icon--left link-icon--back"
-        ></va-icon>
-      );
-
-      return (
-        <Host>
-          <div class="link-container">
-            {backArrow}
-            <a
-              href={href}
-              class={linkClass}
-              onClick={handleClick}
-              aria-label={this.label}
-            >
-              {text}
-            </a>
-          </div>
         </Host>
       );
     }
@@ -267,7 +230,11 @@ export class VaLink {
     if (iconName) {
       return (
         <Host>
-          <a href={href} class={linkClass} onClick={handleClick}>
+          <a
+            href={href}
+            class={linkClass}
+            onClick={handleClick}
+          >
             <va-icon icon={iconName} size={iconSize} part="icon"></va-icon>
             {text}
           </a>
@@ -280,10 +247,10 @@ export class VaLink {
         <Host>
           <a
             href={href}
-            rel="noreferrer"
+            rel='noreferrer'
             class={linkClass}
             onClick={handleClick}
-            target="_blank"
+            target='_blank'
           >
             {text}
             <va-icon class="external-link-icon" icon="launch"></va-icon>
@@ -296,12 +263,7 @@ export class VaLink {
     // Default
     return (
       <Host>
-        <a
-          href={href}
-          class={linkClass}
-          onClick={handleClick}
-          aria-label={this.label}
-        >
+        <a href={href} class={linkClass} onClick={handleClick} aria-label={this.label}>
           {text}
         </a>
       </Host>

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -62,10 +62,10 @@ describe('va-memorable-date', () => {
                   </va-select>
                 </div>
                 <div class="usa-form-group usa-form-group--day">
-                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--day-input" show-input-error="false"></va-text-input>
+                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--day-input"></va-text-input>
                 </div>
                 <div class="usa-form-group usa-form-group--year">
-                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--year-input" show-input-error="false" value=""></va-text-input>
+                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--year-input" value=""></va-text-input>
                 </div>
               </div>
             </fieldset>
@@ -152,10 +152,10 @@ describe('va-memorable-date', () => {
                 </va-select>
               </div>
               <div class="usa-form-group usa-form-group--day">
-                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--day-input" show-input-error="false"></va-text-input>
+                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--day-input"></va-text-input>
               </div>
               <div class="usa-form-group usa-form-group--year">
-                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--year-input" show-input-error="false" value=""></va-text-input>
+                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--year-input" value=""></va-text-input>
               </div>
             </div>
           </fieldset>
@@ -714,13 +714,13 @@ describe('va-memorable-date', () => {
               <slot></slot>
               <div class="usa-memorable-date">
                 <div class="usa-form-group usa-form-group--month">
-                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--month-input" show-input-error="false"></va-text-input>
+                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--month-input"></va-text-input>
                 </div>
                 <div class="usa-form-group usa-form-group--day">
-                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--day-input" show-input-error="false"></va-text-input>
+                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--day-input"></va-text-input>
                 </div>
                 <div class="usa-form-group usa-form-group--year">
-                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--year-input" show-input-error="false" value=""></va-text-input>
+                  <va-text-input aria-describedby="dateHint" class="hydrated memorable-date-input usa-form-group--year-input" value=""></va-text-input>
                 </div>
               </div>
             </fieldset>
@@ -767,13 +767,13 @@ describe('va-memorable-date', () => {
             <slot></slot>
             <div class="usa-memorable-date">
               <div class="usa-form-group usa-form-group--month">
-                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--month-input" show-input-error="false"></va-text-input>
+                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--month-input"></va-text-input>
               </div>
               <div class="usa-form-group usa-form-group--day">
-                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--day-input" show-input-error="false"></va-text-input>
+                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--day-input"></va-text-input>
               </div>
               <div class="usa-form-group usa-form-group--year">
-                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--year-input" show-input-error="false" value=""></va-text-input>
+                <va-text-input aria-describedby="dateHint hint" class="hydrated memorable-date-input usa-form-group--year-input" value=""></va-text-input>
               </div>
             </div>
           </fieldset>

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../utils/date-utils';
 import { getHeaderLevel } from '../../utils/utils';
 
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { Build } from '@stencil/core';
 import classnames from 'classnames';
 
@@ -239,6 +239,14 @@ export class VaMemorableDate {
   })
   componentLibraryAnalytics: EventEmitter;
 
+  componentDidLoad() {
+    // We are setting the error on each va-text-input for screen readers, but do not want to show it visually.
+    const textInputs = this.el.shadowRoot.querySelectorAll('va-text-input, va-select');
+    textInputs.forEach((input) => {
+      input.shadowRoot.querySelector('#input-error-message').classList.add('sr-only');
+    });
+  }
+
   connectedCallback() {
     i18next.on('languageChanged', () => {
       forceUpdate(this.el);
@@ -369,7 +377,6 @@ export class VaMemorableDate {
           inputmode="numeric"
           type="text"
           error={this.invalidMonth ? getStandardErrorMessage(error) : null}
-          show-input-error="false"
         />
       </div>;
       const legendClass = classnames({
@@ -417,7 +424,6 @@ export class VaMemorableDate {
                     inputmode="numeric"
                     type="text"
                     error={this.invalidDay ? getStandardErrorMessage(error) : null}
-                    show-input-error="false"
                   />
                 </div>
                 <div class="usa-form-group usa-form-group--year">
@@ -438,7 +444,6 @@ export class VaMemorableDate {
                     inputmode="numeric"
                     type="text"
                     error={this.invalidYear ? getStandardErrorMessage(error) : null}
-                    show-input-error="false"
                   />
                 </div>
               </div>

--- a/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
+++ b/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
@@ -8,7 +8,7 @@ import {
   Element,
   forceUpdate
 } from '@stencil/core';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { Build } from '@stencil/core';
 
 import iconHttpsSvg from '../../assets/icon-https.svg';

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
@@ -7,7 +7,7 @@ import {
   h,
   Prop
 } from '@stencil/core';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { Build } from '@stencil/core';
 import { consoleDevError } from '../../utils/utils';
 

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -11,7 +11,7 @@ import {
   getAssetPath,
 } from '@stencil/core';
 import classnames from 'classnames';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { Build } from '@stencil/core';
 
 import { makeArray } from '../../utils/utils';

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -12,7 +12,7 @@ import {
 } from '@stencil/core';
 import classnames from 'classnames';
 import { getSlottedNodes } from '../../utils/utils';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { Build } from '@stencil/core';
 import { getHeaderLevel } from '../../utils/utils';
 

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -22,7 +22,7 @@ describe('va-select', () => {
           <span id="input-error-message" role="alert"></span>
           <slot></slot>
           <select id="options" part="select" aria-invalid="false" class="usa-select">
-            <option value=""></option>
+            <option value="">- Select -</option>
             <option value="">Please choose an option</option>
             <option value="foo">Foo</option>
             <option value="bar">Bar</option>

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -12,7 +12,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { getSlottedNodes } from '../../utils/utils';
 
 /**

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -9,7 +9,7 @@ describe('va-text-input', () => {
     const element = await page.find('va-text-input');
 
     expect(element).toEqualHtml(`
-      <va-text-input class="hydrated" label="Hello, world" show-input-error="">
+      <va-text-input class="hydrated" label="Hello, world">
         <mock:shadow-root>
         <div class="input-wrap">
           <label for="inputField" class="usa-label" id="input-label" part="label">
@@ -36,19 +36,6 @@ describe('va-text-input', () => {
     expect(error.innerText).toContain('This is a mistake');
     expect(input.getAttribute('aria-invalid')).toEqual('true');
     expect(input.getAttribute('aria-describedby')).toBe('input-error-message');
-    const errorMesage = await page.find('va-text-input >>> #input-error-message');
-    // verify showInputError isn't set to false
-    expect(errorMesage).not.toHaveClass('usa-sr-only');
-  });
-
-  it('renders an with a hidden error message when showInputError is false', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-text-input label="Hello, world" error="This is a mistake" show-input-error="false"/>');
-
-    // Render the error message text
-    const errorMesage = await page.find('va-text-input >>> #input-error-message');
-    expect(errorMesage).toHaveClass('usa-sr-only');
-    
   });
 
   it('sets aria-invalid based on invalid prop', async () => {

--- a/packages/web-components/src/components/va-text-input/va-text-input.scss
+++ b/packages/web-components/src/components/va-text-input/va-text-input.scss
@@ -65,10 +65,3 @@ input.usa-input {
     padding-left: 25px;
   }
 }
-
-:host([error]:not([error=""])[show-input-error=false]) {
-  // override error left border when show-input-error is set false
-  border-left: 0;
-  padding-left: 0;
-  margin-left: 0;
-}

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -12,7 +12,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { consoleDevError, getCharacterMessage, getHeaderLevel } from '../../utils/utils';
 
 if (Build.isTesting) {
@@ -60,12 +60,6 @@ export class VaTextInput {
    * Whether or not to add usa-input--error as class if error message is outside of component
    */
   @Prop() reflectInputError?: boolean = false;
-
-  /**
-   * When `false`, hides the error message from view, but not from the screen reader. Should only be used if error is being displayed elsewhere. Must use kebab-case on this attribute for it to work properly.
-   */
-  // Dev note: When camelCase is used instead of kebab-case it doesn't reflect in the DOM and one of the CSS selectors won't be applied. Maybe worth revisiting to see if this is still the case after a stencil upgrade.
-  @Prop({ reflect: true }) showInputError?: boolean = true;
 
   /**
    * Whether or not `aria-invalid` will be set on the inner input. Useful when
@@ -168,11 +162,11 @@ export class VaTextInput {
    */
   @Prop() formHeading?: string;
 
-  /**
+    /**
    * Whether the component should show a character count message.
    * Has no effect without maxlength being set.
    */
-  @Prop() charcount?: boolean = false;
+    @Prop() charcount?: boolean = false;
 
    /**
    * Whether this component will be used to accept a currency value.
@@ -355,7 +349,6 @@ export class VaTextInput {
       label,
       error,
       reflectInputError,
-      showInputError,
       invalid,
       required,
       value,
@@ -379,6 +372,7 @@ export class VaTextInput {
       inputSuffix,
       inputIconSuffix
     } = this;
+
     const type = this.getInputType();
     const maxlength = this.getMaxlength();
     const inputmode = this.getInputmode();
@@ -430,10 +424,6 @@ export class VaTextInput {
       'usa-character-count__status--invalid': maxlength && value?.length > maxlength
     });
 
-    const errorClass = classnames({
-      'usa-sr-only': !showInputError,
-    });
-
     const isFormsPattern = useFormsPattern === 'single' || useFormsPattern === 'multiple' ? true : false;
     let formsHeading = null;
     if (isFormsPattern) {
@@ -474,7 +464,7 @@ export class VaTextInput {
             </label>
           )}
           <slot></slot>
-          <span id="input-error-message" role="alert" class={errorClass}>
+          <span id="input-error-message" role="alert">
             {error && (
               <Fragment>
                 <span class="usa-sr-only">{i18next.t('error')}</span>

--- a/packages/web-components/src/components/va-textarea/va-textarea.tsx
+++ b/packages/web-components/src/components/va-textarea/va-textarea.tsx
@@ -11,7 +11,7 @@ import {
   Fragment,
 } from '@stencil/core';
 import classnames from 'classnames';
-import i18next from 'i18next';
+import { i18next } from '../..';
 import { consoleDevError, getCharacterMessage, getHeaderLevel } from '../../utils/utils';
 
 if (Build.isTesting) {

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,5 +1,7 @@
 import '../../core/src/i18n/i18n-setup';
 
+export { i18next } from '../../core/src/i18n/i18n-setup';
+
 export { Components, JSX } from './components';
 
 export { CONTACTS, contactsMap } from './contacts';

--- a/packages/web-components/tsconfig.bindings.json
+++ b/packages/web-components/tsconfig.bindings.json
@@ -15,7 +15,8 @@
     "removeComments": false,
     "sourceMap": true,
     "jsx": "react",
-    "target": "es5"
+    "target": "es5",
+    "skipLibCheck": true
   },
   "include": ["react-bindings/**/*.ts", "react-bindings/**/*.tsx"],
   "compileOnSave": false,


### PR DESCRIPTION
## Chromatic
<!-- This `i18n-web-components` is a placeholder for a CI job - it will be updated automatically -->
https://i18n-web-components--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
