### PR TITLE
va-addition-info & va-alert-expandable: Change link to button

### DIFF
--- a/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
+++ b/packages/web-components/src/components/va-additional-info/test/va-additional-info.e2e.ts
@@ -13,14 +13,14 @@ describe('va-additional-info', () => {
     expect(element).toEqualHtml(`
       <va-additional-info trigger="More info" class="hydrated">
         <mock:shadow-root>
-          <a aria-controls="info" aria-expanded="false" role="button" tabindex="0">
+          <button aria-controls="info" aria-expanded="false" type="button">
             <div>
               <span class="additional-info-title">
                 More info
               </span>
               <va-icon class="additional-info-icon hydrated"></va-icon>
             </div>
-          </a>
+          </button>
           <div class="closed" id="info" style="--calc-max-height:calc(0px + 1.125rem);">
             <slot></slot>
           </div>
@@ -48,12 +48,12 @@ describe('va-additional-info', () => {
       `<va-additional-info trigger="Additional information"></va-additional-info>`,
     );
 
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.click();
+    const buttonEl = await page.find('va-additional-info >>> button');
+    await buttonEl.click();
 
     await axeCheck(page);
 
-    expect(anchorEl.getAttribute('aria-expanded')).toEqual('true');
+    expect(buttonEl.getAttribute('aria-expanded')).toEqual('true');
   });
 
   it('expands when clicked', async () => {
@@ -72,13 +72,13 @@ describe('va-additional-info', () => {
     );
 
     // Use click to expand
-    const anchorEl = await page.find('va-additional-info >>> a');
-    expect(anchorEl.getAttribute('aria-expanded')).toEqual('false');
+    const buttonEl = await page.find('va-additional-info >>> button');
+    expect(buttonEl.getAttribute('aria-expanded')).toEqual('false');
 
-    await anchorEl.click();
+    await buttonEl.click();
     // Allow the transition to complete
     await page.waitForTimeout(600);
-    expect(anchorEl.getAttribute('aria-expanded')).toEqual('true');
+    expect(buttonEl.getAttribute('aria-expanded')).toEqual('true');
 
     const postOpacity = await handle.evaluate(
       (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
@@ -107,8 +107,8 @@ describe('va-additional-info', () => {
     );
 
     // Use keyboard to expand
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.press(' ');
+    const buttonEl = await page.find('va-additional-info >>> button');
+    await buttonEl.press(' ');
     // Allow the transition to complete
     await page.waitForTimeout(600);
 
@@ -139,8 +139,8 @@ describe('va-additional-info', () => {
     );
 
     // Use keyboard to expand
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.press('Enter');
+    const buttonEl = await page.find('va-additional-info >>> button');
+    await buttonEl.press('Enter');
     // Allow the transition to complete
     await page.waitForTimeout(600);
 
@@ -166,8 +166,8 @@ describe('va-additional-info', () => {
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.click();
+    const buttonEl = await page.find('va-additional-info >>> button');
+    await buttonEl.click();
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'expand',
@@ -189,11 +189,11 @@ describe('va-additional-info', () => {
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
-    const anchorEl = await page.find('va-additional-info >>> a');
+    const buttonEl = await page.find('va-additional-info >>> button');
 
     // Click once to expand, again to collapse
-    await anchorEl.click();
-    await anchorEl.click();
+    await buttonEl.click();
+    await buttonEl.click();
 
     const secondEvent = analyticsSpy.events[1];
     expect(secondEvent.detail.action).toEqual('collapse');
@@ -210,8 +210,8 @@ describe('va-additional-info', () => {
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.click();
+    const buttonEl = await page.find('va-additional-info >>> button');
+    await buttonEl.click();
 
     expect(analyticsSpy).toHaveReceivedEventTimes(0);
   });
@@ -224,8 +224,8 @@ describe('va-additional-info', () => {
       </va-additional-info>
     `);
     const handle = await page.waitForSelector('pierce/#info');
-    const anchorEl = await page.find('va-additional-info >>> a');
-    await anchorEl.click();
+    const buttonEl = await page.find('va-additional-info >>> button');
+    await buttonEl.click();
     await page.waitForSelector('pierce/#info.open');
     const calcMaxHeight = await handle.evaluate((domElement: HTMLElement) =>
       domElement.style.getPropertyValue('--calc-max-height'),

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.css
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.css
@@ -6,8 +6,8 @@
 }
 
 /* Add left side blue border if disable border prop disabled or not present */
-:host(:not([disable-border])) a[aria-expanded='true'] ~ #info,
-:host([disable-border='false']) a[aria-expanded='true'] ~ #info {
+:host(:not([disable-border])) button[aria-expanded='true'] ~ #info,
+:host([disable-border='false']) button[aria-expanded='true'] ~ #info {
   padding-left: calc(20px - 7px);
   border-left: 7px solid transparent;
   border-left-color: var(--vads-color-primary-alt-darkest);
@@ -21,10 +21,19 @@
   visibility: hidden;
 }
 
-a {
+button {
   align-items: flex-start;
   cursor: pointer;
   display: flex;
+  background: transparent;
+  border: none;
+  width: 100%;
+  padding: 0;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+    color: inherit;
+  }
 }
 
 .additional-info-title {
@@ -58,7 +67,7 @@ a {
   vertical-align: bottom;
 }
 
-a[aria-expanded='true'] .additional-info-icon {
+button[aria-expanded='true'] .additional-info-icon {
   transform: rotate(270deg);
   transition: transform 0.15s linear;
 }

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
@@ -72,13 +72,6 @@ export class VaAdditionalInfo {
     this.open = !this.open;
   }
 
-  handleKeydown(event): void {
-    if (event.key === ' ' || event.key === 'Enter') {
-      event.preventDefault();
-      this.toggleOpen();
-    }
-  }
-
   // Ensures that the CSS animation is consistent and uses the correct max-height for its content
   updateInfoMaxHeight() {
     const infoElm = this.el.shadowRoot.getElementById('info');
@@ -108,7 +101,6 @@ export class VaAdditionalInfo {
           aria-controls="info"
           aria-expanded={this.open ? 'true' : 'false'}
           onClick={this.toggleOpen.bind(this)}
-          onKeyDown={this.handleKeydown.bind(this)}
         >
           <div>
             <span class="additional-info-title">{this.trigger}</span>

--- a/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
+++ b/packages/web-components/src/components/va-additional-info/va-additional-info.tsx
@@ -98,16 +98,15 @@ export class VaAdditionalInfo {
 
   render() {
     const infoClass = classnames({
-      'open': this.open,
-      'closed': !this.open
+      open: this.open,
+      closed: !this.open,
     });
     return (
       <Host>
-        <a
-          role="button"
+        <button
+          type="button"
           aria-controls="info"
           aria-expanded={this.open ? 'true' : 'false'}
-          tabIndex={0}
           onClick={this.toggleOpen.bind(this)}
           onKeyDown={this.handleKeydown.bind(this)}
         >
@@ -119,7 +118,7 @@ export class VaAdditionalInfo {
               size={3}
             ></va-icon>
           </div>
-        </a>
+        </button>
         <div id="info" class={infoClass}>
           <slot></slot>
         </div>

--- a/packages/web-components/src/components/va-alert-expandable/test/va-alert-expandable.e2e.ts
+++ b/packages/web-components/src/components/va-alert-expandable/test/va-alert-expandable.e2e.ts
@@ -14,7 +14,7 @@ describe('va-alert-expandable', () => {
       <va-alert-expandable status="warning" trigger="Limited services and hours" class="hydrated">
         <mock:shadow-root>
         <div class="alert-expandable warning">
-          <a role="button" aria-controls="alert-body" aria-expanded="false" tabindex="0" class="alert-expandable-trigger">
+          <button type="button" aria-controls="alert-body" aria-expanded="false" class="alert-expandable-trigger">
             <va-icon class="alert-expandable__status-icon hydrated"></va-icon>
             <div>
               <span class="alert-expandable-title">
@@ -23,7 +23,7 @@ describe('va-alert-expandable', () => {
               </span>
               <va-icon class="alert-expandable-icon hydrated"></va-icon>
             </div>
-          </a>
+          </button>
           <div id="alert-body" class="alert-expandable-body closed" style="--calc-max-height:calc(12px + 2rem);"><div id="slot-wrap"><slot></slot></div></div>
         </div>
         </mock:shadow-root>
@@ -50,12 +50,12 @@ describe('va-alert-expandable', () => {
       `<va-alert-expandable status="warning" trigger="Limited services and hours"></va-alert-expandable>`,
     );
 
-    const anchorEl = await page.find('va-alert-expandable >>> a');
-    await anchorEl.click();
+    const buttonEl = await page.find('va-alert-expandable >>> button');
+    await buttonEl.click();
 
     await axeCheck(page);
 
-    expect(anchorEl.getAttribute('aria-expanded')).toEqual('true');
+    expect(buttonEl.getAttribute('aria-expanded')).toEqual('true');
   });
 
   it('expands when clicked', async () => {
@@ -74,13 +74,13 @@ describe('va-alert-expandable', () => {
     );
 
     // Use click to expand
-    const anchorEl = await page.find('va-alert-expandable >>> a');
-    expect(anchorEl.getAttribute('aria-expanded')).toEqual('false');
+    const buttonEl = await page.find('va-alert-expandable >>> button');
+    expect(buttonEl.getAttribute('aria-expanded')).toEqual('false');
 
-    await anchorEl.click();
+    await buttonEl.click();
     // Allow the transition to complete
     await page.waitForTimeout(600);
-    expect(anchorEl.getAttribute('aria-expanded')).toEqual('true');
+    expect(buttonEl.getAttribute('aria-expanded')).toEqual('true');
 
     const postOpacity = await handle.evaluate(
       (domElement: HTMLElement) => window.getComputedStyle(domElement).opacity,
@@ -109,8 +109,8 @@ describe('va-alert-expandable', () => {
     );
 
     // Use keyboard to expand
-    const anchorEl = await page.find('va-alert-expandable >>> a');
-    await anchorEl.press(' ');
+    const buttonEl = await page.find('va-alert-expandable >>> button');
+    await buttonEl.press(' ');
     // Allow the transition to complete
     await page.waitForTimeout(600);
 
@@ -141,8 +141,8 @@ describe('va-alert-expandable', () => {
     );
 
     // Use keyboard to expand
-    const anchorEl = await page.find('va-alert-expandable >>> a');
-    await anchorEl.press('Enter');
+    const buttonEl = await page.find('va-alert-expandable >>> button');
+    await buttonEl.press('Enter');
     // Allow the transition to complete
     await page.waitForTimeout(600);
 
@@ -168,8 +168,8 @@ describe('va-alert-expandable', () => {
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
-    const anchorEl = await page.find('va-alert-expandable >>> a');
-    await anchorEl.click();
+    const buttonEl = await page.find('va-alert-expandable >>> button');
+    await buttonEl.click();
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       action: 'expand',
@@ -191,11 +191,11 @@ describe('va-alert-expandable', () => {
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
-    const anchorEl = await page.find('va-alert-expandable >>> a');
+    const buttonEl = await page.find('va-alert-expandable >>> button');
 
     // Click once to expand, again to collapse
-    await anchorEl.click();
-    await anchorEl.click();
+    await buttonEl.click();
+    await buttonEl.click();
 
     const secondEvent = analyticsSpy.events[1];
     expect(secondEvent.detail.action).toEqual('collapse');
@@ -212,8 +212,8 @@ describe('va-alert-expandable', () => {
 
     const analyticsSpy = await page.spyOnEvent('component-library-analytics');
 
-    const anchorEl = await page.find('va-alert-expandable >>> a');
-    await anchorEl.click();
+    const buttonEl = await page.find('va-alert-expandable >>> button');
+    await buttonEl.click();
 
     expect(analyticsSpy).toHaveReceivedEventTimes(0);
   });
@@ -226,8 +226,8 @@ describe('va-alert-expandable', () => {
       </va-alert-expandable>
     `);
     const handle = await page.waitForSelector('pierce/#alert-body');
-    const anchorEl = await page.find('va-alert-expandable >>> a');
-    await anchorEl.click();
+    const buttonEl = await page.find('va-alert-expandable >>> button');
+    await buttonEl.click();
     await page.waitForSelector('pierce/#alert-body.open');
     const calcMaxHeight = await handle.evaluate((domElement: HTMLElement) =>
       domElement.style.getPropertyValue('--calc-max-height'),

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.css
@@ -31,6 +31,10 @@
   cursor: pointer;
   display: flex;
   padding: 0.75rem;
+  width: 100%;
+  border: none;
+  background: transparent;
+
 }
 
 div.warning .alert-expandable-trigger:hover {
@@ -93,7 +97,7 @@ div.continue .alert-expandable-trigger:hover {
   vertical-align: bottom;
 }
 
-a[aria-expanded='true'] .alert-expandable-icon {
+button[aria-expanded='true'] .alert-expandable-icon {
   transform: rotate(270deg);
   transition: transform 0.15s linear;
 }

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
@@ -127,11 +127,10 @@ export class VaAlertExpandable {
     return (
       <Host>
         <div role={role} aria-live={ariaLive} class={alertClasses}>
-          <a
-            role="button"
+          <button
+            type="button"
             aria-controls="alert-body"
             aria-expanded={this.open ? 'true' : 'false'}
-            tabIndex={0}
             onClick={this.toggleOpen.bind(this)}
             onKeyDown={this.handleKeydown.bind(this)}
             class="alert-expandable-trigger"
@@ -154,7 +153,7 @@ export class VaAlertExpandable {
                 size={3}
               ></va-icon>
             </div>
-          </a>
+          </button>
           <div id="alert-body" class={bodyClasses}>
             <div id="slot-wrap">
               <slot></slot>

--- a/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
+++ b/packages/web-components/src/components/va-alert-expandable/va-alert-expandable.tsx
@@ -79,13 +79,6 @@ export class VaAlertExpandable {
     this.open = !this.open;
   }
 
-  handleKeydown(event): void {
-    if (event.key === ' ' || event.key === 'Enter') {
-      event.preventDefault();
-      this.toggleOpen();
-    }
-  }
-
   // Ensures that the CSS animation is consistent and uses the correct max-height for its content
   /* eslint-disable i18next/no-literal-string */
   updateAlertBodyMaxHeight() {
@@ -132,7 +125,6 @@ export class VaAlertExpandable {
             aria-controls="alert-body"
             aria-expanded={this.open ? 'true' : 'false'}
             onClick={this.toggleOpen.bind(this)}
-            onKeyDown={this.handleKeydown.bind(this)}
             class="alert-expandable-trigger"
           >
             {!iconless && (


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

The `va-additional-info` and `va-alert-expandable` web components are both using a clickable link to toggle the expandable content. To improve assistive technology user's experience, and [follow our guidelines](https://design.va.gov/components/button/#links-vs-buttons), this PR changes the link into a button.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3657

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

No visual changes

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
