### PR TITLE
va-official-gov-banner: swap icons

### DIFF
--- a/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
+++ b/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
@@ -6,7 +6,7 @@ import {
   Event,
   Prop,
   Element,
-  forceUpdate
+  forceUpdate,
 } from '@stencil/core';
 import { i18next } from '../..';
 import { Build } from '@stencil/core';
@@ -63,34 +63,38 @@ export class VaOfficialGovBanner {
     i18next.off('languageChanged');
   }
 
-  componentDidLoad(){
+  componentDidLoad() {
     // Initial loading of formatted text.
     this.govSiteExplanationText();
     this.govSiteLockText();
   }
 
   private handleClick = () => {
-    const content = this.el.shadowRoot?.querySelector('.content') as HTMLElement;
+    const content = this.el.shadowRoot?.querySelector(
+      '.content',
+    ) as HTMLElement;
     const button = this.el.shadowRoot?.querySelector('button') as HTMLElement;
-    const header = this.el.shadowRoot?.querySelector('div#header') as HTMLElement;
+    const header = this.el.shadowRoot?.querySelector(
+      'div#header',
+    ) as HTMLElement;
 
     button.setAttribute(
       'aria-expanded',
-      button.getAttribute('aria-expanded') === 'true'
-        ? 'false'
-        : 'true'
+      button.getAttribute('aria-expanded') === 'true' ? 'false' : 'true',
     );
 
     header.classList.toggle('expanded');
     // Toggle the hidden attribute on the content.
-    content.hidden ? content.removeAttribute('hidden') : content.setAttribute('hidden', 'true');
+    content.hidden
+      ? content.removeAttribute('hidden')
+      : content.setAttribute('hidden', 'true');
 
     if (!this.disableAnalytics) {
       const isOpen = button.getAttribute('aria-expanded') === 'true';
       const detail = {
         componentName: 'va-official-gov-banner',
         action: isOpen ? 'expand' : 'collapse',
-      }
+      };
       this.componentLibraryAnalytics.emit(detail);
     }
   };
