### PR TITLE
va-file-input: Fix for required label when inside a header

### DIFF
--- a/packages/web-components/src/components/va-file-input/va-file-input.scss
+++ b/packages/web-components/src/components/va-file-input/va-file-input.scss
@@ -210,3 +210,11 @@
   color: var(--vads-color-secondary-dark);
   margin-left: 0.25rem;
 }
+
+h1, h2, h3, h4, h5, h6 {
+  .required {
+    font-family: initial;
+    font-size: initial;
+    font-weight: initial;
+  }
+}


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#3093](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3093)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2025-01-30 at 12 59 23 PM](https://github.com/user-attachments/assets/7fbb2e1b-efc2-46f6-ba84-022fa86843b9)


## Acceptance criteria
- [ ] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
