### PR TITLE
css-library: Adding line-length tokens

### DIFF
--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 25 Oct 2024 15:10:34 GMT
+ * Generated on Mon, 28 Oct 2024 15:35:17 GMT
  */
 
 :root {
@@ -146,6 +146,13 @@
   --vads-font-size-heading-level-4: 17px;
   --vads-font-size-heading-level-5: 15px;
   --vads-font-size-heading-level-6: 15px;
+  --vads-size-line-length-1: 44ex;
+  --vads-size-line-length-2: 60ex;
+  --vads-size-line-length-3: 64ex;
+  --vads-size-line-length-4: 68ex;
+  --vads-size-line-length-5: 72ex;
+  --vads-size-line-length-6: 88ex;
+  --vads-size-line-length-none: 999ex;
   --units-0: 0;
   --units-1: 0.5rem;
   --units-2: 1rem;

--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 28 Oct 2024 15:35:17 GMT
+ * Generated on Fri, 01 Nov 2024 17:33:49 GMT
  */
 
 :root {
@@ -152,7 +152,7 @@
   --vads-size-line-length-4: 68ex;
   --vads-size-line-length-5: 72ex;
   --vads-size-line-length-6: 88ex;
-  --vads-size-line-length-none: 999ex;
+  --vads-size-line-length-none: inherit;
   --units-0: 0;
   --units-1: 0.5rem;
   --units-2: 1rem;

--- a/packages/css-library/dist/tokens/json/variables.json
+++ b/packages/css-library/dist/tokens/json/variables.json
@@ -2699,6 +2699,159 @@
       }
     }
   },
