### PR TITLE
va-search-input: add clear search button

### DIFF
--- a/packages/storybook/stories/va-search-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-search-input-uswds.stories.jsx
@@ -111,6 +111,7 @@ const TypeaheadTemplate = ({ value, suggestions }) => {
       </p>
 
       <VaSearchInput
+        value={value}
         onInput={handleInput}
         onSubmit={handleSubmit}
         suggestions={latestSuggestions}

--- a/packages/storybook/stories/va-search-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-search-input-uswds.stories.jsx
@@ -17,7 +17,7 @@ export default {
   },
 };
 
-const Template = ({'button-text': buttonText, value, label, suggestions, uswds, small, big }) => (
+const Template = ({'button-text': buttonText, value, label, suggestions, small, big }) => (
   <div style={{ height: '100px'}}>
     <VaSearchInput
       buttonText={buttonText}
@@ -111,7 +111,6 @@ const TypeaheadTemplate = ({ value, suggestions }) => {
       </p>
 
       <VaSearchInput
-        value={value}
         onInput={handleInput}
         onSubmit={handleSubmit}
         suggestions={latestSuggestions}

--- a/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
+++ b/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
@@ -174,6 +174,19 @@ describe('va-search-input', () => {
     expect(inputValue).toContain('');
   });
 
+  it('clears input value when clear button is clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-search-input value="benefits"></va-search-input>');
+    
+    const button = await page.find('va-search-input >>> button.usa-search__clear-input');
+    await button.click();
+
+    const input = await page.find('va-search-input >>> input');
+    const inputValue = await input.getProperty('value');
+
+    expect(inputValue).toContain('');
+  });
+
   it('focuses next suggestion when pressing ArrowDown when suggestions are visible', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-search-input></va-search-input>');
@@ -372,7 +385,7 @@ describe('va-search-input', () => {
   it('fires an analytics event when search button is clicked', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-search-input label="Search" value="benefits""></va-search-input>',
+      '<va-search-input label="Search" value="benefits"></va-search-input>',
     );
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');

--- a/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
+++ b/packages/web-components/src/components/va-search-input/test/va-search-input.e2e.ts
@@ -35,7 +35,7 @@ describe('va-search-input', () => {
     await axeCheck(page);
   });
 
-  it('renders with button with text', async () => {
+  it('renders with search button with text', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-search-input button-text="Search VA.gov"></va-search-input>',
@@ -48,6 +48,9 @@ describe('va-search-input', () => {
         <form class="usa-search" role="search">
           <label class="usa-sr-only" for="search-field">Search</label>
           <input class="usa-input" id="search-field" name="search" type="search" aria-autocomplete="none" aria-label="Search" autocomplete="off">
+          <button aria-label="Clear the search contents" class="usa-search__clear-input" type="button">
+            <va-icon class="hydrated usa-search__clear-icon"></va-icon>
+          </button>
           <button class="usa-button" type="submit">
           <span class="usa-search__submit-text">Search VA.gov</span>
           <va-icon class="hydrated usa-search__submit-icon"></va-icon>
@@ -84,7 +87,7 @@ describe('va-search-input', () => {
     });
 
     const submitSpy = await page.spyOnEvent('submit');
-    const button = await page.find('va-search-input >>> button');
+    const button = await page.find('va-search-input >>> button[type="submit"]');
     await button.click();
 
     expect(submitSpy).toHaveReceivedEventTimes(1);
@@ -366,7 +369,7 @@ describe('va-search-input', () => {
     expect(suggestions.length).toEqual(5);
   });
 
-  it('fires an analytics event when button is clicked', async () => {
+  it('fires an analytics event when search button is clicked', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-search-input label="Search" value="benefits""></va-search-input>',
@@ -374,7 +377,7 @@ describe('va-search-input', () => {
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
-    const button = await page.find('va-search-input >>> button');
+    const button = await page.find('va-search-input >>> button[type="submit"]');
     await button.click();
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
@@ -396,7 +399,8 @@ describe('va-search-input', () => {
 
     const component = await page.find('va-search-input');
     await component.press('Tab'); // on the input
-    await component.press('Tab'); // on the button
+    await component.press('Tab'); // on the clear button
+    await component.press('Tab'); // on the search button
     await component.press('Tab'); // off the component
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
@@ -408,7 +412,7 @@ describe('va-search-input', () => {
     });
   });
 
-  it('does not fire an analytics event when button is clicked if analytics are disabled with only the prop name', async () => {
+  it('does not fire an analytics event when search button is clicked if analytics are disabled with only the prop name', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-search-input disable-analytics label="Search" value="benefits""></va-search-input>',
@@ -416,13 +420,13 @@ describe('va-search-input', () => {
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
-    const button = await page.find('va-search-input >>> button');
+    const button = await page.find('va-search-input >>> button[type="submit"]');
     await button.click();
 
     expect(analyticsSpy).not.toHaveReceivedEvent();
   });
 
-  it('does not fire an analytics event when button is clicked if analytics are disabled with the explicit "true" value', async () => {
+  it('does not fire an analytics event when search button is clicked if analytics are disabled with the explicit "true" value', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-search-input disable-analytics="true" label="Search" value="benefits""></va-search-input>',
@@ -430,7 +434,7 @@ describe('va-search-input', () => {
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
-    const button = await page.find('va-search-input >>> button');
+    const button = await page.find('va-search-input >>> button[type="submit"]');
     await button.click();
 
     expect(analyticsSpy).not.toHaveReceivedEvent();
@@ -446,7 +450,8 @@ describe('va-search-input', () => {
 
     const component = await page.find('va-search-input');
     await component.press('Tab'); // on the input
-    await component.press('Tab'); // on the button
+    await component.press('Tab'); // on the clear button
+    await component.press('Tab'); // on the search button
     await component.press('Tab'); // off the component
 
     expect(analyticsSpy).not.toHaveReceivedEvent();
@@ -462,7 +467,8 @@ describe('va-search-input', () => {
 
     const component = await page.find('va-search-input');
     await component.press('Tab'); // on the input
-    await component.press('Tab'); // on the button
+    await component.press('Tab'); // on the clear button
+    await component.press('Tab'); // on the search button
     await component.press('Tab'); // off the component
 
     expect(analyticsSpy).not.toHaveReceivedEvent();

--- a/packages/web-components/src/components/va-search-input/va-search-input.scss
+++ b/packages/web-components/src/components/va-search-input/va-search-input.scss
@@ -11,6 +11,13 @@
   display: block;
   border: none;
   padding: 0;
+
+  input[type="search"]::-webkit-search-decoration,
+  input[type="search"]::-webkit-search-cancel-button,
+  input[type="search"]::-webkit-search-results-button,
+  input[type="search"]::-webkit-search-results-decoration {
+  -webkit-appearance:none;
+}
 }
 
 .usa-input {
@@ -56,4 +63,21 @@
     width: auto;
   }
 }
+.usa-search__clear-input {
+  background-color: transparent;
+  border: 0px;
+  bottom: 1px;
+  position: absolute;
+  top: 1px;
+  z-index: 100;
+  right: calc(3rem + 3px);
+  margin-right: 32px;
+}
 
+:host([value]:not([value=""])) .usa-search__clear-input{
+  display: block; 
+}
+
+:host([value=""]) .usa-search__clear-input{
+  display: none;
+}

--- a/packages/web-components/src/components/va-search-input/va-search-input.scss
+++ b/packages/web-components/src/components/va-search-input/va-search-input.scss
@@ -64,6 +64,7 @@
   }
 }
 .usa-search__clear-input {
+  cursor: pointer;
   background-color: transparent;
   border: 0px;
   bottom: 1px;

--- a/packages/web-components/src/components/va-search-input/va-search-input.scss
+++ b/packages/web-components/src/components/va-search-input/va-search-input.scss
@@ -74,6 +74,19 @@
   margin-right: 32px;
 }
 
+:host([big="true"]) .usa-search__clear-input  {
+  right: calc(6rem + 6px);
+}
+
+:host([small="true"]) .usa-search__clear-input{
+  right: calc(0.5rem + 6px);
+}
+@media (max-width:29.99em) { 
+  .usa-search__clear-input  {
+    right: calc(0.5rem + 6px) !important;
+  }
+}
+
 :host([value]:not([value=""])) .usa-search__clear-input{
   display: block; 
 }

--- a/packages/web-components/src/components/va-search-input/va-search-input.tsx
+++ b/packages/web-components/src/components/va-search-input/va-search-input.tsx
@@ -245,6 +245,13 @@ export class VaSearchInput {
     this.handleSubmit();
   };
 
+  // clear the input and focus the input
+  private handleClearButtonClick = () => {
+    this.inputRef.value = "";
+    this.value = "";
+    this.inputRef.focus();
+  };
+
   // Listbox event handlers
   /**
    * Sets search input value to the suggestion clicked,
@@ -263,6 +270,7 @@ export class VaSearchInput {
     );
     this.inputRef.removeAttribute('aria-activedescendant');
     this.isListboxOpen = false;
+    this.value = suggestion.innerText;
     this.handleSubmit();
   };
 
@@ -407,6 +415,7 @@ export class VaSearchInput {
       formattedSuggestions,
       handleBlur,
       handleButtonClick,
+      handleClearButtonClick,
       handleInput,
       handleInputFocus,
       handleInputKeyDown,
@@ -471,6 +480,13 @@ export class VaSearchInput {
             role={role}
             value={value}
           />
+          <button type="button" onClick={handleClearButtonClick} class="usa-search__clear-input" aria-label="Clear the search contents">
+            <va-icon
+              class="usa-search__clear-icon"
+              icon="close"
+              size={3}
+            />
+          </button>
           <button
             class="usa-button"
             type="submit"


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
