### PR TITLE
CSS Library: add `img` folder to dist

### DIFF
--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 11 Dec 2024 15:09:52 GMT
+ * Generated on Wed, 18 Dec 2024 16:54:03 GMT
  */
 
 :root {

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 11 Dec 2024 15:09:52 GMT
+// Generated on Wed, 18 Dec 2024 16:54:03 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;

--- a/packages/css-library/package.json
+++ b/packages/css-library/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@department-of-veterans-affairs/css-library",
-  "version": "0.16.1",
+  "version": "0.16.1-rc1",
   "description": "Department of Veterans Affairs stylesheets, tokens, and utilities",
   "packageManager": "yarn@3.2.0",
   "files": [
     "dist/**/*.css",
     "dist/**/*.scss",
     "dist/**/*.json",
-    "dist/fonts/*"
+    "dist/fonts/*",
+    "dist/img/*"
   ],
   "scripts": {
     "build:tokens": "style-dictionary build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3311,7 +3311,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@department-of-veterans-affairs/css-library@npm:^0.16.1, @department-of-veterans-affairs/css-library@workspace:packages/css-library":
+"@department-of-veterans-affairs/css-library@npm:^0.16.1":
+  version: 0.16.1
+  resolution: "@department-of-veterans-affairs/css-library@npm:0.16.1"
+  dependencies:
+    "@divriots/style-dictionary-to-figma": "npm:^0.4.0"
+    "@uswds/uswds": "npm:^3.9.0"
+    rimraf: "npm:^5.0.5"
+  checksum: 10/cec494b2da20ff7f62c7bec5d198da580375610f966e3c460b768b07a5f84a3fbdd988743e78c462d3f7d0560da7edb2fb131ace195b1ecbf55c4adfe617e08a
+  languageName: node
+  linkType: hard
+
+"@department-of-veterans-affairs/css-library@workspace:packages/css-library":
   version: 0.0.0-use.local
   resolution: "@department-of-veterans-affairs/css-library@workspace:packages/css-library"
   dependencies:


### PR DESCRIPTION
## Chromatic
<!-- This `mc-img-rc-test` is a placeholder for a CI job - it will be updated automatically -->
https://mc-img-rc-test--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
This PR adds the `img` directory to builds that get published to npm. A rc release was pushed to npm from this branch to address the needs of a lighthouse team in charge of maintaining developer.va.gov. [This thread](https://dsva.slack.com/archives/CBU0KDSB1/p1734483945839889) has more context. 

In general we should ship our own img directory to support teams that aren't strictly building products in vets-website or content-build. 
