### PR TITLE
Storybook: Capitalize first letter in focus button labels

### DIFF
--- a/packages/storybook/stories/va-checkbox-group-uswds.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-group-uswds.stories.jsx
@@ -285,7 +285,7 @@ const FormsPatternMultipleTemplate = ({
         />
       </va-checkbox-group>
       <hr />
-      <va-button text="click to focus header" onClick={handleClick} uswds={false}></va-button>
+      <va-button text="Click to focus header" onClick={handleClick}></va-button>
     </>
   );
 };
@@ -349,7 +349,7 @@ const FormsPatternSingleTemplate = ({
 
       <hr />
 
-      <va-button text="click to focus header" onClick={handleClick} uswds={false}></va-button>
+      <va-button text="Click to focus header" onClick={handleClick}></va-button>
     </>
   );
 };

--- a/packages/storybook/stories/va-memorable-date-uswds.stories.jsx
+++ b/packages/storybook/stories/va-memorable-date-uswds.stories.jsx
@@ -173,9 +173,8 @@ const FormsPatternSingleTemplate = ({ label, name, hint, required, error, value,
       <hr />
 
       <va-button 
-        text="click to focus header" 
-        onClick={handleClick}
-        uswds={false}>
+        text="Click to focus header" 
+        onClick={handleClick}>
       </va-button>
     </>
   );
@@ -224,9 +223,8 @@ const FormsPatternMultipleTemplate = ({ label, name, hint, required, error, valu
       <hr />
 
       <va-button 
-        text="click to focus header" 
-        onClick={handleClick}
-        uswds={false}>
+        text="Click to focus header" 
+        onClick={handleClick}>
       </va-button>
     </>
   );

--- a/packages/storybook/stories/va-radio-uswds.stories.jsx
+++ b/packages/storybook/stories/va-radio-uswds.stories.jsx
@@ -331,9 +331,8 @@ const FormsPatternMultipleTemplate = ({ label, required }) => {
 
       <hr />
       <va-button
-        text="click to focus header"
+        text="Click to focus header"
         onClick={handleClick}
-        uswds={false}
       ></va-button>
     </>
   );
@@ -387,7 +386,7 @@ const FormsPatternSingleTemplate = ({
 
       <hr />
 
-      <va-button text="click to focus header" onClick={handleClick} uswds={false}></va-button>
+      <va-button text="Click to focus header" onClick={handleClick}></va-button>
     </>
   );
 };

--- a/packages/storybook/stories/va-select-uswds.stories.jsx
+++ b/packages/storybook/stories/va-select-uswds.stories.jsx
@@ -286,7 +286,7 @@ const FormsPatternSingleTemplate = args => {
       <hr />
 
       <va-button
-        text="click to focus header"
+        text="Click to focus header"
         onClick={handleClick}
       ></va-button>
     </>

--- a/packages/storybook/stories/va-text-input-uswds.stories.jsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.jsx
@@ -259,9 +259,8 @@ const FormsPatternMultipleTemplate = ({ name, value, uswds }) => {
       <va-text-input name={name} label="Email address" value={value} />
       <hr />
       <va-button
-        text="click to focus header"
+        text="Click to focus header"
         onClick={handleClick}
-        uswds={false}
       ></va-button>
     </>
   );
@@ -304,9 +303,8 @@ const FormsPatternSingleTemplate = ({ name, value, error }) => {
       <hr />
 
       <va-button
-        text="click to focus header"
+        text="Click to focus header"
         onClick={handleClick}
-        uswds={false}
       ></va-button>
     </>
   );

--- a/packages/storybook/stories/va-textarea-uswds.stories.jsx
+++ b/packages/storybook/stories/va-textarea-uswds.stories.jsx
@@ -153,9 +153,8 @@ const FormsPatternSingleTemplate = ({
       <hr />
 
       <va-button 
-        text="click to focus header" 
-        onClick={handleClick}
-        uswds={false}>
+        text="Click to focus header" 
+        onClick={handleClick}>
       </va-button>
     </>
   );
@@ -230,9 +229,8 @@ const FormsPatternMultipleTemplate = ({
       <hr />
 
       <va-button 
-        text="click to focus header"
-        onClick={handleClick}
-        uswds={false}>
+        text="Click to focus header"
+        onClick={handleClick}>
       </va-button>
     </>
   );


### PR DESCRIPTION
## Chromatic
<!-- This `storybook-button-label` is a placeholder for a CI job - it will be updated automatically -->
https://storybook-button-label--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

No ticket for this I just noticed a few places where we weren't following our own guideline examples for button labels (capitalize first letter): https://design.va.gov/components/button/#button-labels

## Screenshots

**before**

![Screenshot 2025-03-10 at 10 42 14 AM](https://github.com/user-attachments/assets/9a412026-c7b6-44e4-95d3-879b00cb62c5)

**after**

![Screenshot 2025-03-10 at 10 44 21 AM](https://github.com/user-attachments/assets/852ffd3c-7be8-4555-b42d-90832edebc42)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
