### PR TITLE
va-radio: update legend color and font weight

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -32,6 +32,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          onlyChanged: true
+          onlyChanged: false
           workingDir: packages/storybook
-          skip: "dependabot/**"
+          skip: 'dependabot/**'

--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -20,3 +20,8 @@
   margin-top: 24px;
   max-width: 480px;
 }
+
+legend.usa-legend {
+  color: red;
+  font-weight: bold;
+}

--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -22,6 +22,6 @@
 }
 
 legend.usa-legend {
-  color: red;
+  color: #AA0000;
   font-weight: bold;
 }

--- a/packages/web-components/src/components/va-radio/va-radio.scss
+++ b/packages/web-components/src/components/va-radio/va-radio.scss
@@ -22,6 +22,6 @@
 }
 
 legend.usa-legend {
-  color: #AA0000;
+  color: #1a4480;
   font-weight: bold;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `tutorial-video-pr` is a placeholder for a CI job - it will be updated automatically -->
https://tutorial-video-pr--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This PR updates the `va-radio` legend (title) color and font weight. Color contrast testing was done to make sure that it meets WCAG AAA standards.

Figma: https://www.figma.com/design/afurtw4iqQe6y4gXfNfkkk/VADS-Component-Library?node-id=351-2593&node-type=canvas&t=eghoCYp92GIBQHaC-0

Closes [#12456](https://github.com/)

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

**Before**

![Screenshot 2024-10-02 at 10 47 13 AM](https://github.com/user-attachments/assets/f461b978-f4f4-4c8e-8faf-84cc0b244cdc)

**After**

![Screenshot 2024-10-02 at 12 50 06 PM](https://github.com/user-attachments/assets/c3c245b2-6094-4c9a-80d7-a527ba257cb3)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
