### PR TITLE
va-file-input-multiple: Fix multiple emits of vaMultipleChange

### DIFF
--- a/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.e2e.ts
+++ b/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.e2e.ts
@@ -107,6 +107,8 @@ describe('va-file-input-multiple', () => {
     await input
       .uploadFile(filePath)
       .catch(e => console.log('uploadFile error', e));
+    
+    await page.waitForChanges();
 
     expect(fileUploadSpy).toHaveReceivedEventTimes(1);
   });

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -145,7 +145,7 @@ export class VaFileInput {
     }
   };
 
-  private handleFile = (file: File) => {
+  private handleFile = (file: File, emitChange: boolean = true) => {
     if (this.accept) {
       const normalizedAcceptTypes = this.normalizeAcceptProp(this.accept);
       if (!this.isAcceptedFileType(file.type, normalizedAcceptTypes)) {
@@ -156,7 +156,9 @@ export class VaFileInput {
     }
 
     this.file = file;
-    this.vaChange.emit({ files: [this.file] });
+    if (emitChange) {
+      this.vaChange.emit({ files: [this.file] });
+    }
     this.uploadStatus = 'success';
     this.internalError = null;
     this.generateFileContents(this.file);
@@ -356,7 +358,7 @@ export class VaFileInput {
     } = this;
 
     if (value) {
-      this.handleFile(value);
+      this.handleFile(value, false);
     }
 
     const displayError = this.error || this.internalError;


### PR DESCRIPTION
## Chromatic
<!-- This `file-input-mult-event-double-emit` is a placeholder for a CI job - it will be updated automatically -->
https://file-input-mult-event-double-emit--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes [va-file-input-multiple emits twice on file upload #3549](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3549)

A call of `handleFile` was added to the `render` function of `va-file-input` when read only was added. The `handleFile` emits `vaChange` which caused the second `vaMultipleChange` to fire in `va-file-input-multiple`. I added a parameter to conditionally emit change and set it to false for this call of `handleFile`.

Additionally this issue wasn't caught by tests because we only waited for the input change. Added `waitForChanges` to the page before checking how many times `vaMultipleChange` was emitted.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
