### PR TITLE
va-process-list-item: move status eyebrow into header so that it gets read by screen readers

### DIFF
--- a/packages/web-components/src/components/va-process-list/test/va-process-list-item.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list-item.e2e.ts
@@ -30,7 +30,11 @@ describe('va-process-list-item', () => {
     expect(element).toEqualHtml(`
       <va-process-list-item class="hydrated usa-process-list__item" role="listitem" header="Heading">
         <!---->
-        <h3 class="usa-process-list__heading" part="header">Heading</h3>
+        <h3 aria-label="Heading" class="usa-process-list__heading" part="header">
+          <span aria-hidden="true">
+            <div>Heading</div>
+          </span>
+        </h3>
         <p>Some content</p>
       </va-process-list-item>
     `);
@@ -47,7 +51,11 @@ describe('va-process-list-item', () => {
     expect(element).toEqualHtml(`
       <va-process-list-item class="hydrated usa-process-list__item" role="listitem" header="Heading" level="1">
         <!---->
-        <h1 class="usa-process-list__heading" part="header">Heading</h1>
+        <h1 aria-label="Heading" class="usa-process-list__heading" part="header">
+          <span aria-hidden="true">
+            <div>Heading</div>
+          </span>
+        </h1>
         <p>Some content</p>
       </va-process-list-item>
     `);

--- a/packages/web-components/src/components/va-process-list/test/va-process-list-item.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list-item.e2e.ts
@@ -30,10 +30,8 @@ describe('va-process-list-item', () => {
     expect(element).toEqualHtml(`
       <va-process-list-item class="hydrated usa-process-list__item" role="listitem" header="Heading">
         <!---->
-        <h3 aria-label="Heading" class="usa-process-list__heading" part="header">
-          <span aria-hidden="true">
-            <div>Heading</div>
-          </span>
+        <h3 class="usa-process-list__heading" part="header">
+          <div>Heading</div>
         </h3>
         <p>Some content</p>
       </va-process-list-item>
@@ -51,10 +49,8 @@ describe('va-process-list-item', () => {
     expect(element).toEqualHtml(`
       <va-process-list-item class="hydrated usa-process-list__item" role="listitem" header="Heading" level="1">
         <!---->
-        <h1 aria-label="Heading" class="usa-process-list__heading" part="header">
-          <span aria-hidden="true">
-            <div>Heading</div>
-          </span>
+        <h1 class="usa-process-list__heading" part="header">
+          <div>Heading</div>
         </h1>
         <p>Some content</p>
       </va-process-list-item>

--- a/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
@@ -49,19 +49,15 @@ describe('va-process-list', () => {
         </mock:shadow-root>
         <va-process-list-item class="hydrated usa-process-list__item" header="Step one" role="listitem">
           <!---->  
-          <h3 aria-label="Step one" class="usa-process-list__heading" part="header">
-            <span aria-hidden="true">
-              <div>Step one</div>
-            </span>
+          <h3 class="usa-process-list__heading" part="header">
+            <div>Step one</div>
           </h3>
           <p>Some content</p>
         </va-process-list-item>
         <va-process-list-item class="hydrated usa-process-list__item" header="Step two" role="listitem">
           <!---->
-          <h3 aria-label="Step two" class="usa-process-list__heading" part="header">
-            <span aria-hidden="true">
-              <div>Step two</div>
-            </span>
+          <h3 class="usa-process-list__heading" part="header">
+            <div>Step two</div>
           </h3>
           <p>Additional content</p>
           <ul>

--- a/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
+++ b/packages/web-components/src/components/va-process-list/test/va-process-list.e2e.ts
@@ -49,12 +49,20 @@ describe('va-process-list', () => {
         </mock:shadow-root>
         <va-process-list-item class="hydrated usa-process-list__item" header="Step one" role="listitem">
           <!---->  
-          <h3 class="usa-process-list__heading" part="header">Step one</h3>
+          <h3 aria-label="Step one" class="usa-process-list__heading" part="header">
+            <span aria-hidden="true">
+              <div>Step one</div>
+            </span>
+          </h3>
           <p>Some content</p>
         </va-process-list-item>
         <va-process-list-item class="hydrated usa-process-list__item" header="Step two" role="listitem">
           <!---->
-          <h3 class="usa-process-list__heading" part="header">Step two</h3>
+          <h3 aria-label="Step two" class="usa-process-list__heading" part="header">
+            <span aria-hidden="true">
+              <div>Step two</div>
+            </span>
+          </h3>
           <p>Additional content</p>
           <ul>
             <li>Item one</li>

--- a/packages/web-components/src/components/va-process-list/va-process-list-item.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list-item.scss
@@ -8,8 +8,11 @@
 }
 
 .usa-process-list__heading-eyebrow {
+  @extend .usa-process-list__heading; // needed for "source Sans Pro" font-family
   color: var(--vads-color-base-darker);
   text-transform: uppercase;
+  font-weight: normal;
+  font-size: var(--vads-font-size-source-sans-normalized);
 }
 
 va-process-list-item[pending='true'] .usa-process-list__heading {

--- a/packages/web-components/src/components/va-process-list/va-process-list-item.scss
+++ b/packages/web-components/src/components/va-process-list/va-process-list-item.scss
@@ -17,9 +17,17 @@
 
 va-process-list-item[pending='true'] .usa-process-list__heading {
   color: var(--vads-process-list-color-text-pending-on-light);
+
+  .usa-process-list__heading-eyebrow {
+    color: var(--vads-color-base-darker);
+  }
 }
 va-process-list-item[active='true'] .usa-process-list__heading {
   color: var(--vads-color-primary);
+
+  .usa-process-list__heading-eyebrow {
+    color: var(--vads-color-base-darker);
+  }
 }
 
 /* h6 remains as Source Sans Pro, everything else uses Bitter */

--- a/packages/web-components/src/components/va-process-list/va-process-list-item.tsx
+++ b/packages/web-components/src/components/va-process-list/va-process-list-item.tsx
@@ -59,11 +59,9 @@ export class VaProcessListItem {
       <Host role="listitem" class='usa-process-list__item'>
         {header || status ? (
           // aria-label hack to avoid header being read twice in voiceOver
-          <HeaderLevel part="header" class='usa-process-list__heading' aria-label={`${status ? `${statusTextMap[status]}: ` : ''}${header}`}>
-            <span aria-hidden="true">
-              {status ? <div class="usa-process-list__heading-eyebrow">{statusTextMap[status]}</div> : null}
-              {header ? <div>{header}</div> : null}
-            </span>
+          <HeaderLevel part="header" class='usa-process-list__heading'>
+            {status ? <div class="usa-process-list__heading-eyebrow">{statusTextMap[status]}</div> : null}
+            {header ? <div>{header}</div> : null}
           </HeaderLevel> 
         ): null}
         <slot/>

--- a/packages/web-components/src/components/va-process-list/va-process-list-item.tsx
+++ b/packages/web-components/src/components/va-process-list/va-process-list-item.tsx
@@ -57,11 +57,15 @@ export class VaProcessListItem {
     
     return (
       <Host role="listitem" class='usa-process-list__item'>
-        { status ?
-          <div class="usa-process-list__heading-eyebrow">{statusTextMap[status]}</div>
-          : null
-        }
-        {header ? <HeaderLevel part="header" class='usa-process-list__heading'>{header}</HeaderLevel> : null}
+        {header || status ? (
+          // aria-label hack to avoid header being read twice in voiceOver
+          <HeaderLevel part="header" class='usa-process-list__heading' aria-label={`${status ? `${statusTextMap[status]}: ` : ''}${header}`}>
+            <span aria-hidden="true">
+              {status ? <div class="usa-process-list__heading-eyebrow">{statusTextMap[status]}</div> : null}
+              {header ? <div>{header}</div> : null}
+            </span>
+          </HeaderLevel> 
+        ): null}
         <slot/>
       </Host>
     )


### PR DESCRIPTION
## Chromatic
<!-- This `98739-proc-list-eyebrow-acc` is a placeholder for a CI job - it will be updated automatically -->
https://98739-proc-list-eyebrow-acc--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
This PR moves the status eyebrow text inside the header so that it doesn't get skipped by screen readers.

\* moving the eyebrow into the header caused the color of the eyebrow in the current step to be blue. I overrode this so that they are #3d4551

Closes [98739](https://github.com/department-of-veterans-affairs/va.gov-team/issues/98739)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual differences:

Before:
![Screenshot 2024-12-13 at 10 46 06 AM](https://github.com/user-attachments/assets/921ffd95-92ce-4051-85c7-891e1a2f0e28)

After:
![Screenshot 2024-12-16 at 10 14 02 AM](https://github.com/user-attachments/assets/6af1134d-5a18-4f22-8cdd-3c2932863d66)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
