### PR TITLE
va-textarea: Fixing it so textarea components are resizable again

### DIFF
--- a/packages/web-components/src/components/va-textarea/va-textarea.scss
+++ b/packages/web-components/src/components/va-textarea/va-textarea.scss
@@ -12,11 +12,6 @@
 @import '../../mixins/focusable.css';
 @import '../../mixins/headers.css';
 
-
-.usa-textarea {
-  resize: inherit;
-}
-
 :host {
   color: var(--vads-color-base);
   display: block;


### PR DESCRIPTION
## Chromatic
<!-- This `2977-textarea-resizing-fix` is a placeholder for a CI job - it will be updated automatically -->
https://2977-textarea-resizing-fix--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#2977](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2977)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
Before: 
![Screenshot 2024-09-27 at 9 39 33 AM](https://github.com/user-attachments/assets/be529f6e-f436-4aa1-95ec-645509d9ebb8)
After:
![Screenshot 2024-09-27 at 9 38 57 AM](https://github.com/user-attachments/assets/7882f9ff-116f-4cb7-bf5c-54ffc8707453)

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
