### PR TITLE
va-link | Remove duplicate screen reader content

### DIFF
--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -23,13 +23,13 @@ describe('va-link', () => {
   it('adds a lang attribute if the language prop set on default va-link', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      '<va-link href="https://www.va.gov" text="Share your VA medical records" language="en" />'
+      '<va-link href="https://www.va.gov" text="Share your VA medical records" language="en" />',
     );
 
     const element = await page.find('va-link >>> a');
     expect(element.getAttribute('lang')).toBe('en');
     expect(element.getAttribute('hrefLang')).toBe('en');
-  })
+  });
 
   it('renders active link', async () => {
     const page = await newE2EPage();
@@ -185,9 +185,9 @@ describe('va-link', () => {
     <va-link class="hydrated" external="" href="https://www.va.gov" text="Veteran's Affairs">
       <mock:shadow-root>
         <a href="https://www.va.gov" rel="noreferrer" class="link--center" target="_blank">
-          Veteran's Affairs (opens in a new tab)
-          <span class="usa-sr-only">
-            opens in a new tab
+          Veteran's Affairs
+          <span class="screen-only">
+            (opens in a new tab)
           </span>
         </a>
       </mock:shadow-root>

--- a/packages/web-components/src/components/va-link/va-link.scss
+++ b/packages/web-components/src/components/va-link/va-link.scss
@@ -80,3 +80,9 @@ abbr {
 .external-link-icon {
   margin-left: 4px;
 }
+
+@media print {
+  .screen-only {
+    display: none;
+  }
+}

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -161,7 +161,7 @@ export class VaLink {
       iconName,
       iconSize,
       language,
-      label
+      label,
     } = this;
 
     const linkClass = classNames({
@@ -302,8 +302,7 @@ export class VaLink {
             aria-label={label}
             target="_blank"
           >
-            {text} (opens in a new tab)
-            <span class="usa-sr-only">opens in a new tab</span>
+            {text} <span class="screen-only">(opens in a new tab)</span>
           </a>
         </Host>
       );


### PR DESCRIPTION
## Chromatic
<!-- This `106044-ext-link` is a placeholder for a CI job - it will be updated automatically -->
https://106044-ext-link--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
- Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3699
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106044
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3718 (hide "opens in a new tab" when printing)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

| Before - duplicate "opens in a new tab" text |
|----|
| <img width="582" alt="Screenshot 2025-03-31 at 12 00 09 PM" src="https://github.com/user-attachments/assets/33593f1a-0097-4f2f-be05-de6f31515145" /> |
| After - Remove duplicate & change to screen only class |
| <img width="889" alt="Screenshot 2025-03-31 at 11 47 49 AM" src="https://github.com/user-attachments/assets/13a9dc4f-7568-401b-874e-21362ca87ea0" /> |
| After - print view |
| <img width="727" alt="Screenshot 2025-03-31 at 11 47 33 AM" src="https://github.com/user-attachments/assets/06d97b5d-39af-44ed-9fe8-7ebd8d61b2b9" /> |

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
