### PR TITLE
va-table: Adding optional "full-width" prop for shorter-form content

### DIFF
--- a/packages/storybook/stories/va-table-uswds.stories.jsx
+++ b/packages/storybook/stories/va-table-uswds.stories.jsx
@@ -48,6 +48,7 @@ const Template = args => {
     columns,
     scrollable,
     striped,
+    'full-width': fullWidth,
   } = args;
 
   return (
@@ -58,6 +59,7 @@ const Template = args => {
       table-type={tableType}
       sortable={!!sortable}
       striped={striped}
+      full-width={fullWidth}
     >
       <va-table-row>
         {columns.map((col, i) => (
@@ -434,6 +436,28 @@ ScrollableWithStripes.args = {
   'striped': true,
   'table-type': 'bordered',
   'scrollable': true,
+};
+
+const FullWidthColumns = [
+  'Letter of the Alphabet',
+  'Number Position',
+  'ROT13 (Rotate by 13 places)',
+];
+const FullWidthRows = [
+  ['A', '1', 'N'],
+  ['E', '5', 'R'],
+  ['I', '9', 'V'],
+  ['O', '15', 'B'],
+  ['U', '21', 'H'],
+];
+
+export const FullWidth = Template.bind(null);
+FullWidth.args = {
+  'table-title':
+    'This is a table with minimal content that has been set to be "full width".',
+  'rows': FullWidthRows,
+  'columns': FullWidthColumns,
+  'full-width': true,
 };
 
 Default.argTypes = propStructure(vaTableDocs);

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1592,6 +1592,10 @@ export namespace Components {
     }
     interface VaTable {
         /**
+          * When active, forces the table to expand to the full-width of its container
+         */
+        "fullWidth"?: boolean;
+        /**
           * When active, the table can be horizontally scrolled and is focusable
          */
         "scrollable"?: boolean;
@@ -1626,6 +1630,10 @@ export namespace Components {
           * The number of columns in the table
          */
         "cols"?: number;
+        /**
+          * When active, the table will expand to the full width of its container
+         */
+        "fullWidth": boolean;
         "rows"?: number;
         /**
           * When active, the table can be horizontally scrolled and is focusable
@@ -5059,6 +5067,10 @@ declare namespace LocalJSX {
     }
     interface VaTable {
         /**
+          * When active, forces the table to expand to the full-width of its container
+         */
+        "fullWidth"?: boolean;
+        /**
           * When active, the table can be horizontally scrolled and is focusable
          */
         "scrollable"?: boolean;
@@ -5093,6 +5105,10 @@ declare namespace LocalJSX {
           * The number of columns in the table
          */
         "cols"?: number;
+        /**
+          * When active, the table will expand to the full width of its container
+         */
+        "fullWidth"?: boolean;
         /**
           * Fires when the component is closed by clicking on the close icon. This fires only when closeable is true.
          */

--- a/packages/web-components/src/components/va-table/va-table-inner/test/va-table-inner.e2e.ts
+++ b/packages/web-components/src/components/va-table/va-table-inner/test/va-table-inner.e2e.ts
@@ -116,6 +116,20 @@ describe('va-table', () => {
     const table = await page.find('va-table-inner >>> .usa-table');
     expect(table).toHaveClass('usa-table--striped');
   });
+
+  it('is not full-width by default', async () => {
+    const page = await newE2EPage();
+    await page.setContent(makeTable());
+    const divEl = await page.find('va-table-inner >>> div');
+    expect(divEl).not.toHaveClass('va-table--full-width');
+  });
+
+  it('has the full-width class when full-width is true', async () => {
+    const page = await newE2EPage();
+    await page.setContent(makeTable({ 'full-width': true }));
+    const divEl = await page.find('va-table-inner >>> div');
+    expect(divEl).toHaveClass('va-table--full-width');
+  });
 });
 
 describe('sorted va-table ', () => {

--- a/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.scss
+++ b/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.scss
@@ -19,6 +19,15 @@
   padding: 0;
   width: 100%;
 }
+
+:host .va-table--full-width {
+  display: flex;
+
+  table {
+    flex: auto;
+  }
+}
+
 :host thead tr th {
   button {
     background-color: transparent;

--- a/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
+++ b/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
@@ -71,6 +71,11 @@ export class VaTableInner {
   @Prop() striped: boolean = false;
 
   /**
+   * When active, the table will expand to the full width of its container
+   */
+  @Prop() fullWidth: boolean = false;
+
+  /**
    * If sortable is true, the direction of next sort for the column that was just sorted
    */
   @State() sortdir?: string = null;
@@ -145,10 +150,11 @@ export class VaTableInner {
    * @param innerHTML string of html
    * @returns parsed string escaped of html entities
    */
-  parseHTMLToString (innerHTML:string) {
+  parseHTMLToString(innerHTML: string) {
     let parser = new DOMParser();
 
-    return parser.parseFromString(innerHTML, 'text/html').documentElement.textContent;
+    return parser.parseFromString(innerHTML, 'text/html').documentElement
+      .textContent;
   }
 
   /**
@@ -163,9 +169,9 @@ export class VaTableInner {
         {Array.from({ length: this.cols }).map((_, i) => {
           const slotName = `va-table-slot-${row * this.cols + i}`;
           const slot = <slot name={slotName}></slot>;
-          const header = this.parseHTMLToString(this.el.querySelector(
-            `[slot="va-table-slot-${i}"]`,
-          ).innerHTML);
+          const header = this.parseHTMLToString(
+            this.el.querySelector(`[slot="va-table-slot-${i}"]`).innerHTML,
+          );
           const dataSortActive = row > 0 && this.sortindex === i ? true : false;
           return i === 0 || row === 0 ? (
             <th
@@ -324,27 +330,29 @@ export class VaTableInner {
           this.updateSpan(th, thSorted, nextSortDirection, content);
 
           // update sr text to reflect sort
-          setTimeout(()=>{
+          setTimeout(() => {
             this.updateSRtext(thSorted, content, currentSortDirection);
-          }, 500)
+          }, 500);
         });
     }
   }
 
   render() {
-    const { tableTitle, tableType, stacked, scrollable, striped } = this;
-    const classes = classnames({
+    const { tableTitle, tableType, stacked, scrollable, striped, fullWidth } =
+      this;
+    const containerClasses = classnames({
+      'usa-table-container--scrollable': scrollable,
+      'va-table--full-width': fullWidth,
+    });
+    const tableClasses = classnames({
       'usa-table': true,
       'usa-table--stacked': stacked,
       'usa-table--borderless': tableType === 'borderless',
       'usa-table--striped': striped,
     });
     return (
-      <div
-        tabIndex={scrollable ? 0 : null}
-        class={scrollable ? 'usa-table-container--scrollable' : undefined}
-      >
-        <table class={classes}>
+      <div tabIndex={scrollable ? 0 : null} class={containerClasses}>
+        <table class={tableClasses}>
           {tableTitle && <caption>{tableTitle}</caption>}
           <thead>{this.makeRow(0)}</thead>
           <tbody id="va-table-body">{this.getBodyRows()}</tbody>

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -54,6 +54,11 @@ export class VaTable {
    */
   @Prop() striped: boolean = false;
 
+  /**
+   * When active, forces the table to expand to the full-width of its container
+   */
+  @Prop() fullWidth?: boolean = false;
+
   // The number of va-table-rows
   @State() rows: number;
 
@@ -151,6 +156,10 @@ export class VaTable {
 
     if (this.tableType) {
       vaTable.setAttribute('table-type', this.tableType);
+    }
+
+    if (this.fullWidth) {
+      vaTable.setAttribute('full-width', String(this.fullWidth));
     }
 
     //make a fragment containing all the cells, one for each slot


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#3563](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3563)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2025-01-30 at 10 31 39 AM](https://github.com/user-attachments/assets/f1314073-6d20-4c3d-b5b2-a26e981d0451)

## Acceptance criteria
- [ ] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
