### PR TITLE
va-alert: Align container text to the left on large screens

### DIFF
--- a/packages/web-components/src/components/va-alert/va-alert.scss
+++ b/packages/web-components/src/components/va-alert/va-alert.scss
@@ -40,6 +40,10 @@
   padding-right: 3.563rem;
 }
 
+.usa-alert .usa-alert__body {
+  margin-left: 0;
+}
+
 // Overriding USWDS' default success icon when using the 'continue' status
 .usa-alert--continue.usa-alert--success .usa-alert__body::before {
   mask: none;


### PR DESCRIPTION
## Chromatic
<!-- This `3419-alert-text-alignment` is a placeholder for a CI job - it will be updated automatically -->
https://3419-alert-text-alignment--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR updated the `va-alert` styles to apply left-aligned text.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3419

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
**Before:**
![Screenshot 2024-11-19 at 11 19 34 AM](https://github.com/user-attachments/assets/381c234b-2a3f-4ffb-9560-19e29b1e2d25)


**After:**
![Screenshot 2024-11-19 at 11 18 47 AM](https://github.com/user-attachments/assets/48f0d87f-f40f-4224-85c1-5897dc6955bd)



## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
