### PR TITLE
va-breadcrumb: add prop to conditionally use #content or a custom href for the current page

### DIFF
--- a/packages/storybook/stories/va-breadcrumbs-uswds.stories.tsx
+++ b/packages/storybook/stories/va-breadcrumbs-uswds.stories.tsx
@@ -15,17 +15,12 @@ export default {
     },
   },
 };
-const dataArray = [
-  { label: 'VA.gov home', href: '#one' },
-  { label: 'Level two', href: '#two' },
-  { label: 'Level three', href: '#three' },
-];
-
-const Template = ({ label, 'disable-analytics': disableAnalytics }) => (
+const Template = ({ label, 'disable-analytics': disableAnalytics, 'current-page-redirect': currentPageRedirect, 'breadcrumb-list': breadcrumbList }) => (
   <VaBreadcrumbs
     label={label}
     disableAnalytics={disableAnalytics}
-    breadcrumbList={dataArray}
+    breadcrumbList={breadcrumbList}
+    currentPageRedirect={currentPageRedirect}
   ></VaBreadcrumbs>
 );
 
@@ -223,6 +218,12 @@ const WithRouterTemplate = ({
   );
 };
 
+const dataArray = [
+  { label: 'VA.gov home', href: '#one' },
+  { label: 'Level two', href: '#two' },
+  { label: 'Level three', href: '#three' },
+];
+
 const defaultArgs = {
   'label': 'Breadcrumb',
   'breadcrumb-list':
@@ -234,6 +235,7 @@ const defaultArgs = {
 export const Default = Template.bind(null);
 Default.args = {
   ...defaultArgs,
+  'breadcrumb-list': dataArray,
 };
 Default.argTypes = propStructure(breadcrumbsDocs);
 
@@ -248,3 +250,14 @@ MultipleLanguages.args = { ...defaultArgs };
 
 export const WithRouterLinkSupport = WithRouterTemplate.bind(null);
 WithRouterLinkSupport.args = { ...defaultArgs };
+
+export const CurrentPageRedirect = Template.bind(null);
+CurrentPageRedirect.args = { 
+  ...defaultArgs, 
+  'current-page-redirect': true, 
+  'breadcrumb-list': [
+    { "label": "VA.gov home", "href": "/" }, 
+    { "label": "Last Page", "href": "/example-last-page" }, 
+    { "label": "Current Page", "href": "/introduction" }
+  ] 
+};

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -224,6 +224,10 @@ export namespace Components {
          */
         "breadcrumbList"?: Breadcrumb[] | string;
         /**
+          * When true, the current page link will use the last href value provided in the breadcrumb list instead of the #content hash.
+         */
+        "currentPageRedirect"?: boolean;
+        /**
           * Analytics tracking function(s) will not be called
          */
         "disableAnalytics"?: boolean;
@@ -3617,6 +3621,10 @@ declare namespace LocalJSX {
           * Represents a list of breadcrumbs. Use a JSON array of objects with label and href properties, then wrap in a string if using non-React-binding version. See Storybook examples for React-binding version. For pure web components, here's an example link: ``[{"href": "/link1", "label": "Link 1"}]`.
          */
         "breadcrumbList"?: Breadcrumb[] | string;
+        /**
+          * When true, the current page link will use the last href value provided in the breadcrumb list instead of the #content hash.
+         */
+        "currentPageRedirect"?: boolean;
         /**
           * Analytics tracking function(s) will not be called
          */

--- a/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
+++ b/packages/web-components/src/components/va-breadcrumbs/test/va-breadcrumbs.e2e.ts
@@ -213,4 +213,39 @@ describe('va-breadcrumbs', () => {
     expect(firstAnchorText).toBe('home');
   });
 
+  it('does not use #content for the last link when currentPageRedirect is true', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs breadcrumb-list='[{ "label": "One", "href": "/one" }, { "label": "Two", "href": "/two" }, { "label": "Three", "href": "/three" }]' current-page-redirect></va-breadcrumbs>
+    `);
+
+    const anchorElements = await page.findAll('va-breadcrumbs >>> a');
+    const lastAnchorHref = await anchorElements[2].getProperty('href');
+
+    expect(lastAnchorHref).not.toContain('#content');
+  });
+
+  it('uses #content for the last link when currentPageRedirect is false', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs breadcrumb-list='[{ "label": "One", "href": "/one" }, { "label": "Two", "href": "/two" }, { "label": "Three", "href": "/three" }]'></va-breadcrumbs>
+    `);
+
+    const anchorElements = await page.findAll('va-breadcrumbs >>> a');
+    const lastAnchorHref = await anchorElements[2].getProperty('href');
+
+    expect(lastAnchorHref).toContain('#content');
+  });
+
+  it('uses the href value from the last breadcrumb when currentPageRedirect is true', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-breadcrumbs breadcrumb-list='[{ "label": "One", "href": "/one" }, { "label": "Two", "href": "/two" }, { "label": "Three", "href": "/three" }]' current-page-redirect></va-breadcrumbs>
+    `);
+
+    const anchorElements = await page.findAll('va-breadcrumbs >>> a');
+    const lastAnchorHref = await anchorElements[2].getProperty('href');
+
+    expect(lastAnchorHref).toContain('/three');
+  });
 });

--- a/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
+++ b/packages/web-components/src/components/va-breadcrumbs/va-breadcrumbs.tsx
@@ -50,6 +50,11 @@ export class VaBreadcrumbs {
   @Prop() homeVeteransAffairs?: boolean = true;
 
   /**
+   * When true, the current page link will use the last href value provided in the breadcrumb list instead of the #content hash.
+   */
+  @Prop() currentPageRedirect?: boolean = false;
+
+  /**
    *
    * Represents an internal state of the component which stores the list of breadcrumbs parsed from the 'breadcrumbList' prop.
    * Each breadcrumb is represented as an object with at least two properties: 'label' and 'href'.
@@ -331,7 +336,7 @@ export class VaBreadcrumbs {
                     : undefined
                 }
               >
-                {index === this.formattedBreadcrumbs.length - 1 ? (
+                {(!this.currentPageRedirect && index === this.formattedBreadcrumbs.length - 1) ? (
                   <a
                     class="usa-breadcrumb__link"
                     href="#content"


### PR DESCRIPTION
## Chromatic
<!-- This `1903-last-breadcrumb` is a placeholder for a CI job - it will be updated automatically -->
https://1903-last-breadcrumb--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

[Staging review feedback](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2117) asked that we make the last breadcrumb item (the current page) a link that navigates to the `#content` hash on the page. But the forms library needs this link to be more flexibility in order to navigate users to the introduction page.

This update will add a new prop `current-page-redirect` (boolean) that will use the provided href value for the last link instead of overriding it with `#content`.

Closes https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1903

## Screenshots

![Screenshot 2025-04-08 at 10 24 21 AM](https://github.com/user-attachments/assets/bd330f92-8d95-4ff5-b922-12e0e4b598da)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
