### PR TITLE
va-radio: arrow key accessibility

### DIFF
--- a/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
+++ b/packages/web-components/src/components/va-radio/test/va-radio.e2e.ts
@@ -86,7 +86,7 @@ describe('va-radio', () => {
     expect(errorElement).toEqualHtml(`
      <span class="usa-error-message" role="alert">
        <span class="usa-sr-only">
-         error
+         Error
        </span>
        This is an error
      </span>
@@ -109,7 +109,7 @@ describe('va-radio', () => {
     const element = await page.find('va-radio >>> .usa-label--required');
     expect(element).toEqualHtml(`
       <span class="usa-label--required" part="required">
-        required
+        (*Required)
       </span>
     `);
   });

--- a/packages/web-components/src/components/va-radio/va-radio.tsx
+++ b/packages/web-components/src/components/va-radio/va-radio.tsx
@@ -135,14 +135,12 @@ export class VaRadio {
 
     switch (event.key) {
       case ' ':
-        event.preventDefault();
         if (currentNode.checked) return;
         nextNode = currentNode;
         this.selectNextNode(currentNode);
         break;
       case 'ArrowDown':
       case 'ArrowRight':
-        event.preventDefault();
         if (currentNodeIndex === radioOptionNodes.length - 1) {
           nextNode = radioOptionNodes[0];
           this.deselectCurrentNode(currentNode);
@@ -155,7 +153,6 @@ export class VaRadio {
         break;
       case 'ArrowUp':
       case 'ArrowLeft':
-        event.preventDefault();
         if (currentNodeIndex === 0) {
           nextNode = radioOptionNodes[radioOptionNodes.length - 1];
           this.deselectCurrentNode(currentNode);
@@ -212,7 +209,6 @@ export class VaRadio {
 
   private selectNextNode(node: HTMLVaRadioOptionElement): void {
     node.setAttribute('checked', '');
-    node.focus();
   }
 
   private getHeaderLevel() {


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Remove event preventDefault() and focus() calls to enable keyboard selection using arrow keys.
**This is a JAWS ticket so @rsmithadhoc will need to verify

Closes [3928](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3928)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No Visual changes

## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue
