### PR TITLE
[SIMPLE_FORMS] feat: add ability for user to set value and readOnly mode for file input component

### DIFF
--- a/packages/storybook/stories/va-file-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from 'react';
-import {VaFileInput} from '@department-of-veterans-affairs/web-components/react-bindings';
+import React, { useEffect, useState } from 'react';
+import { VaFileInput } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
+import testImage from './images/search-bar.png';
 
 VaFileInput.displayName = 'VaFileInput';
 
@@ -30,7 +31,9 @@ const defaultArgs = {
     alert(`File change event received: ${event?.detail?.files[0]?.name}`),
   'uswds': true,
   'header-size': null,
-  'children': null
+  'readOnly': false,
+  'value': null,
+  'children': null,
 };
 
 const Template = ({
@@ -44,7 +47,9 @@ const Template = ({
   vaChange,
   uswds,
   headerSize,
-  children
+  readOnly,
+  value,
+  children,
 }) => {
   return (
     <VaFileInput
@@ -58,6 +63,8 @@ const Template = ({
       onVaChange={vaChange}
       uswds={uswds}
       header-size={headerSize}
+      readOnly={readOnly}
+      value={value}
       children={children}
     />
   );
@@ -99,25 +106,42 @@ HeaderLabel.args = {
   ...defaultArgs,
   label: 'Header label',
   headerSize: 3,
-  required: true
-}
+  required: true,
+};
 
 const additionalFormInputsContent = (
   <div>
-    <va-select className="hydrated" uswds label='What kind of file is this?' required>
-      <option key="1" value="1">Public Document</option>
-      <option key="2" value="2">Private Document</option>
+    <va-select
+      className="hydrated"
+      uswds
+      label="What kind of file is this?"
+      required
+    >
+      <option key="1" value="1">
+        Public Document
+      </option>
+      <option key="2" value="2">
+        Private Document
+      </option>
     </va-select>
-  </div>);
+  </div>
+);
 
 export const AdditionalFormInputs = Template.bind(null);
 AdditionalFormInputs.args = {
   ...defaultArgs,
   label: 'Header label',
-  children: additionalFormInputsContent
-}
+  children: additionalFormInputsContent,
+};
 
-const CustomValidationTemplate = ({ label, name, accept, required, error, hint }) => {
+const CustomValidationTemplate = ({
+  label,
+  name,
+  accept,
+  required,
+  error,
+  hint,
+}) => {
   const [errorVal, setErrorVal] = useState(error);
 
   function validateFileContents(event) {
@@ -130,8 +154,7 @@ const CustomValidationTemplate = ({ label, name, accept, required, error, hint }
         const contents = reader.result;
         const hasX = contents.includes('X');
 
-        if (hasX)
-          setErrorVal('File contains an \'X\' character');
+        if (hasX) setErrorVal("File contains an 'X' character");
       };
 
       reader.readAsText(file);
@@ -152,13 +175,20 @@ const CustomValidationTemplate = ({ label, name, accept, required, error, hint }
       />
       <hr />
       <div>
-        <p>The parent component captures the file from the onVaChange event, reads its contents, and validates it. The error prop is dynamically set if the validation fails.</p>
-        <p>This example validates that the file does not contain the character 'X'. The validation runs when the file changes or is removed.</p>
+        <p>
+          The parent component captures the file from the onVaChange event,
+          reads its contents, and validates it. The error prop is dynamically
+          set if the validation fails.
+        </p>
+        <p>
+          This example validates that the file does not contain the character
+          'X'. The validation runs when the file changes or is removed.
+        </p>
       </div>
       <div className="vads-u-margin-top--2">
-      <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
-        <code>
-{`const [errorVal, setErrorVal] = useState(error);
+        <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
+          <code>
+            {`const [errorVal, setErrorVal] = useState(error);
 
 function validateFileContents(event) {
   setErrorVal(null);
@@ -198,17 +228,48 @@ return (
   );
 };
 
-
 export const CustomValidation = CustomValidationTemplate.bind(null);
 CustomValidation.args = {
   ...defaultArgs,
-  label: 'Upload a file which does not contain the character \'X\'',
+  label: "Upload a file which does not contain the character 'X'",
   hint: 'Select a TXT file',
-  accept: '.txt'
-}
+  accept: '.txt',
+};
 
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = {
   ...defaultArgs,
-  'enable-analytics': true
+  'enable-analytics': true,
 };
+
+const FileUploadedTemplate = args => {
+  const [mockFile, setMockFile] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadImage = async () => {
+      const response = await fetch(testImage);
+      const blob = await response.blob();
+      const file = new File([blob], 'test.jpg', { type: 'image/jpeg' });
+
+      if (isMounted) {
+        setMockFile(file);
+      }
+    };
+
+    loadImage();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return <Template {...args} value={mockFile} />;
+};
+
+export const FileUploaded = FileUploadedTemplate.bind(null);
+FileUploaded.args = { ...defaultArgs, vaChange: event => event };
+
+export const ReadOnly = FileUploadedTemplate.bind(null);
+ReadOnly.args = { ...defaultArgs, vaChange: event => event, readOnly: true };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -421,9 +421,17 @@ export namespace Components {
          */
         "name"?: string;
         /**
+          * Optionally displays the read-only view
+         */
+        "readOnly"?: boolean;
+        /**
           * Sets the input to required and renders the (*Required) text.
          */
         "required"?: boolean;
+        /**
+          * The value attribute for the file view element.
+         */
+        "value"?: File;
     }
     interface VaFileInputMultiple {
         /**
@@ -2427,13 +2435,37 @@ declare namespace LocalJSX {
          */
         "onComponent-library-analytics"?: (event: VaFileInputCustomEvent<any>) => void;
         /**
+          * The event emitted when the change file button is clicked.
+         */
+        "onFileChangeClick"?: (event: VaFileInputCustomEvent<any>) => void;
+        /**
+          * The event emitted when the delete file confirmation button is clicked.
+         */
+        "onFileDeleteCancelClick"?: (event: VaFileInputCustomEvent<any>) => void;
+        /**
+          * The event emitted when the delete file button is clicked.
+         */
+        "onFileDeleteClick"?: (event: VaFileInputCustomEvent<any>) => void;
+        /**
+          * The event emitted when the delete file cancel button is clicked.
+         */
+        "onFileDeleteConfirmClick"?: (event: VaFileInputCustomEvent<any>) => void;
+        /**
           * The event emitted when the file input value changes.
          */
         "onVaChange"?: (event: VaFileInputCustomEvent<any>) => void;
         /**
+          * Optionally displays the read-only view
+         */
+        "readOnly"?: boolean;
+        /**
           * Sets the input to required and renders the (*Required) text.
          */
         "required"?: boolean;
+        /**
+          * The value attribute for the file view element.
+         */
+        "value"?: File;
     }
     interface VaFileInputMultiple {
         /**

--- a/packages/web-components/src/components/va-file-input/va-file-input.scss
+++ b/packages/web-components/src/components/va-file-input/va-file-input.scss
@@ -95,7 +95,7 @@
 
   .selected-files-wrapper {
     background-color: var(--vads-color-primary-lighter);
-    border: 1px solid var(--vads-color-base-light)
+    border: 1px solid var(--vads-color-base-light);
   }
 
   .selected-files-label {
@@ -137,7 +137,6 @@
   }
 
   .file-info-section {
-    border-bottom: 1px solid var(--vads-color-base-lighter);
     padding: 0 8px 8px;
     display: flex;
     align-items: center;
@@ -159,6 +158,7 @@
   }
 
   .additional-info-slot {
+    border-top: 1px solid var(--vads-color-base-lighter);
     padding-bottom: 16px;
   }
 
@@ -166,7 +166,7 @@
   /* TO DO: decide whether to import from CSS-Library or simply rename,
   /* as this is the only attibute currently needed from utilities
   */
-  .vads-u-line-height--2{
+  .vads-u-line-height--2 {
     line-height: 1.15;
   }
 

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -487,27 +487,25 @@ export class VaFileInput {
                     </span>
                   </div>
                 </div>
-                {file && (
+                {file && !readOnly && (
                   <div>
                     <div class="additional-info-slot">
                       <slot></slot>
                     </div>
-                    {!readOnly && (
-                      <div class="file-button-section">
-                        <va-button-icon
-                          buttonType="change-file"
-                          onClick={this.changeFile}
-                          label="Change file"
-                          aria-label={'change file ' + file.name}
-                        ></va-button-icon>
-                        <va-button-icon
-                          buttonType="delete"
-                          onClick={this.openModal}
-                          aria-label={'delete file ' + file.name}
-                          label="Delete"
-                        ></va-button-icon>
-                      </div>
-                    )}
+                    <div class="file-button-section">
+                      <va-button-icon
+                        buttonType="change-file"
+                        onClick={this.changeFile}
+                        label="Change file"
+                        aria-label={'change file ' + file.name}
+                      ></va-button-icon>
+                      <va-button-icon
+                        buttonType="delete"
+                        onClick={this.openModal}
+                        aria-label={'delete file ' + file.name}
+                        label="Delete"
+                      ></va-button-icon>
+                    </div>
                     <va-modal
                       modalTitle="Delete this file?"
                       visible={this.showModal}

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -12,7 +12,7 @@ import {
 } from '@stencil/core';
 import i18next from 'i18next';
 import { fileInput } from './va-file-input-upgrader';
-import { extensionToMimeType } from "./fileExtensionToMimeType";
+import { extensionToMimeType } from './fileExtensionToMimeType';
 
 /**
  * @componentName File input
@@ -51,6 +51,11 @@ export class VaFileInput {
    * The text displayed on the button.
    */
   @Prop() buttonText: string;
+
+  /**
+   * The value attribute for the file view element.
+   */
+  @Prop() value?: File;
 
   /**
    * Sets the input to required and renders the (*Required) text.
@@ -96,6 +101,31 @@ export class VaFileInput {
   @Event() vaChange: EventEmitter;
 
   /**
+   * The event emitted when the change file button is clicked.
+   */
+  @Event() fileChangeClick: EventEmitter;
+
+  /**
+   * The event emitted when the delete file button is clicked.
+   */
+  @Event() fileDeleteClick: EventEmitter;
+
+  /**
+   * The event emitted when the delete file confirmation button is clicked.
+   */
+  @Event() fileDeleteCancelClick: EventEmitter;
+
+  /**
+   * The event emitted when the delete file cancel button is clicked.
+   */
+  @Event() fileDeleteConfirmClick: EventEmitter;
+
+  /**
+   * Optionally displays the read-only view
+   */
+  @Prop() readOnly?: boolean = false;
+
+  /**
    * The event used to track usage of the component. This is emitted when the
    * file input changes and enableAnalytics is true.
    */
@@ -109,10 +139,10 @@ export class VaFileInput {
   private handleChange = (e: Event) => {
     const input = e.target as HTMLInputElement;
     if (input.files && input.files.length > 0) {
-      this.handleFile(input.files[0])
+      this.handleFile(input.files[0]);
     }
     input.value = '';
-  }
+  };
 
   private handleDrop = (event: DragEvent) => {
     event.preventDefault();
@@ -151,7 +181,7 @@ export class VaFileInput {
         },
       });
     }
-  }
+  };
 
   private removeFile = (notifyParent: boolean = true) => {
     this.closeModal();
@@ -170,7 +200,7 @@ export class VaFileInput {
     const modal = this.el.shadowRoot.querySelector('va-modal');
     modal.setAttribute('status', 'warning');
     this.showModal = true;
-  }
+  };
 
   private closeModal = () => {
     this.showModal = false;
@@ -178,7 +208,7 @@ export class VaFileInput {
     setTimeout(() => {
       this.fileInputRef.focus();
     }, 0);
-  }
+  };
 
   private changeFile = () => {
     if (this.fileInputRef) {
@@ -186,11 +216,12 @@ export class VaFileInput {
     }
   };
 
-  private updateStatusMessage(message:string) {
+  private updateStatusMessage(message: string) {
     // Add delay to encourage screen reader readout
     setTimeout(() => {
-      const statusMessageDiv = this.el.shadowRoot.querySelector("#statusMessage");
-      statusMessageDiv ? statusMessageDiv.textContent = message : "";
+      const statusMessageDiv =
+        this.el.shadowRoot.querySelector('#statusMessage');
+      statusMessageDiv ? (statusMessageDiv.textContent = message) : '';
     }, 1000);
   }
 
@@ -221,9 +252,12 @@ export class VaFileInput {
       item = item.trim();
       return item.startsWith('.') ? extensionToMimeType[item] : item;
     });
-  }
+  };
 
-  private isAcceptedFileType = (fileType: string, acceptedTypes: string[]): boolean => {
+  private isAcceptedFileType = (
+    fileType: string,
+    acceptedTypes: string[],
+  ): boolean => {
     for (const type of acceptedTypes) {
       if (type === fileType) {
         return true;
@@ -233,7 +267,7 @@ export class VaFileInput {
       }
     }
     return false;
-  }
+  };
 
   private renderLabelOrHeader = (
     label: string,
@@ -304,6 +338,7 @@ export class VaFileInput {
     const {
       label,
       name,
+      value,
       required,
       accept,
       error,
@@ -313,8 +348,13 @@ export class VaFileInput {
       headerSize,
       fileContents,
       fileType,
-      headless
+      headless,
+      readOnly,
     } = this;
+
+    if (value) {
+      this.handleFile(value);
+    }
 
     const displayError = this.error || this.internalError;
     const ariaDescribedbyIds =
@@ -341,11 +381,14 @@ export class VaFileInput {
     if (error) {
       fileThumbnail = (
         <div class="thumbnail-container">
-          <va-icon icon="error" size={3} class="thumbnail-preview thumbnail-error"/>
+          <va-icon
+            icon="error"
+            size={3}
+            class="thumbnail-preview thumbnail-error"
+          />
         </div>
       );
-    }
-    else if (fileContents) {
+    } else if (fileContents) {
       if (fileType.startsWith('image/')) {
         fileThumbnail = (
           <div class="thumbnail-container" aria-hidden="true">
@@ -364,8 +407,10 @@ export class VaFileInput {
         );
       }
     }
-    let selectedFileClassName = headless ? "headless-selected-files-wrapper" : "selected-files-wrapper"
-    const hintClass = "usa-hint" + (headless ? " usa-sr-only" : "")
+    let selectedFileClassName = headless
+      ? 'headless-selected-files-wrapper'
+      : 'selected-files-wrapper';
+    const hintClass = 'usa-hint' + (headless ? ' usa-sr-only' : '');
     return (
       <Host class={{ 'has-error': !!displayError }}>
         <span class={{ 'usa-sr-only': !!headless }}>
@@ -381,8 +426,7 @@ export class VaFileInput {
             id="fileInputField"
             class="file-input"
             style={{
-              visibility:
-                this.uploadStatus === 'success' ? 'hidden' : 'unset',
+              visibility: this.uploadStatus === 'success' ? 'hidden' : 'unset',
             }}
             type="file"
             ref={el => (this.fileInputRef = el as HTMLInputElement)}
@@ -401,26 +445,30 @@ export class VaFileInput {
                   </Fragment>
                 )}
               </span>
-              <div class='usa-sr-only' aria-live="polite" id="statusMessage"></div>
+              <div
+                class="usa-sr-only"
+                aria-live="polite"
+                id="statusMessage"
+              ></div>
               <div class={fileInputTargetClasses}>
                 <div class="file-input-box"></div>
                 <div class="file-input-instructions">
-                  <span class="file-input-drag-text">
-                    Drag files here or{' '}
-                  </span>
-                  <span class="file-input-choose-text">
-                    choose from folder
-                  </span>
+                  <span class="file-input-drag-text">Drag files here or </span>
+                  <span class="file-input-choose-text">choose from folder</span>
                 </div>
               </div>
             </div>
           )}
           {uploadStatus !== 'idle' && (
             <div class={selectedFileClassName}>
-              {!headless &&
+              {!headless && (
                 <div class="selected-files-label">Selected files</div>
-              }
-              <div class='usa-sr-only' aria-live="polite" id="statusMessage"></div>
+              )}
+              <div
+                class="usa-sr-only"
+                aria-live="polite"
+                id="statusMessage"
+              ></div>
               <va-card class="va-card">
                 <div class="file-info-section">
                   {fileThumbnail}
@@ -444,30 +492,33 @@ export class VaFileInput {
                     <div class="additional-info-slot">
                       <slot></slot>
                     </div>
-                    <div class="file-button-section">
-                      <va-button-icon
-                        buttonType="change-file"
-                        onClick={this.changeFile}
-                        label="Change file"
-                        aria-label={'change file ' + file.name}
-                      ></va-button-icon>
-                      <va-button-icon
-                        buttonType="delete"
-                        onClick={this.openModal}
-                        aria-label={'delete file ' + file.name}
-                        label="Delete"
-                      ></va-button-icon>
-                    </div>
+                    {!readOnly && (
+                      <div class="file-button-section">
+                        <va-button-icon
+                          buttonType="change-file"
+                          onClick={this.changeFile}
+                          label="Change file"
+                          aria-label={'change file ' + file.name}
+                        ></va-button-icon>
+                        <va-button-icon
+                          buttonType="delete"
+                          onClick={this.openModal}
+                          aria-label={'delete file ' + file.name}
+                          label="Delete"
+                        ></va-button-icon>
+                      </div>
+                    )}
                     <va-modal
-                      modalTitle='Delete this file?'
+                      modalTitle="Delete this file?"
                       visible={this.showModal}
-                      primaryButtonText='Yes, remove this'
-                      secondaryButtonText='No, keep this'
+                      primaryButtonText="Yes, remove this"
+                      secondaryButtonText="No, keep this"
                       onCloseEvent={this.closeModal}
                       onPrimaryButtonClick={() => this.removeFile(true)}
                       onSecondaryButtonClick={this.closeModal}
                     >
-                      We'll remove the uploaded document <span class="file-label">{file.name}</span>
+                      We'll remove the uploaded document{' '}
+                      <span class="file-label">{file.name}</span>
                     </va-modal>
                   </div>
                 )}
@@ -477,5 +528,5 @@ export class VaFileInput {
         </div>
       </Host>
     );
-  } 
+  }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `jap&#x2F;simple-forms&#x2F;2960-form-input-updates` is a placeholder for a CI job - it will be updated automatically -->
https://jap&#x2F;simple-forms&#x2F;2960-form-input-updates--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
