### PR TITLE
CSS-Library: Addition of vads-c-eyebrow class

### DIFF
--- a/packages/css-library/dist/stylesheets/modules/m-eyebrow.css
+++ b/packages/css-library/dist/stylesheets/modules/m-eyebrow.css
@@ -1,4 +1,4 @@
-.vads-m-eyebrow {
+.vads-c-eyebrow {
   font-family: "Source Sans Pro Web", "Source Sans Pro", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
   font-size: 1rem;
   font-style: normal;

--- a/packages/css-library/dist/stylesheets/modules/m-eyebrow.css
+++ b/packages/css-library/dist/stylesheets/modules/m-eyebrow.css
@@ -1,0 +1,10 @@
+.vads-m-eyebrow {
+  font-family: "Source Sans Pro Web", "Source Sans Pro", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 400;
+  color: #3d4551;
+  text-transform: uppercase;
+}
+
+/*# sourceMappingURL=m-eyebrow.css.map */

--- a/packages/css-library/dist/stylesheets/modules/m-eyebrow.css.map
+++ b/packages/css-library/dist/stylesheets/modules/m-eyebrow.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sourceRoot":"","sources":["../../../src/stylesheets/modules/m-eyebrow.scss","../../tokens/scss/variables.scss"],"names":[],"mappings":"AAEA;EACE,aCyHiB;EDxHjB,WCiIe;EDhIf,YC6HkB;ED5HlB,aC0HmB;EDzHnB,OCwBuB;EDvBvB","file":"m-eyebrow.css"}

--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 14 Feb 2025 17:48:16 GMT
+ * Generated on Tue, 25 Feb 2025 14:53:53 GMT
  */
 
 :root {

--- a/packages/css-library/dist/tokens/css/variables.css
+++ b/packages/css-library/dist/tokens/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 25 Feb 2025 14:53:53 GMT
+ * Generated on Wed, 26 Feb 2025 14:28:34 GMT
  */
 
 :root {

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 25 Feb 2025 14:53:53 GMT
+// Generated on Wed, 26 Feb 2025 14:28:34 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;

--- a/packages/css-library/dist/tokens/scss/variables.scss
+++ b/packages/css-library/dist/tokens/scss/variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 14 Feb 2025 17:48:16 GMT
+// Generated on Tue, 25 Feb 2025 14:53:53 GMT
 
 $xsmall-screen: 320px;
 $small-screen: 481px;

--- a/packages/css-library/src/stylesheets/modules/m-eyebrow.scss
+++ b/packages/css-library/src/stylesheets/modules/m-eyebrow.scss
@@ -1,6 +1,6 @@
 @import '../../../dist/tokens/scss/variables.scss';
 
-.vads-m-eyebrow {
+.vads-c-eyebrow {
   font-family: $font-family-sans;
   font-size: $font-size-root;
   font-style: $font-style-normal;

--- a/packages/css-library/src/stylesheets/modules/m-eyebrow.scss
+++ b/packages/css-library/src/stylesheets/modules/m-eyebrow.scss
@@ -1,0 +1,10 @@
+@import '../../../dist/tokens/scss/variables.scss';
+
+.vads-m-eyebrow {
+  font-family: $font-family-sans;
+  font-size: $font-size-root;
+  font-style: $font-style-normal;
+  font-weight: $font-weight-normal;
+  color: $vads-color-base-darker;
+  text-transform: uppercase;
+}

--- a/packages/storybook/.storybook/style.scss
+++ b/packages/storybook/.storybook/style.scss
@@ -1,6 +1,7 @@
 $formation-asset-path: '~@department-of-veterans-affairs/formation/assets';
 
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/uswds-typography.css";
+@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-eyebrow.css";
 
 @import '@department-of-veterans-affairs/formation/sass/base/_b-mixins.scss';
 @import '@department-of-veterans-affairs/formation/sass/base/_b-variables.scss';

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -18,6 +18,7 @@
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
+    "@department-of-veterans-affairs/css-library": "workspace:^",
     "@department-of-veterans-affairs/formation": "^11.0.6",
     "@mdx-js/react": "^1.6.22",
     "@storybook/addon-a11y": "7.6.19",

--- a/packages/storybook/stories/Eyebrow.stories.mdx
+++ b/packages/storybook/stories/Eyebrow.stories.mdx
@@ -1,0 +1,27 @@
+import { Canvas, Meta, Story, Subtitle, Title } from '@storybook/addon-docs';
+import { Guidance, MaturityScale } from './wc-helpers';
+import { additionalDocs } from './additional-docs';
+
+<Meta title="Components/Eyebrow" id="components/eyebrow" />
+
+<Title>Eyebrow</Title>
+<Subtitle>Eyebrow component class</Subtitle>
+<MaturityScale
+  category={additionalDocs['Eyebrow'].maturityCategory}
+  level={additionalDocs['Eyebrow'].maturityLevel}
+/>
+<Guidance
+  href={additionalDocs['Eyebrow'].guidanceHref}
+  name={additionalDocs['Eyebrow'].guidanceName}
+/>
+
+## Stories
+
+### Default
+
+<Canvas>
+  <Story name="Default">
+    <h2 className="vads-m-eyebrow">Eyebrow Title</h2>
+    <h1>Main Headline</h1>
+  </Story>
+</Canvas>

--- a/packages/storybook/stories/Eyebrow.stories.mdx
+++ b/packages/storybook/stories/Eyebrow.stories.mdx
@@ -21,7 +21,7 @@ import { additionalDocs } from './additional-docs';
 
 <Canvas>
   <Story name="Default">
-    <h2 className="vads-m-eyebrow">Eyebrow Title</h2>
+    <h2 className="vads-c-eyebrow">Eyebrow Title</h2>
     <h1>Main Headline</h1>
   </Story>
 </Canvas>

--- a/packages/storybook/stories/additional-docs.js
+++ b/packages/storybook/stories/additional-docs.js
@@ -28,6 +28,13 @@ export const additionalDocs = {
     maturityLevel: DEPRECATED,
   },
   // MDX
+  'Eyebrow': {
+    guidanceHref: 'eyebrow',
+    guidanceTag: 'Eyebrow',
+    maturityCategory: CAUTION,
+    maturityLevel: CANDIDATE,
+  },
+  // MDX
   'Link - Action': {
     guidanceHref: 'link/action',
     guidanceName: 'Action link',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,7 +3322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@department-of-veterans-affairs/css-library@workspace:packages/css-library":
+"@department-of-veterans-affairs/css-library@workspace:^, @department-of-veterans-affairs/css-library@workspace:packages/css-library":
   version: 0.0.0-use.local
   resolution: "@department-of-veterans-affairs/css-library@workspace:packages/css-library"
   dependencies:
@@ -3427,6 +3427,7 @@ __metadata:
     "@babel/preset-react": "npm:^7.23.3"
     "@babel/preset-typescript": "npm:^7.23.3"
     "@department-of-veterans-affairs/component-library": "workspace:packages/core"
+    "@department-of-veterans-affairs/css-library": "workspace:^"
     "@department-of-veterans-affairs/formation": "npm:^11.0.6"
     "@mdx-js/react": "npm:^1.6.22"
     "@storybook/addon-a11y": "npm:7.6.19"


### PR DESCRIPTION
## Chromatic
<!-- This `2580-eyebrow-css-class` is a placeholder for a CI job - it will be updated automatically -->
https://2580-eyebrow-css-class--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes [#2580](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2580)

## QA Checklist
- [X] Component maintains 1:1 parity with design mocks
- [X] Text is consistent with what's been provided in the mocks
- [X] Component behaves as expected across breakpoints
- [X] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [X] Tab order and focus state work as expected
- [X] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [X] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2025-02-25 at 9 54 58 AM](https://github.com/user-attachments/assets/419aed3b-b1e0-4cb6-a1fc-0d1c3113e3ac)

## Acceptance criteria
- [x] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue
