### PR TITLE
Use headline text for alert close button ARIA label

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -83,7 +83,7 @@ export namespace Components {
      */
     interface VaAlert {
         /**
-          * Aria-label text for the close button.
+          * Aria-label text for the close button. If not provided, the text will be "Close {headline} notification".
          */
         "closeBtnAriaLabel"?: string;
         /**
@@ -3430,7 +3430,7 @@ declare namespace LocalJSX {
      */
     interface VaAlert {
         /**
-          * Aria-label text for the close button.
+          * Aria-label text for the close button. If not provided, the text will be "Close {headline} notification".
          */
         "closeBtnAriaLabel"?: string;
         /**

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -64,6 +64,24 @@ describe('va-alert', () => {
     expect(button).not.toBeNull();
   });
 
+  it('uses the headline text for the close button ARIA label, if no custom text is provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-alert closeable="true"><h4 slot="headline">This is an alert</h4></va-alert>');
+
+    let button = await page.find('va-alert >>> button');
+
+    expect(button.getAttribute('aria-label')).toEqual('Close This is an alert notification');
+  });
+
+  it('uses the custom text for the close button ARIA label, if provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-alert closeable="true" close-btn-aria-label="Close this notification"><h4 slot="headline">This is an alert</h4></va-alert>');
+
+    let button = await page.find('va-alert >>> button');
+
+    expect(button.getAttribute('aria-label')).toEqual('Close this notification');
+  });
+
   it('fires a custom "close" event when the close button is clicked', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -157,7 +157,6 @@ export class VaAlert {
   }
 
   componentDidRender() {
-    // If the close button aria label is not set, update the text to contain the headline text.
     if (!this.closeBtnAriaLabel) {
       this.updateCloseAriaLabelWithHeadlineText();
     }

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -156,7 +156,7 @@ export class VaAlert {
     this.vaComponentDidLoad.emit();
   }
 
-  componentDidUpdate() {
+  componentDidRender() {
     // If the close button aria label is not set, update the text to contain the headline text.
     if (!this.closeBtnAriaLabel) {
       this.updateCloseAriaLabelWithHeadlineText();

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -153,11 +153,14 @@ export class VaAlert {
   }
 
   componentDidLoad() {
+    this.vaComponentDidLoad.emit();
+  }
+
+  componentDidUpdate() {
     // If the close button aria label is not set, update the text to contain the headline text.
     if (!this.closeBtnAriaLabel) {
       this.updateCloseAriaLabelWithHeadlineText();
     }
-    this.vaComponentDidLoad.emit();
   }
 
   render() {

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -51,9 +51,9 @@ export class VaAlert {
   @Prop() visible?: boolean = true;
 
   /**
-   * Aria-label text for the close button.
+   * Aria-label text for the close button. If not provided, the text will be "Close {headline} notification".
    */
-  @Prop() closeBtnAriaLabel?: string = 'Close notification';
+  @Prop({ mutable: true }) closeBtnAriaLabel?: string;
 
   /**
    * If `true`, a close button will be displayed.
@@ -107,6 +107,11 @@ export class VaAlert {
     this.closeEvent.emit(e);
   }
 
+  private updateCloseAriaLabelWithHeadlineText(): void {
+    const headline = this.el.shadowRoot.querySelector('slot[name="headline"]');
+    this.closeBtnAriaLabel = `Close ${headline.assignedNodes()[0].textContent} notification`;
+  }
+
   private handleAlertBodyClick(e: MouseEvent): void {
     let headlineText = null;
 
@@ -148,6 +153,10 @@ export class VaAlert {
   }
 
   componentDidLoad() {
+    // If the close button aria label is not set, update the text to contain the headline text.
+    if (!this.closeBtnAriaLabel) {
+      this.updateCloseAriaLabelWithHeadlineText();
+    }
     this.vaComponentDidLoad.emit();
   }
 


### PR DESCRIPTION
## Chromatic
<!-- This `close-label` is a placeholder for a CI job - it will be updated automatically -->
https://close-label--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3768

Updated the alert close button to say "Close {headline} notification" if no custom text is provided. If the custom text property is set (`<va-alert closeable="true" close-btn-aria-label="Close this notification">`), that will take precedence. So any places that already use that prop will not be affected.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
  - N/A - No visual change. 
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

### With custom text
![image](https://github.com/user-attachments/assets/e94fe747-378f-42aa-bfff-eacdf99f9fb6)

### Without custom text

![image](https://github.com/user-attachments/assets/87b67306-9ff0-4864-9131-34f4696e33f1)


## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue
