### PR TITLE
va-alert-sign-in: update story time-limit to 60 days

### DIFF
--- a/packages/storybook/stories/va-alert-sign-in.stories.jsx
+++ b/packages/storybook/stories/va-alert-sign-in.stories.jsx
@@ -222,7 +222,7 @@ OptionalSignInVerified.args = {
   ...defaultArgs,
   'variant': ASIVariants.signInOptional,
   'no-sign-in-link': 'https://example.com/',
-  'time-limit': '20 minutes',
+  'time-limit': '60 days',
 };
 
 export const VerifyWithIdMe = Template.bind(null);


### PR DESCRIPTION
## Chromatic
<!-- This `alert-sign-in-story-time` is a placeholder for a CI job - it will be updated automatically -->
https://alert-sign-in-story-time--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description
The time-limit should be either 60 days or 1 year.

Slack convo: https://dsva.slack.com/archives/C07M02V2YBG/p1737753686183039

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![Screenshot 2025-01-24 at 3 38 33 PM](https://github.com/user-attachments/assets/c89b2f32-050c-4418-a261-d94bacec04d2)



## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
