### PR TITLE
va-file-input-multiple: allow for slots to be conditionally rendered on file inputs

### DIFF
--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.jsx
@@ -8,7 +8,6 @@ import testImage from './images/search-bar.png';
 VaFileInputMultiple.displayName = 'VaFileInputMultiple';
 
 const fileInputMultipleDocs = getWebComponentDocs('va-file-input-multiple');
-
 export default {
   title: 'Components/File input multiple USWDS',
   id: 'uswds/va-file-input-multiple',
@@ -33,6 +32,7 @@ const defaultArgs = {
   'children': null,
   'value': null,
   'read-only': false,
+  'slotFieldIndexes': null
 };
 
 const Template = ({
@@ -48,6 +48,7 @@ const Template = ({
   value,
   readOnly,
   children,
+  slotFieldIndexes,
 }) => {
   return (
     <VaFileInputMultiple
@@ -63,6 +64,7 @@ const Template = ({
       value={value}
       read-only={readOnly}
       children={children}
+      slot-field-indexes={slotFieldIndexes}
     />
   );
 };
@@ -106,6 +108,7 @@ const AdditionalFormInputsContentTemplate = ({
   'enable-analytics': enableAnalytics,
   vaMultipleChange,
   headerSize,
+  slotFieldIndexes,
   children,
 }) => {
   return (
@@ -119,6 +122,7 @@ const AdditionalFormInputsContentTemplate = ({
         hint={hint}
         enable-analytics={enableAnalytics}
         onVaMultipleChange={vaMultipleChange}
+        slot-field-indexes={slotFieldIndexes}
         header-size={headerSize}
       >
         {children}
@@ -161,6 +165,70 @@ AdditionalFormInputs.args = {
   ...defaultArgs,
   label: 'Additional Form Inputs',
   children: additionalFormInputsContent,
+};
+
+
+const AdditionalFormInputsOnSpecificFieldsContentTemplate = ({
+  label,
+  name,
+  accept,
+  errors,
+  required,
+  hint,
+  'enable-analytics': enableAnalytics,
+  vaMultipleChange,
+  headerSize,
+  slotFieldIndexes,
+  children,
+}) => {
+  return (
+    <>
+      <VaFileInputMultiple
+        label={label}
+        name={name}
+        accept={accept}
+        required={required}
+        errors={errors}
+        hint={hint}
+        enable-analytics={enableAnalytics}
+        onVaMultipleChange={vaMultipleChange}
+        slotFieldIndexes={slotFieldIndexes}
+        header-size={headerSize}
+      >
+        {children}
+      </VaFileInputMultiple>
+      <hr />
+      <div>
+        <p>This example showcases how to only render additional content for specific file input fields.</p>
+      </div>
+      <div className="vads-u-margin-top--2">
+          <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
+            <code>
+  {`const additionalFormInputsContent = (
+  <div>
+    <va-select label='What kind of file is this?' required>
+      <option key="1" value="1">Public Document</option>
+      <option key="2" value="2">Private Document</option>
+    </va-select>
+  </div>
+);
+
+<VaFileInputMultiple slot-field-indexes="[1,3]" ... >
+  {additionalFormInputsContent}
+</VaFileInputMultiple>`}
+            </code>
+          </pre>
+      </div>
+    </>
+  );
+};
+
+export const AdditionalFormInputsOnSpecificFields = AdditionalFormInputsOnSpecificFieldsContentTemplate.bind(null);
+AdditionalFormInputsOnSpecificFields.args = {
+  ...defaultArgs,
+  label: 'Additional Form Inputs On Specific Inputs',
+  children: additionalFormInputsContent,
+  slotFieldIndexes: '[1,3]'
 };
 
 const ErrorsTemplate = ({ label, name, hint }) => {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -682,6 +682,10 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
+          * Optional, shows the additional info slot content only for indexes of file inputs provided. Defaults to `null` (show on all fields). ex: [1,3]
+         */
+        "slotFieldIndexes"?: Number[];
+        /**
           * The value attribute for the file view element.
          */
         "value"?: File[];
@@ -3990,6 +3994,10 @@ declare namespace LocalJSX {
           * If true, the file input is marked as required, and users must select a file.
          */
         "required"?: boolean;
+        /**
+          * Optional, shows the additional info slot content only for indexes of file inputs provided. Defaults to `null` (show on all fields). ex: [1,3]
+         */
+        "slotFieldIndexes"?: Number[];
         /**
           * The value attribute for the file view element.
          */

--- a/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.e2e.ts
+++ b/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.e2e.ts
@@ -41,6 +41,73 @@ describe('va-file-input-multiple', () => {
     expect(secondFileInput.innerHTML).toContain(`<span>Drag an additional file here or <span class="file-input-choose-text">choose from folder</span></span>`);
   });
 
+  it('renders the file input additional info slot when slot-field-indexes is null', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<va-file-input-multiple><span class="additional_info">additional info</span></va-file-input-multiple>`);
+
+    const filePath = path.relative(process.cwd(), __dirname + '/1x1.png');
+
+    const input = await page.$('pierce/#fileInputField') as ElementHandle<HTMLInputElement>;
+    expect(input).not.toBeNull();
+
+    await input
+      .uploadFile(filePath)
+      .catch(e => console.log('uploadFile error', e));
+
+    await page.waitForChanges();
+    
+    const additionalInfo = await page.find('va-file-input-multiple >>> va-file-input span.additional_info');
+    expect(additionalInfo.textContent).toEqual('additional info');
+  });
+
+  it('renders the file input additional info slot only for indexes in slot-field-indexes', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<va-file-input-multiple slot-field-indexes="[1,2]"><span class="additional_info">additional info</span></va-file-input-multiple>`);
+
+    const filePath = path.relative(process.cwd(), __dirname + '/1x1.png');
+
+    const input = await page.$('pierce/#fileInputField') as ElementHandle<HTMLInputElement>;
+    expect(input).not.toBeNull();
+
+    await input
+      .uploadFile(filePath)
+      .catch(e => console.log('uploadFile error', e));
+
+    await page.waitForChanges();
+
+    const additionalInfo = await page.find('va-file-input-multiple >>> va-file-input span.additional_info');
+    expect(additionalInfo).toBeNull;
+
+    let inputs = await page.$$('pierce/#fileInputField');
+    const input2 = inputs[1] as ElementHandle<HTMLInputElement>;
+    expect(inputs).not.toBeNull();
+    expect(input2).not.toBeNull();
+    await input2
+      .uploadFile(filePath)
+      .catch(e => console.log('uploadFile error', e));
+
+    await page.waitForChanges();
+
+    let inputEls= await page.findAll('va-file-input-multiple >>> va-file-input');
+    const additionalInfo2 = await inputEls[1].find('span.additional_info');
+    expect(additionalInfo2.textContent).toEqual('additional info');
+
+
+    inputs = await page.$$('pierce/#fileInputField');
+    const input3 = inputs[2] as ElementHandle<HTMLInputElement>;
+    expect(inputs).not.toBeNull();
+    expect(input3).not.toBeNull();
+    await input3
+      .uploadFile(filePath)
+      .catch(e => console.log('uploadFile error', e));
+
+    await page.waitForChanges();
+
+    inputEls= await page.findAll('va-file-input-multiple >>> va-file-input');
+    const additionalInfo3 = await inputEls[2].find('span.additional_info');
+    expect(additionalInfo3.textContent).toEqual('additional info');
+  });
+
   it('renders hint text', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-file-input-multiple hint="This is hint text" />');

--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -308,7 +308,7 @@ export class VaFileInputMultiple {
     this.setSlotContent();
     theFileInputs.forEach((fileEntry, index) => {
       if (this.files[index].content &&
-          (!this.slotFieldIndexes || this.slotFieldIndexes.indexOf(index) !== -1)
+          (!this.slotFieldIndexes || this.slotFieldIndexes.includes(index))
       ) {
         this.files[index].content.forEach(node => fileEntry.append(node));
       }

--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -80,6 +80,11 @@ export class VaFileInputMultiple {
   @Prop() readOnly?: boolean = false;
 
   /**
+   * Optional, shows the additional info slot content only for indexes of file inputs provided. Defaults to `null` (show on all fields). ex: [1,3]
+   */
+  @Prop() slotFieldIndexes?: Number[] = null; 
+
+  /**
    * Event emitted when any change to the file inputs occurs.
    * Sends back an array of FileDetails
    */
@@ -302,7 +307,9 @@ export class VaFileInputMultiple {
     const theFileInputs = this.el.shadowRoot.querySelectorAll(`va-file-input`);
     this.setSlotContent();
     theFileInputs.forEach((fileEntry, index) => {
-      if (this.files[index].content) {
+      if (this.files[index].content &&
+          (!this.slotFieldIndexes || this.slotFieldIndexes.indexOf(index) !== -1)
+      ) {
         this.files[index].content.forEach(node => fileEntry.append(node));
       }
     });


### PR DESCRIPTION
## Chromatic
<!-- This `3551-file-input-mult-cond-slot` is a placeholder for a CI job - it will be updated automatically -->
https://3551-file-input-mult-cond-slot--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Adds a property to allow for showing slot content only on specific file input fields.

Use case: An uploaded file requires a password to open the file. The UI should show an input field for that specific file to provide the password.

This solution adds a `slot-field-indexes` property that accepts a number array containing the indexes of the file input fields where slot content should be rendered.

Closes [3551](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3551)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2025-01-15 at 1 58 07 PM](https://github.com/user-attachments/assets/97bf6f25-0e9b-4bc5-8eaa-52b2beeece94)

![Screenshot 2025-01-15 at 1 57 13 PM](https://github.com/user-attachments/assets/dc8730ba-cd23-4b93-99c9-15988ee4bb10)


## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
