### PR TITLE
Add password input field to va-file-input and va-file-input-multiple

### DIFF
--- a/packages/storybook/stories/va-file-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.tsx
@@ -42,6 +42,7 @@ const defaultArgs = {
   'children': null,
   'value': null,
   'read-only': false,
+  'encrypted': false,
   'status-text': null,
   'uploadedFile': null,
   'maxFileSize': Infinity,
@@ -58,6 +59,7 @@ const Template = ({
   vaChange,
   headerSize,
   readOnly,
+  encrypted,
   statusText,
   value,
   children,
@@ -76,6 +78,7 @@ const Template = ({
       onVaChange={vaChange}
       header-size={headerSize}
       readOnly={readOnly}
+      encrypted={encrypted}
       statusText={statusText}
       value={value}
       children={children}
@@ -91,6 +94,10 @@ Default.argTypes = propStructure(fileInputDocs);
 
 export const Required = Template.bind(null);
 Required.args = { ...defaultArgs, required: true };
+
+
+export const AcceptsFilePassword = Template.bind(null);
+AcceptsFilePassword.args = { ...defaultArgs, encrypted: true };
 
 export const AcceptsOnlySpecificFileTypes = Template.bind(null);
 AcceptsOnlySpecificFileTypes.args = {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -624,6 +624,10 @@ export namespace Components {
          */
         "enableAnalytics"?: boolean;
         /**
+          * When true shows a password field
+         */
+        "encrypted"?: boolean;
+        /**
           * The error message to render.
          */
         "error"?: string;
@@ -697,6 +701,10 @@ export namespace Components {
           * If enabled, emits custom analytics events when file changes occur.
          */
         "enableAnalytics"?: boolean;
+        /**
+          * Array of booleans, displays file password field for corresponding file input.
+         */
+        "encrypted": boolean[];
         /**
           * Array of error messages corresponding to each file input. The length and order match the files array.
          */
@@ -4068,6 +4076,10 @@ declare namespace LocalJSX {
          */
         "enableAnalytics"?: boolean;
         /**
+          * When true shows a password field
+         */
+        "encrypted"?: boolean;
+        /**
           * The error message to render.
          */
         "error"?: string;
@@ -4149,6 +4161,10 @@ declare namespace LocalJSX {
           * If enabled, emits custom analytics events when file changes occur.
          */
         "enableAnalytics"?: boolean;
+        /**
+          * Array of booleans, displays file password field for corresponding file input.
+         */
+        "encrypted"?: boolean[];
         /**
           * Array of error messages corresponding to each file input. The length and order match the files array.
          */

--- a/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
+++ b/packages/web-components/src/components/va-file-input-multiple/va-file-input-multiple.tsx
@@ -55,6 +55,11 @@ export class VaFileInputMultiple {
   @Prop() errors: string[] = [];
 
   /**
+   * Array of booleans, displays file password field for corresponding file input.
+   */
+  @Prop() encrypted: boolean[] = [];
+
+  /**
    * Hint text provided to guide users on the expected format or type of files.
    */
   @Prop() hint?: string;
@@ -360,6 +365,7 @@ export class VaFileInputMultiple {
       name,
       accept,
       errors,
+      encrypted,
       enableAnalytics,
       readOnly,
     } = this;
@@ -398,6 +404,7 @@ export class VaFileInputMultiple {
                   ? { uploadMessage: this.additionalFileUploadMessage }
                   : {})}
                 error={errors[pageIndex]}
+                encrypted={encrypted[pageIndex]}
                 onVaChange={event =>
                   this.handleChange(event, fileEntry.key, pageIndex)
                 }

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -115,6 +115,11 @@ export class VaFileInput {
   @Prop() readOnly?: boolean = false;
 
   /**
+   * When true shows a password field
+   */
+  @Prop() encrypted?: boolean = false;
+
+  /**
    * Object representing a previously uploaded file. Example: `{ name: string, type: string, size: number}`
    */
   @Prop() uploadedFile?: UploadedFile;
@@ -419,6 +424,7 @@ export class VaFileInput {
       headless,
       value,
       readOnly,
+      encrypted,
       statusText,
       uploadedFile,
       percentUploaded,
@@ -575,7 +581,9 @@ export class VaFileInput {
                 {(file || value || uploadedFile) && (
                   <div>
                     {this.showSeparator && <hr class="separator" />}
-
+                    {encrypted && (
+                      <va-text-input label="File password" required />
+                    )}
                     <div class="additional-info-slot">
                       <slot></slot>
                     </div>


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description
Partial [Add attribute to va-file-input to display a password field for encrypted files #3935](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3935)

Adds `encrypted` attribute to `va-file-input` to display file password field when `true`.
Adds `encrypted` attribute to `va-file-input-multiple` to accept an array to display file password field when corresponding entry in the array is `true`

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
