### PR TITLE
Toggle the onlyChanged Chromatic setting for a new UI baseline

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -32,6 +32,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          onlyChanged: true
+          onlyChanged: false
           workingDir: packages/storybook
           skip: 'dependabot/**'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -32,6 +32,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          onlyChanged: false
+          onlyChanged: true
           workingDir: packages/storybook
           skip: 'dependabot/**'

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 This is a monorepo containing two main packages:
 
-- `react-components`
 - `web-components`
+- `react-components`
 
 The `core` package is for bundling the two main packages into one for publishing. The `storybook` package is for the combined story files from each `*-components` package.
 The `design-system-dashboard-cli` package is used to gather metrics on design system usage.
@@ -78,36 +78,37 @@ Releases will occur no less often than at the beginning of each sprint (every ot
 # Running Build via Storybook
 
 1. `cd packages/web-components/`
-    1. `yarn install`
-    2. `yarn build`
-    3. `yarn build-bindings` (build React bindings)
-    4. `yarn watch:stencil` (optional)
+   1. `yarn install`
+   2. `yarn build`
+   3. `yarn build-bindings` (build React bindings)
+   4. `yarn watch:stencil` (optional)
 2. `cd ../react-components/`
-    1. `yarn install`
-    2. `yarn build`
+   1. `yarn install`
+   2. `yarn build`
 3. `cd ../core/`
-    1. `yarn install`
-    2. `yarn build`
+   1. `yarn install`
+   2. `yarn build`
 4. `cd ../storybook/`
-    1. `yarn install`
-    2. `yarn storybook`
+   1. `yarn install`
+   2. `yarn storybook`
 
 This will allow you to run Storybook locally to view all components
 
 # Stencil Dev Server for Testing IE11
 
 1. Update `stencil.config.ts` line 16 to `buildEs5: true,`
-    1. [More information on buildEs5 in Stencil](https://stenciljs.com/docs/config#buildes5)
-    2. Stencil Dev Server is run in `dev` mode
+   1. [More information on buildEs5 in Stencil](https://stenciljs.com/docs/config#buildes5)
+   2. Stencil Dev Server is run in `dev` mode
 2. Within `component-library/packages/web-components/src/index.html` Web Components can be added inside of the `<body>` tag for testing
-    1. Example:
 
-    ```
-    <body>
-        <va-progress-bar label="Add a label here" percent={35}></va-progress-bar>
-        <va-segmented-progress-bar current={2} total={6}></va-segmented-progress-bar>
-    </body>
-    ```
+   1. Example:
+
+   ```
+   <body>
+       <va-progress-bar label="Add a label here" percent={35}></va-progress-bar>
+       <va-segmented-progress-bar current={2} total={6}></va-segmented-progress-bar>
+   </body>
+   ```
 
 3. Run `yarn serve` inside `packages/web-components/` to start the Stencil Dev Server
 


### PR DESCRIPTION
## Chromatic
<!-- This `chromatic-ui-diff` is a placeholder for a CI job - it will be updated automatically -->
https://chromatic-ui-diff--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This PR toggled the `onlyChanged` setting in the [Chromatic workflow](https://github.com/department-of-veterans-affairs/component-library/blob/e84f6b581038fb0127514bead45185bbda82b6b1/.github/workflows/chromatic.yml#L35) so that it generated a new UI Test baseline. I'm hoping that this will resolve the issue where UI changes were not being flagged.

The full build run flagged a couple of changes that had not already been accepted yet here:  https://www.chromatic.com/build?appId=65a6e2ed2314f7b8f98609d8&number=1572

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
