### PR TITLE
va-process-list: change color variable from usa to vads

### DIFF
--- a/packages/web-components/src/components/va-process-list/va-process-list-item.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list-item.scss
@@ -8,7 +8,7 @@
 }
 
 .usa-process-list__heading-eyebrow {
-  color: var(--uswds-system-color-gray-cool-70);
+  color: var(--vads-color-base-darker);
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
## Chromatic
<!-- This `1365-process-list-color-variable` is a placeholder for a CI job - it will be updated automatically -->
https://1365-process-list-color-variable--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Change `--uswds-system-color-gray-cool-70` color variable to `--vads-color-base-darker`

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual change

## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
