### PR TITLE
va-alert: Fixing it so close button on slim alerts doesn't overflow

### DIFF
--- a/packages/web-components/src/components/va-alert/va-alert.scss
+++ b/packages/web-components/src/components/va-alert/va-alert.scss
@@ -17,10 +17,6 @@
   font-family: var(--font-serif);
 }
 
-.va-alert-close:hover {
-  color: var(--vads-color-base);
-}
-
 .va-alert-close {
   margin: 1rem;
   padding: 0;
@@ -35,6 +31,15 @@
   position: absolute;
   right: 0;
   top: 0;
+}
+
+.va-alert-close:hover {
+  color: var(--vads-color-base);
+}
+
+// shrink the close button's margins when 'slim' so it doesn't overflow
+.usa-alert--slim .va-alert-close {
+  margin: 0.2em;
 }
 
 :host([closeable]:not([closeable='false'])) .usa-alert .usa-alert__body {


### PR DESCRIPTION
## Chromatic
<!-- This `3704-fix-slim-alert-close-btn` is a placeholder for a CI job - it will be updated automatically -->
https://3704-fix-slim-alert-close-btn--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#3704](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3704)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
Slim alert on 1 line:
![Screenshot 2025-01-27 at 2 26 26 PM](https://github.com/user-attachments/assets/4b358582-7ad4-469c-bc55-444639785196)

Slim alert on 2 lines:
![Screenshot 2025-01-27 at 2 26 35 PM](https://github.com/user-attachments/assets/65e9c2ee-59a1-44d0-bbae-5b4bdcfc8907)

## Acceptance criteria
- [ ] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
