### PR TITLE
Clean up text in va-file-input-multiple story

### DIFF
--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
@@ -81,7 +81,7 @@ HeaderSize.args = {
 
 const additionalFormInputsContent = (
   <div>
-    <va-select uswds label='What kind of file is this?' required>
+    <va-select label='What kind of file is this?' required>
       <option key="1" value="1">Public Document</option>
       <option key="2" value="2">Private Document</option>
     </va-select>
@@ -123,7 +123,7 @@ const AdditionalFormInputsContentTemplate = ({
             <code>
   {`const additionalFormInputsContent = (
   <div>
-    <va-select uswds label='What kind of file is this?' required>
+    <va-select label='What kind of file is this?' required>
       <option key="1" value="1">Public Document</option>
       <option key="2" value="2">Private Document</option>
     </va-select>

--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
@@ -115,7 +115,7 @@ const AdditionalFormInputsContentTemplate = ({
       </VaFileInputMultiple>
       <hr/>
       <div>
-        <p>To add additional fields associated with some file, you can pass custom content into the slot of this component and it will render in each file input.</p>
+        <p>You can collect additional information about an uploaded file by passing inputs to the slot of this component. The slot content will render after a file is uploaded.</p>
         <p>This example showcases how to include custom content, such as dropdowns, within the file input component.</p>
       </div>
       <div className="vads-u-margin-top--2">

--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
@@ -81,7 +81,7 @@ HeaderSize.args = {
 
 const additionalFormInputsContent = (
   <div>
-    <va-select className="hydrated" uswds label='What kind of file is this?' required>
+    <va-select uswds label='What kind of file is this?' required>
       <option key="1" value="1">Public Document</option>
       <option key="2" value="2">Private Document</option>
     </va-select>
@@ -123,7 +123,7 @@ const AdditionalFormInputsContentTemplate = ({
             <code>
   {`const additionalFormInputsContent = (
   <div>
-    <va-select className="hydrated" uswds label='What kind of file is this?' required>
+    <va-select uswds label='What kind of file is this?' required>
       <option key="1" value="1">Public Document</option>
       <option key="2" value="2">Private Document</option>
     </va-select>


### PR DESCRIPTION
## Chromatic
<!-- This `file-input-multiple-text-update` is a placeholder for a CI job - it will be updated automatically -->
https://file-input-multiple-text-update--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes [Unable to use the slot in VAFileInputMultiple #3153](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3153)

Storybook text only update.

Was planning on a larger overhaul of this text, but the example provided worked for me in vets-website