### PR TITLE
va-alert-sign-in: Modifying headline to use rems

### DIFF
--- a/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.scss
+++ b/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.scss
@@ -26,9 +26,9 @@
 }
 
 :host .headline {
-  font-size: 21.28px; /* 1.33rem */
+  font-size: 1.33rem;
   margin-top: 0;
-  margin-bottom: 8px; /* 0.5rem */
+  margin-bottom: 0.5rem;
   font-family: var(--font-serif);
 }
 


### PR DESCRIPTION
## Chromatic
<!-- This `3611-sign-in-alert-a11y` is a placeholder for a CI job - it will be updated automatically -->
https://3611-sign-in-alert-a11y--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#3611](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3611)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
100% zoom:
![Screenshot 2024-12-16 at 9 20 50 AM](https://github.com/user-attachments/assets/1298401d-74b5-409a-92d6-2fe47fffb721)
130% zoom:
![Screenshot 2024-12-16 at 9 21 03 AM](https://github.com/user-attachments/assets/bc32adec-ea58-4c7a-86fe-e1cf4bffcb2d)

## Acceptance criteria
- [x] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
