### PR TITLE
va-banner: add dismissed-banner-id prop

### DIFF
--- a/packages/storybook/stories/va-banner.stories.jsx
+++ b/packages/storybook/stories/va-banner.stories.jsx
@@ -30,6 +30,7 @@ const Template = ({
   visible,
   'window-session': windowSession,
   'data-label': dataLabel,
+  'dismissed-banner-id': dismissedBannerId,
 }) => {
   return (
     <va-banner
@@ -40,6 +41,7 @@ const Template = ({
       visible={visible}
       window-session={windowSession}
       data-label={dataLabel}
+      dismissed-banner-id={dismissedBannerId}
     >
       <p>
         We have temporarily closed our Acute Psychiatry at our Lyons Campus. All
@@ -58,7 +60,7 @@ const defaultArgs = {
   'type': 'info',
   'visible': true,
   'window-session': false,
-  'data-label': "Info banner"
+  'data-label': 'Info banner',
 };
 
 export const Default = Template.bind(null);
@@ -71,4 +73,11 @@ export const Dismissible = Template.bind(null);
 Dismissible.args = {
   ...defaultArgs,
   'show-close': true,
+};
+
+export const DismissibleWithSpecificBannerId = Template.bind(null);
+DismissibleWithSpecificBannerId.args = {
+  ...defaultArgs,
+  'show-close': true,
+  'dismissed-banner-id': 'specific-banner-id',
 };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -187,7 +187,7 @@ export namespace Components {
          */
         "disableAnalytics"?: boolean;
         /**
-          * Optional dissmissedBannerId to allow setting specfic id to be stored in DISMISSED_BANNERS if not set it will default to the headline and innerHTML of the banner
+          * Optional dismissedBannerId to allow setting specific id to be stored in DISMISSED_BANNERS if not set it will default to the headline and innerHTML of the banner
          */
         "dismissedBannerId"?: string;
         /**
@@ -3449,7 +3449,7 @@ declare namespace LocalJSX {
          */
         "disableAnalytics"?: boolean;
         /**
-          * Optional dissmissedBannerId to allow setting specfic id to be stored in DISMISSED_BANNERS if not set it will default to the headline and innerHTML of the banner
+          * Optional dismissedBannerId to allow setting specific id to be stored in DISMISSED_BANNERS if not set it will default to the headline and innerHTML of the banner
          */
         "dismissedBannerId"?: string;
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -187,6 +187,10 @@ export namespace Components {
          */
         "disableAnalytics"?: boolean;
         /**
+          * Optional dissmissedBannerId to allow setting specfic id to be stored in DISMISSED_BANNERS if not set it will default to the headline and innerHTML of the banner
+         */
+        "dismissedBannerId"?: string;
+        /**
           * The headline of the banner.
          */
         "headline": string;
@@ -3444,6 +3448,10 @@ declare namespace LocalJSX {
           * If true, doesn't fire the CustomEvent which can be used for analytics tracking.
          */
         "disableAnalytics"?: boolean;
+        /**
+          * Optional dissmissedBannerId to allow setting specfic id to be stored in DISMISSED_BANNERS if not set it will default to the headline and innerHTML of the banner
+         */
+        "dismissedBannerId"?: string;
         /**
           * The headline of the banner.
          */

--- a/packages/web-components/src/components/va-banner/test/va-banner.spec.ts
+++ b/packages/web-components/src/components/va-banner/test/va-banner.spec.ts
@@ -8,7 +8,7 @@ describe('va-banner', () => {
     cmp.el.innerHTML = 'This is test content';
     cmp.showClose = true;
     expect(cmp.dismissedBanners).toEqual([]);
-    cmp["dismiss"]();
+    cmp['dismiss']();
     expect(cmp.dismissedBanners).toEqual([
       'Test headline:This is test content',
     ]);
@@ -18,6 +18,14 @@ describe('va-banner', () => {
     let cmp = new VaBanner();
     cmp.headline = 'Test headline';
     cmp.el.innerHTML = 'This is test content';
-    expect(cmp["prepareBannerID"]()).toEqual('Test headline:This is test content');
+    expect(cmp['prepareBannerID']()).toEqual(
+      'Test headline:This is test content',
+    );
+  });
+
+  it('prepareBannerID should return back dismissedBannerId string when proivided', () => {
+    let cmp = new VaBanner();
+    cmp.dismissedBannerId = 'Test dismissedBannerId';
+    expect(cmp['prepareBannerID']()).toEqual('Test dismissedBannerId');
   });
 });

--- a/packages/web-components/src/components/va-banner/test/va-banner.spec.ts
+++ b/packages/web-components/src/components/va-banner/test/va-banner.spec.ts
@@ -23,7 +23,7 @@ describe('va-banner', () => {
     );
   });
 
-  it('prepareBannerID should return back dismissedBannerId string when proivided', () => {
+  it('prepareBannerID should return back dismissedBannerId string when provided', () => {
     let cmp = new VaBanner();
     cmp.dismissedBannerId = 'Test dismissedBannerId';
     expect(cmp['prepareBannerID']()).toEqual('Test dismissedBannerId');

--- a/packages/web-components/src/components/va-banner/va-banner.tsx
+++ b/packages/web-components/src/components/va-banner/va-banner.tsx
@@ -99,7 +99,7 @@ export class VaBanner {
    */
   private prepareBannerID = () =>
     /* eslint-disable-next-line i18next/no-literal-string */
-    this.dismissedBannerId || `${this.headline}:${this.el.innerHTML}`;
+    this.dismissedBannerId && this.dismissedBannerId.length ? this.dismissedBannerId : `${this.headline}:${this.el.innerHTML}`;
 
   private dismiss = () => {
     // Derive the current banner ID.

--- a/packages/web-components/src/components/va-banner/va-banner.tsx
+++ b/packages/web-components/src/components/va-banner/va-banner.tsx
@@ -71,7 +71,7 @@ export class VaBanner {
   @Prop() dataLabel?: string;
 
   /**
-   * Optional dissmissedBannerId to allow setting specfic id to be stored in DISMISSED_BANNERS
+   * Optional dissmissedBannerId to allow setting specific id to be stored in DISMISSED_BANNERS
    * if not set it will default to the headline and innerHTML of the banner
    */
   @Prop() dismissedBannerId?: string;

--- a/packages/web-components/src/components/va-banner/va-banner.tsx
+++ b/packages/web-components/src/components/va-banner/va-banner.tsx
@@ -71,6 +71,12 @@ export class VaBanner {
   @Prop() dataLabel?: string;
 
   /**
+   * Optional dissmissedBannerId to allow setting specfic id to be stored in DISMISSED_BANNERS
+   * if not set it will default to the headline and innerHTML of the banner
+   */
+  @Prop() dismissedBannerId?: string;
+
+  /**
    * Keep track of locally dismissed Banners
    * */
   @State() dismissedBanners: Array<String> = [];
@@ -86,8 +92,14 @@ export class VaBanner {
   })
   componentLibraryAnalytics: EventEmitter;
 
-  /* eslint-disable-next-line i18next/no-literal-string */
-  private prepareBannerID = () => `${this.headline}:${this.el.innerHTML}`;
+  /**
+   * Prepares the BannerID to be used for identifying and labeling dismissed banners in
+   * DIMISSED_BANNERS localStorage. If dismissedBannerID is provided that will be returned,
+   * otherwise it will default to contents of the banner
+   */
+  private prepareBannerID = () =>
+    /* eslint-disable-next-line i18next/no-literal-string */
+    this.dismissedBannerId || `${this.headline}:${this.el.innerHTML}`;
 
   private dismiss = () => {
     // Derive the current banner ID.


### PR DESCRIPTION
## Chromatic
<!-- This `vdsd-3738-dismissed-banner-id` is a placeholder for a CI job - it will be updated automatically -->
https://vdsd-3738-dismissed-banner-id--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3738
Related  https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20401
This adds an optional `dismissed-banner-id` property to the `va-banner` component. When set, this property will be stored in the user's Local Storage upon dismissing the banner. When not set, the `va-banner` will default to what it does today, utilizing the content of the banner to identify what has been dimissed.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why) I would consider this not applicable as none of these changes will effect what the user sees or experiences
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why) I would consider this not applicable as none of these changes will effect what the user sees or experiences
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why) this is testable in storybook and will be implemented in vets-website with https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20346

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
