### PR TITLE
Update external link description

### DIFF
--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -84,7 +84,7 @@ export class VaLink {
   @Prop() reverse?: boolean = false;
 
   /**
-   * If 'true', will open in a new tab and have icon denoting that. Will also have the text "opens in a new tab" appended to the link text in screen reader only span
+   * If 'true', will open in a new tab and will have the text "opens in a new tab" appended to the link text in screen reader only span
    */
   @Prop() external?: boolean = false;
 


### PR DESCRIPTION
Remove reference to icon in external link variation that had been [removed earlier](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3303). 