### PR TITLE
va-date | Show default days with no month selected

### DIFF
--- a/packages/web-components/src/components/va-date/test/va-date.e2e.ts
+++ b/packages/web-components/src/components/va-date/test/va-date.e2e.ts
@@ -34,6 +34,42 @@ describe('va-date', () => {
     expect(dayOptions).toHaveLength(32); // 31 + one empty option
   });
 
+  it('renders day options when no month is selected, nd updates when month is selected', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-date name="test"></va-date>');
+
+    const handleYear = await page.$('pierce/[name="testYear"]');
+    const handleMonth = await page.$('pierce/[name="testMonth"]');
+
+    // No month selected
+    const dayOptions = await page.findAll(
+      'va-date >>> va-select.select-day >>> select >>> option',
+    );
+    expect(dayOptions).toHaveLength(32); // 31 + one empty option
+
+    // February selected, with no year
+    await handleMonth.select('2');
+    await page.waitForChanges();
+    const febDayOptions = await page.findAll(
+      'va-date >>> va-select.select-day >>> select >>> option',
+    );
+    expect(febDayOptions).toHaveLength(30); // 29 + one empty option
+
+    // Click three times to select all text in input
+    await handleYear.click({ clickCount: 3 });
+    await handleYear.press('2');
+    await handleYear.press('0');
+    await handleYear.press('2');
+    await handleYear.press('1');
+    await page.waitForChanges();
+
+    // February selected, with non-leap year
+    const nonLeapYearDayOptions = await page.findAll(
+      'va-date >>> va-select.select-day >>> select >>> option',
+    );
+    expect(nonLeapYearDayOptions).toHaveLength(29); // 28 + one empty option
+  });
+
   it('passes an axe check', async () => {
     const page = await newE2EPage();
     await page.setContent(
@@ -344,7 +380,7 @@ describe('va-date', () => {
     await handleMonth.select('2');
     await page.waitForChanges();
     expect(elementMonth.getAttribute('value')).toBe('2');
-    expect(elementDay.getAttribute('value')).toBe('');
+    expect(elementDay.getAttribute('value')).toBe('31');
   });
 
   it('year input only allows for 4 characters to be used', async () => {

--- a/packages/web-components/src/components/va-date/va-date.tsx
+++ b/packages/web-components/src/components/va-date/va-date.tsx
@@ -12,10 +12,10 @@ import { i18next } from '../..';
 
 import {
   months,
-  days,
   validate,
   getErrorParameters,
   zeroPadStart,
+  daysForSelectedMonth,
 } from '../../utils/date-utils';
 
 /**
@@ -238,7 +238,12 @@ export class VaDate {
     const [year, month, day] = (value || '')
       .split('-')
       .map(val => parseInt(val));
-    const daysForSelectedMonth = month > 0 ? days[month] : [];
+    // Build array of days for the selected month
+    // If month is not selected, use 31 days
+    const arrayDaysForSelectedMonth = Array.from(
+      { length: daysForSelectedMonth(year, month) },
+      (_, index) => index + 1,
+    );
     const errorParameters = (error: string) => {
       return getErrorParameters(error, year, month);
     };
@@ -286,7 +291,7 @@ export class VaDate {
                 // If day value set is greater than amount of days in the month
                 // set to empty string instead
                 // Value must be a string
-                value={daysForSelectedMonth.length < day ? '' : day?.toString()}
+                value={day?.toString()}
                 onVaSelect={handleDateChange}
                 onBlur={this.handleDayBlur}
                 invalid={this.invalidDay}
@@ -294,10 +299,9 @@ export class VaDate {
                 error={this.dayTouched && this.invalidDay ? this.error : null}
                 showError={false}
               >
-                {daysForSelectedMonth &&
-                  daysForSelectedMonth.map(day => (
-                    <option value={day}>{day}</option>
-                  ))}
+                {arrayDaysForSelectedMonth.map(day => (
+                  <option value={day}>{day}</option>
+                ))}
               </va-select>
             )}
             <va-text-input

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -306,10 +306,12 @@ export function getErrorParameters(error: string, year: number, month: number) {
 
 // Get last day of the month (month is zero based, so we're +1 month, day 0);
 // new Date() will recalculate and go back to last day of the previous month.
-// Return 31 for undefined month or year to not invalidate the day with
-// partial data (this used to be set to zero by default)
+// Return expected days for month, or 31 for undefined month or year to not
+// invalidate the day with partial data (this used to be set to zero by default)
 export const daysForSelectedMonth = (year: number, month: number): number =>
-  year && month ? new Date(year, month, 0).getDate() : 31;
+  year && month
+    ? new Date(year, month, 0).getDate()
+    : days[month]?.length || 31;
 
 // Allow 0-9, Backspace, Delete, Left and Right Arrow, and Tab to clear data or move to next field
 export const validKeys = [

--- a/packages/web-components/src/utils/date-utils.ts
+++ b/packages/web-components/src/utils/date-utils.ts
@@ -1,9 +1,7 @@
 import i18next from 'i18next';
 import { Components } from '../components';
 
-import {
-  Build,
-} from '@stencil/core';
+import { Build } from '@stencil/core';
 
 if (Build.isTesting) {
   // Make i18next.t() return the key instead of the value
@@ -158,43 +156,42 @@ export const internalErrors = [
   'day-range',
   'month-range',
   'date-error',
-  'month-select'
+  'month-select',
 ];
 
 /**
- the month error key for a va-select instance varies if 
+ the month error key for a va-select instance varies if
  the instance is inside va-date or va-memorable-date
  */
 function getMonthErrorKey(monthSelect: boolean): string {
   return monthSelect ? 'month-select' : 'month-range';
 }
 
-
 interface ValidateConfig {
-  component: Components.VaDate | Components.VaMemorableDate,
-  year: number,
-  month: number,
-  day: number,
-  monthYearOnly?: boolean,
-  yearTouched?: boolean,
-  monthTouched?: boolean,
-  dayTouched?: boolean,
-  monthSelect?: boolean,
-  monthOptional?: boolean
+  component: Components.VaDate | Components.VaMemorableDate;
+  year: number;
+  month: number;
+  day: number;
+  monthYearOnly?: boolean;
+  yearTouched?: boolean;
+  monthTouched?: boolean;
+  dayTouched?: boolean;
+  monthSelect?: boolean;
+  monthOptional?: boolean;
 }
 
 export function validate({
-                           component,
-                           year,
-                           month,
-                           day,
-                           monthYearOnly,
-                           yearTouched,
-                           monthTouched,
-                           dayTouched,
-                           monthSelect,
-                           monthOptional
-                         }: ValidateConfig): void {
+  component,
+  year,
+  month,
+  day,
+  monthYearOnly,
+  yearTouched,
+  monthTouched,
+  dayTouched,
+  monthSelect,
+  monthOptional,
+}: ValidateConfig): void {
   const maxDays = daysForSelectedMonth(year, month);
 
   // Reset previous invalid states
@@ -222,18 +219,19 @@ export function validate({
   }
 
   // Validate required fields
-  if (component.required && (!year || (monthRequired && !month) || (!monthYearOnly && !day))) {
+  if (
+    component.required &&
+    (!year || (monthRequired && !month) || (!monthYearOnly && !day))
+  ) {
     if (monthRequired && monthTouched && !month) {
       component.invalidMonth = true;
       component.error = 'date-error';
       return;
-    }
-    else if (dayTouched && !day && !monthYearOnly) {
+    } else if (dayTouched && !day && !monthYearOnly) {
       component.invalidDay = true;
       component.error = 'date-error';
       return;
-    }
-    else if (yearTouched && !year) {
+    } else if (yearTouched && !year) {
       component.invalidYear = true;
       component.error = 'date-error';
       return;
@@ -258,7 +256,12 @@ export function validate({
   }
 
   // Validate year, month, and day ranges if they have a value regardless of whether they are required
-  if (monthRequired && month && (month < minMonths || month > maxMonths) && monthTouched) {
+  if (
+    monthRequired &&
+    month &&
+    (month < minMonths || month > maxMonths) &&
+    monthTouched
+  ) {
     component.invalidMonth = true;
     component.error = getMonthErrorKey(monthSelect);
     return;
@@ -275,20 +278,20 @@ export function validate({
   }
 
   // Remove any error message if none of the fields are invalid
-  if (!component.invalidYear && !component.invalidMonth && !component.invalidDay) {
+  if (
+    !component.invalidYear &&
+    !component.invalidMonth &&
+    !component.invalidDay
+  ) {
     if (!component.error || internalErrors.includes(component.error)) {
       component.error = null;
     }
   }
 }
 
-export function getErrorParameters(
-  error: string,
-  year: number,
-  month: number) {
-
+export function getErrorParameters(error: string, year: number, month: number) {
   const maxDay = daysForSelectedMonth(year, month);
-  switch(error) {
+  switch (error) {
     case 'month-range':
     case 'month-select':
       return { start: 1, end: maxMonths };
@@ -379,4 +382,4 @@ export const isDateSameDay = (date1: Date, date2: Date) => {
 export const zeroPadStart = (number: number | string) =>
   `00${(number || '').toString()}`.slice(-2);
 
-  /* eslint-enable i18next/no-literal-string */
+/* eslint-enable i18next/no-literal-string */


### PR DESCRIPTION
## Chromatic
<!-- This `3651-default-days` is a placeholder for a CI job - it will be updated automatically -->
https://3651-default-days--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
When no month is selected, the day select is empty:
- This PR shows a default of 31 days when no month is selected
- When a month is selected, it will show the appropriate number of days
- When February is selected, it will show 29 for leap years and 28 for all other years
- When February is selected and a value greater than the accepted days, the select shows "Select" option, but the original value is still in place.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3651

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![day select shows 31 days with no month selected. It shows 29 when February is selected and no year value, and shows 28 when a non-leap year is entered](https://github.com/user-attachments/assets/3e30b9e9-52fc-4cd2-ba49-c0723d3784e8)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
