### PR TITLE
va-checkbox: Fix description slot

### DIFF
--- a/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
@@ -72,21 +72,10 @@ describe('va-checkbox', () => {
     expect(element.textContent).toContain('required');
   });
 
-  it('renders a description slot', async () => {
+  it('renders description prop', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-checkbox><p slot="description">This is a description!</p></va-checkbox',
-    );
-    const element = await page.find('va-checkbox');
-    const inputEl = await page.find('va-checkbox >>> input');
-    expect(element).toEqualText('This is a description!');
-    expect(inputEl.getAttribute('aria-describedby')).toEqual('description');
-  });
-
-  it('should prefer rendering the description prop over the slotted element', async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      '<va-checkbox description="Description prop"><p slot="description">Slotted description</p></va-checkbox',
+      '<va-checkbox description="Description prop"></va-checkbox>',
     );
     const element = await page.find('va-checkbox');
     const inputEl = await page.find('va-checkbox >>> input');
@@ -95,6 +84,48 @@ describe('va-checkbox', () => {
       await page.find('va-checkbox >>> slot[name="description"]'),
     ).toBeNull();
     expect(inputEl.getAttribute('aria-describedby')).toEqual('description');
+  });
+
+  it('renders a description slot (and an empty one)', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-checkbox><p slot="description">This is a description!</p><p slot="description"></p></va-checkbox>',
+    );
+    const element = await page.find('va-checkbox');
+    const inputEl = await page.find('va-checkbox >>> input');
+    const descriptionDiv = await page.find('va-checkbox >>> div#description');
+    expect(element).toEqualText('This is a description!');
+    expect(descriptionDiv).not.toBeNull();;
+    // should still add the description aria-describedby with one empty slot
+    expect(inputEl.getAttribute('aria-describedby')).toEqual('description');
+  });
+
+  it('should prefer rendering the description prop over the slotted element', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-checkbox description="Description prop"><p slot="description">Slotted description</p></va-checkbox>',
+    );
+    const element = await page.find('va-checkbox');
+    const inputEl = await page.find('va-checkbox >>> input');
+    expect(element.shadowRoot.textContent).toContain('Description prop');
+    expect(
+      await page.find('va-checkbox >>> slot[name="description"]'),
+    ).toBeNull();
+    expect(inputEl.getAttribute('aria-describedby')).toEqual('description');
+  });
+
+  it('should not add aria-describedby for empty description slots', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-checkbox><p slot="description"></p><p slot="description"></p></va-checkbox>',
+    );
+    const element = await page.find('va-checkbox');
+    const inputEl = await page.find('va-checkbox >>> input');
+    expect(element).toEqualText('');
+    expect(
+      await page.find('va-checkbox >>> slot[name="description"]'),
+    ).toBeNull();
+    expect(inputEl.getAttribute('aria-describedby')).toBeNull();
   });
 
   it('adds new aria-describedby for error message', async () => {

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -178,8 +178,9 @@ export class VaCheckbox {
       messageAriaDescribedby,
       name
     } = this;
-
-    const hasDescription = description || !!this.el.querySelector('[slot="description"]');
+    const hasDescriptionSlot =
+      !description &&
+      this.el.querySelectorAll('[slot="description"]:not(:empty)').length > 0;
 
     const inputClass = classnames({
       'usa-checkbox__input': true,
@@ -192,16 +193,14 @@ export class VaCheckbox {
     const ariaDescribedbyIds = [
       messageAriaDescribedby ? 'input-message' : '',
       error ? 'checkbox-error-message' : '',
-      hasDescription ? 'description' : '',
+      description || hasDescriptionSlot ? 'description' : '',
       // Return null so we don't add the attribute if we have an empty string
     ].filter(Boolean).join(' ').trim() || null;
 
     return (
       <Host>
-        {description ?
-          <legend id="description" class={descriptionClass}>{description}</legend> :
-          <slot name="description" />
-        }
+        {description && <legend id="description" class={descriptionClass}>{description}</legend>}
+        {hasDescriptionSlot && <div id="description"><slot name="description" /></div>}
 
         {hint && <span class="usa-hint">{hint}</span>}
         <span id="checkbox-error-message" role="alert">


### PR DESCRIPTION
## Chromatic
<!-- This `3226-cb-aria` is a placeholder for a CI job - it will be updated automatically -->
https://3226-cb-aria--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

When a description slot is added to the va-checkbox, a "description" ID is added to the input's aria-describedby, but there is no associated ID. I also noticed that the web component in vets-website _always_ renders a description slot, even if it ends up empty. To fix this, the selector for the description slot also checks if the slot is empty (`'[slot="description"]:not(:empty)'`); and check for multiple slots (since that's possible)

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3226

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

Before
![Screen from Higher Level Review form with aria-describedby="description" but that `description` doesn't exist.](https://github.com/user-attachments/assets/3e1d2d6a-7626-4d0d-a953-de9d064f6a49)

Voice over before (missing description ID)
<img width="637" alt="checkbox with Description JSX storybook reading out message aria-describedby text, but not the associated description within the slot" src="https://github.com/user-attachments/assets/1a8f9adc-b462-41f0-b2af-d0052e33011d">

After: Voice over with div with description ID wrapping the slots
<img width="636" alt="checkbox with Description JSX storybook reading out message aria-describedby and description slot text" src="https://github.com/user-attachments/assets/48665d49-be5d-45c5-b734-b7ae7b910c4f">

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
