### PR TITLE
Revert "va-checkbox | Fix interactive elements in description"

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "49.4.0",
+  "version": "49.4.1",
   "license": "MIT",
   "scripts": {
     "build": "webpack"

--- a/packages/storybook/stories/va-checkbox-uswds.stories.jsx
+++ b/packages/storybook/stories/va-checkbox-uswds.stories.jsx
@@ -2,10 +2,7 @@
 /* eslint-disable react/no-unescaped-entities */
 import React, { useState, useEffect } from 'react';
 import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
-import {
-  VaCheckbox,
-  VaModal,
-} from '@department-of-veterans-affairs/web-components/react-bindings';
+import { VaCheckbox } from '@department-of-veterans-affairs/web-components/react-bindings';
 
 VaCheckbox.displayName = 'VaCheckbox';
 
@@ -212,69 +209,30 @@ Tile.args = {
     'This is optional text that can be used to describe the label in more detail.',
 };
 
-export const TitleWithCustomContent = () => {
-  const [isVisible, setIsVisible] = useState(false);
-  const onCloseEvent = () => {
-    setIsVisible(false);
-    // Make sure to move focus back to the remove button on cancel; when
-    // removing, focus should go to the button or link to add a new entry
-    document
-      .querySelector('va-checkbox va-button')
-      .shadowRoot.querySelector('button')
-      .focus();
-  };
-  const openModal = e => {
-    // Stop checkbox from toggling when clicking the button
-    e.preventDefault();
-    e.stopPropagation();
-    setIsVisible(true);
-  };
-  return (
-    <>
-      <VaModal
-        clickToClose
-        visible={isVisible}
-        onCloseEvent={onCloseEvent}
-        onPrimaryButtonClick={onCloseEvent}
-        onSecondaryButtonClick={onCloseEvent}
-        modalTitle="Remove entry"
-        primaryButtonText="Pretend"
-        secondaryButtonText="Cancel"
-      >
-        <p>This is supposed to remove the entry</p>
-      </VaModal>
-      <va-checkbox label="Issue 1" tile>
-        <div slot="internal-description">
-          <div className="vads-u-margin-top--0p5">
-            <strong>Detail</strong>: Internal description slot for issue 1
-          </div>
-          <div className="vads-u-margin-top--1">
-            <strong>Date</strong> Jan 2, 2025
-          </div>
+export const TitleWithCustomContent = () => (
+  <>
+    <va-checkbox label="Issue 1" tile onBlur={e => console.log(e)}>
+      <div slot="internal-description">
+        <div className="vads-u-margin-top--0p5">
+          <strong>Detail</strong>: Internal description slot for issue 1
         </div>
-      </va-checkbox>
-      <va-checkbox label="Issue 2" tile>
-        <div slot="internal-description">
-          <div className="vads-u-margin-top--0p5">
-            <strong>Detail</strong>: Internal description slot for issue 2
-          </div>
-          <div className="vads-u-margin-top--1">
-            <strong>Date</strong> Jan 4, 2025
-          </div>
-          <div className="vads-u-margin-top--1">
-            <va-link href="#title-with-custom-content" text="Edit" />
-            <va-button
-              onClick={openModal}
-              secondary
-              text="Remove"
-              class="vads-u-margin-left--2"
-            />
-          </div>
+        <div className="vads-u-margin-top--1">
+          <strong>Date</strong> Jan 2, 2025
         </div>
-      </va-checkbox>
-    </>
-  );
-};
+      </div>
+    </va-checkbox>
+    <va-checkbox label="Issue 2" tile onBlur={e => console.log(e)}>
+      <div slot="internal-description">
+        <div className="vads-u-margin-top--0p5">
+          <strong>Detail</strong>: Internal description slot for issue 2
+        </div>
+        <div className="vads-u-margin-top--1">
+          <strong>Date</strong> Jan 4, 2025
+        </div>
+      </div>
+    </va-checkbox>
+  </>
+);
 
 export const Checked = Template.bind(null);
 Checked.args = { ...defaultArgs, checked: true };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "17.4.0",
+  "version": "17.4.1",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
+++ b/packages/web-components/src/components/va-checkbox/test/va-checkbox.e2e.ts
@@ -326,11 +326,11 @@ describe('va-checkbox', () => {
         <mock:shadow-root>
           <span id="checkbox-error-message" role="alert"></span>
           <div class="va-checkbox__container" part="checkbox">
-            <input aria-invalid="false" class="va-checkbox__input" id="checkbox-element" type="checkbox">
-            <label class="va-checkbox__label" for="checkbox-element">
-              <span part="label">test</span>
-              <slot name="internal-description"></slot>
-            </label>
+          <input aria-invalid="false" class="va-checkbox__input" id="checkbox-element" type="checkbox">
+          <label class="va-checkbox__label" for="checkbox-element">
+            <span part="label">test</span>
+            <slot name="internal-description"></slot>
+          </label>
           </div>
         </mock:shadow-root>
         <p slot="internal-description">

--- a/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
+++ b/packages/web-components/src/components/va-checkbox/va-checkbox.tsx
@@ -12,7 +12,6 @@ import {
 } from '@stencil/core';
 import classnames from 'classnames';
 import { i18next } from '../..';
-import { isInteractiveElement } from '../../utils/utils';
 
 if (Build.isTesting) {
   // Make i18next.t() return the key instead of the value
@@ -155,17 +154,14 @@ export class VaCheckbox {
   };
 
   private handleClick = (e: Event) => {
-    // Ignore interative elements in the internal description slot
-    if (!isInteractiveElement(e.target as HTMLElement)) {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      this.checked = !this.checked;
-      const checkbox: HTMLInputElement =
-        this.el.shadowRoot.querySelector('#checkbox-element');
-      checkbox.focus();
-      this.vaChange.emit({ checked: this.checked });
-      if (this.enableAnalytics) this.fireAnalyticsEvent();
-    }
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    this.checked = !this.checked;
+    const checkbox: HTMLInputElement =
+      this.el.shadowRoot.querySelector('#checkbox-element');
+    checkbox.focus();
+    this.vaChange.emit({ checked: this.checked });
+    if (this.enableAnalytics) this.fireAnalyticsEvent();
   };
 
   /**

--- a/packages/web-components/src/utils/utils.spec.ts
+++ b/packages/web-components/src/utils/utils.spec.ts
@@ -1,9 +1,4 @@
-import {
-  format,
-  getSlottedNodes,
-  isNumeric,
-  isInteractiveElement,
-} from './utils';
+import { format, getSlottedNodes, isNumeric } from './utils';
 
 describe('format', () => {
   it('returns empty string for no names defined', () => {
@@ -50,6 +45,7 @@ describe('getSlottedNodes()', () => {
   }
 
   it('gathers slot nodes in the shadow DOM if slot is used', async () => {
+    
     var mockObject = {
       assignedNodes: () => {
         return ['h2', 'a', 'a'];
@@ -61,14 +57,15 @@ describe('getSlottedNodes()', () => {
 
     const defElement_shadowRoot_querySelector =
       defaultElement.shadowRoot.querySelector;
-
-    const spy = jest.spyOn(defaultElement.shadowRoot, 'querySelector');
+      
+    const spy = jest
+      .spyOn(defaultElement.shadowRoot, 'querySelector');
     spy.mockImplementation(selectors => {
-      if (selectors === 'slot') {
-        return mockObject as unknown as Element;
-      }
-      return defElement_shadowRoot_querySelector(selectors);
-    });
+        if (selectors === 'slot') {
+          return mockObject as unknown as Element;
+        }
+        return defElement_shadowRoot_querySelector(selectors);
+      });
 
     const slottedNodes = getSlottedNodes(defaultElement, null);
     expect(slottedNodes).toEqual(['h2', 'a', 'a']);
@@ -97,38 +94,5 @@ describe('getSlottedNodes()', () => {
 
     const slottedNodes = getSlottedNodes(defaultElement, 'a');
     expect(slottedNodes).toEqual([{ nodeName: 'A' }]);
-  });
-});
-
-describe('isInteractiveElement()', () => {
-  const testElement = tag => {
-    const el = document.createElement(tag);
-    return isInteractiveElement(el);
-  };
-  it('returns true for an anchor element', () => {
-    expect(testElement('va-test')).toEqual(true);
-  });
-  it('returns true for an anchor element', () => {
-    expect(testElement('a')).toEqual(true);
-  });
-
-  it('returns true for a button element', () => {
-    expect(testElement('button')).toEqual(true);
-  });
-
-  it('returns true for an input element', () => {
-    expect(testElement('input')).toEqual(true);
-  });
-
-  it('returns true for a select element', () => {
-    expect(testElement('select')).toEqual(true);
-  });
-
-  it('returns true for a textarea element', () => {
-    expect(testElement('textarea')).toEqual(true);
-  });
-
-  it('returns false for a div element', () => {
-    expect(testElement('div')).toEqual(false);
   });
 });

--- a/packages/web-components/src/utils/utils.ts
+++ b/packages/web-components/src/utils/utils.ts
@@ -179,14 +179,3 @@ export function getHeaderLevel(headerInput: number | string): string | null {
   }
   return headerLevel >= 1 && headerLevel <= 6 ? `h${headerLevel}` : null;
 }
-
-/**
- * Checks if an element is interactive
- */
-export function isInteractiveElement(el: HTMLElement): boolean {
-  const { tagName } = el;
-  return (
-    tagName.startsWith('VA-') ||
-    ['INPUT', 'BUTTON', 'A', 'DETAILS', 'TEXTAREA', 'SELECT'].includes(tagName)
-  );
-}


### PR DESCRIPTION
Reverts department-of-veterans-affairs/component-library#1515

@Mottie - I am reverting this work because it's breaking a ton of cypress tests in vets-website. You can checkout some of the failures in [this pull request](https://github.com/department-of-veterans-affairs/vets-website/pull/35207). 

I verified this to be the case by installing a dummy release in vets-website [with verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio) and running a bunch of the tests that are failing in the above PR. They all passed. 