### PR TITLE
update version for core and web-components

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "47.0.0",
+  "version": "47.1.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -27,7 +27,7 @@
     "serve": "stencil build --dev --watch --serve"
   },
   "dependencies": {
-    "@department-of-veterans-affairs/css-library": "^0.12.1",
+    "@department-of-veterans-affairs/css-library": "^0.12.2",
     "@stencil/core": "4.20.0",
     "aria-hidden": "^1.1.3",
     "body-scroll-lock": "^4.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3209,7 +3209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@department-of-veterans-affairs/css-library@npm:^0.12.1, @department-of-veterans-affairs/css-library@workspace:packages/css-library":
+"@department-of-veterans-affairs/css-library@npm:^0.12.2, @department-of-veterans-affairs/css-library@workspace:packages/css-library":
   version: 0.0.0-use.local
   resolution: "@department-of-veterans-affairs/css-library@workspace:packages/css-library"
   dependencies:
@@ -3343,7 +3343,7 @@ __metadata:
   dependencies:
     "@axe-core/puppeteer": "npm:^4.4.0"
     "@babel/core": "npm:^7.12.13"
-    "@department-of-veterans-affairs/css-library": "npm:^0.12.1"
+    "@department-of-veterans-affairs/css-library": "npm:^0.12.2"
     "@department-of-veterans-affairs/formation": "npm:^11.0.6"
     "@stencil/core": "npm:4.20.0"
     "@stencil/postcss": "npm:^2.0.0"


### PR DESCRIPTION
## Chromatic
<!-- This `mc-comp-lib-47.1.0` is a placeholder for a CI job - it will be updated automatically -->
https://mc-comp-lib-47.1.0--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
Updates version for core and web-components. css-library was updated on Friday [here](https://github.com/department-of-veterans-affairs/component-library/pull/1352/files#diff-1c40d3600debc345902064e33f34f49a99e1230a0a9ec56e6aa590bd93188d11)
