### PR TITLE
Do not merge: Updated `va-table-inner` to properly scope table header row to columns

### DIFF
--- a/packages/web-components/src/components/va-table/va-table-inner/test/va-table-inner.e2e.ts
+++ b/packages/web-components/src/components/va-table/va-table-inner/test/va-table-inner.e2e.ts
@@ -72,14 +72,24 @@ describe('va-table', () => {
     await page.setContent(makeTable());
     const caption = await page.find('va-table-inner >>> caption');
     expect(caption.innerHTML).toEqual('this is a caption');
-  })
+  });
 
   it('renders a table with the proper number of rows and columns', async () => {
     const page = await newE2EPage();
     await page.setContent(makeTable());
 
     const table = await page.find('va-table-inner');
-    expect(table.getAttribute('rows')).toEqual("2");
-    expect(table.getAttribute('cols',)).toEqual("3");
+    expect(table.getAttribute('rows')).toEqual('2');
+    expect(table.getAttribute('cols')).toEqual('3');
   });
-})
+
+  it('sets the proper scope attributes for rows and columns', async () => {
+    const page = await newE2EPage();
+    await page.setContent(makeTable());
+
+    const columnHeader = await page.find('va-table-inner >>> thead >>> th');
+    const rowHeader = await page.find('va-table-inner >>> tbody >>> th');
+    expect(columnHeader.getAttribute('scope')).toEqual('col');
+    expect(rowHeader.getAttribute('scope')).toEqual('row');
+  });
+});

--- a/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
+++ b/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
@@ -26,10 +26,9 @@ export class VaTableInner {
    * The title of the table
    */
   @Prop() tableTitle: string;
-
   /*
-  * The number of rows in the table
-  */
+   * The number of rows in the table
+   */
   @Prop() rows?: number;
 
   /**
@@ -63,13 +62,20 @@ export class VaTableInner {
       <tr>
         {Array.from({ length: this.cols }).map((_, i) => {
           const slotName = `va-table-slot-${row * this.cols + i}`;
-          const slot = <slot name={slotName}></slot>
-          return (i === 0 || row === 0)
-            ? <th scope="row">{slot}</th>
-            : <td>{slot}</td>
+          const slot = <slot name={slotName}></slot>;
+
+          if (row === 0) {
+            return <th scope="col">{slot}</th>;
+          }
+
+          if (i === 0) {
+            return <th scope="row">{slot}</th>;
+          }
+
+          return <td>{slot}</td>;
         })}
       </tr>
-    )
+    );
   }
 
   /**
@@ -78,7 +84,7 @@ export class VaTableInner {
   getBodyRows(): HTMLTableRowElement[] {
     const rows = [];
     for (let i = 1; i < this.rows; i++) {
-      rows.push(this.makeRow(i))
+      rows.push(this.makeRow(i));
     }
     return rows;
   }
@@ -92,12 +98,10 @@ export class VaTableInner {
     });
     return (
       <table class={classes}>
-        { tableTitle && <caption>{tableTitle}</caption> }
-        <thead>{ this.makeRow(0) }</thead>
-        <tbody id="va-table-body">
-          { this.getBodyRows() }
-        </tbody>
+        {tableTitle && <caption>{tableTitle}</caption>}
+        <thead>{this.makeRow(0)}</thead>
+        <tbody id="va-table-body">{this.getBodyRows()}</tbody>
       </table>
-    )
+    );
   }
 }


### PR DESCRIPTION
## Chromatic
<!-- This `patch&#x2F;tpierce-va-table-95120` is a placeholder for a CI job - it will be updated automatically -->
https://patch&#x2F;tpierce-va-table-95120--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [x] Link to any related issues in the description so they can be cross-referenced.
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/95120

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