@@ -101,28 +105,35 @@ export class VaOfficialGovBanner {
    * and the innerHTML of the element will be updated.
    */
   private govSiteExplanationText = () => {
-    const el = this.el.shadowRoot?.querySelector('.gov-site-explanation-text') as HTMLElement;
+    const el = this.el.shadowRoot?.querySelector(
+      '.gov-site-explanation-text',
+    ) as HTMLElement;
     if (el) {
       const text = i18next.t('gov-site-explanation', { tld: this.tld });
       if (text) {
-        el.innerHTML = text.replace(`.${this.tld}`, `<strong>.${this.tld}</strong>`);
+        el.innerHTML = text.replace(
+          `.${this.tld}`,
+          `<strong>.${this.tld}</strong>`,
+        );
       }
     }
-  }
+  };
 
   /**
    * This will add <strong> tags around various words in the text that is provided
    * as well as add the SVG lock image.
    */
   private govSiteLockText = () => {
-    const el = this.el.shadowRoot?.querySelector('.gov-site-lock-text') as HTMLElement;
+    const el = this.el.shadowRoot?.querySelector(
+      '.gov-site-lock-text',
+    ) as HTMLElement;
 
     // eslint-disable-next-line i18next/no-literal-string
     const lockSvg = `(&nbsp;<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" role="img" aria-labelledby="banner-lock-description" focusable="false">
     <title id="banner-lock-title">Lock</title>
     <desc id="banner-lock-description">Locked padlock icon</desc>
     <path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path>
-    </svg></span>&nbsp;)`
+    </svg></span>&nbsp;)`;
 
     let html = i18next.t('gov-site-lock', { image: 'SVG', tld: this.tld });
 
@@ -134,15 +145,15 @@ export class VaOfficialGovBanner {
     if (el) {
       el.innerHTML = html;
     }
-  }
+  };
 
   render() {
     const { tld } = this;
     if (tld === 'gov' || tld === 'mil') {
       return (
         <Host>
-            <div class="banner">
-            <div class="accordion"  >
+          <div class="banner">
+            <div class="accordion">
               <div id="header">
                 <div class="inner">
                   <div class="grid-col-auto">
@@ -150,7 +161,8 @@ export class VaOfficialGovBanner {
                       role="presentation"
                       class="header-flag"
                       src="https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/tiny-usa-flag.png"
-                      alt="" />
+                      alt=""
+                    />
                   </div>
                   <div class="grid-col-fill" aria-hidden="true">
                     <p class="header-text">{i18next.t('gov-site-label')}</p>
@@ -160,8 +172,11 @@ export class VaOfficialGovBanner {
                     onClick={this.handleClick}
                     type="button"
                     aria-expanded="false"
-                    aria-controls="official-gov-banner">
-                    <span class="button-text">{i18next.t('gov-site-button')}</span>
+                    aria-controls="official-gov-banner"
+                  >
+                    <span class="button-text">
+                      {i18next.t('gov-site-button')}
+                    </span>
                   </button>
                 </div>
               </div>
@@ -169,13 +184,13 @@ export class VaOfficialGovBanner {
               <div class="content" id="official-gov-banner" hidden>
                 <div class="grid-row">
                   <div class="col">
-                    <img
-                      src={iconHttpsSvg}
-                      role="presentation"
-                      alt="" />
+                    <img src={iconHttpsSvg} role="presentation" alt="" />
                     <div class="media-block">
                       <p>
-                        <strong>{i18next.t('gov-site-website', { tld })}</strong><br />
+                        <strong>
+                          {i18next.t('gov-site-website', { tld })}
+                        </strong>
+                        <br />
                         <span class="gov-site-explanation-text">
                           {this.govSiteExplanationText()}
                         </span>
@@ -183,13 +198,11 @@ export class VaOfficialGovBanner {
                     </div>
                   </div>
                   <div class="col">
-                    <img
-                      src={iconDotGovSvg}
-                      role="presentation"
-                      alt="" />
+                    <img src={iconDotGovSvg} role="presentation" alt="" />
                     <div class="media-block">
                       <p>
-                        <strong>{i18next.t('gov-site-https', { tld })}</strong><br />
+                        <strong>{i18next.t('gov-site-https', { tld })}</strong>
+                        <br />
                         <span class="gov-site-lock-text">
                           {this.govSiteLockText()}
                         </span>
@@ -204,5 +217,4 @@ export class VaOfficialGovBanner {
       );
     }
   }
-
 }

--- a/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
+++ b/packages/web-components/src/components/va-official-gov-banner/va-official-gov-banner.tsx
@@ -184,7 +184,7 @@ export class VaOfficialGovBanner {
               <div class="content" id="official-gov-banner" hidden>
                 <div class="grid-row">
                   <div class="col">
-                    <img src={iconHttpsSvg} role="presentation" alt="" />
+                    <img src={iconDotGovSvg} role="presentation" alt="" />
                     <div class="media-block">
                       <p>
                         <strong>
@@ -198,7 +198,7 @@ export class VaOfficialGovBanner {
                     </div>
                   </div>
                   <div class="col">
-                    <img src={iconDotGovSvg} role="presentation" alt="" />
+                    <img src={iconHttpsSvg} role="presentation" alt="" />
                     <div class="media-block">
                       <p>
                         <strong>{i18next.t('gov-site-https', { tld })}</strong>


### PR DESCRIPTION
- **style(web-components): format va-official-gov-banner component**
- **fix(web-components): swap official gov banner icons**

## Chromatic

<!-- This `2941-fix-gov-banner` is a placeholder for a CI job - it will be updated automatically -->

https://2941-fix-gov-banner--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Configuring this pull request

- [x] Link to any related issues in the description so they can be cross-referenced.
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
  - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
  - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2941

## QA Checklist

- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![Capture-2025-03-17-093006](https://github.com/user-attachments/assets/0486df1a-b166-4c44-a46f-d414f9bb3d95)


## Acceptance criteria

- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done

- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue
