### PR TITLE
Add sign in alert no prefill variation

### DIFF
--- a/packages/storybook/stories/va-alert-sign-in.stories.jsx
+++ b/packages/storybook/stories/va-alert-sign-in.stories.jsx
@@ -156,6 +156,10 @@ const SlotVariants = {
     slotNames: ['SignInButton'],
     buttons: [SignInButton],
   },
+  [ASIVariants.signInOptionalNoPrefill]: {
+    slotNames: ['SignInButton'],
+    buttons: [SignInButton],
+  },
   [ASIVariants.signInEither]: {
     slotNames: ['LoginGovSignInButton', 'IdMeSignInButton'],
     buttons: [LoginGovSignInButton, IdMeSignInButton],
@@ -221,6 +225,14 @@ export const OptionalSignInVerified = Template.bind(null);
 OptionalSignInVerified.args = {
   ...defaultArgs,
   'variant': ASIVariants.signInOptional,
+  'no-sign-in-link': 'https://example.com/',
+  'time-limit': '60 days',
+};
+
+export const OptionalSignInVerifiedNoPrefill = Template.bind(null);
+OptionalSignInVerifiedNoPrefill.args = {
+  ...defaultArgs,
+  'variant': ASIVariants.signInOptionalNoPrefill,
   'no-sign-in-link': 'https://example.com/',
   'time-limit': '60 days',
 };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -157,7 +157,7 @@ export namespace Components {
          */
         "timeLimit"?: string;
         /**
-          * **Required.** Determines the text content and border/background color. Must be one of "signInRequired", "signInOptional", "signInEither", "verifyIdMe", or "verifyLoginGov".
+          * **Required.** Determines the text content and border/background color. Must be one of "signInRequired", "signInOptional", "signInOptionalNoPrefill", "signInEither", "verifyIdMe", or "verifyLoginGov".
          */
         "variant": string;
         /**
@@ -3431,7 +3431,7 @@ declare namespace LocalJSX {
          */
         "timeLimit"?: string;
         /**
-          * **Required.** Determines the text content and border/background color. Must be one of "signInRequired", "signInOptional", "signInEither", "verifyIdMe", or "verifyLoginGov".
+          * **Required.** Determines the text content and border/background color. Must be one of "signInRequired", "signInOptional", "signInOptionalNoPrefill", "signInEither", "verifyIdMe", or "verifyLoginGov".
          */
         "variant"?: string;
         /**

--- a/packages/web-components/src/components/va-alert-sign-in/AlertSignInVariants.ts
+++ b/packages/web-components/src/components/va-alert-sign-in/AlertSignInVariants.ts
@@ -2,6 +2,7 @@ export enum AlertSignInVariants {
   /* eslint-disable i18next/no-literal-string */
   signInRequired = 'signInRequired',
   signInOptional = 'signInOptional',
+  signInOptionalNoPrefill = 'signInOptionalNoPrefill',
   verifyIdMe = 'verifyIdMe',
   verifyLoginGov = 'verifyLoginGov',
   signInEither = 'signInEither',

--- a/packages/web-components/src/components/va-alert-sign-in/test/va-alert-sign-in.e2e.ts
+++ b/packages/web-components/src/components/va-alert-sign-in/test/va-alert-sign-in.e2e.ts
@@ -138,6 +138,21 @@ describe('va-alert-sign-in', () => {
     ).toBeTruthy();
   });
 
+  it('should set variant to "optional no prefill" when specified', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<va-alert-sign-in variant="${ASIVariants.signInOptionalNoPrefill}"></va-alert-sign-in>`,
+    );
+
+    const element = await page.find('va-alert-sign-in >>> .usa-alert');
+
+    expect(
+      element.classList.contains(
+        `va-alert-sign-in--${ASIVariants.signInOptionalNoPrefill}`,
+      ),
+    ).toBeTruthy();
+  });
+
   it('should set variant to "either" when specified', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
+++ b/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
@@ -18,7 +18,7 @@ export class VaAlertSignIn {
   @Element() el!: any;
 
   /**
-   * **Required.** Determines the text content and border/background color. Must be one of "signInRequired", "signInOptional", "signInEither", "verifyIdMe", or "verifyLoginGov".
+   * **Required.** Determines the text content and border/background color. Must be one of "signInRequired", "signInOptional", "signInOptionalNoPrefill", "signInEither", "verifyIdMe", or "verifyLoginGov".
    */
   @Prop() variant: string = ASIVariants.signInRequired;
 
@@ -61,10 +61,12 @@ export class VaAlertSignIn {
     const classes = classnames('usa-alert', `va-alert-sign-in--${variant}`, {
       'usa-alert--info':
         variant === ASIVariants.signInRequired ||
-        variant === ASIVariants.signInOptional,
+        variant === ASIVariants.signInOptional ||
+        variant === ASIVariants.signInOptionalNoPrefill,
       'usa-alert--warning':
         variant !== ASIVariants.signInRequired &&
-        variant !== ASIVariants.signInOptional,
+        variant !== ASIVariants.signInOptional &&
+        variant !== ASIVariants.signInOptionalNoPrefill,
     });
 
     // Create a header element
@@ -121,6 +123,44 @@ export class VaAlertSignIn {
             from when you start or make changes to submit your form.
           </li>
         </ul>
+        <p>
+          <strong>Don't yet have a verified account?</strong> Create a{' '}
+          <strong>Login.gov</strong> or <strong>ID.me</strong> account. We'll
+          help you verify your identity for your account now.
+        </p>
+        <p>
+          <strong>Not sure if your account is verified?</strong> Sign in here.
+          If you still need to verify your identity, we'll help you do that now.
+        </p>
+        <p>
+          <strong>Note:</strong> You can sign in after you start filling out
+          your form. But you'll lose any information you already filled in.
+        </p>
+        <p>
+          <slot name="SignInButton"></slot>
+        </p>
+        {this.noSignInLink && (
+          <p>
+            <va-link
+              href={this.noSignInLink}
+              text="Start your form without signing in"
+              disableAnalytics={true}
+            ></va-link>
+          </p>
+        )}
+      </div>
+    );
+
+    const OptionalNoPrefillVariant = () => (
+      <div class="va-alert-sign-in__body">
+        <HeaderLevel class="headline">
+          Sign in with a verified account
+        </HeaderLevel>
+        <p>
+          When you sign in with an identity-verified account, you can save your
+          work in progress. You'll have 60 days from when you start or make
+          changes to submit your form.
+        </p>
         <p>
           <strong>Don't yet have a verified account?</strong> Create a{' '}
           <strong>Login.gov</strong> or <strong>ID.me</strong> account. We'll
@@ -242,6 +282,7 @@ export class VaAlertSignIn {
     const BodyVariants = {
       [ASIVariants.signInEither]: SignInEitherVariant,
       [ASIVariants.signInOptional]: OptionalVariant,
+      [ASIVariants.signInOptionalNoPrefill]: OptionalNoPrefillVariant,
       [ASIVariants.signInRequired]: RequiredVariant,
       [ASIVariants.verifyIdMe]: IdMeVariant,
       [ASIVariants.verifyLoginGov]: LoginGovVariant,


### PR DESCRIPTION
## Chromatic
<!-- This `sign-in-alert-no-prefill` is a placeholder for a CI job - it will be updated automatically -->
https://sign-in-alert-no-prefill--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3791

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
  - **N/A** - only a text update. 
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

<img width="500" alt="image" src="https://github.com/user-attachments/assets/52abfd07-8acc-4116-aafa-57bbfdc6fa69" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/011d46bd-33c1-431b-a3ce-357dc37560bb" />



## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue
