### PR TITLE
va-checkbox & va-radio-option: Remove option-label

### DIFF
--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -224,10 +224,10 @@ export class VaCheckbox {
             disabled={disabled}
             onChange={this.handleChange}
           />
-          <label htmlFor="checkbox-element" id="option-label" class="usa-checkbox__label" part="label">
+          <label htmlFor="checkbox-element" class="usa-checkbox__label" part="label">
             {label}&nbsp;
             {required && <span class="usa-label--required">{i18next.t('required')}</span>}
-            {checkboxDescription && <span class="usa-checkbox__label-description" aria-describedby="option-label" part="description">{checkboxDescription}</span>}
+            {checkboxDescription && <span class="usa-checkbox__label-description" part="description">{checkboxDescription}</span>}
           </label>
           {messageAriaDescribedby && (
             <span id='input-message' class="usa-sr-only dd-privacy-hidden">

--- a/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.tsx
@@ -102,7 +102,6 @@ export class VaRadioOption {
             <span
               class="usa-radio__label-description dd-privacy-hidden"
               data-dd-action-name="description"
-              aria-describedby="option-label"
             >
               {description}
             </span>


### PR DESCRIPTION
## Chromatic
<!-- This `3226-option-label` is a placeholder for a CI job - it will be updated automatically -->
https://3226-option-label--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

- `va-checkbox` label ID and `aria-describedby` are unnecessary (and redundant) because the checkbox description is nested in the label
- `va-radio-option` no longer has the label ID, so the `aria-describedby` isn't pointing to anything

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3225

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

va-radio before with `aria-describedby` on description

<img width="650" alt="Screen from Higher Level Review form with aria-describedby='option-label' but that `option-label` doesn't exist" src="https://github.com/user-attachments/assets/6322d9c5-169e-4cde-b1fe-a606859f9313" />

va-radio after with no `aria-describedby` on the description
<img width="650" alt="Showing storybook Booker T Washington radio option with description text and HTML with no aria-describedby on the description" src="https://github.com/user-attachments/assets/a12c5744-0d7c-40ae-91ad-a0ae0147264a">

va-checkbox after with no ID on the `label` or `aria-describedby` on the description
<img width="650" alt="Showing Sojourner Truth checkbox with description text and HTMl with no ID on the label and no aria-describedby on the description" src="https://github.com/user-attachments/assets/a5967dcf-610b-4296-b168-e3a164f359d8">

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
