### PR TITLE
Update focus-visible outline on va-segmented-progress-bar

### DIFF
--- a/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.scss
+++ b/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.scss
@@ -8,3 +8,9 @@
 *, ::after, ::before {
   box-sizing: border-box;
 }
+
+:host {
+  .usa-step-indicator__heading:focus-visible {
+    outline: 2px solid var(--vads-color-action-focus-on-light);
+  }
+}


### PR DESCRIPTION
## Chromatic
<!-- This `segmented-progress-bar-focus-highlight` is a placeholder for a CI job - it will be updated automatically -->
https://segmented-progress-bar-focus-highlight--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes [Segmented progress bar focus state is not yellow #3801](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3801)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
