### PR TITLE
va-process-list-item: add optional slot for header

### DIFF
--- a/packages/storybook/stories/va-process-list-uswds.stories.jsx
+++ b/packages/storybook/stories/va-process-list-uswds.stories.jsx
@@ -111,6 +111,51 @@ const HeaderSizeTemplate = (defaultArgs) => {
   );
 };
 
+const HeaderSlotTemplate = (defaultArgs) => {
+  return (
+    <va-process-list>
+      <va-process-list-item>
+        <h4 slot="header">Check to be sure you can request a Board Appeal</h4>
+        <p>
+            You can request a Board Appeal up to 1 year from the date on your
+            decision notice. (Exception: if you have a contested claim, you have
+            only 60 days from the date on your decision notice to request a Board
+            Appeal.)
+          </p>
+          <p>You can request a Board Appeal for these claim decisions:</p>
+          <ul>
+            <li>An initial claim</li>
+            <li>A Supplemental Claim</li>
+            <li>A Higher-Level Review</li>
+          </ul>
+          <p>
+            <strong>Note: </strong>
+            You can’t request a Board Appeal if you’ve already requested one for
+            this same claim.
+          </p>
+      </va-process-list-item>
+      <va-process-list-item>
+        <h4 slot="header">Gather your information</h4>
+        <p>Here’s what you’ll need to apply:</p>
+        <ul>
+          <li>Your mailing address</li>
+          <li>
+            The VA decision date for each issue you’d like us to review (this is
+            the date on the decision notice you got in the mail)
+          </li>
+        </ul>
+      </va-process-list-item>
+      <va-process-list-item>
+        <h4 slot="header">Start your request</h4>
+        <p>
+          We’ll take you through each step of the process. It should take about
+          30 minutes.
+        </p>
+      </va-process-list-item>
+    </va-process-list>
+  );
+};
+
 const CustomSizingTemplate = (defaultArgs) => {
   return (
     <va-process-list>
@@ -166,6 +211,9 @@ export const CustomStatusText = CustomStatusTextTemplate.bind(null);
 Status.args = { ...defaultArgs };
 
 export const HeaderSize = HeaderSizeTemplate.bind(null);
+HeaderSize.args = { ...defaultArgs };
+
+export const HeaderSlot = HeaderSlotTemplate.bind(null);
 HeaderSize.args = { ...defaultArgs };
 
 export const CustomSizing = CustomSizingTemplate.bind(null);

--- a/packages/web-components/src/components/va-process-list/test/va-process-list-item.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list-item.e2e.ts
@@ -53,6 +53,43 @@ describe('va-process-list-item', () => {
     `);
   })
 
+  it('renders with a header slot', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-process-list-item>
+        <h2 slot="header">Header</h2>
+        <p>Some content</p>
+      </va-process-list>
+    `);
+    const element = await page.find('va-process-list-item');
+    expect(element).toEqualHtml(`
+      <va-process-list-item class="hydrated usa-process-list__item" role="listitem">
+        <!---->
+        <h2 slot="header">Header</h2>
+        <p>Some content</p>
+      </va-process-list-item>
+    `);
+  })
+
+  it('does not show header slot when header prop is defined', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-process-list-item header="header prop">
+        <h2 slot="header">Header</h2>
+        <p>Some content</p>
+      </va-process-list>
+    `);
+    const element = await page.find('va-process-list-item');
+    expect(element).toEqualHtml(`
+      <va-process-list-item class="hydrated usa-process-list__item" header="header prop" role="listitem">
+        <!---->
+        <h2 slot="header" hidden="">Header</h2>
+        <h3 class="usa-process-list__heading">header prop</h3>
+        <p>Some content</p>
+      </va-process-list-item>
+    `);
+  })
+
   it('passes an axe check', async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/packages/web-components/src/components/va-process-list/va-process-list-item.tsx
+++ b/packages/web-components/src/components/va-process-list/va-process-list-item.tsx
@@ -60,7 +60,7 @@ export class VaProcessListItem {
           <div class="usa-process-list__heading-eyebrow">{statusTextMap[status]}</div>
           : null
         }
-        {header ? <HeaderTag class='usa-process-list__heading'>{header}</HeaderTag> : null}
+        {header ? <HeaderTag class='usa-process-list__heading'>{header}</HeaderTag> : <slot name="header"/>}
         <slot/>
       </Host>
     )


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
There is currently not an option available to adopt header styles (h1-h6) for the header. There is a way to change the header level but the header styles do not change. 
This change is to add a header slot to give teams the flexibility to use the header element of choice along with the default styling for that element. 
By default, if the header prop is set, the header slot will not render. This is to maintain backwards compatibility.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2593

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
