### PR TITLE
Storybook: replace deprecated action link class with web component

### DIFF
--- a/packages/storybook/stories/wc-helpers.jsx
+++ b/packages/storybook/stories/wc-helpers.jsx
@@ -119,12 +119,10 @@ export function Guidance({ href, name }) {
 
   return (
     <div className="vads-u-margin-bottom--5">
-      <a
-        className="vads-c-action-link--green"
+      <va-link-action
         href={`https://design.va.gov/components/${href}`}
-      >
-        View guidance for the {name} component in the Design System
-      </a>
+        text={`View guidance for the ${name} component in the Design System`}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Chromatic
<!-- This `847-storybook-action-link` is a placeholder for a CI job - it will be updated automatically -->
https://847-storybook-action-link--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

We were still using the deprecated `vads-c-action-link--green` utility class in Storybook instead of the web component so this PR replaces it.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/847

## Screenshots

![Screenshot 2025-03-12 at 1 33 37 PM](https://github.com/user-attachments/assets/1fdf844c-9cc9-4e2d-853d-15833e9f644c)


## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
