### PR TITLE
Initial build of service-list web component

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1541,6 +1541,19 @@ export namespace Components {
         "width"?: string;
     }
     /**
+     * @componentName Service List
+     * @maturityCategory use with caution
+     * @maturityLevel candidate
+     */
+    interface VaServiceList {
+        "action": any;
+        "icon": string;
+        "optionalLink": string;
+        "serviceDetails": any;
+        "serviceName": string;
+        "serviceStatus": string;
+    }
+    /**
      * @componentName Statement of truth
      * @maturityCategory caution
      * @maturityLevel candidate
@@ -3020,6 +3033,17 @@ declare global {
         prototype: HTMLVaSelectElement;
         new (): HTMLVaSelectElement;
     };
+    /**
+     * @componentName Service List
+     * @maturityCategory use with caution
+     * @maturityLevel candidate
+     */
+    interface HTMLVaServiceListElement extends Components.VaServiceList, HTMLStencilElement {
+    }
+    var HTMLVaServiceListElement: {
+        prototype: HTMLVaServiceListElement;
+        new (): HTMLVaServiceListElement;
+    };
     interface HTMLVaStatementOfTruthElementEventMap {
         "vaInputChange": any;
         "vaInputBlur": any;
@@ -3213,6 +3237,7 @@ declare global {
         "va-search-input": HTMLVaSearchInputElement;
         "va-segmented-progress-bar": HTMLVaSegmentedProgressBarElement;
         "va-select": HTMLVaSelectElement;
+        "va-service-list": HTMLVaServiceListElement;
         "va-statement-of-truth": HTMLVaStatementOfTruthElement;
         "va-summary-box": HTMLVaSummaryBoxElement;
         "va-table": HTMLVaTableElement;
@@ -4992,6 +5017,19 @@ declare namespace LocalJSX {
         "width"?: string;
     }
     /**
+     * @componentName Service List
+     * @maturityCategory use with caution
+     * @maturityLevel candidate
+     */
+    interface VaServiceList {
+        "action"?: any;
+        "icon"?: string;
+        "optionalLink"?: string;
+        "serviceDetails"?: any;
+        "serviceName"?: string;
+        "serviceStatus"?: string;
+    }
+    /**
      * @componentName Statement of truth
      * @maturityCategory caution
      * @maturityLevel candidate
@@ -5434,6 +5472,7 @@ declare namespace LocalJSX {
         "va-search-input": VaSearchInput;
         "va-segmented-progress-bar": VaSegmentedProgressBar;
         "va-select": VaSelect;
+        "va-service-list": VaServiceList;
         "va-statement-of-truth": VaStatementOfTruth;
         "va-summary-box": VaSummaryBox;
         "va-table": VaTable;
@@ -5758,6 +5797,12 @@ declare module "@stencil/core" {
              * @translations Spanish
              */
             "va-select": LocalJSX.VaSelect & JSXBase.HTMLAttributes<HTMLVaSelectElement>;
+            /**
+             * @componentName Service List
+             * @maturityCategory use with caution
+             * @maturityLevel candidate
+             */
+            "va-service-list": LocalJSX.VaServiceList & JSXBase.HTMLAttributes<HTMLVaServiceListElement>;
             /**
              * @componentName Statement of truth
              * @maturityCategory caution

--- a/packages/web-components/src/components/va-service-list/test/va-service-list.e2e.ts
+++ b/packages/web-components/src/components/va-service-list/test/va-service-list.e2e.ts
@@ -1,0 +1,118 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('va-service-list', () => {
+  /**
+   * Helper function to set up the component with dynamic props
+   */
+  async function setupComponent({
+    serviceDetails = `{
+      "Approved on": "May 11, 2011",
+      "Program": "Post-9/11 GI Bill",
+      "Eligibility": "70%"
+    }`,
+    action = `{
+      "href": "https://www.va.gov/education",
+      "text": "Verify income"
+    }`,
+    icon = "school",
+    serviceName = "Education",
+    serviceStatus = "Eligible",
+    optionalLink = "https://va.gov",
+  } = {}) {
+    const page = await newE2EPage();
+    await page.setContent(`<va-service-list></va-service-list>`);
+
+    const elementHandle = await page.$('va-service-list');
+
+    await page.evaluate(
+      (el, props) => {
+        el.serviceDetails = props.serviceDetails;
+        el.action = props.action;
+        el.icon = props.icon;
+        el.serviceName = props.serviceName;
+        el.serviceStatus = props.serviceStatus;
+        el.optionalLink = props.optionalLink;
+      },
+      elementHandle,
+      { serviceDetails, action, icon, serviceName, serviceStatus, optionalLink }
+    );
+
+    await page.waitForChanges();
+    await page.evaluate(() => new Promise((resolve) => setTimeout(resolve, 5000)));
+
+    return { page, elementHandle };
+  }
+
+  it('renders correctly with action bar when serviceStatus is Eligible', async () => {
+    const { page, elementHandle } = await setupComponent({ serviceStatus: "Eligible" });
+
+    const shadowRootExists = await page.evaluate((el) => !!el.shadowRoot, elementHandle);
+    expect(shadowRootExists).toBe(true);
+
+    const shadowInnerHTML = await page.evaluate((el) => el.shadowRoot.innerHTML, elementHandle);
+    expect(shadowInnerHTML.replace(/\s+/g, ' ')).toEqualHtml(`
+      <div class="service-list">
+        <a href="/">
+          <div class="header">
+            <slot name="icon">
+              <va-icon class="icon hydrated"></va-icon>
+            </slot>
+            <slot name="service-name">
+              <h3 class="service-name">Education</h3>
+            </slot>
+            <va-icon class="chevron-icon hydrated"></va-icon>
+          </div>
+        </a>
+        <div class="action-bar">
+          <va-link-action class="hydrated"></va-link-action>
+        </div>
+        <div class="status">
+          <span class="usa-label">Eligible</span>
+        </div>
+        <ul class="service-list-items">
+          <li>
+            <div>
+              <strong>APPROVED ON:</strong> May 11, 2011
+            </div>
+          </li>
+          <li>
+            <div>
+              <strong>PROGRAM:</strong> Post-9/11 GI Bill
+            </div>
+          </li>
+          <li>
+            <div>
+              <strong>ELIGIBILITY:</strong> 70%
+            </div>
+          </li>
+        </ul>
+        <slot name="optional-link">
+          <va-link class="hydrated"></va-link>
+        </slot>
+      </div>
+    `);
+  });
+
+  it('does NOT render action bar when serviceStatus is NOT Eligible"', async () => {
+    const { page, elementHandle } = await setupComponent({ serviceStatus: "Ineligible" });
+
+    const shadowInnerHTML = await page.evaluate((el) => el.shadowRoot.innerHTML, elementHandle);
+
+    expect(shadowInnerHTML).not.toContain('<div class="action-bar">');
+  });
+
+});
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/packages/web-components/src/components/va-service-list/va-service-list.scss
+++ b/packages/web-components/src/components/va-service-list/va-service-list.scss
@@ -1,0 +1,57 @@
+@use '../../../css-library/src/stylesheets/formation-overrides/elements/labels' as *;
+@import '../../mixins/uswds-error-border.scss';
+@import '../../mixins/focusable.css';
+@import '../../mixins/headers.css';
+
+:host {
+  display: block;
+}
+.service-list{
+padding: 1rem 2rem 2rem 1rem;
+border: 1px solid #757575;
+
+a {
+  text-decoration: none;
+  color: unset;
+}
+.header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .icon {
+    // color: unset;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    height: 40px !important;
+    width: 40px !important;
+    min-width: 40px !important;
+    max-width: 40px !important;
+    color: #ffffff !important;
+    background-color: #162e51 !important;
+  }
+
+  .service-name {
+    margin-left: 1rem;
+    color: #005ea2;
+  }
+  .chevron-icon {
+    margin-left: auto;
+    font-size: 24px;
+  }
+}
+.status {
+  margin-top: 1rem;
+}
+.action-bar {
+  padding: 0.5rem 1rem;
+  margin-top: 1rem;
+  background-color: $vads-color-error-lighter;
+}
+ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+}

