### PR TITLE
va-language-toggle: resolve Stencil test warning and errors

### DIFF
--- a/packages/web-components/src/components/va-language-toggle/test/va-language-toggle.e2e.ts
+++ b/packages/web-components/src/components/va-language-toggle/test/va-language-toggle.e2e.ts
@@ -2,41 +2,37 @@ import { newE2EPage } from "@stencil/core/testing";
 import { axeCheck } from "../../../testing/test-helpers";
 
 describe('va-language-toggle', () => {
-  const enHref = "/resources/the-pact-act-and-your-va-benefits/";
-  const esHref = "/resources/the-pact-act-and-your-va-benefits-esp/"
-  const tlHref = "/resources/the-pact-act-and-your-va-benefits-tl/"
-
   it('renders', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-language-toggle en-href="${enHref}" es-href="${esHref}" tl-href="${tlHref}" />`);
+    await page.setContent(`<va-language-toggle en-href="#" es-href="#" tl-href="#" />`);
     const element = await page.find('va-language-toggle');
     expect(element).toHaveClass('hydrated');
   });
 
   it('English is the default language', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-language-toggle en-href="${enHref}" es-href="${esHref}" tl-href="${tlHref}" />`);
+    await page.setContent(`<va-language-toggle en-href="#" es-href="#" tl-href="#" />`);
     const anchor = await page.find('va-language-toggle >>> va-link');
     expect(anchor).toHaveClass('is-current-lang');
   });
 
   it('only renders links for those languages with supplied hrefs', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-language-toggle en-href="${enHref}" es-href="${esHref}" />`);
+    await page.setContent(`<va-language-toggle en-href="#" es-href="#" />`);
     const anchors = await page.findAll('va-language-toggle >>> a');
     expect(anchors).toHaveLength(2);
   })
 
   it('if language prop is set the matching language is bolded', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-language-toggle language="es" en-href="${enHref}" es-href="${esHref}" tl-href="${tlHref}" />`);
+    await page.setContent(`<va-language-toggle language="es" en-href="#" es-href="#" tl-href="#" />`);
     const [_, anchor] = await page.findAll('va-language-toggle >>> va-link');
     expect(anchor).toHaveClass('is-current-lang');
   });
 
   it('if router-links is set, clicking an anchor tag does not result in page navigation', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-language-toggle router-links="true" en-href="${enHref}" es-href="${esHref}" tl-href="${tlHref}" />`);
+    await page.setContent(`<va-language-toggle router-links="true" en-href="#" es-href="#" tl-href="#" />`);
     const [startUrl] = page.url().split('?');
     const [_, anchor] = await page.findAll('va-language-toggle >>> a');
     await anchor.click();
@@ -46,7 +42,7 @@ describe('va-language-toggle', () => {
 
   it('fires a language-toggle event when a link is clicked', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-language-toggle en-href="${enHref}" es-href="${esHref}" tl-href="${tlHref}" />`);
+    await page.setContent(`<va-language-toggle en-href="#" es-href="#" tl-href="#" />`);
     const toggleSpy = await page.spyOnEvent('vaLanguageToggle');
     const [_, anchor] = await page.findAll('va-language-toggle >>> a');
     await anchor.click();
@@ -55,7 +51,7 @@ describe('va-language-toggle', () => {
 
   it('fires a component-analytics event when a link is clicked', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-language-toggle en-href="${enHref}" es-href="${esHref}" tl-href="${tlHref}" />`);
+    await page.setContent(`<va-language-toggle en-href="#" es-href="#" tl-href="$#}" />`);
     const toggleSpy = await page.spyOnEvent('component-library-analytics');
     const anchor = await page.find('va-language-toggle >>> a');
     await anchor.click();
@@ -64,7 +60,7 @@ describe('va-language-toggle', () => {
 
   it('passes an aXe check', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<va-language-toggle en-href="${enHref}" es-href="${esHref}" tl-href="${tlHref}" />`);
+    await page.setContent(`<va-language-toggle en-href="#" es-href="#" tl-href="#" />`);
     await axeCheck(page);
   });
 });

--- a/packages/web-components/src/components/va-language-toggle/va-language-toggle.tsx
+++ b/packages/web-components/src/components/va-language-toggle/va-language-toggle.tsx
@@ -22,7 +22,7 @@ export class VaLanguageToggle {
   /**
    * The ISO language code for the page. Default is 'en'.
    */
-  @Prop() language: string = 'en';
+  @Prop({ mutable: true }) language: string = 'en';
 
   /**
    * The English language href for the page. Required.
@@ -48,7 +48,7 @@ export class VaLanguageToggle {
    * If true, specifies that the toggle is being used on a page with a router and clicking on a link will not result in page navigation.
    */
   @Prop() routerLinks?: boolean = false;
-  
+
   /**
    * Event fired when a link is clicked. Includes the selected language's ISO code.
    */
@@ -65,7 +65,7 @@ export class VaLanguageToggle {
     })
     componentLibraryAnalytics: EventEmitter;
 
-  // get the current page's url with language as a query param. 
+  // get the current page's url with language as a query param.
   // allows for marking "pages" as visited
   getUrl(langCode: string): string {
     const url = new URL(window.location.href);
@@ -96,30 +96,27 @@ export class VaLanguageToggle {
   }
 
   componentWillLoad() {
-    // always include English
-    const urls = [{
+    this.urls = [{
       label: "English",
       lang: "en",
       href: this.enHref
     }];
 
     if (this.esHref) {
-      urls.push({
+      this.urls = [...this.urls, {
         label: "Español",
         lang: "es",
         href: this.esHref
-      });
+      }];
     }
 
     if (this.tlHref) {
-      urls.push({
+      this.urls = [...this.urls, {
         label: "Tagalog",
         lang: "tl",
         href: this.tlHref
-      });
+      }];
     }
-
-    this.urls = urls;
   }
 
   render() {


### PR DESCRIPTION
## Chromatic
<!-- This `stencil-language-toggle-tests` is a placeholder for a CI job - it will be updated automatically -->
https://stencil-language-toggle-tests--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This PR will resolve some Stencil test warnings for the va-language-toggle component.

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
