### PR TITLE
va-table: Enabling stacked tables to always be full-width

### DIFF
--- a/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.scss
+++ b/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.scss
@@ -29,6 +29,18 @@
   }
 }
 
+// Using 29.99em instead of 480px because it matches USWDS' styles
+@media screen and (max-width: 29.99em) {
+  :host div {
+    display: flex;
+    width: 100%;
+
+    table {
+      flex: auto;
+    }
+  }
+}
+
 :host thead tr th {
   button {
     background-color: transparent;


### PR DESCRIPTION
## Chromatic
<!-- This `3776-fix-stacked-full-width-tables` is a placeholder for a CI job - it will be updated automatically -->
https://3776-fix-stacked-full-width-tables--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#3776](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3776)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [X] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
After:
![Screenshot 2025-02-21 at 10 18 51 AM](https://github.com/user-attachments/assets/cd70af94-a596-413d-a647-ab0928a598ff)


## Acceptance criteria
- [X] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue
