### PR TITLE
48.1.1 update versions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "48.1.0",
+  "version": "48.1.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "16.1.0",
+  "version": "16.1.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.10.0",
     "@babel/core": "^7.12.13",
-    "@department-of-veterans-affairs/css-library": "^0.15.0",
+    "@department-of-veterans-affairs/css-library": "^0.16.0",
     "@department-of-veterans-affairs/formation": "^11.0.6",
     "@stencil/postcss": "^2.0.0",
     "@stencil/react-output-target": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3311,18 +3311,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@department-of-veterans-affairs/css-library@npm:^0.15.0":
-  version: 0.15.0
-  resolution: "@department-of-veterans-affairs/css-library@npm:0.15.0"
-  dependencies:
-    "@divriots/style-dictionary-to-figma": "npm:^0.4.0"
-    "@uswds/uswds": "npm:^3.9.0"
-    rimraf: "npm:^5.0.5"
-  checksum: 10/cc7dcd60edf4e2d0d027cedf5a4ad8c800f2997f8fe70591b636b571686f2168c713b0f2e18b52c109b11ccda1b7a2605a5432feef9224d73b6ef304187e3e3a
-  languageName: node
-  linkType: hard
-
-"@department-of-veterans-affairs/css-library@workspace:packages/css-library":
+"@department-of-veterans-affairs/css-library@npm:^0.16.0, @department-of-veterans-affairs/css-library@workspace:packages/css-library":
   version: 0.0.0-use.local
   resolution: "@department-of-veterans-affairs/css-library@workspace:packages/css-library"
   dependencies:
@@ -3456,7 +3445,7 @@ __metadata:
   dependencies:
     "@axe-core/puppeteer": "npm:^4.10.0"
     "@babel/core": "npm:^7.12.13"
-    "@department-of-veterans-affairs/css-library": "npm:^0.15.0"
+    "@department-of-veterans-affairs/css-library": "npm:^0.16.0"
     "@department-of-veterans-affairs/formation": "npm:^11.0.6"
     "@stencil/core": "npm:4.20.0"
     "@stencil/postcss": "npm:^2.0.0"


### PR DESCRIPTION
## Chromatic
<!-- This `mc-48.1.1` is a placeholder for a CI job - it will be updated automatically -->
https://mc-48.1.1--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
Updates versions of packages for release. 

CSS-Library wasn't updated because it was bumped in a prior pull request
