### PR TITLE
build: allow vite to lazy load stencil components

### DIFF
--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -14,7 +14,7 @@ export const config: Config = {
     sass({
       includePaths: [
         '../../node_modules/@uswds/uswds/packages/',
-        'src/global/'
+        'src/global/',
       ],
     }),
     postcss({
@@ -22,27 +22,32 @@ export const config: Config = {
     }),
   ],
   // This is for IE11 support
-  // https://stenciljs.com/docs/config-extras
   buildEs5: 'prod',
+  // https://stenciljs.com/docs/config-extras
   extras: {
     scriptDataOpts: true,
     appendChildSlotFix: false,
     cloneNodeFix: false,
-    slotChildNodesFix: true
+    slotChildNodesFix: true,
+    enableImportInjection: true,
   },
   outputTargets: [
     reactOutputTarget({
-      componentCorePackage: '@department-of-veterans-affairs/web-components/dist/types',
+      componentCorePackage:
+        '@department-of-veterans-affairs/web-components/dist/types',
       proxiesFile: './react-bindings/index.ts',
-      includeImportCustomElements: false
+      includeImportCustomElements: false,
     }),
     {
       type: 'dist',
       esmLoaderPath: '../loader',
       copy: [
         { src: 'assets', dest: path.join(__dirname, 'dist/assets') },
-        { src: 'img/sprite.svg', dest: path.join(__dirname, 'dist/img/sprite.svg') }
-      ]
+        {
+          src: 'img/sprite.svg',
+          dest: path.join(__dirname, 'dist/img/sprite.svg'),
+        },
+      ],
     },
     {
       type: 'www',
@@ -51,7 +56,7 @@ export const config: Config = {
     {
       type: 'dist-custom-elements',
       customElementsExportBehavior: 'single-export-module',
-    }
+    },
   ],
   testing: {
     browserArgs: ['--no-sandbox', '--disable-setuid-sandbox'],


### PR DESCRIPTION
## Chromatic

<!-- This `stencil-lazy-load` is a placeholder for a CI job - it will be updated automatically -->

https://stencil-lazy-load--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Configuring this pull request

- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
  - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
  - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description

Enable stencil flag to allow lazy loading in build chains such as vite.

See <https://stenciljs.com/docs/config-extras#enableimportinjection>

There's a nominal increase in bundle size for CJS and ESM targets, but IMO it's not significant enough to warrant concern.

<details>
<summary>Bundle size comparison</summary>

#### `main` as of 15d5d4bde7cdd209cf94f3658fd00cfd86498f8a

```
main
packages/web-components/dist $ du -sck *
124     assets
1088    cjs
3568    collection
1740    component-library
1332    components
1208    esm
856     esm-es5
80      img
4       index.cjs.js
4       index.js
576     types
10580   total
```

#### This Branch

```
stencil-lazy-load
packages/web-components/dist $ du -sck *
124     assets
1104    cjs
3568    collection
1740    component-library
1332    components
1216    esm
860     esm-es5
80      img
4       index.cjs.js
4       index.js
576     types
10608   total
```

</details>

## QA Checklist

- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

## Acceptance criteria

- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done

- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
