### PR TITLE
va-telephone: Allow non-US phone numbers

### DIFF
--- a/packages/storybook/stories/va-telephone.stories.jsx
+++ b/packages/storybook/stories/va-telephone.stories.jsx
@@ -60,6 +60,7 @@ const Template = ({
   extension,
   'not-clickable': notClickable,
   international,
+  'country-code': countryCode,
   vanity,
   tty,
   sms,
@@ -67,14 +68,13 @@ const Template = ({
 }) => {
   return (
     <div>
-      {messageAriaDescribedBy && (
-        <span>Main number to facility </span>
-      )}
+      {messageAriaDescribedBy && <span>Main number to facility </span>}
       <va-telephone
         contact={contact}
         extension={extension}
         not-clickable={notClickable}
         international={international}
+        country-code={countryCode}
         vanity={vanity}
         tty={tty}
         sms={sms}
@@ -89,6 +89,7 @@ const defaultArgs = {
   'extension': undefined,
   'not-clickable': false,
   'international': false,
+  'country-code': undefined,
   'tty': false,
   'sms': false,
   'vanity': undefined,
@@ -123,6 +124,13 @@ export const International = Template.bind(null);
 International.args = {
   ...defaultArgs,
   international: true,
+};
+
+export const CountryCode = Template.bind(null);
+CountryCode.args = {
+  ...defaultArgs,
+  'contact': '(02) 8555 8888',
+  'country-code': '63',
 };
 
 export const TTY = Template.bind(null);

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1517,6 +1517,10 @@ export namespace Components {
          */
         "contact": string;
         /**
+          * Prepends the country code to the given contact number. Do NOT include the '+'
+         */
+        "countryCode"?: string;
+        /**
           * Optional numeric string phone number extension
          */
         "extension"?: string;
@@ -4746,6 +4750,10 @@ declare namespace LocalJSX {
           * Numeric string representing the contact number. Typical length is 3 or 10 digits - SMS short codes will be 5 or 6 digits.
          */
         "contact": string;
+        /**
+          * Prepends the country code to the given contact number. Do NOT include the '+'
+         */
+        "countryCode"?: string;
         /**
           * Optional numeric string phone number extension
          */

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -42,9 +42,20 @@ describe('va-telephone', () => {
     await axeCheck(page);
   });
 
+  it('passes an axe check for a phone number with a country code', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone country-code="63" contact="(02) 8555 8888"></va-telephone>',
+    );
+
+    await axeCheck(page);
+  });
+
   it('ignores non-digits in the contact prop', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-telephone contact="(877) 955-1234"></va-telephone>');
+    await page.setContent(
+      '<va-telephone contact="(877) 955-1234"></va-telephone>',
+    );
 
     const link = await page.find('va-telephone >>> a');
     expect(link.getAttribute('href')).toEqual('tel:+18779551234');
@@ -116,6 +127,17 @@ describe('va-telephone', () => {
     const link = await page.find('va-telephone >>> a');
     expect(link.getAttribute('href')).toEqual('tel:+18779551234,123');
     expect(link.innerText).toEqual('877-955-1234, ext. 123');
+  });
+
+  it('handles a phone number with a country code', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone country-code="63" contact="(02) 8555 8888"></va-telephone>',
+    );
+
+    const link = await page.find('va-telephone >>> a');
+    expect(link.getAttribute('href')).toEqual('tel:+630285558888');
+    expect(link.innerText).toEqual('+63 (02) 8555 8888');
   });
 
   it('handles a 3 digit contact prop', async () => {

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -9,56 +9,72 @@ describe('formatPhoneNumber', () => {
   const vanity = 'ABCD';
   it('formats a contact number with no extension', () => {
     expect(
-      VaTelephone.formatPhoneNumber(contact, null, null, null, null, null),
+      VaTelephone.formatPhoneNumber({
+        contact,
+      }),
     ).toBe('888-555-1234');
   });
 
   it('formats a contact number with extension', () => {
     expect(
-      VaTelephone.formatPhoneNumber(contact, extension, null, null, null, null),
+      VaTelephone.formatPhoneNumber({
+        contact,
+        extension,
+      }),
     ).toBe('888-555-1234, ext. 123');
   });
 
   it('formats a 3 digit contact number', () => {
     expect(
-      VaTelephone.formatPhoneNumber(N11, null, null, null, null, null),
+      VaTelephone.formatPhoneNumber({
+        contact: N11,
+      }),
     ).toBe('911');
   });
 
   it('does not use extension for 3 digit contact', () => {
     expect(
-      VaTelephone.formatPhoneNumber(N11, extension, null, null, null),
+      VaTelephone.formatPhoneNumber({
+        contact: N11,
+        extension,
+      }),
     ).toBe('911');
   });
 
   it('does not use international formatting for 3 digit contact', () => {
     expect(
-      VaTelephone.formatPhoneNumber(N11, extension, true, null, null, null),
+      VaTelephone.formatPhoneNumber({
+        contact: N11,
+        extension,
+        international: true,
+      }),
     ).toBe('911');
   });
 
   it('formats a contact number with vanity prop', () => {
     expect(
-      VaTelephone.formatPhoneNumber(contact, null, null, null, vanity),
+      VaTelephone.formatPhoneNumber({
+        contact,
+        vanity,
+      }),
     ).toBe('888-555-ABCD (1234)');
   });
 
   it('formats a TTY number', () => {
     expect(
-      VaTelephone.formatPhoneNumber(N11, null, null, null, null, true),
+      VaTelephone.formatPhoneNumber({
+        contact: N11,
+        tty: true,
+      }),
     ).toBe('TTY: 911');
   });
 
   it('formats a contact number with a country code', () => {
     expect(
-      VaTelephone.formatPhoneNumber(
-        intlContact,
-        null,
-        null,
-        countryCode,
-        null,
-        null,
-      ),
+      VaTelephone.formatPhoneNumber({
+        contact: intlContact,
+        countryCode: '63',
+      }),
     ).toBe('+63 (02) 8555 8888');
   });
 });
@@ -72,30 +88,45 @@ describe('createHref', () => {
   const extension = '123';
 
   it('creates a tel link for a phone number', () => {
-    expect(VaTelephone.createHref(contact, null, null, null)).toBe(
-      'tel:+18885551234',
-    );
+    expect(
+      VaTelephone.createHref({
+        contact,
+      }),
+    ).toBe('tel:+18885551234');
   });
 
   it('creates a tel link for a phone number with extension', () => {
-    expect(VaTelephone.createHref(contact, extension, null, null)).toBe(
-      'tel:+18885551234,123',
-    );
+    expect(
+      VaTelephone.createHref({
+        contact,
+        extension,
+      }),
+    ).toBe('tel:+18885551234,123');
   });
 
   it('creates a tel link for a phone number with a country code', () => {
-    expect(VaTelephone.createHref(intlContact, null, null, countryCode)).toBe(
-      'tel:+630285558888',
-    );
+    expect(
+      VaTelephone.createHref({
+        contact: intlContact,
+        countryCode,
+      }),
+    ).toBe('tel:+630285558888');
   });
 
   it('creates a tel link for an N11 number', () => {
-    expect(VaTelephone.createHref(n11, null, null, null)).toBe('tel:911');
+    expect(
+      VaTelephone.createHref({
+        contact: n11,
+      }),
+    ).toBe('tel:911');
   });
 
   it('creates an sms link for an SMS number', () => {
-    expect(VaTelephone.createHref(contactSms, null, true, null)).toBe(
-      'sms:123456',
-    );
+    expect(
+      VaTelephone.createHref({
+        contact: contactSms,
+        sms: true,
+      }),
+    ).toBe('sms:123456');
   });
 });

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -2,57 +2,100 @@ import { VaTelephone } from '../va-telephone';
 
 describe('formatPhoneNumber', () => {
   const contact = '8885551234';
+  const countryCode = '63';
+  const intlContact = '(02) 8555 8888';
   const N11 = '911';
   const extension = '123';
   const vanity = 'ABCD';
   it('formats a contact number with no extension', () => {
-    expect(VaTelephone.formatPhoneNumber(contact, null, null, null)).toBe('888-555-1234');
+    expect(
+      VaTelephone.formatPhoneNumber(contact, null, null, null, null, null),
+    ).toBe('888-555-1234');
   });
 
   it('formats a contact number with extension', () => {
-    expect(VaTelephone.formatPhoneNumber(contact, extension, null, null)).toBe(
-      '888-555-1234, ext. 123',
-    );
+    expect(
+      VaTelephone.formatPhoneNumber(contact, extension, null, null, null, null),
+    ).toBe('888-555-1234, ext. 123');
   });
 
   it('formats a 3 digit contact number', () => {
-    expect(VaTelephone.formatPhoneNumber(N11, null, null, null)).toBe('911');
+    expect(
+      VaTelephone.formatPhoneNumber(N11, null, null, null, null, null),
+    ).toBe('911');
   });
 
   it('does not use extension for 3 digit contact', () => {
-    expect(VaTelephone.formatPhoneNumber(N11, extension, null, null)).toBe('911');
+    expect(
+      VaTelephone.formatPhoneNumber(N11, extension, null, null, null),
+    ).toBe('911');
   });
 
   it('does not use international formatting for 3 digit contact', () => {
-    expect(VaTelephone.formatPhoneNumber(N11, extension, true, null)).toBe('911');
+    expect(
+      VaTelephone.formatPhoneNumber(N11, extension, true, null, null, null),
+    ).toBe('911');
   });
 
   it('formats a contact number with vanity prop', () => {
-    expect(VaTelephone.formatPhoneNumber(contact, null, null, vanity)).toBe('888-555-ABCD (1234)');
+    expect(
+      VaTelephone.formatPhoneNumber(contact, null, null, null, vanity),
+    ).toBe('888-555-ABCD (1234)');
   });
 
   it('formats a TTY number', () => {
-    expect(VaTelephone.formatPhoneNumber(N11, null, null, null, true)).toBe('TTY: 911');
+    expect(
+      VaTelephone.formatPhoneNumber(N11, null, null, null, null, true),
+    ).toBe('TTY: 911');
+  });
+
+  it('formats a contact number with a country code', () => {
+    expect(
+      VaTelephone.formatPhoneNumber(
+        intlContact,
+        null,
+        null,
+        countryCode,
+        null,
+        null,
+      ),
+    ).toBe('+63 (02) 8555 8888');
   });
 });
 
 describe('createHref', () => {
   const contact = '8885551234';
+  const countryCode = '63';
+  const intlContact = '(02) 8555 8888';
   const contactSms = '123456';
   const n11 = '911';
   const extension = '123';
+
   it('creates a tel link for a phone number', () => {
-    expect(VaTelephone.createHref(contact, null, null)).toBe('tel:+18885551234');
+    expect(VaTelephone.createHref(contact, null, null, null)).toBe(
+      'tel:+18885551234',
+    );
   });
+
   it('creates a tel link for a phone number with extension', () => {
-    expect(VaTelephone.createHref(contact, extension, null)).toBe(
+    expect(VaTelephone.createHref(contact, extension, null, null)).toBe(
       'tel:+18885551234,123',
     );
   });
-  it('creates a tel link for an N11 number', () => {
-    expect(VaTelephone.createHref(n11, null, null)).toBe('tel:911');
+
+  it('creates a tel link for a phone number with a country code', () => {
+    expect(VaTelephone.createHref(intlContact, null, null, countryCode)).toBe(
+      'tel:+630285558888',
+    );
   });
+
+  it('creates a tel link for an N11 number', () => {
+    expect(VaTelephone.createHref(n11, null, null, null)).toBe('tel:911');
+  });
+
   it('creates an sms link for an SMS number', () => {
-    expect(VaTelephone.createHref(contactSms, null, true)).toBe('sms:123456');
+    expect(VaTelephone.createHref(contactSms, null, true, null)).toBe(
+      'sms:123456',
+    );
   });
 });

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -73,7 +73,7 @@ describe('formatPhoneNumber', () => {
     expect(
       VaTelephone.formatPhoneNumber({
         contact: intlContact,
-        countryCode: '63',
+        countryCode,
       }),
     ).toBe('+63 (02) 8555 8888');
   });

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -105,16 +105,24 @@ export class VaTelephone {
    * `international` and `extension` args only work on 10 digit contacts
    */
   /* eslint-disable i18next/no-literal-string */
-  static formatPhoneNumber(
-    num: string,
-    extension: string,
-    international: boolean = false,
-    countryCode: string,
-    vanity: string,
-    tty: boolean = false,
-  ): string {
+  static formatPhoneNumber({
+    contact: num,
+    extension,
+    international = false,
+    countryCode,
+    vanity,
+    tty = false,
+  }: {
+    contact: string;
+    extension?: string;
+    international?: boolean;
+    countryCode?: string;
+    vanity?: string;
+    tty?: boolean;
+  }): string {
     const splitNumber = countryCode ? [num] : VaTelephone.splitContact(num);
     let formattedNum = splitNumber.join('');
+
     if (formattedNum.length === 10 && !countryCode) {
       const [area, local, last4] = splitNumber;
       formattedNum = `${area}-${local}-${last4}`;
@@ -124,21 +132,29 @@ export class VaTelephone {
         formattedNum = `${area}-${local}-${vanity} (${last4})`;
       }
     }
+
     if (countryCode) {
       formattedNum = `+${countryCode} ${formattedNum}`;
     }
+
     if (tty) {
       formattedNum = `TTY: ${formattedNum}`;
     }
+
     return formattedNum;
   }
 
-  static createHref(
-    contact: string,
-    extension: string,
-    sms: boolean,
-    countryCode: string,
-  ): string {
+  static createHref({
+    contact,
+    extension,
+    sms,
+    countryCode,
+  }: {
+    contact: string;
+    extension?: string;
+    sms?: boolean;
+    countryCode?: string;
+  }): string {
     const cleanedContact = VaTelephone.cleanContact(contact);
     const isN11 = cleanedContact.length === 3;
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
@@ -182,15 +198,20 @@ export class VaTelephone {
       sms,
       messageAriaDescribedby,
     } = this;
-    const formattedNumber = VaTelephone.formatPhoneNumber(
-      contact,
+    const formattedNumber = VaTelephone.formatPhoneNumber({
+      contact: contact,
       extension,
       international,
       countryCode,
       vanity,
       tty,
-    );
-    const href = VaTelephone.createHref(contact, extension, sms, countryCode);
+    });
+    const href = VaTelephone.createHref({
+      contact,
+      extension,
+      sms,
+      countryCode,
+    });
 
     // Null so we don't add the attribute if we have an empty string
     const ariaDescribedbyIds = messageAriaDescribedby

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -42,6 +42,11 @@ export class VaTelephone {
   @Prop() international?: boolean = false;
 
   /**
+   * Prepends the country code to the given contact number. Do NOT include the '+'
+   */
+  @Prop() countryCode?: string;
+
+  /**
    * Indicates if this is a number meant to be called
    * from a teletypewriter for deaf users.
    */
@@ -75,11 +80,11 @@ export class VaTelephone {
   })
   componentLibraryAnalytics: EventEmitter;
 
-  static cleanContact(contact: string) :string {
+  static cleanContact(contact: string): string {
     return (contact || '').replace(/[^\d]/g, '');
   }
 
-  static splitContact(contact: string) :string[] {
+  static splitContact(contact: string): string[] {
     const cleanedContact = VaTelephone.cleanContact(contact);
     if (cleanedContact.length === 10) {
       // const regex = /(?<area>\d{3})(?<local>\d{3})(?<last4>\d{4})/g;
@@ -99,17 +104,19 @@ export class VaTelephone {
    * Format telephone number for display.
    * `international` and `extension` args only work on 10 digit contacts
    */
+  /* eslint-disable i18next/no-literal-string */
   static formatPhoneNumber(
     num: string,
     extension: string,
     international: boolean = false,
+    countryCode: string,
     vanity: string,
     tty: boolean = false,
   ): string {
-    const splitNumber = VaTelephone.splitContact(num);
+    const splitNumber = countryCode ? [num] : VaTelephone.splitContact(num);
     let formattedNum = splitNumber.join('');
-    if (formattedNum.length === 10) {
-      const [ area, local, last4 ] = splitNumber;
+    if (formattedNum.length === 10 && !countryCode) {
+      const [area, local, last4] = splitNumber;
       formattedNum = `${area}-${local}-${last4}`;
       if (international) formattedNum = `+1-${formattedNum}`;
       if (extension) formattedNum = `${formattedNum}, ext. ${extension}`;
@@ -117,13 +124,21 @@ export class VaTelephone {
         formattedNum = `${area}-${local}-${vanity} (${last4})`;
       }
     }
+    if (countryCode) {
+      formattedNum = `+${countryCode} ${formattedNum}`;
+    }
     if (tty) {
       formattedNum = `TTY: ${formattedNum}`;
     }
     return formattedNum;
   }
 
-  static createHref(contact: string, extension: string, sms: boolean): string {
+  static createHref(
+    contact: string,
+    extension: string,
+    sms: boolean,
+    countryCode: string,
+  ): string {
     const cleanedContact = VaTelephone.cleanContact(contact);
     const isN11 = cleanedContact.length === 3;
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
@@ -134,11 +149,15 @@ export class VaTelephone {
       href = `sms:${cleanedContact}`;
     } else if (isN11) {
       href = `tel:${cleanedContact}`;
+    } else if (countryCode) {
+      href = `tel:+${countryCode}${cleanedContact}`;
     } else {
+      // RFC3966 (https://www.rfc-editor.org/rfc/rfc3966#section-5.1.5) calls for the inclusion of country codes whenever possible, so we add the +1 unless we know there's a different country code (above)
       href = `tel:+1${cleanedContact}`;
     }
     return `${href}${extension ? `,${extension}` : ''}`;
   }
+  /* eslint-enable i18next/no-literal-string */
 
   private handleClick(): void {
     this.componentLibraryAnalytics.emit({
@@ -152,37 +171,45 @@ export class VaTelephone {
   }
 
   render() {
-    const { 
-      contact, 
-      extension, 
-      notClickable, 
-      international, 
-      tty, 
-      vanity, 
-      sms, 
-      messageAriaDescribedby 
+    const {
+      contact,
+      extension,
+      notClickable,
+      international,
+      countryCode,
+      tty,
+      vanity,
+      sms,
+      messageAriaDescribedby,
     } = this;
     const formattedNumber = VaTelephone.formatPhoneNumber(
       contact,
       extension,
       international,
+      countryCode,
       vanity,
-      tty
+      tty,
     );
+    const href = VaTelephone.createHref(contact, extension, sms, countryCode);
 
     // Null so we don't add the attribute if we have an empty string
-    const ariaDescribedbyIds = messageAriaDescribedby ? 'number-description' : null;
+    const ariaDescribedbyIds = messageAriaDescribedby
+      ? // eslint-disable-next-line i18next/no-literal-string
+        'number-description'
+      : null;
 
-    return ( 
+    return (
       <Host>
         {notClickable ? (
           <Fragment>
-            <span aria-hidden="true" aria-describedby={ariaDescribedbyIds}>{formattedNumber}</span>
+            <span aria-hidden="true" aria-describedby={ariaDescribedbyIds}>
+              {formattedNumber}
+            </span>
           </Fragment>
         ) : (
           <a
             aria-describedby={ariaDescribedbyIds}
-            href={VaTelephone.createHref(contact, extension, sms)}
+            href={href}
             onClick={this.handleClick.bind(this)}
           >
             {formattedNumber}


### PR DESCRIPTION
## Chromatic
<!-- This `3472-allow-non-us-numbers` is a placeholder for a CI job - it will be updated automatically -->
https://3472-allow-non-us-numbers--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#3472](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3472)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2024-11-05 at 4 28 11 PM](https://github.com/user-attachments/assets/54910f85-6f21-4f79-8d13-5032fcc6ad1a)

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
