### PR TITLE
Adjust va-language-toggle font size and padding

### DIFF
--- a/packages/web-components/src/components/va-language-toggle/va-language-toggle.scss
+++ b/packages/web-components/src/components/va-language-toggle/va-language-toggle.scss
@@ -11,7 +11,7 @@
     color: var(--vads-color-black);
     text-decoration: none;
     padding-top: 10px;
-    padding-bottom: 12px;
+    padding-bottom: 16px;
     &:focus {
       outline: 2px solid var(--vads-color-action-focus-on-light);
       outline-offset: 2px;
@@ -21,7 +21,7 @@
     &::part(anchor) {
       text-decoration: none;
       padding-top: 10px;
-      padding-bottom: 12px;
+      padding-bottom: 16px;
     }
     color: var(--vads-color-link);
     padding-bottom: 2px;

--- a/packages/web-components/src/components/va-language-toggle/va-language-toggle.scss
+++ b/packages/web-components/src/components/va-language-toggle/va-language-toggle.scss
@@ -1,6 +1,6 @@
 :host div {
   display: inline-block;
-  font-size: 1.2em;
+
   div.inner-div {
     border-right: 1px solid var(--vads-color-base-light);
     padding-right: 8px;
@@ -10,6 +10,8 @@
     font-weight: var(--font-weight-bold);
     color: var(--vads-color-black);
     text-decoration: none;
+    padding-top: 10px;
+    padding-bottom: 12px;
     &:focus {
       outline: 2px solid var(--vads-color-action-focus-on-light);
       outline-offset: 2px;
@@ -18,6 +20,8 @@
   va-link {
     &::part(anchor) {
       text-decoration: none;
+      padding-top: 10px;
+      padding-bottom: 12px;
     }
     color: var(--vads-color-link);
     padding-bottom: 2px;


### PR DESCRIPTION
## Chromatic
<!-- This `lang-toggle-adjust-size` is a placeholder for a CI job - it will be updated automatically -->
https://lang-toggle-adjust-size--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Follow up to [Language toggle accessibility updates #3564](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3564)

Revert font size to baseline. Increase padding to make touch target larger

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2025-02-21 at 10 27 47](https://github.com/user-attachments/assets/7a24560a-5083-40e5-a105-02e2e9306eee)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
