### PR TITLE
va-telephone | Remove aria-hidden from notClickable phone

### DIFF
--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -92,7 +92,7 @@ describe('va-telephone', () => {
     expect(element).toEqualHtml(`
       <va-telephone class="hydrated" contact="8779551234" not-clickable>
         <mock:shadow-root>
-          <span aria-hidden="true">
+          <span>
             877-955-1234
           </span>
         </mock:shadow-root>
@@ -110,7 +110,7 @@ describe('va-telephone', () => {
     expect(element).toEqualHtml(`
       <va-telephone class="hydrated" contact="8779551234" extension="123" not-clickable>
         <mock:shadow-root>
-          <span aria-hidden="true">
+          <span>
             877-955-1234, ext. 123
           </span>
         </mock:shadow-root>
@@ -169,7 +169,9 @@ describe('va-telephone', () => {
 
   it('handles a vanity number as a contact prop', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-telephone contact="8772228387" vanity="VETS"></va-telephone>');
+    await page.setContent(
+      '<va-telephone contact="8772228387" vanity="VETS"></va-telephone>',
+    );
 
     const link = await page.find('va-telephone >>> a');
     expect(link.getAttribute('href')).toEqual('tel:+18772228387');
@@ -199,7 +201,9 @@ describe('va-telephone', () => {
 
   it('when messageAriaDescribedby exists, the message is added to the dom', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-telephone contact="8772228387" message-aria-describedby="main number"></va-telephone>');
+    await page.setContent(
+      '<va-telephone contact="8772228387" message-aria-describedby="main number"></va-telephone>',
+    );
 
     const messageSpan = await page.find('va-telephone >>> #number-description');
     expect(messageSpan).not.toBeNull();
@@ -208,7 +212,9 @@ describe('va-telephone', () => {
 
   it('passes an axe check when messageAriaDescribedby is set', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-telephone contact="8772228387" messageAriaDescribedby="main number"></va-telephone>');
+    await page.setContent(
+      '<va-telephone contact="8772228387" messageAriaDescribedby="main number"></va-telephone>',
+    );
 
     await axeCheck(page);
   });

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -223,9 +223,7 @@ export class VaTelephone {
       <Host>
         {notClickable ? (
           <Fragment>
-            <span aria-hidden="true" aria-describedby={ariaDescribedbyIds}>
-              {formattedNumber}
-            </span>
+            <span aria-describedby={ariaDescribedbyIds}>{formattedNumber}</span>
           </Fragment>
         ) : (
           <a


### PR DESCRIPTION
## Chromatic
<!-- This `3747-telephone-hidden` is a placeholder for a CI job - it will be updated automatically -->
https://3747-telephone-hidden--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
When `va-telephone` is set to `notClickable`, the span wrapping the phone number includes an `aria-hidden="true"` which makes screen readers ignore the phone number. 

See https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3747

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

N/A - video of problem in original ticket

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