--- a/packages/web-components/src/components/va-service-list/va-service-list.tsx
+++ b/packages/web-components/src/components/va-service-list/va-service-list.tsx
@@ -1,0 +1,101 @@
+/* eslint-disable i18next/no-literal-string */
+import { Component, Host, h, Prop, Watch, State } from '@stencil/core';
+
+/**
+ * @componentName Service List
+ * @maturityCategory use with caution
+ * @maturityLevel candidate
+ */
+@Component({
+  tag: 'va-service-list',
+  styleUrl: 'va-service-list.scss',
+  shadow: true,
+})
+export class VaServiceList {
+  @Prop() serviceDetails: any;  
+  @Prop() serviceName: string;
+  @Prop() serviceStatus: string;
+  @Prop() icon: string;
+  @Prop() action: any;
+  @Prop() optionalLink: string;
+
+  @State() parsedServiceDetails: any = {};
+  @State() parsedAction: any = {};
+
+  @Watch('serviceDetails')
+  handleServiceDetailsChange(newValue: any) {
+    if (!newValue) return;
+    try {
+      this.parsedServiceDetails = typeof newValue === 'string' ? JSON.parse(newValue) : newValue;
+    } catch (error) {
+      console.error('Error parsing serviceDetails:', error);
+      this.parsedServiceDetails = {};
+    }
+  }
+
+  @Watch('action')
+  handleActionChange(newValue: any) {
+    if (!newValue) return;
+    try {
+      this.parsedAction = typeof newValue === 'string' ? JSON.parse(newValue) : newValue;
+    } catch (error) {
+      console.error('Error parsing action:', error);
+      this.parsedAction = {};
+    }
+  }
+
+  componentWillLoad() {
+    this.handleServiceDetailsChange(this.serviceDetails);
+    this.handleActionChange(this.action);
+  }
+
+  render() {
+    const { parsedServiceDetails, parsedAction, icon, serviceName, serviceStatus, optionalLink } = this;
+
+    const serviceListItems = Object.entries(parsedServiceDetails).map(([key, value]) => (
+      <li>
+        <div>
+          <strong>{key.toUpperCase()}:</strong> {value}
+        </div>
+      </li>
+    ));
+
+    const actionNeeded = serviceStatus === 'Eligible';
+
+    return (
+      <Host>
+        <div class="service-list">
+          <a href="/">
+            <div class="header">
+              <slot name="icon">
+                <va-icon class="icon" size={3} icon={icon}></va-icon>
+              </slot>
+              <slot name="service-name">
+                <h3 class="service-name">{serviceName}</h3>
+              </slot>
+              <va-icon class="chevron-icon" icon="chevron_right"></va-icon>
+            </div>
+          </a>
+
+          {actionNeeded && (
+            <div class="action-bar">
+              <va-link-action type="secondary" href={parsedAction?.href} text={parsedAction?.text} />
+            </div>
+          )}
+
+          <div class="status">
+            <span class="usa-label">{serviceStatus}</span>
+          </div>
+
+          <ul class="service-list-items">{serviceListItems}</ul>
+
+          {optionalLink && 
+          <slot name="optional-link">
+            <va-link href={optionalLink} text="Click here"></va-link>
+          </slot>
+          }
+        </div>
+      </Host>
+    );
+  }
+}


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes [#295](https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/295)

## Summary
- Added new service-list web component
- Added Storybook file
- Added e2e test for component

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<img width="935" alt="Screenshot 2025-01-31 at 11 07 24 AM" src="https://github.com/user-attachments/assets/b567bf2e-0f75-4d2d-b4f1-1242567b9158" />

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
