### PR TITLE
va-select: add import for focusable mixin

### DIFF
--- a/packages/web-components/src/components/va-select/va-select.scss
+++ b/packages/web-components/src/components/va-select/va-select.scss
@@ -10,6 +10,7 @@
 
 @import '../../mixins/uswds-input-width.scss';
 @import '../../mixins/uswds-error-border.scss';
+@import '../../mixins/focusable.css';
 
 :host {
   display: block;


### PR DESCRIPTION
## Chromatic
<!-- This `3282-va-select-focus-styles` is a placeholder for a CI job - it will be updated automatically -->
https://3282-va-select-focus-styles--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
va-select currently has the default browser focus styles. This PR adds the focusable mixin so that the focus will be the va yellow focus style.

Closes [3282](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3282)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
Before:
![Screenshot 2024-10-24 at 1 22 19 PM](https://github.com/user-attachments/assets/4db0ce56-0e98-434f-aae4-c78595515d36)

After:
![Screenshot 2024-10-24 at 1 21 59 PM](https://github.com/user-attachments/assets/80647c40-eb1d-41a1-bc29-a45948009f68)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
