### PR TITLE
Update `va-pagination` list item and next and previous links accessible labels for better screen reader consistency

### DIFF
--- a/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
+++ b/packages/web-components/src/components/va-pagination/test/va-pagination.e2e.ts
@@ -22,8 +22,8 @@ describe('va-pagination', () => {
               <li class="usa-pagination__item usa-pagination__page-no va-pagination__item">
                 <a aria-label="page 3, last page" href="javascript:void(0)" class="usa-pagination__button">3</a>
               </li>
-              <li class="usa-pagination__item usa-pagination__arrow" aria-label="Next page">
-                <a href="javascript:void(0)" class="usa-pagination__link usa-pagination__next-page">
+              <li class="usa-pagination__item usa-pagination__arrow">
+                <a aria-label="Next page" href="javascript:void(0)" class="usa-pagination__link usa-pagination__next-page">
                   <span class="usa-pagination__link-text">next</span>
                   <div id="next-arrow-icon">
                     <svg class="usa-icon" aria-hidden="true" role="img">
@@ -51,44 +51,66 @@ describe('va-pagination', () => {
 
   it('only selected "page" has selected class', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-pagination page="1" pages="24" max-page-list-length="7"/>`);
-    const firstPage = await page.findAll('va-pagination >>> li.usa-pagination__page-no a.usa-pagination__button.usa-current');
+    await page.setContent(
+      `<va-pagination page="1" pages="24" max-page-list-length="7"/>`,
+    );
+    const firstPage = await page.findAll(
+      'va-pagination >>> li.usa-pagination__page-no a.usa-pagination__button.usa-current',
+    );
     expect(firstPage.length).toEqual(1);
-    expect(firstPage[0].innerHTML).toEqual("1");
+    expect(firstPage[0].innerHTML).toEqual('1');
   });
 
   it('renders first and last page with ellipses when middle pages do not contain them', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-pagination page="10" pages="24" max-page-list-length="7"/>`);
-    const ellipses = await page.findAll('va-pagination >>> li.usa-pagination__overflow');
+    await page.setContent(
+      `<va-pagination page="10" pages="24" max-page-list-length="7"/>`,
+    );
+    const ellipses = await page.findAll(
+      'va-pagination >>> li.usa-pagination__overflow',
+    );
     expect(ellipses).toHaveLength(2);
 
-    const pageNumbers = await page.findAll('va-pagination >>> li.usa-pagination__page-no a.usa-pagination__button');
-    expect(pageNumbers[0].innerHTML).toEqual("1");
-    expect(pageNumbers[pageNumbers.length - 1].innerHTML).toEqual("24");
+    const pageNumbers = await page.findAll(
+      'va-pagination >>> li.usa-pagination__page-no a.usa-pagination__button',
+    );
+    expect(pageNumbers[0].innerHTML).toEqual('1');
+    expect(pageNumbers[pageNumbers.length - 1].innerHTML).toEqual('24');
   });
 
   it('does not render a "Next" button when on last page', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-pagination page="24" pages="24" max-page-list-length="7"/>`);
-    const next = await page.find('va-pagination >>> a.usa-pagination__next-page');
+    await page.setContent(
+      `<va-pagination page="24" pages="24" max-page-list-length="7"/>`,
+    );
+    const next = await page.find(
+      'va-pagination >>> a.usa-pagination__next-page',
+    );
     expect(next).toBeNull();
   });
 
   it('does not show last page number if unbounded flag is set', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-pagination page="1" pages="24" max-page-list-length="7" unbounded/>`);
-    const pageNumbers = await page.findAll('va-pagination >>> li.usa-pagination__page-no a.usa-pagination__button');
-    expect(pageNumbers[pageNumbers.length - 1].innerHTML).toEqual("6");
+    await page.setContent(
+      `<va-pagination page="1" pages="24" max-page-list-length="7" unbounded/>`,
+    );
+    const pageNumbers = await page.findAll(
+      'va-pagination >>> li.usa-pagination__page-no a.usa-pagination__button',
+    );
+    expect(pageNumbers[pageNumbers.length - 1].innerHTML).toEqual('6');
   });
 
   it('renders all page numbers if total pages is less than or equal to 7', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-pagination page="3" pages="7" max-page-list-length="7"/>`);
+    await page.setContent(
+      `<va-pagination page="3" pages="7" max-page-list-length="7"/>`,
+    );
 
     const pageNumbers = [1, 2, 3, 4, 5, 6, 7];
 
-    const anchors = await page.findAll('va-pagination >>> a.usa-pagination__button');
+    const anchors = await page.findAll(
+      'va-pagination >>> a.usa-pagination__button',
+    );
     for (const number of pageNumbers) {
       expect(anchors[number - 1].innerHTML).toEqual(number.toString());
     }
@@ -98,8 +120,12 @@ describe('va-pagination', () => {
     // this is an edge case where even though it is set to 6 items, 7 items is the minimum needed to display everything needed
     // [first page] [second page] [third/previous page] [fourth/current page] [fifth/next page] [ellipsis] [last page]
     const page = await newE2EPage();
-    await page.setContent(`<va-pagination page="4" pages="24" max-page-list-length="6"/>`);
-    const paginationItems = await page.findAll('va-pagination >>> li.usa-pagination__item');
+    await page.setContent(
+      `<va-pagination page="4" pages="24" max-page-list-length="6"/>`,
+    );
+    const paginationItems = await page.findAll(
+      'va-pagination >>> li.usa-pagination__item',
+    );
 
     // should be 9, the 6 page items, one ellipsis and 2 prev/next buttons
     expect(paginationItems).toHaveLength(9);

--- a/packages/web-components/src/components/va-pagination/va-pagination.scss
+++ b/packages/web-components/src/components/va-pagination/va-pagination.scss
@@ -1,6 +1,7 @@
 @forward 'settings';
+@use 'uswds-helpers/src/styles/_usa-sr-only.scss';
 @use 'usa-pagination/src/styles/_usa-pagination.scss';
-@use 'usa-icon/src/styles/_usa-icon.scss';
+@use 'usa-icon/src/styles/_usa-icon.scss'; 
 
 @import '../../mixins/focusable.css';
 

--- a/packages/web-components/src/components/va-pagination/va-pagination.tsx
+++ b/packages/web-components/src/components/va-pagination/va-pagination.tsx
@@ -240,11 +240,7 @@ export class VaPagination {
   }
 
   render() {
-    const {
-      ariaLabelSuffix,
-      page,
-      pages,
-    } = this;
+    const { ariaLabelSuffix, page, pages } = this;
 
     if (pages === 1) {
       return <div />;
@@ -276,8 +272,9 @@ export class VaPagination {
     const previousButton =
       page > 1 ? (
         <Fragment>
-          <li class={arrowClasses} aria-label={previousAriaLabel}>
+          <li class={arrowClasses}>
             <a
+              aria-label={previousAriaLabel}
               onClick={() =>
                 this.handlePageSelect(page - 1, 'nav-paginate-number')
               }
@@ -306,11 +303,11 @@ export class VaPagination {
                   1
                 </a>
               </li>
-              <li
-                class={ellipsisClasses}
-                aria-label="ellipsis indicating non-visible pages"
-              >
-                <span>…</span>
+              <li class={ellipsisClasses}>
+                <span class="usa-sr-only">
+                  Ellipsis indicating non-visible pages
+                </span>
+                <span aria-hidden="true">…</span>
               </li>
             </Fragment>
           )}
@@ -353,11 +350,11 @@ export class VaPagination {
       pageNumbersToRender.indexOf(pages) === -1 ? (
         <Fragment>
           {pages > this.SHOW_ALL_PAGES && (
-            <li
-              class={ellipsisClasses}
-              aria-label="ellipsis indicating non-visible pages"
-            >
-              <span>…</span>
+            <li class={ellipsisClasses}>
+              <span class="usa-sr-only">
+                Ellipsis indicating non-visible pages
+              </span>
+              <span aria-hidden="true">…</span>
             </li>
           )}
           {!this.unbounded && pages > this.SHOW_ALL_PAGES && (
@@ -381,8 +378,9 @@ export class VaPagination {
     const nextButton =
       page < pages ? (
         <Fragment>
-          <li class={arrowClasses} aria-label={nextAriaLabel}>
+          <li class={arrowClasses}>
             <a
+              aria-label={nextAriaLabel}
               onClick={() =>
                 this.handlePageSelect(page + 1, 'nav-paginate-number')
               }
@@ -390,9 +388,7 @@ export class VaPagination {
               class="usa-pagination__link usa-pagination__next-page"
               href="javascript:void(0)"
             >
-              <span class="usa-pagination__link-text">
-                {i18next.t('next')}
-              </span>
+              <span class="usa-pagination__link-text">{i18next.t('next')}</span>
               <div id="next-arrow-icon"></div>
             </a>
           </li>


### PR DESCRIPTION
## Chromatic
<!-- This `patch-tpierce-95248` is a placeholder for a CI job - it will be updated automatically -->
https://patch-tpierce-95248--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [x] Link to any related issues in the description so they can be cross-referenced.
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [x] Complete all sections below.
- [ ] Delete this section once complete

## Description
This PR is a work in progress **WIP** so I can test with additional screen reader and browsers, and confirm the best way to test locally with vets-website codebase.

I discovered the `<va-pagination>` web component did not read out the ellipsis or the full Next | Previous link accessible labels in NVDA or VoiceOver while conducting an audit. I traced the root cause to `aria-label` not being supported on non-interactive elements like LI.

I propose moving the Next and Previous `aria-label` attributes onto the A tag from the parent LI, and refactoring the ellipsis to use two spans, a visual `...` and a semantic SR-only span with words to be read aloud.

See [Aria-Label is not always the answer](https://eevis.codes/blog/2021-11-29/aria-label-is-not-always-the-answer/) and [NVDA fails to read aira-label text for most elements](https://github.com/nvaccess/nvda/issues/7807) for inspiration to make this change.

Closes [<95248>](https://github.com/department-of-veterans-affairs/va.gov-team/issues/95248)

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] ~~Designer has signed off on changes (if applicable. If not applicable provide reason why)~~
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
Tested with Verdaccio locally using Chrome + Win11. Tested two instances of the table, specifically Benefits Payments and GI Bill School Comparison. Screenshots are from GIBCT.

**Desktop**
![Screenshot 2024-11-06 114254](https://github.com/user-attachments/assets/a843812d-898f-4e86-afb7-dbb1bfd0cb11)

---

**Mobile**
![Screenshot 2024-11-06 114329](https://github.com/user-attachments/assets/abaa8860-6599-450d-9b84-110c596053be)

## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] ~~Documentation has been updated, if applicable~~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
