### PR TITLE
va-accordion: check for open accordion items on load

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
@@ -285,4 +285,16 @@ describe('va-accordion', () => {
       },
     });
   });
+
+  it('shows "Collapse all -" if one or more accordion-items is open on load', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-accordion section-heading="The Section Heading">
+        <va-accordion-item header="First item" open="true">Some content</va-accordion-item>
+      </va-accordion>`);
+    
+    const button = await page.find('va-accordion >>> button');
+
+    expect(button.innerText).toEqual('collapse-all -');
+  })
 });

--- a/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
@@ -286,7 +286,7 @@ describe('va-accordion', () => {
     });
   });
 
-  it('shows "Collapse all -" if one or more accordion-items is open on load', async () => {
+  it('shows "Collapse all -" if all accordion-items are open on load', async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-accordion section-heading="The Section Heading">
@@ -296,5 +296,18 @@ describe('va-accordion', () => {
     const button = await page.find('va-accordion >>> button');
 
     expect(button.innerText).toEqual('collapse-all -');
-  })
+  });
+
+  it('shows "Collapse all -" if some of accordion-items are open on load', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-accordion section-heading="The Section Heading">
+        <va-accordion-item header="First item" open="true">Some content</va-accordion-item>
+        <va-accordion-item header="Second item">Some content</va-accordion-item>
+      </va-accordion>`);
+    
+    const button = await page.find('va-accordion >>> button');
+
+    expect(button.innerText).toEqual('collapse-all -');
+  });
 });

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -138,7 +138,7 @@ export class VaAccordion {
       this.accordionsOpened();
   }
 
-  private accordionsOpened() {
+  private accordionsOpened(method='every') {
     // Track user clicks on va-accordion-item within an array to compare if all values are true or false
     let accordionItems = [];
     getSlottedNodes(this.el, 'va-accordion-item').forEach(item => {
@@ -146,10 +146,10 @@ export class VaAccordion {
     });
     const allOpen = currentValue => currentValue === 'true';
     const allClosed = currentValue => currentValue === 'false';
-    if (accordionItems.every(allOpen)) {
+    if (accordionItems[method](allOpen)) {
       this.expanded = true;
     }
-    if (accordionItems.every(allClosed)) {
+    if (accordionItems[method](allClosed)) {
       this.expanded = false;
     }
   }
@@ -181,6 +181,11 @@ export class VaAccordion {
 
   disconnectedCallback() {
     i18next.off('languageChanged');
+  }
+
+  // if one or more accordion-items are open on load, then we should put component in state to "Collapse all"
+  componentDidLoad() {
+    this.accordionsOpened('some');
   }
 
   render() {


### PR DESCRIPTION
## Chromatic
<!-- This `2524-accordion-expand` is a placeholder for a CI job - it will be updated automatically -->
https://2524-accordion-expand--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR fixes a bug where if `va-accordion` has sections expanded on load (i.e. a `va-accordion-item` has `open="true"` attribute) then the button text in the upper right corner would say <code>Expand all +</code>, not `Collapse all -`.

Closes [2524](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2524)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

Given this markup:

<img width="902" alt="Screenshot 2024-09-20 at 11 14 13 AM" src="https://github.com/user-attachments/assets/e000a6c9-42bd-4578-9a99-7b15f10ec800">

**Before**:

<img width="1323" alt="Screenshot 2024-09-20 at 11 13 47 AM" src="https://github.com/user-attachments/assets/ce360c1c-b7dd-4e39-8ba0-b6e838a91362">

**After**:

<img width="1145" alt="Screenshot 2024-09-20 at 11 04 11 AM" src="https://github.com/user-attachments/assets/bc12ce73-ef41-4d90-a169-9134c5180480">



## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
