### PR TITLE
Version bump for release 3-12-2025

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "49.3.0",
+  "version": "49.4.0",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "17.3.0",
+  "version": "17.4.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.10.0",
     "@babel/core": "^7.12.13",
-    "@department-of-veterans-affairs/css-library": "^0.18.1",
+    "@department-of-veterans-affairs/css-library": "^0.20.0",
     "@department-of-veterans-affairs/formation": "^11.0.6",
     "@stencil/postcss": "^2.0.0",
     "@stencil/react-output-target": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3311,18 +3311,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@department-of-veterans-affairs/css-library@npm:^0.18.1":
-  version: 0.18.1
-  resolution: "@department-of-veterans-affairs/css-library@npm:0.18.1"
-  dependencies:
-    "@divriots/style-dictionary-to-figma": "npm:^0.4.0"
-    "@uswds/uswds": "npm:^3.9.0"
-    rimraf: "npm:^5.0.5"
-  checksum: 10/a563ae422095f3d436a3fca329c6d2f5ffc33ef7fc717e04d83128783d6aa4a8ec71787e0464dcb7ca53a76b5b3f2988eb61253da0bfe16315c42bf7e9e6219f
-  languageName: node
-  linkType: hard
-
-"@department-of-veterans-affairs/css-library@workspace:^, @department-of-veterans-affairs/css-library@workspace:packages/css-library":
+"@department-of-veterans-affairs/css-library@npm:^0.20.0, @department-of-veterans-affairs/css-library@workspace:^, @department-of-veterans-affairs/css-library@workspace:packages/css-library":
   version: 0.0.0-use.local
   resolution: "@department-of-veterans-affairs/css-library@workspace:packages/css-library"
   dependencies:
@@ -3460,7 +3449,7 @@ __metadata:
   dependencies:
     "@axe-core/puppeteer": "npm:^4.10.0"
     "@babel/core": "npm:^7.12.13"
-    "@department-of-veterans-affairs/css-library": "npm:^0.18.1"
+    "@department-of-veterans-affairs/css-library": "npm:^0.20.0"
     "@department-of-veterans-affairs/formation": "npm:^11.0.6"
     "@stencil/core": "npm:4.20.0"
     "@stencil/postcss": "npm:^2.0.0"


### PR DESCRIPTION
## Chromatic
<!-- This `mc-release-branch` is a placeholder for a CI job - it will be updated automatically -->
https://mc-release-branch--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Updates version of web components and core. Leaves out css-library because a manual release was done yesterday for that package.

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
