### PR TITLE
va-radio: re-add mixins

### DIFF
--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -10,6 +10,8 @@
 
 @import '../../mixins/uswds-error-border.scss';
 @import '../../mixins/focusable.css';
+@import '../../mixins/accessibility.css';
+@import '../../mixins/headers.css';
 
 :host {
   display: block;


### PR DESCRIPTION
## Chromatic
<!-- This `mc-add-mixins-va-radio` is a placeholder for a CI job - it will be updated automatically -->
https://mc-add-mixins-va-radio--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
This re-adds a couple of mixins to va-radio that caused a regression in production to to using the browser default stylesheet. 
[This slack thread](https://dsva.slack.com/archives/C01DBGX4P45/p1724445319663739) has more information and some screenshots on the regression

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
