### PR TITLE
Update info sent back from vaMultipleChange

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -3669,7 +3669,7 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         /**
-          * Event emitted when any change to the file inputs occurs.
+          * Event emitted when any change to the file inputs occurs. Sends back an array of FileDetails
          */
         "onVaMultipleChange"?: (event: VaFileInputMultipleCustomEvent<any>) => void;
         /**

--- a/packages/web-components/src/components/va-file-input-multiple/FileDetails.ts
+++ b/packages/web-components/src/components/va-file-input-multiple/FileDetails.ts
@@ -1,0 +1,13 @@
+/**
+ * Represents the information that will be emitted on vaMultipleChange
+ * Each entry contains a file and a boolean representing if it had changed
+ *
+ * @interface
+ * @property {File | null} file - The file object managed by this entry; can be null if no file is currently selected.
+ * @property {Boolean} changed - Set to true if the action that vaMultipleChange affected this file
+ */
+
+export interface FileDetails {
+  file: File,
+  changed: Boolean
+}

--- a/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.spec.todo.ts
+++ b/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.spec.todo.ts
@@ -1,0 +1,97 @@
+// todo there are two issues blocking using these unit test:
+//    1. upgrade node to v20. our current version of node, 18, does not support
+//       the File type. We could also use a polyfill to get this support
+//    2. update our i18n-setup.js files. va-file-input-multiple imports i18next
+//       from core, which then imports other files, but isn't considered a module
+//       which causes Jest to fail. The simple solution is to change all the files
+//       in core/src/i18n to typescript, but there may be another solution
+
+import { VaFileInputMultiple } from '../va-file-input-multiple';
+import { FileDetails } from "../FileDetails";
+
+describe('checking buildFilesArray output', ()=> {
+  const fileArray = [new File(["foo"], "foo.txt"), new File(["bar"], "bar.txt")];
+  it('should mark the first file as changed', async () => {
+    const component = new VaFileInputMultiple();
+    let filesArray = component.buildFilesArray(fileArray, false, 0);
+    let expectedOutput:FileDetails[] = [ {
+      file: fileArray[0],
+      changed: true
+    },
+    {
+      file: fileArray[1],
+      changed: false
+    }];
+    expect(filesArray).toEqual(expectedOutput);
+  });
+
+  it('should mark the second file as changed', async () => {
+    const component = new VaFileInputMultiple();
+    let filesArray = component.buildFilesArray(fileArray, false, 1);
+    let expectedOutput:FileDetails[] = [ {
+      file: fileArray[0],
+      changed: false
+    },
+    {
+      file: fileArray[1],
+      changed: true
+    }];
+    expect(filesArray).toEqual(expectedOutput);
+  });
+
+  it('should not mark anything as changed when deleted is true', async () => {
+    const component = new VaFileInputMultiple();
+    let filesArray = component.buildFilesArray(fileArray, true, 0);
+    let expectedOutput:FileDetails[] = [ {
+      file: fileArray[0],
+      changed: false
+    },
+    {
+      file: fileArray[1],
+      changed: false
+    }];
+    expect(filesArray).toEqual(expectedOutput);
+  });
+
+  it('should filter out null files', async () => {
+    const component = new VaFileInputMultiple();
+    let filesArray = component.buildFilesArray([...fileArray, null], true, 0);
+    let expectedOutput:FileDetails[] = [ {
+      file: fileArray[0],
+      changed: false
+    },
+    {
+      file: fileArray[1],
+      changed: false
+    }];
+    expect(filesArray).toEqual(expectedOutput);
+  });
+
+  it('should not mark anything as changed when index is out of range', async () => {
+    const component = new VaFileInputMultiple();
+    let filesArray = component.buildFilesArray(fileArray, false, -1);
+    let expectedOutput:FileDetails[] = [ {
+      file: fileArray[0],
+      changed: false
+    },
+    {
+      file: fileArray[1],
+      changed: false
+    }];
+    expect(filesArray).toEqual(expectedOutput);
+  });
+
+  it('should not mark anything as changed when index is out of range', async () => {
+    const component = new VaFileInputMultiple();
+    let filesArray = component.buildFilesArray(fileArray, false, 10)
+    let expectedOutput:FileDetails[] = [ {
+      file: fileArray[0],
+      changed: false
+    },
+    {
+      file: fileArray[1],
+      changed: false
+    }];
+    expect(filesArray).toEqual(expectedOutput);
+  });
+});


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes [Allow VaFileInputMultiple's onVaChange to act only on the most recent item in the list #3348](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3348)

Currently VaFileInputMultiple's onVaChange sends back an array of type File, one for each file that's been uploaded. This update changes what is sent back to an array of `FileDetails`, which looks like
```
{
  file: File
  changed: Boolean
} 
```
so a developer can easily filter to the file that was updated in the current change.

This PR includes currently unused unit tests in `va-file-input-multiple.spec.todo.ts`. We need to upgrade node and our `i18n` core files before these will work. 

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why) - no accessibility changes
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why) - no design changes
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why) - no text changes
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
What's emitted from `vaMultipleChange`:
![Screenshot 2024-11-01 at 14 49 18](https://github.com/user-attachments/assets/bc1b227f-6a20-423a-be22-71781a0a389e)
![Screenshot 2024-11-01 at 14 49 22](https://github.com/user-attachments/assets/b49e4e95-1254-4a53-b22e-a6e4507a0d41)

## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
