### PR TITLE
Add messageAriaDescribedby to va-radio

### DIFF
--- a/packages/storybook/stories/va-radio-uswds.stories.jsx
+++ b/packages/storybook/stories/va-radio-uswds.stories.jsx
@@ -258,12 +258,11 @@ const USWDSTiledError = ({
   );
 };
 
-const withARIAMessageTemplate = ({
+const withDescriptionMessageTemplate = ({
   'enable-analytics': enableAnalytics,
   error,
   label,
   required,
-  hint,
 }) => {
   let extraMessage = 'Some additional info'
   return (
@@ -274,27 +273,27 @@ const withARIAMessageTemplate = ({
       required={required}
       message-aria-describedby={extraMessage}
     >
+      <p>{extraMessage}</p>
       <va-radio-option
         label="Soujourner Truth"
-        name={name}
+        name={"name"}
         value="1"
       />
       <va-radio-option
         label="Frederick Douglass"
-        name={name}
+        name={"name"}
         value="2"
       />
       <va-radio-option
         label="Booker T. Washington"
-        name={name}
+        name={"name"}
         value="3"
       />
       <va-radio-option
         label="George Washington Carver"
-        name={name}
+        name={"name"}
         value="4"
       />
-      <p>{extraMessage}</p>
     </va-radio>
   );
 };
@@ -493,8 +492,8 @@ IDUsage.args = {
   required: true,
 };
 
-export const withARIAMessage = withARIAMessageTemplate.bind(null);
-withARIAMessage.args = {
+export const withDescriptionMessage = withDescriptionMessageTemplate.bind(null);
+withDescriptionMessage.args = {
   ...defaultArgs,
 };
 

--- a/packages/storybook/stories/va-radio-uswds.stories.jsx
+++ b/packages/storybook/stories/va-radio-uswds.stories.jsx
@@ -258,6 +258,47 @@ const USWDSTiledError = ({
   );
 };
 
+const withARIAMessageTemplate = ({
+  'enable-analytics': enableAnalytics,
+  error,
+  label,
+  required,
+  hint,
+}) => {
+  let extraMessage = 'Some additional info'
+  return (
+    <va-radio
+      enable-analytics={enableAnalytics}
+      error={error}
+      label={label}
+      required={required}
+      message-aria-describedby={extraMessage}
+    >
+      <va-radio-option
+        label="Soujourner Truth"
+        name={name}
+        value="1"
+      />
+      <va-radio-option
+        label="Frederick Douglass"
+        name={name}
+        value="2"
+      />
+      <va-radio-option
+        label="Booker T. Washington"
+        name={name}
+        value="3"
+      />
+      <va-radio-option
+        label="George Washington Carver"
+        name={name}
+        value="4"
+      />
+      <p>{extraMessage}</p>
+    </va-radio>
+  );
+};
+
 const FormsPatternMultipleTemplate = ({ label, required }) => {
   const handleClick = () => {
     const header = document
@@ -450,6 +491,11 @@ export const IDUsage = IdUsageTemplate.bind(null);
 IDUsage.args = {
   ...defaultArgs,
   required: true,
+};
+
+export const withARIAMessage = withARIAMessageTemplate.bind(null);
+withARIAMessage.args = {
+  ...defaultArgs,
 };
 
 export const Internationalization = I18nTemplate.bind(null);

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1188,6 +1188,10 @@ export namespace Components {
          */
         "labelHeaderLevel"?: string;
         /**
+          * An optional message that will be read by screen readers when a radio option is focused.
+         */
+        "messageAriaDescribedby"?: string;
+        /**
           * Whether or not this input field is required.
          */
         "required"?: boolean;
@@ -1217,6 +1221,10 @@ export namespace Components {
           * The text label for the input element.
          */
         "label": string;
+        /**
+          * An optional message that will be read by screen readers when a radio option is focused.
+         */
+        "messageAriaDescribedby"?: string;
         /**
           * The name attribute for the input element.
          */
@@ -3872,6 +3880,10 @@ declare namespace LocalJSX {
          */
         "labelHeaderLevel"?: string;
         /**
+          * An optional message that will be read by screen readers when a radio option is focused.
+         */
+        "messageAriaDescribedby"?: string;
+        /**
           * The event used to track usage of the component. This is emitted when a radio option is selected and enableAnalytics is true.
          */
         "onComponent-library-analytics"?: (event: VaRadioCustomEvent<any>) => void;
@@ -3909,6 +3921,10 @@ declare namespace LocalJSX {
           * The text label for the input element.
          */
         "label": string;
+        /**
+          * An optional message that will be read by screen readers when a radio option is focused.
+         */
+        "messageAriaDescribedby"?: string;
         /**
           * The name attribute for the input element.
          */

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1222,10 +1222,6 @@ export namespace Components {
          */
         "label": string;
         /**
-          * An optional message that will be read by screen readers when a radio option is focused.
-         */
-        "messageAriaDescribedby"?: string;
-        /**
           * The name attribute for the input element.
          */
         "name": string;
@@ -3921,10 +3917,6 @@ declare namespace LocalJSX {
           * The text label for the input element.
          */
         "label": string;
-        /**
-          * An optional message that will be read by screen readers when a radio option is focused.
-         */
-        "messageAriaDescribedby"?: string;
         /**
           * The name attribute for the input element.
          */

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -57,11 +57,6 @@ export class VaRadioOption {
   @Prop() ariaDescribedby?: string;
 
   /**
-   * An optional message that will be read by screen readers when a radio option is focused.
-   */
-  @Prop() messageAriaDescribedby?: string;
-
-  /**
    * The event emitted when the selected option value changes
    */
   @Event({
@@ -82,8 +77,7 @@ export class VaRadioOption {
       label,
       disabled,
       tile,
-      description,
-      messageAriaDescribedby } = this;
+      description } = this;
     const id = this.el.id || (name + value);
 
     const inputClass = classnames({
@@ -115,11 +109,6 @@ export class VaRadioOption {
             </span>
           )}
         </label>
-        {messageAriaDescribedby && (
-          <span id="radio-option-message" class="usa-sr-only dd-privacy-hidden">
-            {messageAriaDescribedby}
-          </span>
-        )}
       </div>
     )
   }

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -95,7 +95,6 @@ export class VaRadioOption {
             disabled={disabled}
             onClick={() => this.handleChange()}
             id={id + 'input'}
-            aria-describedby="radio-option-message"
           />
         <label class="usa-radio__label" htmlFor={id + 'input'}>
           {label}

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -57,6 +57,11 @@ export class VaRadioOption {
   @Prop() ariaDescribedby?: string;
 
   /**
+   * An optional message that will be read by screen readers when a radio option is focused.
+   */
+  @Prop() messageAriaDescribedby?: string;
+
+  /**
    * The event emitted when the selected option value changes
    */
   @Event({
@@ -77,7 +82,8 @@ export class VaRadioOption {
       label,
       disabled,
       tile,
-      description } = this;
+      description,
+      messageAriaDescribedby } = this;
     const id = this.el.id || (name + value);
 
     const inputClass = classnames({
@@ -95,6 +101,7 @@ export class VaRadioOption {
             disabled={disabled}
             onClick={() => this.handleChange()}
             id={id + 'input'}
+            aria-describedby="radio-option-message"
           />
         <label class="usa-radio__label" htmlFor={id + 'input'}>
           {label}
@@ -108,6 +115,11 @@ export class VaRadioOption {
             </span>
           )}
         </label>
+        {messageAriaDescribedby && (
+          <span id="radio-option-message" class="usa-sr-only dd-privacy-hidden">
+            {messageAriaDescribedby}
+          </span>
+        )}
       </div>
     )
   }

--- a/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
+++ b/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
@@ -96,6 +96,15 @@ describe('va-radio', () => {
     `);
   });
 
+  it('renders aria message text if included', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-radio message-aria-describedby="Some additional info"></va-radio>');
+
+    const message = await page.find('va-radio >>> #description-message');
+    expect(message.textContent).toEqual("Some additional info");
+    expect(message).toHaveClass("usa-sr-only");
+  });
+
   it('renders a required span based on prop', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-radio required></va-radio>');

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -117,13 +117,6 @@ export class VaRadio {
   })
   vaValueChange: EventEmitter;
 
-  componentDidRender() {
-    if (this.messageAriaDescribedby) {
-      const radioOptionNodes = (getSlottedNodes(this.el, 'va-radio-option') as HTMLVaRadioOptionElement[])
-      radioOptionNodes.forEach(radioOptionNode => radioOptionNode.setAttribute('message-aria-describedby', this.messageAriaDescribedby))
-    }
-  }
-
   @Listen('keydown')
   handleKeyDown(event: KeyboardEvent) {
     const currentNode = event.target as HTMLVaRadioOptionElement;
@@ -243,12 +236,14 @@ export class VaRadio {
       required, 
       error, 
       headerAriaDescribedby,
+      messageAriaDescribedby,
       useFormsPattern,
       formHeadingLevel,
       formHeading
     } = this;
     const HeaderLevel = this.getHeaderLevel();
     const headerAriaDescribedbyId = headerAriaDescribedby ? 'header-message' : null;
+    const messageAriaDescribedbyId = messageAriaDescribedby ? 'description-message' : null;
     const ariaLabeledByIds = 
     `${useFormsPattern && formHeading ? 'form-question' : ''} ${
       useFormsPattern ? 'form-description' : ''} ${
@@ -282,7 +277,7 @@ export class VaRadio {
         {formsHeading}
         <div class="input-wrap">
           <fieldset class="usa-fieldset" aria-labelledby={ariaLabeledByIds}>
-            <legend class={legendClass} part="legend">
+            <legend class={legendClass} part="legend" aria-describedby={messageAriaDescribedbyId} >
               {HeaderLevel ? (
                 <HeaderLevel part="header" aria-describedby={headerAriaDescribedbyId}>{label}</HeaderLevel>
               ) : (
@@ -290,14 +285,19 @@ export class VaRadio {
               )}&nbsp;
               {
                 useFormsPattern === 'multiple' && (
-                  <span id="header-message" class="sr-only">
+                  <span id="header-message" class="usa-sr-only">
                     {label}
                   </span>
                 )
               }
               {headerAriaDescribedby && (
-                <span id="header-message" class="sr-only">
+                <span id="header-message" class="usa-sr-only">
                   {headerAriaDescribedby}
+                </span>
+              )}
+              {messageAriaDescribedby && (
+                <span id="description-message" class="usa-sr-only">
+                  {messageAriaDescribedby}
                 </span>
               )}
               {required && <span class="usa-label--required" part="required">{i18next.t('required')}</span>}

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -78,6 +78,11 @@ export class VaRadio {
   @Prop() headerAriaDescribedby?: string;
 
   /**
+   * An optional message that will be read by screen readers when a radio option is focused.
+   */
+  @Prop() messageAriaDescribedby?: string;
+
+  /**
    * Enabling this will add a heading and description for integrating into the forms pattern. Accepts `single` or `multiple` to indicate if the form is a single input or will have multiple inputs
    */
   @Prop() useFormsPattern?: string;
@@ -111,6 +116,13 @@ export class VaRadio {
     bubbles: true,
   })
   vaValueChange: EventEmitter;
+
+  componentDidRender() {
+    if (this.messageAriaDescribedby) {
+      const radioOptionNodes = (getSlottedNodes(this.el, 'va-radio-option') as HTMLVaRadioOptionElement[])
+      radioOptionNodes.forEach(radioOptionNode => radioOptionNode.setAttribute('message-aria-describedby', this.messageAriaDescribedby))
+    }
+  }
 
   @Listen('keydown')
   handleKeyDown(event: KeyboardEvent) {


### PR DESCRIPTION
## Chromatic
<!-- This `radio-button-sr-description` is a placeholder for a CI job - it will be updated automatically -->
https://radio-button-sr-description--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes [va-radio description is not being read by screen reader #3059](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3059)

Adds `messageAriaDescribedby` to `va-radio` to be read by screen readers.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![Screenshot 2024-08-28 at 12 13 40](https://github.com/user-attachments/assets/abd26ccc-0216-4f35-b9c5-096213b332bc)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
