### PR TITLE
Checkbox aria checked

### DIFF
--- a/packages/storybook/stories/va-checkbox-uswds.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-uswds.stories.jsx
@@ -109,7 +109,6 @@ const IndeterminateTemplate = ({}) => {
     );
 
     // If all of the checkbox states are true, set indeterminate checkbox to checked.
-    // TODO: 
     if (checked.every(val => val === true)) {
       indeterminateCheckbox.checked = true;
       indeterminateCheckbox.indeterminate = false;

--- a/packages/storybook/stories/va-checkbox-uswds.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-uswds.stories.jsx
@@ -109,6 +109,7 @@ const IndeterminateTemplate = ({}) => {
     );
 
     // If all of the checkbox states are true, set indeterminate checkbox to checked.
+    // TODO: 
     if (checked.every(val => val === true)) {
       indeterminateCheckbox.checked = true;
       indeterminateCheckbox.indeterminate = false;

--- a/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
@@ -284,6 +284,16 @@ describe('va-checkbox', () => {
     expect(checkboxEl).toEqualAttribute('aria-checked', 'mixed');
   });
 
+  it('does not set aria-checked when toggled off', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-checkbox label="Just another checkbox here" />',
+    );
+    const checkboxEl = await page.find('va-checkbox >>> input');
+
+    expect(checkboxEl).not.toHaveAttribute('aria-checked');
+  });
+
   it('does not set the data-indeterminate attribute if checked is set', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -233,21 +233,14 @@ export class VaCheckbox {
         // Return null so we don't add the attribute if we have an empty string
         .trim() || null;
     
-    // let ariaChecked: boolean | string;
-
-    // if (!indeterminate && !checked) {
-      // ariaChecked = false;
-    // } else if (indeterminate && !checked) {
-    //   ariaChecked = 'mixed';
-    // } else {
-    //   ariaChecked = checked;
-    // }
-
-    console.log("Name", label);
-    console.log("indeterminate", indeterminate);
-    console.log("checked", checked);
-    console.log("ariaChecked", indeterminate && !checked ? 'mixed' : checked);
-    console.log("---")
+    let ariaChecked: boolean | string | null;
+    if (indeterminate && !checked) {
+      ariaChecked = 'mixed';
+    } else if (!indeterminate && !checked) {
+      ariaChecked = null;
+    } else {
+      ariaChecked = checked;
+    }
 
     return (
       <Host>
@@ -282,9 +275,8 @@ export class VaCheckbox {
             aria-invalid={error ? 'true' : 'false'}
             disabled={disabled}
             data-indeterminate={indeterminate && !checked}
-            aria-checked={indeterminate && !checked ? 'mixed' : checked}
+            aria-checked={ariaChecked}
           />
-          {console.log("ariaChecked 2", indeterminate && !checked ? 'mixed' : checked)}
           <label htmlFor="checkbox-element" class="va-checkbox__label">
             <span part="label">{label}</span>&nbsp;
             {required && (

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -282,7 +282,7 @@ export class VaCheckbox {
             aria-invalid={error ? 'true' : 'false'}
             disabled={disabled}
             data-indeterminate={indeterminate && !checked}
-            aria-checked={indeterminate && !checked ? 'mixed' : this.checked}
+            aria-checked={indeterminate && !checked ? 'mixed' : checked}
           />
           {console.log("ariaChecked 2", indeterminate && !checked ? 'mixed' : checked)}
           <label htmlFor="checkbox-element" class="va-checkbox__label">

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -232,6 +232,22 @@ export class VaCheckbox {
         .join(' ')
         // Return null so we don't add the attribute if we have an empty string
         .trim() || null;
+    
+    // let ariaChecked: boolean | string;
+
+    // if (!indeterminate && !checked) {
+      // ariaChecked = false;
+    // } else if (indeterminate && !checked) {
+    //   ariaChecked = 'mixed';
+    // } else {
+    //   ariaChecked = checked;
+    // }
+
+    console.log("Name", label);
+    console.log("indeterminate", indeterminate);
+    console.log("checked", checked);
+    console.log("ariaChecked", indeterminate && !checked ? 'mixed' : checked);
+    console.log("---")
 
     return (
       <Host>
@@ -266,8 +282,9 @@ export class VaCheckbox {
             aria-invalid={error ? 'true' : 'false'}
             disabled={disabled}
             data-indeterminate={indeterminate && !checked}
-            aria-checked={indeterminate && !checked ? 'mixed' : checked}
+            aria-checked={indeterminate && !checked ? 'mixed' : this.checked}
           />
+          {console.log("ariaChecked 2", indeterminate && !checked ? 'mixed' : checked)}
           <label htmlFor="checkbox-element" class="va-checkbox__label">
             <span part="label">{label}</span>&nbsp;
             {required && (


### PR DESCRIPTION
## Chromatic
<!-- This `checkbox-aria-checked` is a placeholder for a CI job - it will be updated automatically -->
https://checkbox-aria-checked--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3807

`aria-checked` was not being set on the HTML attribute despite evaluating to `false`. I added a condition to set this to `null` and that removes the attribute as expected when it is unchecked.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![image](https://github.com/user-attachments/assets/dd169250-dcc9-4719-881f-965c2629045b)


## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue
