### PR TITLE
va-file-input: display previously uploaded file

### DIFF
--- a/packages/storybook/stories/va-file-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.jsx
@@ -43,6 +43,7 @@ const defaultArgs = {
   'children': null,
   'value': null,
   'read-only': false,
+  'uploadedFile': null
 };
 
 const Template = ({
@@ -58,6 +59,7 @@ const Template = ({
   readOnly,
   value,
   children,
+  uploadedFile,
 }) => {
   return (
     <VaFileInput
@@ -73,6 +75,7 @@ const Template = ({
       readOnly={readOnly}
       value={value}
       children={children}
+      uploadedFile={uploadedFile}
     />
   );
 };
@@ -243,6 +246,16 @@ WithAnalytics.args = {
   'enable-analytics': true,
 };
 
+export const UploadedFile = Template.bind(null);
+UploadedFile.args = { 
+  ...defaultArgs, 
+  uploadedFile: {
+    name: 'test.jpg',
+    size: 7000,
+    type: 'JPG'
+  } 
+};
+
 const FileUploadedTemplate = args => {
   const [mockFile, setMockFile] = useState(null);
 
@@ -268,9 +281,6 @@ const FileUploadedTemplate = args => {
 
   return <Template {...args} value={mockFile} />;
 };
-
-export const FileUploaded = FileUploadedTemplate.bind(null);
-FileUploaded.args = { ...defaultArgs, vaChange: event => event };
 
 export const ReadOnly = FileUploadedTemplate.bind(null);
 ReadOnly.args = { ...defaultArgs, vaChange: event => event, readOnly: true };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -6,7 +6,9 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Breadcrumb } from "./components/va-breadcrumbs/va-breadcrumbs";
+import { UploadedFile } from "./components/va-file-input/uploadedFile";
 export { Breadcrumb } from "./components/va-breadcrumbs/va-breadcrumbs";
+export { UploadedFile } from "./components/va-file-input/uploadedFile";
 export namespace Components {
     /**
      * @componentName Accordion
@@ -631,6 +633,10 @@ export namespace Components {
           * Custom instructional message in the file input.
          */
         "uploadMessage"?: HTMLElement;
+        /**
+          * Object representing a previously uploaded file. Example: `{ name: string, type: string, size: number}`
+         */
+        "uploadedFile"?: UploadedFile;
         /**
           * The value attribute for the file view element.
          */
@@ -3940,6 +3946,10 @@ declare namespace LocalJSX {
           * Custom instructional message in the file input.
          */
         "uploadMessage"?: HTMLElement;
+        /**
+          * Object representing a previously uploaded file. Example: `{ name: string, type: string, size: number}`
+         */
+        "uploadedFile"?: UploadedFile;
         /**
           * The value attribute for the file view element.
          */

--- a/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
+++ b/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
@@ -159,6 +159,27 @@ describe('va-file-input', () => {
     await axeCheck(page);
   });
 
+  it('Renders file summary when uploadedFile prop is set', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<va-file-input buttonText="Upload a file"/>`);
+
+    await page.$eval('va-file-input', (elm: any) => {
+      // within the browser's context
+      // let's set new property values on the component
+      elm.uploadedFile = {name: 'test.jpg', size: 7000, type: 'jpg'};
+    });
+    await page.waitForChanges();
+
+    const fileInput = await page.find('va-file-input');
+    expect(fileInput).not.toBeNull();
+    const input = await fileInput.shadowRoot.querySelector('input[type=file]');
+    expect(input.getAttribute('style')).toEqual('visibility: hidden;');
+    const summaryCard = await page.find('va-file-input >>> va-card');
+    expect(summaryCard).not.toBeNull();
+    expect(await summaryCard.find('.file-label')).toEqualText('test.jpg');
+    expect(await summaryCard.find('.file-size-label')).toEqualHtml('<span class="file-size-label">7&nbsp;KB</span>');
+  })
+
   // this test usually passes but it is too flaky to enable
   it.skip('opens a modal when delete button clicked and lets user remove or keep file', async () => {
     const page = await newE2EPage();

--- a/packages/web-components/src/components/va-file-input/uploadedFile.ts
+++ b/packages/web-components/src/components/va-file-input/uploadedFile.ts
@@ -1,0 +1,5 @@
+export interface UploadedFile {
+    name: string,
+    type: string,
+    size: number
+}

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -13,6 +13,7 @@ import {
 import { i18next } from '../..';
 import { fileInput } from './va-file-input-upgrader';
 import { extensionToMimeType } from './fileExtensionToMimeType';
+import { UploadedFile } from './uploadedFile';
 
 /**
  * @componentName File input
@@ -37,6 +38,8 @@ export class VaFileInput {
   @State() internalError?: string;
   @State() showModal: boolean = false;
   @State() showSeparator: boolean = true;
+
+  
 
   /**
    * The label for the file input.
@@ -112,6 +115,11 @@ export class VaFileInput {
   @Prop() readOnly?: boolean = false;
 
   /**
+   * Object representing a previously uploaded file. Example: `{ name: string, type: string, size: number}`
+   */
+  @Prop() uploadedFile?: UploadedFile;
+
+  /**
    * The event emitted when the file input value changes.
    */
   @Event() vaChange: EventEmitter;
@@ -154,7 +162,7 @@ export class VaFileInput {
         return;
       }
     }
-
+    this.uploadedFile = null;
     this.file = file;
     if (emitChange) {
       this.vaChange.emit({ files: [this.file] });
@@ -184,6 +192,7 @@ export class VaFileInput {
       this.vaChange.emit({ files: [] });
     }
     this.file = null;
+    this.uploadedFile = null;
     this.updateStatusMessage(`File removed. No file selected.`);
     this.el.focus();
   };
@@ -355,6 +364,7 @@ export class VaFileInput {
       headless,
       value,
       readOnly,
+      uploadedFile
     } = this;
 
     if (value) {
@@ -433,7 +443,7 @@ export class VaFileInput {
             id="fileInputField"
             class="file-input"
             style={{
-              visibility: this.uploadStatus === 'success' ? 'hidden' : 'unset',
+              visibility: (this.uploadStatus === 'success' || uploadedFile) ? 'hidden' : 'unset',
             }}
             type="file"
             ref={el => (this.fileInputRef = el as HTMLInputElement)}
@@ -442,7 +452,7 @@ export class VaFileInput {
             aria-describedby={ariaDescribedbyIds}
             onChange={this.handleChange}
           />
-          {uploadStatus === 'idle' && (
+          {(uploadStatus === 'idle' && !uploadedFile) && (
             <div>
               <span id="file-input-error-alert" role="alert">
                 {displayError && (
@@ -463,7 +473,7 @@ export class VaFileInput {
               </div>
             </div>
           )}
-          {uploadStatus !== 'idle' && (
+          {(uploadStatus !== 'idle' || uploadedFile) && (
             <div class={selectedFileClassName}>
               {!headless && (
                 <div class="selected-files-label">
@@ -479,7 +489,7 @@ export class VaFileInput {
                 <div class="file-info-section">
                   {fileThumbnail}
                   <div class="file-info-group vads-u-line-height--2">
-                    <span class="file-label">{file.name}</span>
+                    <span class="file-label">{file ? file.name : uploadedFile.name}</span>
                     {displayError && (
                       <span id="input-error-message" role="alert">
                         <span class="usa-sr-only">{i18next.t('error')}</span>
@@ -487,11 +497,11 @@ export class VaFileInput {
                       </span>
                     )}
                     <span class="file-size-label">
-                      {this.formatFileSize(file.size)}
+                      {this.formatFileSize(file ? file.size : uploadedFile.size)}
                     </span>
                   </div>
                 </div>
-                {(file || value) && (
+                {(file || value || uploadedFile) && (
                   <div>
                     {this.showSeparator && <hr class="separator" />}
 
@@ -506,12 +516,12 @@ export class VaFileInput {
                             buttonType="change-file"
                             onClick={this.changeFile}
                             label="Change file"
-                            aria-label={'change file ' + file.name}
+                            aria-label={`change file ${file ? file.name : uploadedFile.name}`}
                           ></va-button-icon>
                           <va-button-icon
                             buttonType="delete"
                             onClick={this.openModal}
-                            aria-label={'delete file ' + file.name}
+                            aria-label={`delete file ${file ? file.name : uploadedFile.name}`}
                             label="Delete"
                           ></va-button-icon>
                         </div>
@@ -525,7 +535,7 @@ export class VaFileInput {
                           onSecondaryButtonClick={this.closeModal}
                         >
                           We'll remove the uploaded document{' '}
-                          <span class="file-label">{file.name}</span>
+                          <span class="file-label">{file ? file.name : uploadedFile.name}</span>
                         </va-modal>
                       </Fragment>
                     )}


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Adds a prop that accepts an object with the name, type and size of a previously uploaded file. The UI will display and apply all functionality to this file as if the user had uploaded it (edit/delete)

Closes [3634](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3634)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2025-01-23 at 9 33 10 AM](https://github.com/user-attachments/assets/cddd03d5-0e5d-4c49-aae6-923a058c51c0)


## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
