### PR TITLE
va-checkbox: add normalized font size token to label

### DIFF
--- a/packages/web-components/src/components/va-checkbox/va-checkbox.scss
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.scss
@@ -22,24 +22,12 @@
   margin: 0.75rem 0;
   max-width: 480px;
   cursor: pointer;
-
-  // Temporarily adding vars manually until Storybook is setup to make use of CSS-Library
-  --vads-button-color-background-primary-on-light: #005ea2;
-  --vads-input-background-color-on-light: #ffffff;
-  --vads-input-border-color-on-light: #565c65;
-  --vads-input-prefix-color-fill-on-light: #757575;
-  --vads-input-prefix-color-text-on-light: #757575;
-  --vads-input-suffix-color-text-on-light: #757575;
-  --vads-input-tile-background-active-on-light: rgba(0, 94, 162, 0.1);
-  --vads-input-tile-border-active-on-light: #005ea2;
-  --vads-input-tile-border-on-light: rgba(27, 27, 27, 0.03);
-  --vads-input-tile-border-override: #c9c9c9; // Matches USWDS
 }
 
 .va-checkbox__container--tile {
   border-radius: 0.25rem;
   background-color: var(--vads-input-background-color-on-light);
-  border: 2px solid var(--vads-input-tile-border-override);
+  border: 2px solid #c9c9c9;
   color: var(--vads-color-base);
   padding: 0.75rem 1rem .75rem .5rem;
   margin: 0.5rem 0;
@@ -97,6 +85,7 @@
 }
 
 .va-checkbox__label {
+  font-size: var(--vads-font-size-source-sans-normalized);
   padding-left: 0.6rem;
   cursor: pointer;
 }


### PR DESCRIPTION
## Chromatic
<!-- This `checkbox-label-font-size` is a placeholder for a CI job - it will be updated automatically -->
https://checkbox-label-font-size--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

I noticed that the label font size was calculating to `16px` but we want it to be the normalized font size (1.06rem/16.96px) as verified in [Figma](https://www.figma.com/design/afurtw4iqQe6y4gXfNfkkk/VADS-Component-Library?node-id=457-13307&t=EyAokwpbBgsksjH7-0).

Closes - No ticket

## Screenshots

**before**

![Screenshot 2025-03-07 at 8 37 44 AM](https://github.com/user-attachments/assets/85996dee-9dfc-4d83-ad4b-7ec6c047cc34)

**after**

![Screenshot 2025-03-07 at 8 56 09 AM](https://github.com/user-attachments/assets/797e2586-255a-4b9c-ac78-befe8e242e73)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
