### PR TITLE
va-search-input: remove state decorator from isTouched

### DIFF
--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -51,7 +51,7 @@ export class VaSearchInput {
   /**
    * A boolean indicating whether listbox is open or closed
    */
-  @State() isTouched: boolean = false;
+  isTouched: boolean;
 
   /**
    * Text displayed inside the search button
@@ -157,7 +157,7 @@ export class VaSearchInput {
         composed: true,
       }),
     );
-    
+
     if (!this.disableAnalytics) {
       this.componentLibraryAnalytics.emit({
         componentName: 'va-search-input',


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

This should resolve the Stencil warning about re-renders. It does not appear that `isTouched` needs a [@State](https://stenciljs.com/docs/state#the-state-decorator-state) decorator.

![Screenshot 2024-11-19 at 9 58 45 AM](https://github.com/user-attachments/assets/297170ee-053e-4735-9116-1008af25efa6)


## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
