### PR TITLE
va-modal: set overflow-wrap:anywhere on modal content

### DIFF
--- a/packages/web-components/src/components/va-modal/va-modal.scss
+++ b/packages/web-components/src/components/va-modal/va-modal.scss
@@ -30,7 +30,7 @@
     width: 100%;
   }
 }
-.usa-modal__main *:not(va-button) {
+.usa-modal__main div[role=document] {
   overflow-wrap: anywhere; // Prevent text overflowing the modal when words are longer than the modal width
 }
 

--- a/packages/web-components/src/components/va-modal/va-modal.scss
+++ b/packages/web-components/src/components/va-modal/va-modal.scss
@@ -30,6 +30,9 @@
     width: 100%;
   }
 }
+.usa-modal__main *:not(va-button) {
+  overflow-wrap: anywhere; // Prevent text overflowing the modal when words are longer than the modal width
+}
 
 @media screen and (max-width: 481px) {
   .usa-modal__content {


### PR DESCRIPTION
## Chromatic
<!-- This `3355-modal-overflow-wrap` is a placeholder for a CI job - it will be updated automatically -->
https://3355-modal-overflow-wrap--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Modal content in the title and body were able to overflow the modal when there were no logical breaks, ie long words or urls. Setting `overflow-wrap:anywhere` will force wrapping in these situations.

As per the request in the ticket, this was not applied to the bottom buttons on the modal.
Closes [3355](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3355)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
Before:
![Screenshot 2024-10-23 at 3 50 35 PM](https://github.com/user-attachments/assets/cd4fc4c7-4ec7-437b-95a4-c0e6ab7e47da)

After:
![Screenshot 2024-10-23 at 3 49 34 PM](https://github.com/user-attachments/assets/eee8137c-9415-44e7-ac17-4899af0f98e9)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
