### PR TITLE
va-date: remove unnecessary aria labels for select

### DIFF
--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -267,7 +267,6 @@ export class VaDate {
               onBlur={this.handleMonthBlur}
               invalid={this.invalidMonth}
               class="select-month"
-              aria-label="Please select a month"
               error={this.monthTouched && this.invalidMonth ? error : null}
               showError={false}
             >
@@ -290,7 +289,6 @@ export class VaDate {
                 onBlur={this.handleDayBlur}
                 invalid={this.invalidDay}
                 class="select-day"
-                aria-label="Please select a day"
                 error={this.dayTouched && this.invalidDay ? this.error : null}
                 showError={false}
               >

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -267,7 +267,7 @@ export class VaDate {
               onBlur={this.handleMonthBlur}
               invalid={this.invalidMonth}
               class="select-month"
-              aria-label="Please enter two digits for the month"
+              aria-label="Please select a month"
               error={this.monthTouched && this.invalidMonth ? error : null}
               showError={false}
             >
@@ -290,7 +290,7 @@ export class VaDate {
                 onBlur={this.handleDayBlur}
                 invalid={this.invalidDay}
                 class="select-day"
-                aria-label="Please enter two digits for the day"
+                aria-label="Please select a day"
                 error={this.dayTouched && this.invalidDay ? this.error : null}
                 showError={false}
               >


### PR DESCRIPTION
## Chromatic
<!-- This `3569-va-date-aria-labels` is a placeholder for a CI job - it will be updated automatically -->
https://3569-va-date-aria-labels--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
The aria-labels for the month and day field in va-date were incorrect and more appropriate for input fields. In testing out updating the labels vs removing them it seems like these are unnecessary and may be adding confusion. This PR removes the aria-labels.

Closes [3569](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3569)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes

## Acceptance criteria
- [x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
