### PR TITLE
va-accordion: fix Stencil test re-render warning

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
@@ -292,7 +292,7 @@ describe('va-accordion', () => {
       <va-accordion section-heading="The Section Heading">
         <va-accordion-item header="First item" open="true">Some content</va-accordion-item>
       </va-accordion>`);
-    
+
     const button = await page.find('va-accordion >>> button');
 
     expect(button.innerText).toEqual('collapse-all -');
@@ -305,9 +305,9 @@ describe('va-accordion', () => {
         <va-accordion-item header="First item" open="true">Some content</va-accordion-item>
         <va-accordion-item header="Second item">Some content</va-accordion-item>
       </va-accordion>`);
-    
+
     const button = await page.find('va-accordion >>> button');
 
-    expect(button.innerText).toEqual('collapse-all -');
+    expect(button.innerText).toEqual('expand-all +');
   });
 });

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -140,12 +140,12 @@ export class VaAccordion {
 
   private accordionsOpened(method='every') {
     // Track user clicks on va-accordion-item within an array to compare if all values are true or false
-    let accordionItems = [];
-    getSlottedNodes(this.el, 'va-accordion-item').forEach(item => {
-      accordionItems.push((item as Element).getAttribute('open'));
-    });
-    const allOpen = currentValue => currentValue === 'true';
-    const allClosed = currentValue => currentValue === 'false';
+    const accordionItems = [...this.el.children]
+      .filter((el) => el.tagName.toLowerCase() === 'va-accordion-item')
+      .map((el) => el.open);
+
+    const allOpen = currentValue => currentValue === true;
+    const allClosed = currentValue => currentValue === false;
     if (accordionItems[method](allOpen)) {
       this.expanded = true;
     }
@@ -184,7 +184,7 @@ export class VaAccordion {
   }
 
   // if one or more accordion-items are open on load, then we should put component in state to "Collapse all"
-  componentDidLoad() {
+  componentWillLoad() {
     this.accordionsOpened('some');
   }
 
@@ -198,7 +198,7 @@ export class VaAccordion {
     const accordionItemIDs = [...this.el.children]
       .filter((el) => el.tagName.toLowerCase() === 'va-accordion-item')
       .map((el) => el.id);
-    
+
     return (
       <Host>
         <div class={ accordionClass } ref={(accordionContainer) => this.accordionContainer = accordionContainer}>


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![Screenshot 2024-11-18 at 11 20 19 AM](https://github.com/user-attachments/assets/13d2002c-5a3c-45c3-b72c-7cc5bb6ce156)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
