### PR TITLE
va-select: Adding 'vaSelectBlur' event

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -2988,6 +2988,7 @@ declare global {
     interface HTMLVaSelectElementEventMap {
         "vaKeyDown": any;
         "vaSelect": any;
+        "vaSelectBlur": any;
         "component-library-analytics": any;
     }
     /**
@@ -4955,6 +4956,10 @@ declare namespace LocalJSX {
           * The event emitted when the selected value changes
          */
         "onVaSelect"?: (event: VaSelectCustomEvent<any>) => void;
+        /**
+          * The event emitted when the select element is blurred
+         */
+        "onVaSelectBlur"?: (event: VaSelectCustomEvent<any>) => void;
         /**
           * Whether or not to add usa-input--error as class if error message is outside of component
          */

--- a/packages/web-components/src/components/va-select/test/va-select.e2e.ts
+++ b/packages/web-components/src/components/va-select/test/va-select.e2e.ts
@@ -140,4 +140,21 @@ describe('va-select', () => {
     const selectValue = await select.getProperty('value');
     expect(selectValue).toBe('bar');
   });
+
+  it('emits the vaSelectBlur event', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-select label="A label" value="bar">
+        <option value="">Please choose an option</option>
+        <option value="foo">Foo</option>
+        <option value="bar">Bar</option>
+      </va-select>
+    `);
+    const blurSpy = await page.spyOnEvent('vaSelectBlur');
+    const selectEl = await page.find('va-select >>> select');
+    await selectEl.focus();
+    await selectEl.press('Tab');
+
+    expect(blurSpy).toHaveReceivedEvent();
+  });
 });

--- a/packages/web-components/src/components/va-select/va-select.tsx
+++ b/packages/web-components/src/components/va-select/va-select.tsx
@@ -95,6 +95,11 @@ export class VaSelect {
   @Event() vaSelect: EventEmitter;
 
   /**
+   * The event emitted when the select element is blurred
+   */
+  @Event() vaSelectBlur: EventEmitter;
+
+  /**
    * Displays the select at a specific width. Accepts 2xs (4ex), xs (7ex), sm or small (10ex), md or medium (20ex), lg (30ex), xl (40ex), and 2xl (50ex).
    */
   @Prop() width?: string;
@@ -130,6 +135,13 @@ export class VaSelect {
 
   private handleKeyDown() {
     this.vaKeyDown.emit();
+  }
+
+  private handleBlur(e: Event) {
+    const target: HTMLSelectElement = e.target as HTMLSelectElement;
+    this.value = target.value;
+
+    this.vaSelectBlur.emit({ value: this.value });
   }
 
   private handleChange(e: Event) {
@@ -265,6 +277,7 @@ export class VaSelect {
           required={required || null}
           onKeyDown={() => this.handleKeyDown()}
           onChange={e => this.handleChange(e)}
+          onBlur={e => this.handleBlur(e)}
           part="select"
         >
           <option key="0" value="" selected>


### PR DESCRIPTION
## Chromatic
<!-- This `98157-add-onblur-to-va-select` is a placeholder for a CI job - it will be updated automatically -->
https://98157-add-onblur-to-va-select--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#98157](https://github.com/department-of-veterans-affairs/va.gov-team/issues/98157)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
N/A - No visual changes

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
