### PR TITLE
va-table: show table header for non-stacked & stacked small screen

### DIFF
--- a/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.scss
+++ b/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.scss
@@ -34,10 +34,6 @@ caption {
 }
 
 @media screen and (max-width: 768px) {
-  thead, ::slotted([slot=headers]) {
-    display: none;
-  }
-
   ::slotted(va-table-row) {
     border-bottom: 1px solid var(--vads-color-gray-medium);
   }

--- a/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
+++ b/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
@@ -64,9 +64,10 @@ export class VaTableInner {
         {Array.from({ length: this.cols }).map((_, i) => {
           const slotName = `va-table-slot-${row * this.cols + i}`;
           const slot = <slot name={slotName}></slot>
+          const header = this.el.querySelector(`[slot="va-table-slot-${i}"]`).innerHTML;
           return (i === 0 || row === 0)
-            ? <th scope="row">{slot}</th>
-            : <td>{slot}</td>
+            ? <th data-label={header} scope="row">{slot}</th>
+            : <td data-label={header}>{slot}</td>
         })}
       </tr>
     )


### PR DESCRIPTION
## Chromatic
<!-- This `3327-va-table-screen-fix` is a placeholder for a CI job - it will be updated automatically -->
https://3327-va-table-screen-fix--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR removes the css style which results in showing headers for non stacked tables for small screens.
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3327

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2024-10-14 at 4 00 21 PM](https://github.com/user-attachments/assets/a0b839bd-52b3-4606-8fbb-8ee55876ef67)

Stacked table:
<img width="185" alt="Screenshot 2024-10-15 at 6 36 11 PM" src="https://github.com/user-attachments/assets/beb2a069-9794-4b8f-b679-e597b71e0459">

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
