### PR TITLE
DOCS: Update README `Contributing` entry with Verdaccio instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ This repo uses [`Chromatic`](https://www.chromatic.com/) to streamline reviews b
 Our web components have linting which checks for hard-coded user-facing strings. At the moment this linting isn't integrated into CI - so you will only see it if you run `yarn lint` or if your editor has ESLint integration through a plugin.
 
 ### Local testing with Verdaccio
-Contributors are encouraged to test their design system changes in `vets-website` using [Verdaccio](https://verdaccio.org/). From the website:
+Contributors are encouraged to test their changes in `vets-website` using [Verdaccio](https://verdaccio.org/). What is Verdaccio? From the website:
 
-> Verdaccio is a simple, zero-config-required local private NPM registry&hellip;
+> Verdaccio is a simple, zero-config-required local private NPM registry. No need for an entire database just to get started&hellip;
 
-Verdaccio allows contributors to publish a new version of the VA Design System on their local machine, and rebuild `vets-website` with their changes.
+Verdaccio allows contributors to publish a new version of the VA Design System on their local machine, and preview `vets-website` with their changes.
 
 #### Installing Verdaccio
 1. Verdaccio requires [Python3](https://www.python.org/downloads/). Ensure you have Python3 installed by opening a terminal window and typing the following command:
@@ -43,10 +43,11 @@ Verdaccio allows contributors to publish a new version of the VA Design System o
 
    ```shell
    # Install this version of Verdaccio for compatibility with Node v14.15.0.
-   # NPM
+   
+   # If you're using NPM
    npm install --location=global verdaccio@5.5.0
 
-   # Yarn
+   # If you're using Yarn
    yarn global add verdaccio@5.5.0
    ```
 1. Verify Verdaccio was installed correctly.
@@ -54,7 +55,7 @@ Verdaccio allows contributors to publish a new version of the VA Design System o
    ```shell
    verdaccio --version # Should see output like v5.5.0
    ```
-1. Start Verdaccio on your local machine. The server should be running at `localhost:4873`.
+1. Start Verdaccio on your local machine. The server will be running at `localhost:4873`.
 
    ```shell
    verdaccio

--- a/README.md
+++ b/README.md
@@ -24,6 +24,48 @@ This repo uses [`Chromatic`](https://www.chromatic.com/) to streamline reviews b
 
 Our web components have linting which checks for hard-coded user-facing strings. At the moment this linting isn't integrated into CI - so you will only see it if you run `yarn lint` or if your editor has ESLint integration through a plugin.
 
+### Local testing with Verdaccio
+Contributors are encouraged to test their design system changes in `vets-website` using [Verdaccio](https://verdaccio.org/). From the website:
+
+> Verdaccio is a simple, zero-config-required local private NPM registry&hellip;
+
+Verdaccio allows contributors to publish a new version of the VA Design System on their local machine, and rebuild `vets-website` with their changes.
+
+#### Installing Verdaccio
+1. Verdaccio requires [Python3](https://www.python.org/downloads/). Ensure you have Python3 installed by opening a terminal window and typing the following command:
+
+   ```shell
+   which python3 # Should see output like /usr/bin/python3
+   ```
+   
+   You should see an execution path if Python3 is installed. If not, install it and type `which python3` again in a new terminal window.
+1. Install Verdaccio using NPM or Yarn:
+
+   ```shell
+   # Install this version of Verdaccio for compatibility with Node v14.15.0.
+   # NPM
+   npm install --location=global verdaccio@5.5.0
+
+   # Yarn
+   yarn global add verdaccio@5.5.0
+   ```
+1. Verify Verdaccio was installed correctly.
+
+   ```shell
+   verdaccio --version # Should see output like v5.5.0
+   ```
+1. Start Verdaccio on your local machine. The server should be running at `localhost:4873`.
+
+   ```shell
+   verdaccio
+   ```
+1. Create a new Verdaccio user by entering this command and following the prompts.
+
+   ```shell
+   npm adduser --registry http://localhost:4873/
+   ```
+   
+
 ## Publishing
 
 ### Updating the version

--- a/README.md
+++ b/README.md
@@ -107,7 +107,44 @@ The next step is to update the `core` and `web-component` versions in their resp
    cd ../packages/web-components
    npm publish --registry http://localhost:4873
    ```
-7. You're now ready to switch to your local `vets-website` directory and update the VADS dependency.
+
+#### Link `vets-website` to local Verdaccio registry
+You're now ready to switch to `vets-website` and update the VADS dependency.
+
+1. Run two commands to point to your local Verdaccio registry
+
+   ```shell
+   cd /vets-website
+   yarn config set registry http://localhost:4873
+   npm config set registry http://localhost:4873
+   ```
+2. Add the local `core` package to `vets-website` and start the server
+
+   ```shell
+   yarn add -W @department-of-veterans-affairs/component-library@vX.X.rc-1
+   yarn watch
+   ```
+
+#### Reverting to the default registry
+After you are finished testing, reset `vets-website` to use the standard registry.
+
+   ```shell
+   npm config set registry https://registry.yarnpkg.com/
+
+   # Or alternatively
+   yarn config set registry https://registry.yarnpkg.com/
+   yarn config set npmRegistryServer https://registry.yarnpkg.com/
+   ```
+
+#### Troubleshooting
+If you encounter Webpack errors during the `yarn watch` step in `vets-website`, try deleting the `node_modules/` folder, then reinstalling dependencies.
+
+```shell
+cd vets-website
+rm -rf node_modules/ # Careful with this one
+yarn install
+yarn watch
+```
 
 
 ## Publishing

--- a/README.md
+++ b/README.md
@@ -29,16 +29,20 @@ Contributors are encouraged to test their changes in `vets-website` using [Verda
 
 > Verdaccio is a simple, zero-config-required local private NPM registry. No need for an entire database just to get started&hellip;
 
-Verdaccio allows contributors to publish a new version of the VA Design System on their local machine, and preview `vets-website` with their changes.
+Verdaccio allows contributors to publish a new version of the VA Design System component library on their local machine, and preview `vets-website` with their changes.
 
-#### Installing Verdaccio
-1. Verdaccio requires [Python3](https://www.python.org/downloads/). Ensure you have Python3 installed by opening a terminal window and typing the following command:
+#### Before you begin
+1. VA Design System component library and vets-website require different versions of NodeJS. Be sure you have [NVM installed](https://github.com/nvm-sh/nvm#installing-and-updating) before you begin.
+1. Download Node `v14.15.0` and a current Node `v18.x.x` or `v20.x.x`
+1. Verdaccio also requires [Python3](https://www.python.org/downloads/). Ensure you have Python3 installed by opening a terminal window and typing the following command:
 
    ```shell
    which python3 # Should see output like /usr/bin/python3
    ```
    
    You should see an execution path if Python3 is installed. If not, install it and type `which python3` again in a new terminal window.
+
+#### Installing Verdaccio
 1. Install Verdaccio using NPM or Yarn:
 
    ```shell
@@ -67,9 +71,9 @@ Verdaccio allows contributors to publish a new version of the VA Design System o
    ```
 
 #### Publish your component-library changes to Verdaccio
-The next step is to update the `core` and `web-component` versions in their respective `package.json` files.
+The next step is to update the `core` and `web-component` package versions in their respective `package.json` files.
 
-1. Navigate to `packages/web-components` and change the version. For instance, if the current version is `10.1.1` and [your change is a patch](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number), your version might be `10.1.2-rc1`.
+1. Navigate to `packages/web-components` and change the version. Assuming the current version is `10.1.1`, you could change the version to `10.1.2-rc1` or something similar.
 
    ```diff
    ! packages/web-components/package.json
@@ -95,14 +99,14 @@ The next step is to update the `core` and `web-component` versions in their resp
    +   "@department-of-veterans-affairs/web-components": "^10.2.2-rc1"
    }
    ```
-4. Build the components using the [Running Build via Storybook](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#running-build-via-storybook) instructions. Ignore the last step to start Storybook; you won't need it for this process.
+4. Build the components using the [Running Build via Storybook](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#running-build-via-storybook) instructions. Ignore the last step to start Storybook; you won't need it for this process. _**Note:** You must use Node `v18.x.x` or `v20.x.x` for this step._
 5. Publish the `core` package to Verdaccio
 
    ```shell
    cd ../packages/core
    npm publish --registry http://localhost:4873
    ```
-6. Publish the `web-component` pacakge to Veraccio
+6. Publish the `web-component` package to Veraccio
 
    ```shell
    cd ../packages/web-components
@@ -110,12 +114,13 @@ The next step is to update the `core` and `web-component` versions in their resp
    ```
 
 #### Link `vets-website` to local Verdaccio registry
-You're now ready to switch to `vets-website` and update the VADS dependency.
+You're now ready to switch to `vets-website` and update the VADS dependency. _**Note:** You must use Node `v14.15.0` for this step._
 
-1. Run two commands to point to your local Verdaccio registry
+1. Run the following commands to point to your local Verdaccio registry
 
    ```shell
    cd /vets-website
+   nvm use 14.15.0 # Ensure correct Node version
    yarn config set registry http://localhost:4873
    npm config set registry http://localhost:4873
    ```
@@ -138,14 +143,21 @@ After you are finished testing, reset `vets-website` to use the standard registr
    ```
 
 #### Troubleshooting
-If you encounter Webpack errors during the `yarn watch` step in `vets-website`, try deleting the `node_modules/` folder, then reinstalling dependencies.
+1. If you encounter Webpack errors during the `yarn watch` step in `vets-website`, try deleting the `node_modules/` folder, then reinstalling dependencies.
 
-```shell
-cd vets-website
-rm -rf node_modules/ # Careful with this one
-yarn install
-yarn watch
-```
+   ```shell
+   cd vets-website
+   rm -rf node_modules/ # Careful with this one
+   yarn install
+   yarn watch
+   ```
+2. If you encounter errors in the `component-library` or `vets-website` build or watch steps, try changing your Node version.
+
+   ```shell
+   nvm use 14.15.0 # In /vets-website
+   nvm use 18.x.x # In /component-library OR
+   nvm use 20.x.x # In /component-library
+   ```
 
 
 ## Publishing

--- a/README.md
+++ b/README.md
@@ -64,7 +64,51 @@ Verdaccio allows contributors to publish a new version of the VA Design System o
    ```shell
    npm adduser --registry http://localhost:4873/
    ```
-   
+
+#### Publish your component-library changes to Verdaccio
+The next step is to update the `core` and `web-component` versions in their respective `package.json` files.
+
+1. Navigate to `packages/web-components` and change the version. For instance, if the current version is `10.1.1` and [your change is a patch](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number), your version might be `10.1.2-rc1`.
+
+   ```diff
+   ! packages/web-components/package.json
+
+   - "version": "10.1.1"
+   + "version": "10.1.2-rc1"
+   ```
+2. Navigate to `packages/core` and update the version using the same logic
+
+   ```diff
+   ! packages/core/package.json
+      
+   - "version": "15.0.1"
+   + "version": "15.0.2-rc1"
+   ```
+3. Still in the `packages/core` package.json file, update the VADS dependency entry
+
+   ```diff
+   ! packages/core/package.json
+
+   dependencies: {
+   -   "@department-of-veterans-affairs/web-components": "workspace:*"
+   +   "@department-of-veterans-affairs/web-components": "^10.2.2-rc1"
+   }
+   ```
+4. Build the components using the [Running Build via Storybook](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#running-build-via-storybook) instructions. Ignore the last step to start Storybook; you won't need it for this process.
+5. Publish the `core` package to Verdaccio
+
+   ```shell
+   cd ../packages/core
+   npm publish --registry http://localhost:4873
+   ```
+6. Publish the `web-component` pacakge to Veraccio
+
+   ```shell
+   cd ../packages/web-components
+   npm publish --registry http://localhost:4873
+   ```
+7. You're now ready to switch to your local `vets-website` directory and update the VADS dependency.
+
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Verdaccio allows contributors to publish a new version of the VA Design System c
 1. Install Verdaccio using NPM or Yarn:
 
    ```shell
-   # Install this version of Verdaccio for compatibility with Node v14.15.0.
-   
+   # Ensure Verdaccio compatibility with vets-website
+   nvm use 14.15.0
+
    # If you're using NPM
    npm install --location=global verdaccio@5.5.0
 
@@ -71,9 +72,16 @@ Verdaccio allows contributors to publish a new version of the VA Design System c
    ```
 
 #### Publish your component-library changes to Verdaccio
-The next step is to update the `core` and `web-component` package versions in their respective `package.json` files.
+The next step is to update the `core` and `web-component` package versions in their respective `package.json` files. _**Note:** You must use Node `v18.x.x` or `v20.x.x` for this step._
 
-1. Navigate to `packages/web-components` and change the version. Assuming the current version is `10.1.1`, you could change the version to `10.1.2-rc1` or something similar.
+1. Navigate to `component-library` and switch to Node `[18, 20]`
+
+   ```shell
+   cd component-library/
+   nvm use 18.x.x # Or version 20
+   nvm use 20.x.x
+   ```
+1. Navigate to `packages/web-components` and update the package version. Assuming the current version is `10.1.1`, you could change the version to `10.1.2-rc1` or something similar.
 
    ```diff
    ! packages/web-components/package.json
@@ -81,7 +89,7 @@ The next step is to update the `core` and `web-component` package versions in th
    - "version": "10.1.1"
    + "version": "10.1.2-rc1"
    ```
-2. Navigate to `packages/core` and update the version using the same logic
+2. Navigate to `packages/core` and update the package version using the same logic
 
    ```diff
    ! packages/core/package.json
@@ -99,17 +107,17 @@ The next step is to update the `core` and `web-component` package versions in th
    +   "@department-of-veterans-affairs/web-components": "^10.2.2-rc1"
    }
    ```
-4. Build the components using the [Running Build via Storybook](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#running-build-via-storybook) instructions. Ignore the last step to start Storybook; you won't need it for this process. _**Note:** You must use Node `v18.x.x` or `v20.x.x` for this step._
+4. Build the components using the [Running Build via Storybook](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#running-build-via-storybook) instructions. Ignore the last step to start Storybook; you won't need it for this process.
 5. Publish the `core` package to Verdaccio
 
    ```shell
-   cd ../packages/core
+   cd ../packages/core/
    npm publish --registry http://localhost:4873
    ```
 6. Publish the `web-component` package to Veraccio
 
    ```shell
-   cd ../packages/web-components
+   cd ../packages/web-components/
    npm publish --registry http://localhost:4873
    ```
 
@@ -119,7 +127,7 @@ You're now ready to switch to `vets-website` and update the VADS dependency. _**
 1. Run the following commands to point to your local Verdaccio registry
 
    ```shell
-   cd /vets-website
+   cd vets-website/
    nvm use 14.15.0 # Ensure correct Node version
    yarn config set registry http://localhost:4873
    npm config set registry http://localhost:4873
@@ -132,12 +140,15 @@ You're now ready to switch to `vets-website` and update the VADS dependency. _**
    ```
 
 #### Reverting to the default registry
-After you are finished testing, reset `vets-website` to use the standard registry.
+After you are finished testing, reset `vets-website` to use the standard registry. _**Note:** You must use Node `v14.15.0` for this step._
 
    ```shell
+   # Using NPM
+   nvm use 14.15.0 # Ensure correct Node version
    npm config set registry https://registry.yarnpkg.com/
 
-   # Or alternatively
+   # Or using Yarn
+   nvm use 14.15.0
    yarn config set registry https://registry.yarnpkg.com/
    yarn config set npmRegistryServer https://registry.yarnpkg.com/
    ```
@@ -146,7 +157,7 @@ After you are finished testing, reset `vets-website` to use the standard registr
 1. If you encounter Webpack errors during the `yarn watch` step in `vets-website`, try deleting the `node_modules/` folder, then reinstalling dependencies.
 
    ```shell
-   cd vets-website
+   cd vets-website/
    rm -rf node_modules/ # Careful with this one
    yarn install
    yarn watch
@@ -154,11 +165,9 @@ After you are finished testing, reset `vets-website` to use the standard registr
 2. If you encounter errors in the `component-library` or `vets-website` build or watch steps, try changing your Node version.
 
    ```shell
-   nvm use 14.15.0 # In /vets-website
-   nvm use 18.x.x # In /component-library OR
-   nvm use 20.x.x # In /component-library
+   nvm use 14.15.0
+   nvm use 18.x.x OR nvm use 20.x.x
    ```
-
 
 ## Publishing
 


### PR DESCRIPTION
## Chromatic
<!-- This `patch-tpierce-docsVerdaccio` is a placeholder for a CI job - it will be updated automatically -->
https://patch-tpierce-docsVerdaccio--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Adding a conversation about testing with Verdaccio into the README under `Contributing`. This stemmed from a Slack conversation with @jamigibbs earlier the week of November 4th. I included her instructions and a section on troubleshooting I encountered while testing a component fix.

## QA Checklist
- [ ] ~~Component maintains 1:1 parity with design mocks~~
- [x] Text is consistent with what's been provided in the mocks
- [ ] ~~Component behaves as expected across breakpoints~~
- [ ] ~~Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)~~
- [ ] ~~Designer has signed off on changes (if applicable. If not applicable provide reason why)~~
- [ ] ~~Tab order and focus state work as expected~~
- [ ] ~~Changes have been tested against screen readers (if applicable. If not applicable provide reason why)~~
- [ ] ~~New components are covered by e2e tests; updates to existing components are covered by existing test suite~~
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2024-11-08 161924](https://github.com/user-attachments/assets/d7c5e50c-0935-4336-a735-637a679e9693)

---
![Screenshot 2024-11-08 161852](https://github.com/user-attachments/assets/d300f97f-2e3c-428a-a16d-577385e79871)

## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [ ] ~~A link has been provided to the originating GitHub issue (or connected to it via ZenHub)~~
