### PR TITLE
Va table accessibility issues

### DIFF
--- a/packages/web-components/src/components/va-table/va-table-inner/test/va-table-inner.e2e.ts
+++ b/packages/web-components/src/components/va-table/va-table-inner/test/va-table-inner.e2e.ts
@@ -324,6 +324,41 @@ describe('sorted va-table ', () => {
     await page.setContent(getTableMarkup());
     await checkSorts(page, 7, 'sort-4', 'sort-2');
   });
+
+  it('screen reader text on sort buttons is correct', async () => {
+    const page = await newE2EPage();
+    await page.setContent(getTableMarkup());
+    // we need to update these variables after each sort
+    
+    let buttons = null;
+
+    buttons = await page.findAll('va-table-inner >>> thead >>> th >>> button');
+    // sort ascending
+    buttons = await page.findAll('va-table-inner >>> thead >>> th >>> button');
+
+    // screen reader should say ascending initially
+    expect(buttons[1].getAttribute('title')).toEqual(`Click to sort by Percent in ascending order`)
+    expect(buttons[0].getAttribute('title')).toEqual(`Click to sort by Integer/Float in ascending order`)
+
+    await buttons[1].click();
+    await page.waitForChanges();
+
+    buttons = await page.findAll('va-table-inner >>> thead >>> th >>> button');
+    // screen reader should say descending for clicked button
+    expect(buttons[1].getAttribute('title')).toEqual(`Click to sort by Percent in descending order`);
+    // screen reader should say ascending for non-clicked button
+    expect(buttons[0].getAttribute('title')).toEqual(`Click to sort by Integer/Float in ascending order`);
+
+    // sort descending
+    await buttons[1].click();
+    await page.waitForChanges();
+
+    buttons = await page.findAll('va-table-inner >>> thead >>> th >>> button');
+    // screen reader should say ascending for twice clicked button
+    expect(buttons[1].getAttribute('title')).toEqual(`Click to sort by Percent in ascending order`);
+    // screen reader should say ascending for non-clicked button
+    expect(buttons[0].getAttribute('title')).toEqual(`Click to sort by Integer/Float in ascending order`);
+  });
 });
 
 describe('sort utilities', () => {

--- a/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.scss
+++ b/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.scss
@@ -11,13 +11,14 @@
 }
 
 :host {
-  display: table;
+  display: block;
   font-family: var(--font-source-sans);
   font-size: 1.06rem;
   border-collapse: collapse;
   margin: 0;
   padding: 0;
   width: 100%;
+  overflow-x: auto;
 }
 :host thead tr th {
   button {

--- a/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
+++ b/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
@@ -218,7 +218,7 @@ export class VaTableInner {
     content: string,
   ) {
     const button = th.querySelector('button');
-    let spanSortInfo = `Click to sort by ${content} in ${nextSortDirection} order`;
+    let spanSortInfo = thSorted ? `Click to sort by ${content} in ${nextSortDirection} order` : `Click to sort by ${content} in ascending order`;
     button.setAttribute('title', spanSortInfo);
     if (thSorted) {
       setTimeout(() => {


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Partial [Table sorting - accessibility fixes #3455](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3455)

Makes table's overflow scrollable.

Screenreader button text fixed to say "ascending" when a different column is already sorted by ascending

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
Visible scrollbar:
<img width="582" alt="Screenshot 2024-11-13 at 08 59 43" src="https://github.com/user-attachments/assets/4c96b009-4e01-453b-a668-27a6ec68a337">
Button marked ascending:
![Screenshot 2024-11-13 at 09 05 25](https://github.com/user-attachments/assets/b75badbc-1236-4bc5-99e9-b9c474569883)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
