### PR TITLE
va-button & va-button-pair: allow custom text for continue variation

### DIFF
--- a/packages/storybook/stories/va-button-pair-uswds.stories.jsx
+++ b/packages/storybook/stories/va-button-pair-uswds.stories.jsx
@@ -75,6 +75,13 @@ Continue.args = {
   continue: true,
 };
 
+export const ContinueCustomText = Template.bind(null);
+ContinueCustomText.args = {
+  ...defaultArgs,
+  continue: true,
+  'right-button-text': 'Save and continue',
+};
+
 export const CustomButtonText = Template.bind(null);
 CustomButtonText.args = {
   ...defaultArgs,

--- a/packages/storybook/stories/va-button-uswds.stories.jsx
+++ b/packages/storybook/stories/va-button-uswds.stories.jsx
@@ -55,7 +55,7 @@ const Template = ({
       secondary={secondary}
       primary-alternate={primaryAlternate}
       submit={submit}
-      text={!loading && !text ? 'Default' : text}
+      text={!loading && !text ? null : text}
       onClick= {onClick}
       message-aria-describedby={messageAriaDescribedby}
     />
@@ -65,6 +65,7 @@ const Template = ({
 export const Primary = Template.bind(null);
 Primary.args = {
   ...defaultArgs,
+  text: "Default"
 };
 Primary.argTypes = propStructure(buttonDocs);
 
@@ -93,20 +94,19 @@ export const Continue = Template.bind(null);
 Continue.args = {
   ...defaultArgs,
   _continue: true,
-  text: undefined,
 };
 
 export const Back = Template.bind(null);
 Back.args = {
   ...defaultArgs,
   back: true,
-  text: undefined,
 };
 
 export const Disabled = Template.bind(null);
 Disabled.args = {
   ...defaultArgs,
-  disabled: true
+  disabled: true,
+  text: "Default",
 };
 
 export const Loading = Template.bind(null);
@@ -137,12 +137,12 @@ const TemplateWithForm = ({
   submit,
   text,
   messageAriaDescribedby,
-  onsub,
-  onclk,
+  handleSubmit,
+  handleClick,
 }) => {
   return (
-    <form onSubmit={onsub}>
-      <p>This is inside a form, which has an onsubmit() that displays an alert when the form is submitted</p>
+    <form onSubmit={handleSubmit}>
+      <p>This is inside a form element, which has a callback for onSubmit() and onClick() that displays an alert when the form is submitted</p>
       <va-button
         back={back}
         big={big}
@@ -154,7 +154,7 @@ const TemplateWithForm = ({
         primary-alternate={primaryAlternate}
         submit={submit}
         text={text}
-        onClick={e => onclk(e) }
+        onClick={e => handleClick(e) }
         message-aria-describedby={messageAriaDescribedby}
       />
     </form>
@@ -164,15 +164,14 @@ const TemplateWithForm = ({
 export const Submitted = TemplateWithForm.bind(null);
 Submitted.args = {
   ...defaultArgs,
-  onsub : (e)=>{ 
-    console.log(e.target, "I am submitted!");
-    alert ("form onsubmit method fired!--on form");
+  handleSubmit : (event)=>{ 
+    console.log("Form onSubmit callback fired!", event);
+    alert ("Form onSubmit callback fired!");
   },
-  onclk : (e)=>{ 
-    console.log("called the on click method-on button", e.target);
-    alert( "onclick happened on button"); 
-
+  handleClick : (event)=>{ 
+    console.log("Form onClick callback fired!", event);
+    alert( "Button onClick callback fired!"); 
 },
-  submit: 'prevent',
-  text: "Submit me",
+  submit: "prevent",
+  text: "Submit",
 };

--- a/packages/storybook/stories/va-button-uswds.stories.jsx
+++ b/packages/storybook/stories/va-button-uswds.stories.jsx
@@ -65,7 +65,7 @@ const Template = ({
 export const Primary = Template.bind(null);
 Primary.args = {
   ...defaultArgs,
-  text: "Default"
+  text: "Default",
 };
 Primary.argTypes = propStructure(buttonDocs);
 
@@ -94,6 +94,13 @@ export const Continue = Template.bind(null);
 Continue.args = {
   ...defaultArgs,
   _continue: true,
+};
+
+export const ContinueCustomText = Template.bind(null);
+ContinueCustomText.args = {
+  ...defaultArgs,
+  _continue: true,
+  text: "Save and continue",
 };
 
 export const Back = Template.bind(null);

--- a/packages/storybook/stories/va-button-uswds.stories.jsx
+++ b/packages/storybook/stories/va-button-uswds.stories.jsx
@@ -31,7 +31,7 @@ const defaultArgs = {
 const Template = ({
   back,
   big,
-   _continue,
+   _continue, // "continue" is a reserved word and it doesn't seem to work here as-is.
   disableAnalytics,
   disabled,
   loading,

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -286,7 +286,7 @@ export namespace Components {
          */
         "submit"?: string;
         /**
-          * The text displayed on the button. If `continue` or `back` is true, the value of text is ignored.
+          * The text displayed on the button.
          */
         "text"?: string;
     }
@@ -3560,7 +3560,7 @@ declare namespace LocalJSX {
          */
         "submit"?: string;
         /**
-          * The text displayed on the button. If `continue` or `back` is true, the value of text is ignored.
+          * The text displayed on the button.
          */
         "text"?: string;
     }

--- a/packages/web-components/src/components/va-button-pair/test/va-button-pair.e2e.ts
+++ b/packages/web-components/src/components/va-button-pair/test/va-button-pair.e2e.ts
@@ -113,6 +113,20 @@ describe('va-button-pair', () => {
     expect(rightText).toEqual('world');
   });
 
+  it('continue button displays the text "Continue" when the continue prop is set and no custom text is provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-button-pair continue></va-button-pair>');
+    const button = await page.find('va-button-pair >>> va-button[continue] >>> button');
+    expect(button.textContent).toEqual('Continue');
+  });
+
+  it('continue button displays custom text when the continue prop is set and custom text is provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-button-pair continue text="Save and continue"></va-button-pair>');
+    const button = await page.find('va-button-pair >>> va-button[continue] >>> button');
+    expect(button.textContent).toEqual('Save and continue');
+  });
+
   it('submits form when submit prop is set and "continue" button is clicked', async () => {
     const page = await newE2EPage();
     await page.setContent('<form onsubmit="e=>{e.preventDefault();}"><va-button-pair submit continue></va-button-pair></form>');

--- a/packages/web-components/src/components/va-button-pair/test/va-button-pair.e2e.ts
+++ b/packages/web-components/src/components/va-button-pair/test/va-button-pair.e2e.ts
@@ -122,7 +122,7 @@ describe('va-button-pair', () => {
 
   it('continue button displays custom text when the continue prop is set and custom text is provided', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-button-pair continue text="Save and continue"></va-button-pair>');
+    await page.setContent('<va-button-pair continue right-button-text="Save and continue"></va-button-pair>');
     const button = await page.find('va-button-pair >>> va-button[continue] >>> button');
     expect(button.textContent).toEqual('Save and continue');
   });

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
@@ -132,26 +132,19 @@ export class VaButtonPair {
 
 
   // get text for the left button; custom text takes precedence
-  private getLeftButtonText = () => {
-    let text: string;
-    if (this.leftButtonText) {
-      text = this.leftButtonText;
-    } else {
-      text = this.update ? 'Update' : 'Yes';
-    }
-    return text;
+  private getLeftButtonText = (): string => {
+    if (this.leftButtonText) return this.leftButtonText;
+    if (this.update) return 'Update';
+    return 'Yes';
   }
 
 
   // get text for the right button; custom text takes precedence
-  private getRightButtonText = () => {
-    let text: string;
-    if (this.rightButtonText) {
-      text = this.rightButtonText;
-    } else {
-      text = this.update ? 'Cancel' : 'No';
-    }
-    return text;
+  private getRightButtonText = (): string => {
+    if (this.rightButtonText) return this.rightButtonText;
+    if (this.continue) return this.rightButtonText || 'Continue';
+    if (this.update) return 'Cancel';
+    return 'No';
   }
 
   render() {
@@ -175,6 +168,7 @@ export class VaButtonPair {
                 disable-analytics={disableAnalytics}
                 label={secondaryLabel}
                 onClick={handleSecondaryClick}
+                text={this.getLeftButtonText()}
               />
             </li>
             <li class="usa-button-group__item">
@@ -183,6 +177,7 @@ export class VaButtonPair {
                 disable-analytics={disableAnalytics}
                 label={primaryLabel}
                 onClick={handlePrimaryClick}
+                text={this.getRightButtonText()}
                 submit={submit}
               />
             </li>

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
@@ -134,6 +134,7 @@ export class VaButtonPair {
   // get text for the left button; custom text takes precedence
   private getLeftButtonText = (): string => {
     if (this.leftButtonText) return this.leftButtonText;
+    if (this.continue) return 'Back';
     if (this.update) return 'Update';
     return 'Yes';
   }

--- a/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
+++ b/packages/web-components/src/components/va-button-pair/va-button-pair.tsx
@@ -142,7 +142,7 @@ export class VaButtonPair {
   // get text for the right button; custom text takes precedence
   private getRightButtonText = (): string => {
     if (this.rightButtonText) return this.rightButtonText;
-    if (this.continue) return this.rightButtonText || 'Continue';
+    if (this.continue) return 'Continue';
     if (this.update) return 'Cancel';
     return 'No';
   }

--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -171,11 +171,18 @@ describe('va-button', () => {
     expect(loadingMessageEl.innerHTML).toEqual('Loading complete');
   });
 
-  it('ignores text value and displays Continue when continue is true', async () => {
+  it('displays Continue when continue is true and text is not provided', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-button text="Edit" continue></va-button>');
+    await page.setContent('<va-button continue></va-button>');
     const button = await page.find('va-button >>> button');
     expect(button.textContent).toEqual('Continue');
+  });
+
+  it('displays custom text value when continue is true and text is provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-button text="Save and continue" continue></va-button>');
+    const button = await page.find('va-button >>> button');
+    expect(button.textContent).toEqual('Save and continue');
   });
 
   it('ignores text value and displays Back when back is true', async () => {

--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -185,11 +185,11 @@ describe('va-button', () => {
     expect(button.textContent).toEqual('Save and continue');
   });
 
-  it('ignores text value and displays Back when back is true', async () => {
+  it('displays custom text when text prop is set and Back is true', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-button text="Edit" back></va-button>');
+    await page.setContent('<va-button text="Navigate back" back></va-button>');
     const button = await page.find('va-button >>> button');
-    expect(button.textContent).toEqual('Back');
+    expect(button.textContent).toEqual('Navigate back');
   });
 
   it(`doesn't display icons if both continue and back are true`, async () => {

--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -171,14 +171,14 @@ describe('va-button', () => {
     expect(loadingMessageEl.innerHTML).toEqual('Loading complete');
   });
 
-  it('displays Continue when continue is true and text is not provided', async () => {
+  it('displays "Continue" text when continue prop set and text is not provided', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-button continue></va-button>');
     const button = await page.find('va-button >>> button');
     expect(button.textContent).toEqual('Continue');
   });
 
-  it('displays custom text value when continue is true and text is provided', async () => {
+  it('displays custom text when continue is true and text is provided', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-button text="Save and continue" continue></va-button>');
     const button = await page.find('va-button >>> button');

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -128,11 +128,13 @@ export class VaButton {
     }
   };
 
+  // button text; custom text takes precedence
   private getButtonText = (): string => {
-    if (this.continue) return this.text || 'Continue';
+    if (this.text) return this.text;
+    if (this.continue) return 'Continue';
     if (this.back) return 'Back';
     if (this.loading && !this.text) return 'Loading...';
-    return this.text;
+    return '';
   };
 
   private handleSubmit() {

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -95,7 +95,7 @@ export class VaButton {
   @Prop() submit?: string;
 
   /**
-   * The text displayed on the button. If `continue` or `back` is true, the value of text is ignored.
+   * The text displayed on the button.
    */
   @Prop() text?: string;
 

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -129,7 +129,7 @@ export class VaButton {
   };
 
   private getButtonText = (): string => {
-    if (this.continue) return 'Continue';
+    if (this.continue) return this.text || 'Continue';
     if (this.back) return 'Back';
     if (this.loading && !this.text) return 'Loading...';
     return this.text;

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -134,7 +134,7 @@ export class VaButton {
     if (this.continue) return 'Continue';
     if (this.back) return 'Back';
     if (this.loading && !this.text) return 'Loading...';
-    return '';
+    return;
   };
 
   private handleSubmit() {


### PR DESCRIPTION
## Chromatic
<!-- This `3724-button-continue` is a placeholder for a CI job - it will be updated automatically -->
https://3724-button-continue--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This will allow for a button text override when the `continue` variation is being used for `va-button` and `va-button-pair`. The default text will still be "Continue".

Notes from DSC meeting about opening up button component text: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2362#issuecomment-1901089276

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3724

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![Screenshot 2025-02-07 at 11 50 39 AM](https://github.com/user-attachments/assets/46fe8689-e082-4839-8914-7fbd928b032b)

![Screenshot 2025-02-07 at 11 50 00 AM](https://github.com/user-attachments/assets/b64dbba8-8efe-46c7-a450-7e60b918607f)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
