### PR TITLE
va-language-toggle: Address accessibility issues

### DIFF
--- a/packages/web-components/src/components/va-language-toggle/test/va-language-toggle.e2e.ts
+++ b/packages/web-components/src/components/va-language-toggle/test/va-language-toggle.e2e.ts
@@ -12,7 +12,7 @@ describe('va-language-toggle', () => {
   it('English is the default language', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-language-toggle en-href="#" es-href="#" tl-href="#" />`);
-    const anchor = await page.find('va-language-toggle >>> va-link');
+    const anchor = await page.find('va-language-toggle >>> a');
     expect(anchor).toHaveClass('is-current-lang');
   });
 
@@ -26,7 +26,7 @@ describe('va-language-toggle', () => {
   it('if language prop is set the matching language is bolded', async () => {
     const page = await newE2EPage();
     await page.setContent(`<va-language-toggle language="es" en-href="#" es-href="#" tl-href="#" />`);
-    const [_, anchor] = await page.findAll('va-language-toggle >>> va-link');
+    const [_, anchor] = await page.findAll('va-language-toggle >>> a');
     expect(anchor).toHaveClass('is-current-lang');
   });
 

--- a/packages/web-components/src/components/va-language-toggle/va-language-toggle.scss
+++ b/packages/web-components/src/components/va-language-toggle/va-language-toggle.scss
@@ -1,18 +1,23 @@
 :host div {
   display: inline-block;
-
+  font-size: 1.2em;
   div.inner-div {
     border-right: 1px solid var(--vads-color-base-light);
     padding-right: 8px;
     margin-right: 8px;
   }
-
+  a.is-current-lang {
+    font-weight: var(--font-weight-bold);
+    color: var(--vads-color-black);
+    text-decoration: none;
+    &:focus {
+      outline: 2px solid var(--vads-color-action-focus-on-light);
+      outline-offset: 2px;
+    }
+  }
   va-link {
     &::part(anchor) {
       text-decoration: none;
-    }
-    &.is-current-lang {
-      font-weight: var(--font-weight-bold);
     }
     color: var(--vads-color-link);
     padding-bottom: 2px;

--- a/packages/web-components/src/components/va-language-toggle/va-language-toggle.tsx
+++ b/packages/web-components/src/components/va-language-toggle/va-language-toggle.tsx
@@ -123,7 +123,7 @@ export class VaLanguageToggle {
     const { language, urls } = this;
     return (
       <Host>
-        <div>
+        <div role="group" aria-label="Language selection">
         {urls.map(({href, lang, label}, i) => {
           const anchorClass = classNames({
             'is-current-lang': lang === language
@@ -131,6 +131,21 @@ export class VaLanguageToggle {
           const divClass = classNames({
             'inner-div': (i < urls.length - 1)
           })
+          if (lang === language) {
+          return (
+            <div class={divClass}>
+              <a
+                class={anchorClass}
+                href={href}
+                hrefLang={lang}
+                onClick={(e) => this.handleToggle(e, lang, label)}
+                aria-current={"language"}
+              >
+                {label}
+              </a>
+            </div>
+          )
+        } else {
           return (
             <div class={divClass}>
               <va-link
@@ -143,6 +158,7 @@ export class VaLanguageToggle {
               />
             </div>
           )
+        }
         })}
         </div>
       </Host>


### PR DESCRIPTION
## Chromatic
<!-- This `lang-toggle-accessibility` is a placeholder for a CI job - it will be updated automatically -->
https://lang-toggle-accessibility--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes [Language toggle accessibility updates #3564](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3564)

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2025-02-06 at 09 37 54](https://github.com/user-attachments/assets/30516735-f023-4b8f-8a2e-1bbe28b8ea88)

![Screenshot 2025-02-06 at 09 38 03](https://github.com/user-attachments/assets/931e6fdc-69f7-4f62-bf11-3be7e7741900)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