+  "vads": {
+    "size": {
+      "line-length": {
+        "1": {
+          "value": "44ex",
+          "filePath": "tokens/line-lengths.json",
+          "isSource": true,
+          "original": {
+            "value": "44ex"
+          },
+          "name": "vads-size-line-length-1",
+          "attributes": {
+            "category": "vads",
+            "type": "size",
+            "item": "line-length",
+            "subitem": "1"
+          },
+          "path": [
+            "vads",
+            "size",
+            "line-length",
+            "1"
+          ]
+        },
+        "2": {
+          "value": "60ex",
+          "filePath": "tokens/line-lengths.json",
+          "isSource": true,
+          "original": {
+            "value": "60ex"
+          },
+          "name": "vads-size-line-length-2",
+          "attributes": {
+            "category": "vads",
+            "type": "size",
+            "item": "line-length",
+            "subitem": "2"
+          },
+          "path": [
+            "vads",
+            "size",
+            "line-length",
+            "2"
+          ]
+        },
+        "3": {
+          "value": "64ex",
+          "filePath": "tokens/line-lengths.json",
+          "isSource": true,
+          "original": {
+            "value": "64ex"
+          },
+          "name": "vads-size-line-length-3",
+          "attributes": {
+            "category": "vads",
+            "type": "size",
+            "item": "line-length",
+            "subitem": "3"
+          },
+          "path": [
+            "vads",
+            "size",
+            "line-length",
+            "3"
+          ]
+        },
+        "4": {
+          "value": "68ex",
+          "filePath": "tokens/line-lengths.json",
+          "isSource": true,
+          "original": {
+            "value": "68ex"
+          },
+          "name": "vads-size-line-length-4",
+          "attributes": {
+            "category": "vads",
+            "type": "size",
+            "item": "line-length",
+            "subitem": "4"
+          },
+          "path": [
+            "vads",
+            "size",
+            "line-length",
+            "4"
+          ]
+        },
+        "5": {
+          "value": "72ex",
+          "filePath": "tokens/line-lengths.json",
+          "isSource": true,
+          "original": {
+            "value": "72ex"
+          },
+          "name": "vads-size-line-length-5",
+          "attributes": {
+            "category": "vads",
+            "type": "size",
+            "item": "line-length",
+            "subitem": "5"
+          },
+          "path": [
+            "vads",
+            "size",
+            "line-length",
+            "5"
+          ]
+        },
+        "6": {
+          "value": "88ex",
+          "filePath": "tokens/line-lengths.json",
+          "isSource": true,
+          "original": {
+            "value": "88ex"
+          },
+          "name": "vads-size-line-length-6",
+          "attributes": {
+            "category": "vads",
+            "type": "size",
+            "item": "line-length",
+            "subitem": "6"
+          },
+          "path": [
+            "vads",
+            "size",
+            "line-length",
+            "6"
+          ]
+        },
+        "none": {
+          "value": "999ex",
+          "filePath": "tokens/line-lengths.json",
+          "isSource": true,
+          "original": {
+            "value": "999ex"
+          },
+          "name": "vads-size-line-length-none",
+          "attributes": {
+            "category": "vads",
+            "type": "size",
+            "item": "line-length",
+            "subitem": "none"
+          },
+          "path": [
+            "vads",
+            "size",
+            "line-length",
+            "none"
+          ]
+        }
+      }
+    }
+  },
   "units": {
     "0": {
       "value": "0",

--- a/packages/css-library/dist/tokens/json/variables.json
+++ b/packages/css-library/dist/tokens/json/variables.json
@@ -2829,11 +2829,11 @@
           ]
         },
         "none": {
-          "value": "999ex",
+          "value": "inherit",
           "filePath": "tokens/line-lengths.json",
           "isSource": true,
           "original": {
-            "value": "999ex"
+            "value": "inherit"
           },
           "name": "vads-size-line-length-none",
           "attributes": {

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 25 Oct 2024 15:10:34 GMT
+// Generated on Mon, 28 Oct 2024 15:35:17 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;
@@ -144,6 +144,13 @@ $vads-font-size-heading-level-3: 20px;
 $vads-font-size-heading-level-4: 17px;
 $vads-font-size-heading-level-5: 15px;
 $vads-font-size-heading-level-6: 15px;
+$vads-size-line-length-1: 44ex;
+$vads-size-line-length-2: 60ex;
+$vads-size-line-length-3: 64ex;
+$vads-size-line-length-4: 68ex;
+$vads-size-line-length-5: 72ex;
+$vads-size-line-length-6: 88ex;
+$vads-size-line-length-none: 999ex;
 $units-0: 0;
 $units-1: 0.5rem;
 $units-2: 1rem;

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 28 Oct 2024 15:35:17 GMT
+// Generated on Fri, 01 Nov 2024 17:33:49 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;
@@ -150,7 +150,7 @@ $vads-size-line-length-3: 64ex;
 $vads-size-line-length-4: 68ex;
 $vads-size-line-length-5: 72ex;
 $vads-size-line-length-6: 88ex;
-$vads-size-line-length-none: 999ex;
+$vads-size-line-length-none: inherit;
 $units-0: 0;
 $units-1: 0.5rem;
 $units-2: 1rem;

--- a/packages/css-library/tokens/line-lengths.json
+++ b/packages/css-library/tokens/line-lengths.json
@@ -8,7 +8,7 @@
         "4": { "value": "68ex" },
         "5": { "value": "72ex" },
         "6": { "value": "88ex" },
-        "none": { "value": "999ex" }
+        "none": { "value": "inherit" }
       }
     }
   }

--- a/packages/css-library/tokens/line-lengths.json
+++ b/packages/css-library/tokens/line-lengths.json
@@ -1,0 +1,15 @@
+{
+  "vads": {
+    "size": {
+      "line-length": {
+        "1": { "value": "44ex" },
+        "2": { "value": "60ex" },
+        "3": { "value": "64ex" },
+        "4": { "value": "68ex" },
+        "5": { "value": "72ex" },
+        "6": { "value": "88ex" },
+        "none": { "value": "999ex" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Chromatic
<!-- This `3404-line-length-tokens` is a placeholder for a CI job - it will be updated automatically -->
https://3404-line-length-tokens--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
Closes [#3404](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3404)

## QA Checklist
CSS-Library only change.

## Screenshots
N/A

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
