### PR TITLE
va-modal: set box-sizing to border-box to prevent text overflow

### DIFF
--- a/packages/web-components/src/components/va-modal/va-modal.scss
+++ b/packages/web-components/src/components/va-modal/va-modal.scss
@@ -45,6 +45,7 @@
 :host .usa-modal__main {
   position: relative;
   margin: 0px auto;
+  box-sizing: border-box;
 }
 
 .va-modal-alert__icon {


### PR DESCRIPTION
## Chromatic
<!-- This `2492-modal-text-overflow` is a placeholder for a CI job - it will be updated automatically -->
https://2492-modal-text-overflow--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Text was overflowing the omb-info modal, after digging around it looks like the container of the modal (`:host .usa-modal__main`) was using padding without setting the box-sizing, which allowed for the content to flow off of the screen.

Closes [2492](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2492)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
Before:
![Screenshot 2024-10-07 at 1 33 06 PM](https://github.com/user-attachments/assets/8ef66a72-00f2-45a8-bb1f-45ec32843bb7)

After:
![Screenshot 2024-10-07 at 1 32 25 PM](https://github.com/user-attachments/assets/17807ca6-0a61-488d-b7da-483c71cdd046)



## Acceptance criteria
- [ ] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
