### PR TITLE
va-radio-option: Hotfix to restore focus styles

### DIFF
--- a/packages/web-components/src/components/va-radio-option/va-radio-option.scss
+++ b/packages/web-components/src/components/va-radio-option/va-radio-option.scss
@@ -88,10 +88,6 @@ va-radio-option .usa-radio__label {
   box-sizing: border-box;
 }
 
-va-radio-option input:focus {
-  outline: none !important;
-}
-
 // Formation overrides
 va-radio-option input[type="radio"] + label {
   margin-bottom: 0;


### PR DESCRIPTION
## Chromatic
<!-- This `9999-fix-radio-focus` is a placeholder for a CI job - it will be updated automatically -->
https://9999-fix-radio-focus--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Hotfix to restore focus styles to radio buttons.

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2025-02-04 at 1 49 52 PM](https://github.com/user-attachments/assets/1bf07b72-71b1-476b-8770-35a8575d97e4)

## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
