### PR TITLE
Remove alert presentation role

### DIFF
--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -136,10 +136,5 @@ const observeDocsRoot = () => {
 }
 
 document.body.onload = function () {
-  // Fix for React 17/NVDA bug where React root is read as "clickable"
-  // https://github.com/nvaccess/nvda/issues/13262
-  // https://github.com/facebook/react/issues/20895
-  // document.querySelector('#root').setAttribute('role', 'presentation');
-
   observeDocsRoot();
 };

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -12,7 +12,7 @@ describe('va-alert', () => {
       <va-alert class="hydrated" status="info">
         <mock:shadow-root>
           <div class="usa-alert usa-alert--info">
-            <div class="usa-alert__body" role="presentation">
+            <div class="usa-alert__body">
               <slot name="headline"></slot>
               <slot></slot>
             </div>

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -180,7 +180,6 @@ export class VaAlert {
           <div
             class="usa-alert__body"
             onClick={this.handleAlertBodyClick.bind(this)}
-            role="presentation"
           >
             {status === 'continue' && (
               <va-icon


### PR DESCRIPTION
## Chromatic
<!-- This `remove-alert-presentation-role` is a placeholder for a CI job - it will be updated automatically -->
https://remove-alert-presentation-role--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3420

This was originally added in https://github.com/department-of-veterans-affairs/component-library/pull/280, but here I am reverting this change.

"Clickable" will be announced by NVDA if the element has a click handler or an ancestor element has a click handler. In the chain of parent elements and see if "click" is being handled by one of them, it will announce as clickable. 

While using presentation role is a workaround, it is common in JavaScript applications to have a click handler higher up the chain. Storybook needed `role="presentation"` added to its root element to get this fix to work in the past. That had to be disabled for the Storybook upgrade, and I was not able to get it to work in the newer version. Without that added to Storybook, this fix will still say "Clickable" for the alert because there is a click event on the main Storybook div.

Because of that, I believe it can't be fixed at only the component level, it would require parent elements to not have click handlers. It's likely that this problem would arise in other components and elsewhere around the site. I don't think fixing these by adding `role="presentational"` is sustainable

JAWS changed and turned off clickable announcements by default. NVDA is the only screen reader that announces this by default. I believe they should change the default (Preferences > Document Formatting > Elements > Clickable) to off as well.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

No visual change.

## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
