### PR TITLE
CSS Library: update font-family utility map base name

### DIFF
--- a/packages/css-library/dist/stylesheets/utilities.css
+++ b/packages/css-library/dist/stylesheets/utilities.css
@@ -5304,11 +5304,11 @@ through all possible variants
   order: 0 !important;
 }
 
-.vads-u-font-family-sans {
+.vads-u-font-family--sans {
   font-family: Source Sans Pro, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif !important;
 }
 
-.vads-u-font-family-serif {
+.vads-u-font-family--serif {
   font-family: Bitter, Georgia, Cambria, Times New Roman, Times, serif !important;
 }
 
@@ -14341,10 +14341,10 @@ through all possible variants
   .medium-screen\:vads-u-order--initial {
     order: 0 !important;
   }
-  .medium-screen\:vads-u-font-family-sans {
+  .medium-screen\:vads-u-font-family--sans {
     font-family: Source Sans Pro, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif !important;
   }
-  .medium-screen\:vads-u-font-family-serif {
+  .medium-screen\:vads-u-font-family--serif {
     font-family: Bitter, Georgia, Cambria, Times New Roman, Times, serif !important;
   }
   .medium-screen\:vads-u-font-size--sm {

--- a/packages/css-library/dist/stylesheets/utilities.css
+++ b/packages/css-library/dist/stylesheets/utilities.css
@@ -5304,11 +5304,11 @@ through all possible variants
   order: 0 !important;
 }
 
-.vads-u-font--sans {
+.vads-u-font-family-sans {
   font-family: Source Sans Pro, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif !important;
 }
 
-.vads-u-font--serif {
+.vads-u-font-family-serif {
   font-family: Bitter, Georgia, Cambria, Times New Roman, Times, serif !important;
 }
 
@@ -14341,10 +14341,10 @@ through all possible variants
   .medium-screen\:vads-u-order--initial {
     order: 0 !important;
   }
-  .medium-screen\:vads-u-font--sans {
+  .medium-screen\:vads-u-font-family-sans {
     font-family: Source Sans Pro, Helvetica Neue, Helvetica, Roboto, Arial, sans-serif !important;
   }
-  .medium-screen\:vads-u-font--serif {
+  .medium-screen\:vads-u-font-family-serif {
     font-family: Bitter, Georgia, Cambria, Times New Roman, Times, serif !important;
   }
   .medium-screen\:vads-u-font-size--sm {

--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 04 Oct 2024 19:20:36 GMT
+ * Generated on Fri, 04 Oct 2024 19:27:10 GMT
  */
 
 :root {

--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 01 Oct 2024 21:23:29 GMT
+ * Generated on Fri, 04 Oct 2024 19:20:36 GMT
  */
 
 :root {

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 01 Oct 2024 21:23:29 GMT
+// Generated on Fri, 04 Oct 2024 19:20:36 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 04 Oct 2024 19:20:36 GMT
+// Generated on Fri, 04 Oct 2024 19:27:10 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;

--- a/packages/css-library/src/utilities/font.scss
+++ b/packages/css-library/src/utilities/font.scss
@@ -4,7 +4,7 @@
 
 $u-font-family: (
   font-family: (
-    base: 'vads-u-font-',
+    base: 'vads-u-font-family',
     modifiers: null,
     values: map-collect($tokens-font-family),
     settings: $font-settings,

--- a/packages/css-library/src/utilities/font.scss
+++ b/packages/css-library/src/utilities/font.scss
@@ -4,7 +4,7 @@
 
 $u-font-family: (
   font-family: (
-    base: 'vads-u-font-family',
+    base: 'vads-u-font-family-',
     modifiers: null,
     values: map-collect($tokens-font-family),
     settings: $font-settings,


### PR DESCRIPTION
## Chromatic
<!-- This `font-family-utilities` is a placeholder for a CI job - it will be updated automatically -->
https://font-family-utilities--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

It was reported that the `vads-u-font-family--sans` and `vads-u-font-family--serif` [font family utility](https://design.va.gov/foundation/utilities/font-family) classes weren't working. We discovered that the utility map for these classes had the incorrect base name. This PR will update that.

Issue discussed in this [Slack thread](https://dsva.slack.com/archives/C01DBGX4P45/p1728067148775889).

## Screenshots

<img width="541" alt="Screenshot 2024-10-04 at 2 28 00 PM" src="https://github.com/user-attachments/assets/af721e27-5842-4d24-9b85-569ff73fe923">


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
