### PR TITLE
va-combo-box: rerender defect

### DIFF
--- a/packages/web-components/src/components/va-combo-box/test/va-combo-box.e2e.ts
+++ b/packages/web-components/src/components/va-combo-box/test/va-combo-box.e2e.ts
@@ -5,7 +5,7 @@ describe('va-combo-box', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-          <va-combo-box label="A label" value="bar">
+          <va-combo-box label="A label">
             <option value="foo">Foo</option>
             <option value="bar">Bar</option>
           </va-select>
@@ -13,14 +13,14 @@ describe('va-combo-box', () => {
     const element = await page.find('va-combo-box');
     await page.find('va-combo-box >>> input');
     expect(element).toEqualHtml(`
-            <va-combo-box class="hydrated" label="A label" value="bar">
+            <va-combo-box class="hydrated" label="A label" >
                 <mock:shadow-root>
                     <label class="usa-label" for="options" id="options-label">
                     A label
                     </label>
                     <span id="input-error-message" role="alert"></span>
                     <slot></slot>
-                    <div class="usa-combo-box usa-combo-box--pristine" data-default-value="bar" data-enhanced="true">
+                    <div class="usa-combo-box"  data-enhanced="true">
                     <select aria-hidden="true" class="usa-combo-box__select usa-select usa-sr-only" tabindex="-1">
                         <option value="foo">
                         Foo

--- a/packages/web-components/src/components/va-combo-box/va-combo-box.tsx
+++ b/packages/web-components/src/components/va-combo-box/va-combo-box.tsx
@@ -134,7 +134,7 @@ export class VaComboBox {
     const allNodes = this.el.querySelectorAll('option, optgroup');
 
     const nodes = Array.from(allNodes);
-    return nodes.map((node: HTMLOptionElement | HTMLOptGroupElement, index) => {
+    this.options = nodes.map((node: HTMLOptionElement | HTMLOptGroupElement, index) => {
       if (node.nodeName.toLowerCase() === 'optgroup') {
         return (
           <Fragment>
@@ -225,7 +225,7 @@ export class VaComboBox {
             </Fragment>
           )}
         </span>
-        <slot></slot>
+        <slot onSlotchange={() => this.populateOptions()}></slot>
         <div
           class="usa-combo-box"
           data-default-value={value}
@@ -238,7 +238,7 @@ export class VaComboBox {
             onChange={e => this.handleChange(e)}
             disabled={disabled}
           >
-            {this.populateOptions()}
+            {this.options}
           </select>
         </div>
         {isMessageSet(messageAriaDescribedby) && (


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
This addresses the defect where combo box options where not populating on component re-rendering. 

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
