### PR TITLE
va-date/va-memorable-date: fix style issues with error state

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1368,6 +1368,10 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
+          * Whether an error message should be shown - set to false when this component is used inside va-date or va-memorable-date  in which the error for the va-select will be rendered outside of va-select
+         */
+        "showError"?: boolean;
+        /**
           * Selected value (will get updated on select).
          */
         "value"?: string;
@@ -4091,6 +4095,10 @@ declare namespace LocalJSX {
           * Whether or not this is a required field.
          */
         "required"?: boolean;
+        /**
+          * Whether an error message should be shown - set to false when this component is used inside va-date or va-memorable-date  in which the error for the va-select will be rendered outside of va-select
+         */
+        "showError"?: boolean;
         /**
           * Selected value (will get updated on select).
          */

--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -108,7 +108,7 @@ describe('va-date', () => {
       await handleYear.press('Tab');
       await page.waitForChanges();
 
-      expect(date.getAttribute('error')).toEqual("month-range");
+      expect(date.getAttribute('error')).toEqual("month-select");
     });
 
     it('allows for a custom required message', async () => {
@@ -515,7 +515,7 @@ describe('va-date', () => {
       await handleYear.press('Tab');
       await page.waitForChanges();
 
-      expect(date.getAttribute('error')).toEqual('month-range');
+      expect(date.getAttribute('error')).toEqual('month-select');
     });
 
     it('is valid without a day value', async () => {

--- a/packages/web-components/src/components/va-date/va-date.scss
+++ b/packages/web-components/src/components/va-date/va-date.scss
@@ -1,0 +1,77 @@
+@import '../../../src/mixins/accessibility.css';
+@import '../../mixins/uswds-error-border.scss';
+@import '../../mixins/form-field-error.css';
+@import '../../mixins/hint-text.css';
+
+.usa-label--required {
+  color: var(--vads-color-secondary-dark);
+}
+
+.usa-error-message {
+  color: var(--vads-color-secondary-dark);
+}
+
+
+/** Original Component Style **/
+
+:host {
+  display: block;
+  font-family: var(--font-source-sans);
+  margin-top: 1.875rem;
+}
+
+fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  border: 0;
+  font-size: 1.06rem;
+  padding: 0;
+}
+
+span.required {
+  color: var(--vads-color-secondary-dark);
+}
+
+#error-message {
+  color: var(--vads-color-secondary-dark);
+  display: block;
+  margin-bottom: 0;
+}
+
+.date-container {
+  display: flex;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+:host([error]:not([error=''])) .date-container {
+  padding-top: 0;
+}
+
+.select-month {
+  width: 8.125rem;
+  margin-right: 0.9375rem;
+}
+
+.select-day {
+  width: 5rem;
+  margin-right: 0.9375rem;
+}
+
+.input-year {
+  width: 5rem;
+}
+
+va-select::part(label),
+va-text-input::part(label) {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+va-text-input::part(validation) {
+  display: none;
+}

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -33,7 +33,7 @@ import {
  */
 @Component({
   tag: 'va-date',
-  styleUrl: 'va-date.css',
+  styleUrl: 'va-date.scss',
   shadow: true,
 })
 export class VaDate {
@@ -151,7 +151,8 @@ export class VaDate {
                day,
                yearTouched: this.yearTouched,
                monthTouched: this.monthTouched,
-               dayTouched: this.dayTouched
+               dayTouched: this.dayTouched,
+               monthSelect: true
              });
 
     if (this.error) {
@@ -232,7 +233,6 @@ export class VaDate {
     const errorParameters = (error: string) => {
       return getErrorParameters(error, year, month);
     }
-
     // Fieldset has an implicit aria role of group
     return (
       <Host onBlur={handleDateBlur}>
@@ -261,6 +261,8 @@ export class VaDate {
               invalid={this.invalidMonth}
               class="select-month"
               aria-label="Please enter two digits for the month"
+              error={this.monthTouched && this.invalidMonth ? error : null}
+              showError={false}
             >
               <option value=""></option>
               {months &&
@@ -282,6 +284,8 @@ export class VaDate {
                 invalid={this.invalidDay}
                 class="select-day"
                 aria-label="Please enter two digits for the day"
+                error={this.dayTouched && this.invalidDay ? this.error : null}
+                showError={false}
               >
                 <option value=""></option>
                 {daysForSelectedMonth &&
@@ -302,6 +306,7 @@ export class VaDate {
               invalid={this.invalidYear}
               onInput={handleDateChange}
               onBlur={this.handleYearBlur}
+              error={this.yearTouched && this.invalidYear ? error : null}
               show-input-error="false"
               class="input-year"
               inputmode="numeric"

--- a/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
+++ b/packages/web-components/src/components/va-memorable-date/test/va-memorable-date.e2e.ts
@@ -238,7 +238,7 @@ describe('va-memorable-date', () => {
       await handleYear.press('Tab');
 
       await page.waitForChanges();
-      expect(date.getAttribute('error')).toEqual("month-range");
+      expect(date.getAttribute('error')).toEqual("month-select");
     });
 
     it('does day validation without required prop', async () => {
@@ -900,7 +900,7 @@ describe('va-memorable-date', () => {
       await handleYear.press('Tab');
       await page.waitForChanges();
 
-      expect(date.getAttribute('error')).toEqual("month-range");
+      expect(date.getAttribute('error')).toEqual("month-select");
 
       const errorSpan = await page.find('va-memorable-date >>> span#error-message');
       expect(errorSpan.textContent).toContain("month-select");

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -156,7 +156,8 @@ export class VaMemorableDate {
                      day: dayNum,
                      yearTouched: this.yearTouched,
                      monthTouched: this.monthTouched,
-                     dayTouched: this.dayTouched
+                     dayTouched: this.dayTouched,
+                     monthSelect: this.monthSelect
     });
 
     if (this.error) {
@@ -300,11 +301,7 @@ export class VaMemorableDate {
 
     // get the default message if internal validation fails
     const getStandardErrorMessage = (error: string) => {
-      let key = error;
-      if (monthSelect && error === 'month-range') {
-        key = 'month-select';
-      }
-      return i18next.t(key, errorParameters(error))
+      return i18next.t(error, errorParameters(error))
     }
 
     // Error attribute should be leveraged for custom error messaging
@@ -344,6 +341,7 @@ export class VaMemorableDate {
             reflectInputError={error === 'month-range' ? true : false}
             value={month ? String(parseInt(month)) : month}
             error={this.invalidMonth ? getStandardErrorMessage(error) : null}
+            showError={false}
           >
             {months &&
               months.map(monthOption => (

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -69,4 +69,16 @@ describe('va-select', () => {
     const select = await page.find('va-select >>> select');
     expect(select.classList.contains('usa-input--md')).toBeTruthy();
   });
+
+  it('does not render the error if showError is false', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-select label="A label" value="foo" error="month-range" show-error="false">
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </va-select>
+    `);
+    const span = page.find('span.usa-error-message');
+    expect(span).toBeNull()
+  });
 });

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -100,6 +100,12 @@ export class VaSelect {
   @Prop() width?: string;
 
   /**
+   * Whether an error message should be shown - set to false when this component is used inside va-date or va-memorable-date 
+   * in which the error for the va-select will be rendered outside of va-select
+   */
+  @Prop() showError?: boolean = true;
+
+  /**
    * The event used to track usage of the component. This is emitted when an
    * option is selected and enableAnalytics is true.
    */
@@ -170,7 +176,7 @@ export class VaSelect {
   }
 
   render() {
-    const { error, reflectInputError, invalid, label, required, name, hint, messageAriaDescribedby, width } = this;
+    const { error, reflectInputError, invalid, label, required, name, hint, messageAriaDescribedby, width, showError } = this;
 
     const errorID = 'input-error-message';
     const ariaDescribedbyIds = 
@@ -197,7 +203,7 @@ export class VaSelect {
         )}
         {hint && <span class="usa-hint" id="input-hint">{hint}</span>}
         <span id={errorID} role="alert">
-          {error && (
+          {showError && error && (
             <Fragment>
               <span class="usa-sr-only">{i18next.t('error')}</span> 
               <span class="usa-error-message">{error}</span>

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -157,8 +157,18 @@ export const internalErrors = [
   'year-range',
   'day-range',
   'month-range',
-  'date-error'
+  'date-error',
+  'month-select'
 ];
+
+/**
+ the month error key for a va-select instance varies if 
+ the instance is inside va-date or va-memorable-date
+ */
+function getMonthErrorKey(monthSelect: boolean): string {
+  return monthSelect ? 'month-select' : 'month-range';
+}
+
 
 interface ValidateConfig {
   component: Components.VaDate | Components.VaMemorableDate,
@@ -169,6 +179,7 @@ interface ValidateConfig {
   yearTouched?: boolean,
   monthTouched?: boolean,
   dayTouched?: boolean,
+  monthSelect?: boolean
 }
 
 export function validate({
@@ -179,7 +190,8 @@ export function validate({
                            monthYearOnly,
                            yearTouched,
                            monthTouched,
-                           dayTouched
+                           dayTouched,
+                           monthSelect
                          }: ValidateConfig): void {
 
   const maxDays = daysForSelectedMonth(year, month);
@@ -192,7 +204,7 @@ export function validate({
   // Check NaN and set errors based on NaN values
   if (isNaN(month) && monthTouched) {
     component.invalidMonth = true;
-    component.error = 'month-range';
+    component.error = getMonthErrorKey(monthSelect);
     return;
   }
   if (!monthYearOnly && isNaN(day) && dayTouched) {
@@ -228,7 +240,7 @@ export function validate({
   // Check for empty values after the fields are touched
   if (!month && monthTouched) {
     component.invalidMonth = true;
-    component.error = 'month-range';
+    component.error = getMonthErrorKey(monthSelect);
     return;
   }
   if (!day && !monthYearOnly && dayTouched) {
@@ -245,7 +257,7 @@ export function validate({
   // Validate year, month, and day ranges if they have a value regardless of whether they are required
   if (month && (month < minMonths || month > maxMonths) && monthTouched) {
     component.invalidMonth = true;
-    component.error = 'month-range';
+    component.error = getMonthErrorKey(monthSelect);
     return;
   }
   if (day && !monthYearOnly && (day < minDays || day > maxDays) && dayTouched) {
@@ -273,9 +285,9 @@ export function getErrorParameters(
   month: number) {
 
   const maxDay = daysForSelectedMonth(year, month);
-
   switch(error) {
     case 'month-range':
+    case 'month-select':
       return { start: 1, end: maxMonths };
     case 'day-range':
       return { start: 1, end: maxDay };


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description
This PR addresses a number of issues with the error state in `va-date`:
* fixes extra left padding
* fixes "Select" word getting partially cut off
* fixes default error message, i.e. "Please select a month" not "Please enter a month between 1 and 12."

This PR also brings `va-date` into harmony with `va-memorable-date` in which only month, day, or year will be highlighted as being in an error state at a time, rather than all being shown in an error state; if two or more of month, day, year are in error only the first in error will be shown.

Finally, this PR fixes an issue in `va-memorable-date` where, when `month-select` is true and the month is in an error state, then the error for the month is displayed twice (once for `va-memorable-date` and once for `va-select`).

Closes [3152](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3152)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

**va-date** before:

<img width="584" alt="Screenshot 2024-09-04 at 4 27 15 PM" src="https://github.com/user-attachments/assets/b4164256-c562-49ca-9ef5-30885868f9d2">

**va-date** after:
<img width="708" alt="Screenshot 2024-09-04 at 4 26 48 PM" src="https://github.com/user-attachments/assets/5bf4085d-3035-4949-9be4-24953ec885fd">

**va-memorable-date** before:
<img width="526" alt="Screenshot 2024-09-04 at 4 43 54 PM" src="https://github.com/user-attachments/assets/83533719-5cc7-4fa0-8aa0-7333b1dbc7ce">

**va-memorable-date** after
<img width="502" alt="Screenshot 2024-09-04 at 4 39 47 PM" src="https://github.com/user-attachments/assets/c48fa9ff-8e87-42be-8d4d-53744056af1a">


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
