### PR TITLE
va-alert-expandable & va-alert-sign-in: fix Storybook link to guidance

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -113,6 +113,7 @@ export namespace Components {
     }
     /**
      * @componentName Alert - expandable
+     * @guidanceHref alert/alert-expandable
      * @maturityCategory caution
      * @maturityLevel candidate
      */
@@ -135,7 +136,8 @@ export namespace Components {
         "trigger": string;
     }
     /**
-     * @componentName Alert - Sign In
+     * @componentName Alert - Sign-in
+     * @guidanceHref alert/alert-sign-in
      * @maturityCategory caution
      * @maturityLevel candidate
      */
@@ -2153,6 +2155,7 @@ declare global {
     }
     /**
      * @componentName Alert - expandable
+     * @guidanceHref alert/alert-expandable
      * @maturityCategory caution
      * @maturityLevel candidate
      */
@@ -2171,7 +2174,8 @@ declare global {
         new (): HTMLVaAlertExpandableElement;
     };
     /**
-     * @componentName Alert - Sign In
+     * @componentName Alert - Sign-in
+     * @guidanceHref alert/alert-sign-in
      * @maturityCategory caution
      * @maturityLevel candidate
      */
@@ -3342,6 +3346,7 @@ declare namespace LocalJSX {
     }
     /**
      * @componentName Alert - expandable
+     * @guidanceHref alert/alert-expandable
      * @maturityCategory caution
      * @maturityLevel candidate
      */
@@ -3368,7 +3373,8 @@ declare namespace LocalJSX {
         "trigger": string;
     }
     /**
-     * @componentName Alert - Sign In
+     * @componentName Alert - Sign-in
+     * @guidanceHref alert/alert-sign-in
      * @maturityCategory caution
      * @maturityLevel candidate
      */
@@ -5444,12 +5450,14 @@ declare module "@stencil/core" {
             "va-alert": LocalJSX.VaAlert & JSXBase.HTMLAttributes<HTMLVaAlertElement>;
             /**
              * @componentName Alert - expandable
+             * @guidanceHref alert/alert-expandable
              * @maturityCategory caution
              * @maturityLevel candidate
              */
             "va-alert-expandable": LocalJSX.VaAlertExpandable & JSXBase.HTMLAttributes<HTMLVaAlertExpandableElement>;
             /**
-             * @componentName Alert - Sign In
+             * @componentName Alert - Sign-in
+             * @guidanceHref alert/alert-sign-in
              * @maturityCategory caution
              * @maturityLevel candidate
              */

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
@@ -13,6 +13,7 @@ import classnames from 'classnames';
 
 /**
  * @componentName Alert - expandable
+ * @guidanceHref alert/alert-expandable
  * @maturityCategory caution
  * @maturityLevel candidate
  */

--- a/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
+++ b/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
@@ -4,7 +4,8 @@ import { AlertSignInVariants as ASIVariants } from './AlertSignInVariants';
 import { getHeaderLevel } from '../../utils/utils';
 
 /**
- * @componentName Alert - Sign In
+ * @componentName Alert - Sign-in
+ * @guidanceHref alert/alert-sign-in
  * @maturityCategory caution
  * @maturityLevel candidate
  */


### PR DESCRIPTION
## Chromatic
<!-- This `va-alert-sign-in-storybook` is a placeholder for a CI job - it will be updated automatically -->
https://va-alert-sign-in-storybook--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This will fix the guidance links for va-alert-expandable and va-alert-sign-in. It will also display the maturity circle for va-alert-sign-in.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3667

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![Screenshot 2025-01-09 at 4 07 45 PM](https://github.com/user-attachments/assets/680e1a4c-14e7-405c-a374-046d27203379)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
