### PR TITLE
va-link: re-add font inherit

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "46.0.2",
+  "version": "46.0.3",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -106,26 +106,28 @@ const VariantTemplate = ({
   'icon-size': iconSize,
 }) => {
   return (
-    <va-link
-      abbr-title={abbrTitle}
-      active={active}
-      back={back}
-      calendar={calendar}
-      channel={channel}
-      disable-analytics={disableAnalytics}
-      download={download}
-      href={href}
-      filename={filename}
-      filetype={filetype}
-      pages={pages}
-      reverse={reverse}
-      text={text}
-      external={external}
-      video={video}
-      label={label}
-      icon-name={iconName}
-      icon-size={iconSize}
-    />
+    <p>
+      <va-link
+        abbr-title={abbrTitle}
+        active={active}
+        back={back}
+        calendar={calendar}
+        channel={channel}
+        disable-analytics={disableAnalytics}
+        download={download}
+        href={href}
+        filename={filename}
+        filetype={filetype}
+        pages={pages}
+        reverse={reverse}
+        text={text}
+        external={external}
+        video={video}
+        label={label}
+        icon-name={iconName}
+        icon-size={iconSize}
+      />
+    </p>
   );
 };
 

--- a/packages/storybook/stories/va-link.stories.jsx
+++ b/packages/storybook/stories/va-link.stories.jsx
@@ -201,77 +201,95 @@ const ReverseTemplate = ({ filename, filetype, href, reverse, text }) => {
       }}
     >
       <h4 className="vads-u-color--white">Default Link</h4>
-      <va-link
-        href={href}
-        reverse={reverse}
-        text="Contact a local Veterans Service Organization (VSO)"
-      />
+      <p>
+        <va-link
+          href={href}
+          reverse={reverse}
+          text="Contact a local Veterans Service Organization (VSO)"
+        />
+      </p>
 
       <h4 className="vads-u-color--white">Active Link</h4>
-      <va-link
-        active={true}
-        href={href}
-        reverse={reverse}
-        text="Share your VA medical records"
-      />
+      <p>
+        <va-link
+          active={true}
+          href={href}
+          reverse={reverse}
+          text="Share your VA medical records"
+        />
+      </p>
 
       <h4 className="vads-u-color--white">Back Link</h4>
-      <va-link
-        back
-        href={href}
-        reverse={reverse}
-        text="Back to previous page"
-      />
+      <p>
+        <va-link
+          back
+          href={href}
+          reverse={reverse}
+          text="Back to previous page"
+        />
+      </p>
 
       <h4 className="vads-u-color--white">Calendar Link</h4>
-      <va-link
-        calendar
-        href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR"
-        text="Add to calendar"
-        reverse
-      />
+      <p>
+        <va-link
+          calendar
+          href="data:text/calendar;charset=utf-8,BEGIN%3AVCALENDAR%0D%0AVERSION%3A2.0%0D%0APRODID%3AVA%0D%0ABEGIN%3AVEVENT%0D%0AUID%3A1398DD3C-3572-40FD-84F6-BB6F97C79D67%0D%0ASUMMARY%3AAppointment%20at%20Cheyenne%20VA%20Medical%20Center%0D%0ADESCRIPTION%3AYou%20have%20a%20health%20care%20appointment%20at%20Cheyenne%20VA%20Medical%20Cent%0D%0A%09er%0D%0A%09%5Cn%5Cn2360%20East%20Pershing%20Boulevard%5Cn%0D%0A%09Cheyenne%5C%2C%20WY%2082001-5356%5Cn%0D%0A%09307-778-7550%5Cn%0D%0A%09%5CnSign%20in%20to%20https%3A%2F%2Fva.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappo%0D%0A%09intments%20to%20get%20details%20about%20this%20appointment%5Cn%0D%0ALOCATION%3A2360%20East%20Pershing%20Boulevard%5C%2C%20Cheyenne%5C%2C%20WY%2082001-5356%0D%0ADTSTAMP%3A20221222T021934Z%0D%0ADTSTART%3A20221222T021934Z%0D%0ADTEND%3A20221222T024934Z%0D%0AEND%3AVEVENT%0D%0AEND%3AVCALENDAR"
+          text="Add to calendar"
+          reverse
+        />
+      </p>
 
       <h4 className="vads-u-color--white">Channel Link</h4>
-      <va-link
-        channel
-        href="https://www.va.gov"
-        text="Veteran's Affairs"
-        reverse
-      />
+      <p>
+        <va-link
+          channel
+          href="https://www.va.gov"
+          text="Veteran's Affairs"
+          reverse
+        />
+      </p>
 
       <h4 className="vads-u-color--white">Download Link</h4>
-      <va-link
-        download
-        filetype="PDF"
-        href="https://www.va.gov"
-        pages={5}
-        reverse
-        text="Download VA form 10-10EZ"
-      />
+      <p>
+        <va-link
+          download
+          filetype="PDF"
+          href="https://www.va.gov"
+          pages={5}
+          reverse
+          text="Download VA form 10-10EZ"
+        />
+      </p>
 
       <h4 className="vads-u-color--white">External</h4>
-      <va-link
-        external
-        href="https://design.va.gov/content-style-guide/links#linking-to-external-sites"
-        text="Leave VA.gov"
-        reverse
-      />
+      <p>
+        <va-link
+          external
+          href="https://design.va.gov/content-style-guide/links#linking-to-external-sites"
+          text="Leave VA.gov"
+          reverse
+        />
+      </p>
 
       <h4 className="vads-u-color--white">Icon</h4>
-      <va-link
-        href={href}
-        reverse={reverse}
-        text="National Cemetery Administration"
-        icon-name="mail"
-      />
+      <p>
+        <va-link
+          href={href}
+          reverse={reverse}
+          text="National Cemetery Administration"
+          icon-name="mail"
+        />
+      </p>
 
       <h4 className="vads-u-color--white">Video Link</h4>
-      <va-link
-        href="https://www.va.gov"
-        text="Go to the video about VA disability compensation"
-        video
-        reverse
-      />
+      <p>
+        <va-link
+          href="https://www.va.gov"
+          text="Go to the video about VA disability compensation"
+          video
+          reverse
+        />
+      </p>
     </div>
   );
 };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-link/va-link.scss
+++ b/packages/web-components/src/components/va-link/va-link.scss
@@ -9,6 +9,7 @@
 :host a {
   cursor: pointer;
   text-decoration: underline;
+  font: inherit;
 }
 
 :host a.va-link--reverse,


### PR DESCRIPTION
## Chromatic
<!-- This `mc-fix-header-styles` is a placeholder for a CI job - it will be updated automatically -->
https://mc-fix-header-styles--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
`font: inherit` needs to be re-added to va-link to ensure it inherits font-size when used inside a header. Removing this recently caused a regression on the homepage:

What it should be:
![image](https://github.com/user-attachments/assets/2f6223a5-89cd-4fee-a12c-ab7284fd3ac5)

What it currently is:
![image](https://github.com/user-attachments/assets/5303013b-b9b7-4d52-a587-8b6c584c89fa)

[More context in this slack thread](https://dsva.slack.com/archives/C01DBGX4P45/p1724884067837049?thread_ts=1724445319.663739&cid=C01DBGX4P45)