### PR TITLE
va-on-this-page: updating line-length for list items to use new token

### DIFF
--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
@@ -1,4 +1,5 @@
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/uswds-typography.css";
+@import "~@department-of-veterans-affairs/css-library/dist/tokens/css/variables.css";
 @import '../../mixins/links.css';
 
 :host {
@@ -31,7 +32,7 @@ ul {
 
 li {
   padding: 0.5em;
-  max-width: 285px;
+  max-width: var(--vads-size-line-length-4);
 }
 
 li a {

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
@@ -1,5 +1,4 @@
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/uswds-typography.css";
-@import "~@department-of-veterans-affairs/css-library/dist/tokens/css/variables.css";
 @import '../../mixins/links.css';
 
 :host {


### PR DESCRIPTION
## Chromatic
<!-- This `951-on-this-page-line-length` is a placeholder for a CI job - it will be updated automatically -->
https://951-on-this-page-line-length--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
Closes [#951](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/951)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
