### PR TITLE
va-link: add aria-label to all variations

### DIFF
--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -195,10 +195,80 @@ describe('va-link', () => {
     `);
   });
 
-  it('renders a link with a screen reader label', async () => {
+  it('renders a default link with a screen reader label', async () => {
     const page = await newE2EPage();
     await page.setContent(
       `<va-link href="https://www.va.gov" text="Veteran's Affairs" label="Example label" />`,
+    );
+
+    const label = await page.find('va-link >>> a[aria-label]');
+    expect(label.getAttribute('aria-label')).toBe('Example label');
+  });
+
+  it('renders an external link with a screen reader label', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-link href="https://www.va.gov" text="Veteran's Affairs" label="Example label" external/>`,
+    );
+
+    const label = await page.find('va-link >>> a[aria-label]');
+    expect(label.getAttribute('aria-label')).toBe('Example label');
+  });
+
+  it('renders an icon link with a screen reader label', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-link href="https://www.va.gov" text="Veteran's Affairs" label="Example label" icon="mail" />`,
+    );
+
+    const label = await page.find('va-link >>> a[aria-label]');
+    expect(label.getAttribute('aria-label')).toBe('Example label');
+  });
+
+  it('renders a download link with a screen reader label', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-link href="https://www.va.gov" text="Veteran's Affairs" label="Example label" download />`,
+    );
+
+    const label = await page.find('va-link >>> a[aria-label]');
+    expect(label.getAttribute('aria-label')).toBe('Example label');
+  });
+
+  it('renders a calendar link with a screen reader label', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-link href="https://www.va.gov" text="Veteran's Affairs" label="Example label" calendar />`,
+    );
+
+    const label = await page.find('va-link >>> a[aria-label]');
+    expect(label.getAttribute('aria-label')).toBe('Example label');
+  });
+
+  it('renders a channel link with a screen reader label', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-link href="https://www.va.gov" text="Veteran's Affairs" label="Example label" channel />`,
+    );
+
+    const label = await page.find('va-link >>> a[aria-label]');
+    expect(label.getAttribute('aria-label')).toBe('Example label');
+  });
+
+  it('renders a video link with a screen reader label', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-link href="https://www.va.gov" text="Veteran's Affairs" label="Example label" video />`,
+    );
+
+    const label = await page.find('va-link >>> a[aria-label]');
+    expect(label.getAttribute('aria-label')).toBe('Example label');
+  });
+
+  it('renders a back link with a screen reader label', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-link href="https://www.va.gov" text="Veteran's Affairs" label="Example label" back />`,
     );
 
     const label = await page.find('va-link >>> a[aria-label]');

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -219,6 +219,7 @@ export class VaLink {
           <a
             href={href}
             class={linkClass}
+            aria-label={this.label}
             onClick={handleClick}
             rel="noopener"
             target="_blank"
@@ -238,6 +239,7 @@ export class VaLink {
             href={href}
             class={linkClass}
             download={filename}
+            aria-label={this.label}
             onClick={handleClick}
           >
             <va-icon class="link-icon--left" icon="calendar_today"></va-icon>
@@ -255,6 +257,7 @@ export class VaLink {
             href={href}
             class={linkClass}
             download={filename}
+            aria-label={this.label}
             onClick={handleClick}
           >
             <va-icon class="link-icon--left" icon="file_download"></va-icon>
@@ -274,7 +277,12 @@ export class VaLink {
     if (iconName) {
       return (
         <Host>
-          <a href={href} class={linkClass} onClick={handleClick}>
+          <a
+            href={href}
+            class={linkClass}
+            aria-label={this.label}
+            onClick={handleClick}
+          >
             <va-icon icon={iconName} size={iconSize} part="icon"></va-icon>
             {text}
           </a>
@@ -290,6 +298,7 @@ export class VaLink {
             rel="noreferrer"
             class={linkClass}
             onClick={handleClick}
+            aria-label={this.label}
             target="_blank"
           >
             {text} (opens in a new tab)

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -160,7 +160,8 @@ export class VaLink {
       external,
       iconName,
       iconSize,
-      language
+      language,
+      label
     } = this;
 
     const linkClass = classNames({
@@ -176,7 +177,7 @@ export class VaLink {
             href={href}
             class={linkClass}
             onClick={handleClick}
-            aria-label={this.label}
+            aria-label={label}
           >
             {text}
             <va-icon class="link-icon--active" icon="chevron_right"></va-icon>
@@ -202,7 +203,7 @@ export class VaLink {
               href={href}
               class={linkClass}
               onClick={handleClick}
-              aria-label={this.label}
+              aria-label={label}
             >
               {text}
             </a>
@@ -219,7 +220,7 @@ export class VaLink {
           <a
             href={href}
             class={linkClass}
-            aria-label={this.label}
+            aria-label={label}
             onClick={handleClick}
             rel="noopener"
             target="_blank"
@@ -239,7 +240,7 @@ export class VaLink {
             href={href}
             class={linkClass}
             download={filename}
-            aria-label={this.label}
+            aria-label={label}
             onClick={handleClick}
           >
             <va-icon class="link-icon--left" icon="calendar_today"></va-icon>
@@ -257,7 +258,7 @@ export class VaLink {
             href={href}
             class={linkClass}
             download={filename}
-            aria-label={this.label}
+            aria-label={label}
             onClick={handleClick}
           >
             <va-icon class="link-icon--left" icon="file_download"></va-icon>
@@ -280,7 +281,7 @@ export class VaLink {
           <a
             href={href}
             class={linkClass}
-            aria-label={this.label}
+            aria-label={label}
             onClick={handleClick}
           >
             <va-icon icon={iconName} size={iconSize} part="icon"></va-icon>
@@ -298,7 +299,7 @@ export class VaLink {
             rel="noreferrer"
             class={linkClass}
             onClick={handleClick}
-            aria-label={this.label}
+            aria-label={label}
             target="_blank"
           >
             {text} (opens in a new tab)
@@ -316,7 +317,7 @@ export class VaLink {
           href={href}
           class={linkClass}
           onClick={handleClick}
-          aria-label={this.label}
+          aria-label={label}
           part="anchor"
           lang={lang}
           hrefLang={lang}


### PR DESCRIPTION
## Chromatic
<!-- This `3606-va-link-aria-label` is a placeholder for a CI job - it will be updated automatically -->
https://3606-va-link-aria-label--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

The `label` prop is used for the `aria-label` link attribute but not all va-link variations had the `aria-label` added to them as an option. This PR will make sure that all va-link variations are able to set it.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3606

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

<details closed>
<summary>Link Variations - Voice Over Tests</summary>

![Screenshot 2025-01-13 at 11 05 48 AM](https://github.com/user-attachments/assets/e4dbf44d-0c67-48f5-a1d4-22967e464bd9)
![Screenshot 2025-01-13 at 11 06 11 AM](https://github.com/user-attachments/assets/153e58b8-abff-4fd7-be64-aefd81e564a1)
![Screenshot 2025-01-13 at 11 06 02 AM](https://github.com/user-attachments/assets/8119d988-c618-457d-a70c-1362a42407b1)
![Screenshot 2025-01-13 at 11 05 55 AM](https://github.com/user-attachments/assets/fcc25405-4381-41bb-b7ec-08a49d9005ad)
![Screenshot 2025-01-13 at 11 01 16 AM](https://github.com/user-attachments/assets/47a12898-a29e-4869-8f22-a9380939359c)
![Screenshot 2025-01-13 at 11 01 07 AM](https://github.com/user-attachments/assets/ae7ccafe-47f1-420d-b8c8-835d7e09389e)
![Screenshot 2025-01-13 at 11 00 55 AM](https://github.com/user-attachments/assets/728e249b-1b4a-4f6e-a3ed-3edd9d00d561)
![Screenshot 2025-01-13 at 11 06 27 AM](https://github.com/user-attachments/assets/e48968c2-08e4-4b96-a9dc-01c003381978)
![Screenshot 2025-01-13 at 11 06 18 AM](https://github.com/user-attachments/assets/85ea37ba-be1e-468b-b9aa-abafda5c1f07)

</details>

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
