### PR TITLE
CSS Library: Remove progress-box padding

### DIFF
--- a/packages/css-library/dist/stylesheets/modules/m-omb-info.css
+++ b/packages/css-library/dist/stylesheets/modules/m-omb-info.css
@@ -2,14 +2,5 @@
   Variables ported over from Formation so that we can keep those stylesheets
   working while we work on deprecation.
 **/
-.omb-info--container {
-  padding-left: 1.25rem;
-}
-
-@media (max-width: 40.063em) {
-  .omb-info--container {
-    padding-left: 0.6640625rem;
-  }
-}
 
 /*# sourceMappingURL=m-omb-info.css.map */

--- a/packages/css-library/dist/stylesheets/modules/m-omb-info.css.map
+++ b/packages/css-library/dist/stylesheets/modules/m-omb-info.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sourceRoot":"","sources":["../../../src/stylesheets/formation-overrides/_variables.scss","../../../src/stylesheets/modules/m-omb-info.scss"],"names":[],"mappings":"AAAA;AAAA;AAAA;AAAA;ACQA;EACE;;;AAIF;EAEE;IAEE","file":"m-omb-info.css"}
+{"version":3,"sourceRoot":"","sources":["../../../src/stylesheets/formation-overrides/_variables.scss"],"names":[],"mappings":"AAAA;AAAA;AAAA;AAAA","file":"m-omb-info.css"}

--- a/packages/css-library/dist/stylesheets/shame.css
+++ b/packages/css-library/dist/stylesheets/shame.css
@@ -172,7 +172,7 @@ body .row-padded {
 .progress-box {
   border: 1px solid #f1f1f1;
   margin: 0.9375rem 0;
-  padding: 0.625rem 1.25rem;
+  padding: 0.625rem 0;
 }
 
 .button-icon {

--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 10 Sep 2024 14:57:42 GMT
+ * Generated on Tue, 10 Sep 2024 19:49:21 GMT
  */
 
 :root {

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 10 Sep 2024 14:57:42 GMT
+// Generated on Tue, 10 Sep 2024 19:49:21 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;

--- a/packages/css-library/src/stylesheets/modules/m-omb-info.scss
+++ b/packages/css-library/src/stylesheets/modules/m-omb-info.scss
@@ -4,17 +4,3 @@
 // To avoid double-importing, we're not importing _m-modal.scss,
 //  but if this file is being imported, you'll probably want to include
 //  the modal module as well.
-
-// Align with navigation buttons
-.omb-info--container {
-  padding-left: scale-rem(2rem);
-}
-
-// This media query is matched to the one wrapping .progress-box in edu-benefits.scss
-@media (max-width: 40.063em) {
-  // Match the OMB Info section padding
-  .omb-info--container {
-    // 2rem - .9375rem
-    padding-left: scale-rem(1.0625rem);
-  }
-}

--- a/packages/css-library/src/stylesheets/shame.scss
+++ b/packages/css-library/src/stylesheets/shame.scss
@@ -20,7 +20,7 @@ body {
   // We have no container element, so elements that are full width have to redefine the container layout every time
   // if they want to line up.
   // unused in content-build
-  // Used in vets-website, used in src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx 
+  // Used in vets-website, used in src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
   .row-padded {
     max-width: scale-rem(100rem);
     padding: scale-rule(0 1rem);
@@ -38,7 +38,7 @@ body {
 }
 
 // unused in content-build
-// used in vets-website, used in src/platform/forms-system/src/js/containers/FormApp.jsx 
+// used in vets-website, used in src/platform/forms-system/src/js/containers/FormApp.jsx
 // and src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomFormApp.jsx
 .progress-box {
   button {
@@ -49,7 +49,7 @@ body {
 .progress-box {
   border: 1px solid $color-gray-lightest;
   margin: scale-rule(1.5rem 0);
-  padding: scale-rule(1rem 2rem);
+  padding: scale-rule(1rem 0);
 }
 
 
@@ -82,7 +82,7 @@ body {
 // unused in content-build
 // used in vets-website in src/applications/terms-of-use/components/TermsAcceptanceAction.jsx,
 // src/platform/forms-system/src/js/containers/FormApp.jsx, src/platform/forms-system/src/js/review/submit-states/ClientError.jsx,
-// src/platform/forms-system/src/js/review/submit-states/Pending.jsx, src/platform/forms-system/src/js/review/submit-states/Submitted.jsx, 
+// src/platform/forms-system/src/js/review/submit-states/Pending.jsx, src/platform/forms-system/src/js/review/submit-states/Submitted.jsx,
 // src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx, src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
 .hidden {
   display: none !important;


### PR DESCRIPTION
## Chromatic
<!-- This `1548-remove-padding` is a placeholder for a CI job - it will be updated automatically -->
https://1548-remove-padding--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description

This PR removes any horizontal padding for `.progress-box` and `.omb-info--container` to better left-align content on the introduction page and within forms. For narrower (mobile) screens, this padding 

- https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1548 (ticket)
- https://github.com/department-of-veterans-affairs/vets-website/pull/31870 (vets-website)
- https://github.com/department-of-veterans-affairs/component-library/pull/1324 (component library)
- https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/1056 (formation)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="750" alt="progress-box highlighted in the dev panel showing left & right padding" src="https://github.com/user-attachments/assets/5af3af3a-45a5-468e-867d-676bc7dba088"> | <img width="750" alt="progress-box highlighted in the dev panel showing no left or right padding" src="https://github.com/user-attachments/assets/58632fe8-63db-43d0-baf3-c819958ed4be"> |
| Narrow | <img width="332" alt="320 pixel wide view with progress box padding" src="https://github.com/user-attachments/assets/c2411e5c-ca8c-424b-9d99-077b73bd0057"> | <img width="334" alt="320 pixel wide view with left side content alignment" src="https://github.com/user-attachments/assets/525722a7-48f6-4073-a054-0f33dd79780d"> |

## Acceptance criteria
- [ ] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
