### PR TITLE
va-file-input: Add back default args for storybook example

### DIFF
--- a/packages/storybook/stories/va-file-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.jsx
@@ -87,6 +87,7 @@ const Template = ({
 };
 
 export const Default = Template.bind(null);
+Default.args = { ...defaultArgs };
 Default.argTypes = propStructure(fileInputDocs);
 
 export const Required = Template.bind(null);


### PR DESCRIPTION
## Chromatic
<!-- This `file-input-storybook-default` is a placeholder for a CI job - it will be updated automatically -->
https://file-input-storybook-default--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
It looks like we accidentally removed the default args from the Default storybook example in a [previous PR](https://github.com/department-of-veterans-affairs/component-library/pull/1500/files) so this is just adding it back:

![Screenshot 2025-03-07 at 12 31 49 PM](https://github.com/user-attachments/assets/e033fbe5-89ac-4b6c-8c17-e9caac7a03d3)

## Screenshots

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
