### PR TITLE
css-library: update margin auto value

### DIFF
--- a/packages/css-library/dist/stylesheets/utilities.css
+++ b/packages/css-library/dist/stylesheets/utilities.css
@@ -6247,16 +6247,16 @@ through all possible variants
 }
 
 .vads-u-margin-x--auto {
-  margin-left: -1px !important;
-  margin-right: -1px !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
 }
 
 .vads-u-margin-right--auto {
-  margin-right: -1px !important;
+  margin-right: auto !important;
 }
 
 .vads-u-margin-left--auto {
-  margin-left: -1px !important;
+  margin-left: auto !important;
 }
 
 .vads-u-measure--1 {
@@ -7774,14 +7774,14 @@ through all possible variants
     margin-left: -1px !important;
   }
   .mobile\:vads-u-margin-x--auto {
-    margin-left: -1px !important;
-    margin-right: -1px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
   .mobile\:vads-u-margin-right--auto {
-    margin-right: -1px !important;
+    margin-right: auto !important;
   }
   .mobile\:vads-u-margin-left--auto {
-    margin-left: -1px !important;
+    margin-left: auto !important;
   }
   .mobile\:vads-u-measure--1 {
     max-width: 40ch !important;
@@ -9161,14 +9161,14 @@ through all possible variants
     margin-left: -1px !important;
   }
   .mobile-lg\:vads-u-margin-x--auto {
-    margin-left: -1px !important;
-    margin-right: -1px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
   .mobile-lg\:vads-u-margin-right--auto {
-    margin-right: -1px !important;
+    margin-right: auto !important;
   }
   .mobile-lg\:vads-u-margin-left--auto {
-    margin-left: -1px !important;
+    margin-left: auto !important;
   }
   .mobile-lg\:vads-u-measure--1 {
     max-width: 40ch !important;
@@ -10548,14 +10548,14 @@ through all possible variants
     margin-left: -1px !important;
   }
   .tablet\:vads-u-margin-x--auto {
-    margin-left: -1px !important;
-    margin-right: -1px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
   .tablet\:vads-u-margin-right--auto {
-    margin-right: -1px !important;
+    margin-right: auto !important;
   }
   .tablet\:vads-u-margin-left--auto {
-    margin-left: -1px !important;
+    margin-left: auto !important;
   }
   .tablet\:vads-u-measure--1 {
     max-width: 40ch !important;
@@ -11935,14 +11935,14 @@ through all possible variants
     margin-left: -1px !important;
   }
   .desktop\:vads-u-margin-x--auto {
-    margin-left: -1px !important;
-    margin-right: -1px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
   .desktop\:vads-u-margin-right--auto {
-    margin-right: -1px !important;
+    margin-right: auto !important;
   }
   .desktop\:vads-u-margin-left--auto {
-    margin-left: -1px !important;
+    margin-left: auto !important;
   }
   .desktop\:vads-u-measure--1 {
     max-width: 40ch !important;
@@ -13322,14 +13322,14 @@ through all possible variants
     margin-left: -1px !important;
   }
   .desktop-lg\:vads-u-margin-x--auto {
-    margin-left: -1px !important;
-    margin-right: -1px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
   .desktop-lg\:vads-u-margin-right--auto {
-    margin-right: -1px !important;
+    margin-right: auto !important;
   }
   .desktop-lg\:vads-u-margin-left--auto {
-    margin-left: -1px !important;
+    margin-left: auto !important;
   }
   .desktop-lg\:vads-u-measure--1 {
     max-width: 40ch !important;
@@ -15063,14 +15063,14 @@ through all possible variants
     margin-left: -1px !important;
   }
   .medium-screen\:vads-u-margin-x--auto {
-    margin-left: -1px !important;
-    margin-right: -1px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
   .medium-screen\:vads-u-margin-right--auto {
-    margin-right: -1px !important;
+    margin-right: auto !important;
   }
   .medium-screen\:vads-u-margin-left--auto {
-    margin-left: -1px !important;
+    margin-left: auto !important;
   }
   .medium-screen\:vads-u-measure--1 {
     max-width: 40ch !important;

--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 01 Oct 2024 21:23:29 GMT
+ * Generated on Fri, 04 Oct 2024 16:46:08 GMT
  */
 
 :root {

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 01 Oct 2024 21:23:29 GMT
+// Generated on Fri, 04 Oct 2024 16:46:08 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;

--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/css-library",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Department of Veterans Affairs stylesheets, tokens, and utilities",
   "packageManager": "yarn@3.2.0",
   "files": [

--- a/packages/css-library/src/tokens/margin.scss
+++ b/packages/css-library/src/tokens/margin.scss
@@ -42,6 +42,6 @@ $tokens-margin-x: map-collect(
   $tokens-margin,
   $tokens-negative-margin,
   (
-    auto: -1px,
+    auto: auto,
   )
 );


### PR DESCRIPTION
## Chromatic
<!-- This `mc-margin-auto-fix` is a placeholder for a CI job - it will be updated automatically -->
https://mc-margin-auto-fix--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
The 404 page on va.gov is mis-aligned, this is because margin-auto values in css-library were configured to use -1px instead of `auto`. This PR updates the map value for margin auto

## QA Checklist
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<details><summary>Current settings in prod x--auto is set to -1px</summary>
 
![image](https://github.com/user-attachments/assets/262f9e8c-6580-4767-935e-b53512ebb6c4)

</details>

<details><summary>With margins fixed in css-library</summary>

![image](https://github.com/user-attachments/assets/10705ece-9b67-4575-b58a-b02229da56b5)

</details>

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
