### PR TITLE
va-language-toggle: Add label text to event, remove va-link analytics

### DIFF
--- a/packages/web-components/src/components/va-language-toggle/test/va-language-toggle.e2e.ts
+++ b/packages/web-components/src/components/va-language-toggle/test/va-language-toggle.e2e.ts
@@ -55,7 +55,7 @@ describe('va-language-toggle', () => {
     const toggleSpy = await page.spyOnEvent('component-library-analytics');
     const anchor = await page.find('va-language-toggle >>> a');
     await anchor.click();
-    expect(toggleSpy).toHaveReceivedEvent();
+    expect(toggleSpy).toHaveReceivedEventTimes(1);
   });
 
   it('passes an aXe check', async () => {

--- a/packages/web-components/src/components/va-language-toggle/va-language-toggle.tsx
+++ b/packages/web-components/src/components/va-language-toggle/va-language-toggle.tsx
@@ -74,7 +74,7 @@ export class VaLanguageToggle {
   }
 
   // This method is fired whenever a link is clicked
-  handleToggle(e: Event, langCode: string): void {
+  handleToggle(e: Event, langCode: string, linkText: string): void {
     // don't navigate from current page but set new language
     if (this.routerLinks) {
       e.preventDefault();
@@ -82,14 +82,14 @@ export class VaLanguageToggle {
       window.history.replaceState(null, null, this.getUrl(langCode));
       this.language = langCode;
     }
-
     this.vaLanguageToggle.emit({ language: langCode });
 
     const detail = {
       componentName: 'va-language-toggle',
       action: 'linkClick',
       details: {
-        'pipe-delimited-list-header': langCode
+        'pipe-delimited-list-header': langCode,
+        label: linkText,
       },
     };
     this.componentLibraryAnalytics.emit(detail);
@@ -137,8 +137,9 @@ export class VaLanguageToggle {
                 class={anchorClass}
                 href={href}
                 language={lang}
-                onClick={(e) => this.handleToggle(e, lang)}
+                onClick={(e) => this.handleToggle(e, lang, label)}
                 text={label}
+                disableAnalytics={true}
               />
             </div>
           )


### PR DESCRIPTION
## Chromatic
<!-- This `va-language-toggle-analytics-updates` is a placeholder for a CI job - it will be updated automatically -->
https://va-language-toggle-analytics-updates--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description
Closes [Add va-language-toggle to ds-v3-playground for Analytics testing #3532](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3532)

Making updates based on [analytics team in slack](https://dsva.slack.com/archives/CKCRMLGAC/p1733945144549319?thread_ts=1731948507.349549&cid=CKCRMLGAC)

Added the link text to the event.
Disabled analytics on the `va-link` in `va-language-toggle` to prevent firing two events at once.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
