### PR TITLE
Update README.md for `Verdaccio` testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ You're now ready to switch to `vets-website` and update the VADS dependency. _**
 2. Add the local `core` package to `vets-website` and start the server
 
    ```shell
-   yarn add -W @department-of-veterans-affairs/component-library@vX.X.rc-1
+   yarn add -W @department-of-veterans-affairs/component-library@vX.X.X-rc1
    yarn watch
    ```
 


### PR DESCRIPTION
I mis-matched the Verdaccio version numbers on first instructions, and it's been tripping me up every time I copy / paste during local testing.

## Chromatic
<!-- This `docs-1copenut-update-verdaccio-instructions` is a placeholder for a CI job - it will be updated automatically -->
https://docs-1copenut-update-verdaccio-instructions--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.

## Definition of done
- [x] Documentation has been updated, if applicable
