### PR TITLE
va-telephone vanity to allow full replacement

### DIFF
--- a/packages/storybook/stories/va-telephone.stories.tsx
+++ b/packages/storybook/stories/va-telephone.stories.tsx
@@ -160,3 +160,10 @@ VanityNumber.args = {
   contact: '8772228387',
   vanity: 'VETS',
 };
+
+export const FullVanityNumber = Template.bind(null);
+FullVanityNumber.args = {
+  ...defaultArgs,
+  contact: '8884424551',
+  vanity: '888-GIBILL-1',
+};

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1797,7 +1797,7 @@ export namespace Components {
          */
         "tty"?: boolean;
         /**
-          * Optional vanity phone number. Replaces the last 4 digits with the vanity text input
+          * Optional vanity phone number. Replaces the last 4 digits or the entire text with the vanity text input
          */
         "vanity"?: string;
     }
@@ -5406,7 +5406,7 @@ declare namespace LocalJSX {
          */
         "tty"?: boolean;
         /**
-          * Optional vanity phone number. Replaces the last 4 digits with the vanity text input
+          * Optional vanity phone number. Replaces the last 4 digits or the entire text with the vanity text input
          */
         "vanity"?: string;
     }

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.e2e.ts
@@ -167,7 +167,7 @@ describe('va-telephone', () => {
     expect(link.innerText).toEqual('123456');
   });
 
-  it('handles a vanity number as a contact prop', async () => {
+  it('handles a 4 character vanity number as a contact prop', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<va-telephone contact="8772228387" vanity="VETS"></va-telephone>',
@@ -176,6 +176,17 @@ describe('va-telephone', () => {
     const link = await page.find('va-telephone >>> a');
     expect(link.getAttribute('href')).toEqual('tel:+18772228387');
     expect(link.innerText).toEqual('877-222-VETS (8387)');
+  });
+
+  it('handles a full vanity number as a contact prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-telephone contact="8884424551" vanity="888-GIBILL-1"></va-telephone>',
+    );
+
+    const link = await page.find('va-telephone >>> a');
+    expect(link.getAttribute('href')).toEqual('tel:+18884424551');
+    expect(link.innerText).toEqual('888-GIBILL-1 (888-442-4551)');
   });
 
   it('fires an analytics event when clicked', async () => {

--- a/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
+++ b/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx
@@ -51,13 +51,22 @@ describe('formatPhoneNumber', () => {
     ).toBe('911');
   });
 
-  it('formats a contact number with vanity prop', () => {
+  it('formats a contact number with 4 character vanity prop', () => {
     expect(
       VaTelephone.formatPhoneNumber({
         contact,
         vanity,
       }),
     ).toBe('888-555-ABCD (1234)');
+  });
+
+  it('formats a contact number with full vanity prop', () => {
+    expect(
+      VaTelephone.formatPhoneNumber({
+        contact: '8884424551',
+        vanity: '888-GIBILL-1',
+      }),
+    ).toBe('888-GIBILL-1 (888-442-4551)');
   });
 
   it('formats a TTY number', () => {

--- a/packages/web-components/src/components/va-telephone/va-telephone.tsx
+++ b/packages/web-components/src/components/va-telephone/va-telephone.tsx
@@ -61,7 +61,7 @@ export class VaTelephone {
 
   /**
    * Optional vanity phone number.
-   * Replaces the last 4 digits with the vanity text input
+   * Replaces the last 4 digits or the entire text with the vanity text input
    */
   @Prop() vanity?: string;
 
@@ -130,7 +130,10 @@ export class VaTelephone {
       if (international) formattedNum = `+1-${formattedNum}`;
       if (extension) formattedNum = `${formattedNum}, ext. ${extension}`;
       if (vanity) {
-        formattedNum = `${area}-${local}-${vanity} (${last4})`;
+        formattedNum =
+          vanity.length === 4
+            ? `${area}-${local}-${vanity} (${last4})`
+            : `${vanity} (${formattedNum})`;
       }
     }
 


### PR DESCRIPTION
## Chromatic
<!-- This `2531-vanity-phone` is a placeholder for a CI job - it will be updated automatically -->
https://2531-vanity-phone--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description

Updating `va-telephone` to allow full vanity replacement. The GI Bill team needs to replace more than the last 4 characters of the phone number, but maintain the last number. The easiest way around this requirement was to allow full vanity replacement. 

> 888-GIBILL-1 (888-442-4551)

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2531

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<img width="1045" alt="Storybook full vanity number section showing a full vanity string of '888-GIBILL-1'. When this renders it shows the vanity text followed by the full phone number as digits in parenthesis" src="https://github.com/user-attachments/assets/b6b991bb-bc64-4a41-85c0-95241f049c5a" />

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
