### PR TITLE
va-text-input: resolve Stencil test warnings

### DIFF
--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -193,7 +193,7 @@ export class VaTextInput {
    * Displays a fixed suffix string at the end of the input field.
    */
   @Prop() inputSuffix?: string;
-  
+
 
    /**
    * A string that represents the name of an icon passed to va-icon, which will be applied as a suffix to the input.
@@ -491,7 +491,6 @@ export class VaTextInput {
               class={inputClass}
               id="inputField"
               type={type}
-              value={value}
               onInput={handleInput}
               onBlur={handleBlur}
               aria-describedby={ariaDescribedbyIds}
@@ -510,6 +509,7 @@ export class VaTextInput {
               part="input"
               min={min}
               max={max}
+              value={value}
             />
             {inputSuffix && <div class="usa-input-suffix" part="suffix" aria-hidden="true">{inputSuffix.substring(0, 25)}</div>}
             {inputIconSuffix && <div class="usa-input-suffix" part="input-suffix"><va-icon icon={inputIconSuffix} size={3} part="icon"></va-icon></div>}


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

This PR will update the va-text-input component so that Stencil test warnings when running `yarn test` will be resolved.


## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
