### PR TITLE
web-components: update stencil config for custom elements

### DIFF
--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -44,8 +44,8 @@ export const config: Config = {
       type: 'dist',
       esmLoaderPath: '../loader',
       copy: [
-        { src: 'assets', dest: path.join(__dirname, 'dist/assets')},
-        { src: 'img/sprite.svg', dest: path.join(__dirname, 'dist/img/sprite.svg')}
+        { src: 'assets', dest: path.join(__dirname, 'dist/assets') },
+        { src: 'img/sprite.svg', dest: path.join(__dirname, 'dist/img/sprite.svg') }
       ]
     },
     {
@@ -53,7 +53,8 @@ export const config: Config = {
       serviceWorker: null, // disable service workers
     },
     {
-      type: 'dist-custom-elements'
+      type: 'dist-custom-elements',
+      customElementsExportBehavior: 'single-export-module',
     }
   ],
   testing: {


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
We recently upgraded from Stencil 2 to Stencil 3. 

Stencil 3 changes the default behaviour for [dist-custom-element](https://stenciljs.com/docs/v3/custom-elements) output from a single module to individual exports. This caused our [latest release](https://www.npmjs.com/package/@department-of-veterans-affairs/component-library/v/46.0.0?activeTab=code) to exclude exports for our components, which in turn caused vets-website ci [to fail](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/10565894033/job/29271406278?pr=31593) during a pull request. 

This pull request adds an option to the dist-custom-elements config that reintroduces the single module export we were originally using. 

<details><summary>Current release on vets-website branch missing exports</summary>

![image](https://github.com/user-attachments/assets/0f07862c-fec5-41a7-af55-097fe30d9b84)

</details>

<details><summary>Current branch with output option added, exports have been reintroduced</summary>

![image](https://github.com/user-attachments/assets/2d3ca354-d2c7-4380-9057-7c1f1760f00e)

</details>

The above screenshot matches our last web-components release prior to upgrading to v3 on npm - https://www.npmjs.com/package/@department-of-veterans-affairs/web-components/v/13.0.0?activeTab=code

Which matches our last core release prior to the Stencil v3 upgrade on npm - https://www.npmjs.com/package/@department-of-veterans-affairs/component-library/v/45.0.0?activeTab=code