### PR TITLE
Open accordion when media is print

### DIFF
--- a/packages/storybook/stories/va-accordion-uswds.stories.jsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.jsx
@@ -18,6 +18,9 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={accordionDocs} />,
     },
+    chromatic: {
+      media: 'print'
+    },
   },
 };
 
@@ -326,11 +329,6 @@ Bordered.args = {
 export const Subheader = TemplateSubheader.bind(null);
 Subheader.args = {
   ...defaultArgs,
-  parameters: {
-    chromatic: {
-      media: 'print'
-    }
-  }
 };
 
 export const IconHeaders = TemplateIconHeaders.bind(null);

--- a/packages/storybook/stories/va-accordion-uswds.stories.jsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.jsx
@@ -326,6 +326,11 @@ Bordered.args = {
 export const Subheader = TemplateSubheader.bind(null);
 Subheader.args = {
   ...defaultArgs,
+  parameters: {
+    chromatic: {
+      media: 'print'
+    }
+  }
 };
 
 export const IconHeaders = TemplateIconHeaders.bind(null);

--- a/packages/storybook/stories/va-accordion-uswds.stories.jsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.jsx
@@ -305,12 +305,15 @@ const defaultArgs = {
   'open-single': undefined,
 };
 
-export const Default = Template.bind({parameters:{chromatic: {
-  media: 'print'
-},}});
+export const Default = Template.bind(null);
 Default.args = {
   ...defaultArgs,
 };
+Default.parameters = { 
+  chromatic: {
+    media: 'print'
+  }
+}
 Default.argTypes = propStructure(accordionDocs);
 
 export const SingleSelect = Template.bind(null);

--- a/packages/storybook/stories/va-accordion-uswds.stories.jsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.jsx
@@ -18,9 +18,6 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={accordionDocs} />,
     },
-    chromatic: {
-      media: 'print'
-    },
   },
 };
 
@@ -308,7 +305,9 @@ const defaultArgs = {
   'open-single': undefined,
 };
 
-export const Default = Template.bind(null);
+export const Default = Template.bind({parameters:{chromatic: {
+  media: 'print'
+},}});
 Default.args = {
   ...defaultArgs,
 };

--- a/packages/storybook/stories/va-accordion-uswds.stories.jsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.jsx
@@ -309,11 +309,6 @@ export const Default = Template.bind(null);
 Default.args = {
   ...defaultArgs,
 };
-Default.parameters = { 
-  chromatic: {
-    media: 'print'
-  }
-}
 Default.argTypes = propStructure(accordionDocs);
 
 export const SingleSelect = Template.bind(null);
@@ -357,3 +352,32 @@ export const ManyAccordions = ManyItemsTemplate.bind(null);
 ManyAccordions.args = {
   ...defaultArgs,
 };
+
+
+const PrintTemplate = args => (
+  <va-accordion {...args}>
+    <va-accordion-item id="first" header="First Item">
+        <p>
+          This story is for the Design System Team to be able to test the 
+          accordion items being opened when the page they're on is being printed.
+        </p>
+    </va-accordion-item>
+    <va-accordion-item id="second" header="Second Item">
+        <p>
+          Accordion items will always open when being printed.
+        </p>
+    </va-accordion-item>
+  </va-accordion>
+);
+
+// todo: after upgrading to storybook 8 we can hide this story from the sidebar: https://storybook.js.org/docs/writing-stories/tags
+export const PrintAccordion = PrintTemplate.bind(null);
+PrintAccordion.args = {
+  ...defaultArgs,
+};
+PrintAccordion.parameters = { 
+  chromatic: {
+    media: 'print'
+  },
+  
+}

--- a/packages/web-components/src/components/va-accordion/va-accordion-item.scss
+++ b/packages/web-components/src/components/va-accordion/va-accordion-item.scss
@@ -64,15 +64,15 @@ button {
   max-width: 64ex;
 }
 
+:host(:not([open])) #content,
+:host([open='false']) #content {
+  display: none;
+}
+
 /* overrides hidden attribute on #content */
 @media print {
   :host(:not([open])) #content,
   :host([open='false']) #content {
     display: block;
   }
-}
-
-:host(:not([open])) #content,
-:host([open='false']) #content {
-  display: none;
 }

--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -54,6 +54,7 @@ export const config: Config = {
     }
   ],
   testing: {
+    browserArgs: ['--no-sandbox', '--disable-setuid-sandbox'],
     moduleNameMapper: {
       '^.+.(svg)$': 'jest-transformer-svg',
     },


### PR DESCRIPTION
## Chromatic
<!-- This `dst3350-accordion-print` is a placeholder for a CI job - it will be updated automatically -->
https://dst3350-accordion-print--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes [Bug: collapsed accordions is not printing out their content #3350](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3350)

Reorganizes CSS file so `print` rule isn't overwritten. Adds Print Accordion story to storybooks so we can automatically catch this issue if it happens again,

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] ~~Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)~~ N/A no accessibility changes
- [ ] ~~Designer has signed off on changes (if applicable. If not applicable provide reason why)~~ N/A no design changes
- [x] Tab order and focus state work as expected
- [ ] ~~Changes have been tested against screen readers (if applicable. If not applicable provide reason why)~~ N/A only affects print
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2024-10-10 at 13 47 17](https://github.com/user-attachments/assets/c9c3d836-e8c0-4da5-9431-348e8d8def41)


## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
