### PR TITLE
va-service-list-item: support all va-link props via shared interface

### DIFF
--- a/packages/storybook/stories/va-service-list-item.stories.tsx
+++ b/packages/storybook/stories/va-service-list-item.stories.tsx
@@ -121,7 +121,8 @@ MaximalBase.argTypes = {
     },
   },
   'optionalLink': {
-    description: 'An optional link related to the service',
+    description:
+      'An optional link related to the service. All props of the va-link component are supported as properties of this object.',
     control: { type: 'object' },
     table: {
       category: 'Properties',

--- a/packages/storybook/stories/va-service-list-item.stories.tsx
+++ b/packages/storybook/stories/va-service-list-item.stories.tsx
@@ -180,7 +180,7 @@ export const BaseWithOptionalExternalVaLinkProp = Template.bind({});
 BaseWithOptionalExternalVaLinkProp.args = {
   ...BaseWithOptionalLink.args,
   optionalLink: {
-    href: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    href: 'https://www.va.gov',
     text: 'Optional link to external url',
     external: true,
   },

--- a/packages/storybook/stories/va-service-list-item.stories.tsx
+++ b/packages/storybook/stories/va-service-list-item.stories.tsx
@@ -176,6 +176,15 @@ BaseWithOptionalLink.args = {
   },
 };
 
+export const BaseWithOptionalExternalVaLinkProp = Template.bind({});
+BaseWithOptionalExternalVaLinkProp.args = {
+  ...BaseWithOptionalLink.args,
+  optionalLink: {
+    href: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    text: 'Optional link to external url',
+    external: true,
+  },
+};
 export const BaseWithCriticalAction = Template.bind({});
 BaseWithCriticalAction.args = {
   serviceDetails: {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1614,7 +1614,7 @@ export namespace Components {
          */
         "icon"?: string;
         /**
-          * An optional link related to the service
+          * An optional link related to the service. All props of the va-link component are supported as properties of this object.
          */
         "optionalLink"?: OptionalLink | string;
         /**
@@ -5216,7 +5216,7 @@ declare namespace LocalJSX {
          */
         "icon"?: string;
         /**
-          * An optional link related to the service
+          * An optional link related to the service. All props of the va-link component are supported as properties of this object.
          */
         "optionalLink"?: OptionalLink | string;
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -4345,6 +4345,9 @@ declare namespace LocalJSX {
           * The lang attribute for the anchor tag in the Default va-link. Also used for hreflang.
          */
         "language"?: string;
+        /**
+          * The event used to track usage of the component.
+         */
         "onComponent-library-analytics"?: (event: VaLinkCustomEvent<any>) => void;
         /**
           * The number of pages of the file. Only displayed if download is `true`.

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -6,36 +6,12 @@ import classNames from 'classnames';
  * @maturityCategory use
  * @maturityLevel deployed
  */
-
-export interface VaLinkProps {
-  href: string;
-  text: string;
-  abbrTitle?: string;
-  active?: boolean;
-  back?: boolean;
-  calendar?: boolean;
-  channel?: boolean;
-  disableAnalytics?: boolean;
-  download?: boolean;
-  filename?: string;
-  filetype?: string;
-  pages?: number;
-  video?: boolean;
-  reverse?: boolean;
-  external?: boolean;
-  label?: string;
-  iconName?: string;
-  iconSize?: number;
-  language?: string;
-  componentLibraryAnalytics: EventEmitter;
-}
-
 @Component({
   tag: 'va-link',
   styleUrl: 'va-link.scss',
   shadow: true,
 })
-export class VaLink implements VaLinkProps {
+export class VaLink {
   /**
    * The title used in the abbr element. If filetype is PDF, the abbr title will be Portable Document Format.
    */

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -7,12 +7,35 @@ import classNames from 'classnames';
  * @maturityLevel deployed
  */
 
+export interface VaLinkProps {
+  href: string;
+  text: string;
+  abbrTitle?: string;
+  active?: boolean;
+  back?: boolean;
+  calendar?: boolean;
+  channel?: boolean;
+  disableAnalytics?: boolean;
+  download?: boolean;
+  filename?: string;
+  filetype?: string;
+  pages?: number;
+  video?: boolean;
+  reverse?: boolean;
+  external?: boolean;
+  label?: string;
+  iconName?: string;
+  iconSize?: number;
+  language?: string;
+  componentLibraryAnalytics: EventEmitter;
+}
+
 @Component({
   tag: 'va-link',
   styleUrl: 'va-link.scss',
   shadow: true,
 })
-export class VaLink {
+export class VaLink implements VaLinkProps {
   /**
    * The title used in the abbr element. If filetype is PDF, the abbr title will be Portable Document Format.
    */
@@ -103,15 +126,15 @@ export class VaLink {
    * an integer between 3 and 9 inclusive.
    */
   @Prop() iconSize?: number = 3;
-  /**
-   * The event used to track usage of the component.
-   */
 
   /**
    * The lang attribute for the anchor tag in the Default va-link. Also used for hreflang.
    */
   @Prop() language?: string;
 
+  /**
+   * The event used to track usage of the component.
+   */
   @Event({
     bubbles: true,
     composed: true,

--- a/packages/web-components/src/components/va-service-list-item/test/va-service-list-item.e2e.ts
+++ b/packages/web-components/src/components/va-service-list-item/test/va-service-list-item.e2e.ts
@@ -1,26 +1,29 @@
 import { newE2EPage } from '@stencil/core/testing';
 import { axeCheck } from '../../../testing/test-helpers';
+import { Components } from '../../../components';
+
+const defaultProps: Components.VaServiceListItem = {
+  serviceDetails: {
+    'Approved on': 'May 11, 2011',
+    'Program': 'Post-9/11 GI Bill',
+    'Eligibility': '70%',
+  },
+  action: undefined,
+  icon: 'school',
+  serviceName: 'Education',
+  serviceLink: 'https://www.va.gov/education',
+  serviceStatus: 'Eligible',
+  optionalLink: {
+    href: 'https://www.va.gov',
+    text: 'Optional link (to a page other than the detail page)',
+  },
+};
 
 describe('va-service-list-item', () => {
   /**
    * Helper function to set up the component with dynamic props
    */
-  async function setupComponent({
-    serviceDetails = {
-      'Approved on': 'May 11, 2011',
-      'Program': 'Post-9/11 GI Bill',
-      'Eligibility': '70%',
-    },
-    action = undefined,
-    icon = 'school',
-    serviceName = 'Education',
-    serviceLink = 'https://www.va.gov/education',
-    serviceStatus = 'Eligible',
-    optionalLink = {
-      href: 'https://www.va.gov',
-      text: 'Optional link (to a page other than the detail page)',
-    },
-  } = {}) {
+  async function setupComponent(props: Components.VaServiceListItem = defaultProps) {
     const page = await newE2EPage();
 
     await page.setContent(`<va-service-list-item></va-service-list-item>`);
@@ -28,13 +31,7 @@ describe('va-service-list-item', () => {
     const elementHandle = await page.$('va-service-list-item');
 
     const assignedProps = {
-      serviceDetails,
-      optionalLink,
-      icon,
-      serviceName,
-      serviceLink,
-      serviceStatus,
-      action,
+      ...props,
     };
 
     await page.evaluate(
@@ -66,6 +63,7 @@ describe('va-service-list-item', () => {
 
   it('renders with all elements and the critical action component when an action prop is provided', async () => {
     const { page, elementHandle } = await setupComponent({
+      ...defaultProps,
       action: {
         href: 'https://www.va.gov/education',
         text: 'Take some urgent action',
@@ -182,6 +180,61 @@ describe('va-service-list-item', () => {
     expect(shadowInnerHTML).not.toContain(
       '<va-icon class="icon hydrated"></va-icon>',
     );
+  });
+
+  it.only('renders optionalLink as external link', async () => {
+    const optionalLinkAsExternal = {
+      href: 'https://custom-link.com',
+      text: 'External link',
+      external: true,
+    };
+    const { page, elementHandle } = await setupComponent({
+      ...defaultProps,
+      optionalLink: optionalLinkAsExternal,
+    });
+
+    await page.waitForSelector('va-service-list-item');
+    await page.waitForChanges();
+
+    // get the va-link element's rendered innerHTML
+    const linkElement = await page.evaluate(
+      el => {
+        const shadowRoot = el.shadowRoot;
+        const linkElement = shadowRoot.querySelector('va-link.optional-link');
+        return linkElement ? linkElement.shadowRoot.innerHTML : null;
+      },
+      elementHandle
+    );
+
+    // basic check to make sure the text "opens in a new tab" is present
+    expect(linkElement).toContain('opens in a new tab');
+
+    // this was the best way I could get the attributes of the rendered anchor element
+    const anchorAttributes = await page.evaluate(
+      el => {
+        const shadowRoot = el.shadowRoot;
+        const linkElement = shadowRoot.querySelector('va-link.optional-link');
+        if (!linkElement) return null;
+
+        const linkShadowRoot = linkElement.shadowRoot;
+        const anchorElement = linkShadowRoot.querySelector('a');
+        if (!anchorElement) return null;
+
+        return {
+          href: anchorElement.getAttribute('href'),
+          rel: anchorElement.getAttribute('rel'),
+          target: anchorElement.getAttribute('target'),
+          class: anchorElement.getAttribute('class'),
+        };
+      },
+      elementHandle
+    );
+
+
+    expect(anchorAttributes).not.toBeNull();
+    expect(anchorAttributes.href).toBe(optionalLinkAsExternal.href);
+    expect(anchorAttributes.rel).toBe('noreferrer');
+    expect(anchorAttributes.target).toBe('_blank');
   });
 
   it('does NOT render optionalLink when optionalLink prop is not passed', async () => {

--- a/packages/web-components/src/components/va-service-list-item/test/va-service-list-item.e2e.ts
+++ b/packages/web-components/src/components/va-service-list-item/test/va-service-list-item.e2e.ts
@@ -182,7 +182,7 @@ describe('va-service-list-item', () => {
     );
   });
 
-  it.only('renders optionalLink as external link', async () => {
+  it('renders optionalLink as external link', async () => {
     const optionalLinkAsExternal = {
       href: 'https://custom-link.com',
       text: 'External link',

--- a/packages/web-components/src/components/va-service-list-item/va-service-list-item.tsx
+++ b/packages/web-components/src/components/va-service-list-item/va-service-list-item.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 import { Component, Host, h, Prop, Watch, State, Element } from '@stencil/core';
 import { consoleDevError } from '../../utils/utils';
+import { VaLinkProps } from '../va-link/va-link';
 
 export interface ServiceDetails {
   [key: string]: string;
@@ -9,10 +10,7 @@ export interface ServiceAction {
   href: string;
   text: string;
 }
-export interface OptionalLink {
-  href: string;
-  text: string;
-}
+export type OptionalLink = VaLinkProps;
 
 /**
  * @componentName Service List Item
@@ -130,10 +128,7 @@ export class VaServiceListItem {
     return (
       <Host>
         <div class="service-list-item">
-          <a
-            href={serviceLink}
-            class="service-title-row"
-          >
+          <a href={serviceLink} class="service-title-row">
             <div class="header" tabIndex={0}>
               {icon && (
                 <va-icon class={iconClass} icon={icon} size={3}></va-icon>
@@ -167,6 +162,23 @@ export class VaServiceListItem {
               class="optional-link"
               href={parsedOptionalLink.href}
               text={parsedOptionalLink.text}
+              abbr-title={parsedOptionalLink.abbrTitle}
+              active={parsedOptionalLink.active}
+              back={parsedOptionalLink.back}
+              calendar={parsedOptionalLink.calendar}
+              channel={parsedOptionalLink.channel}
+              disable-analytics={parsedOptionalLink.disableAnalytics}
+              download={parsedOptionalLink.download}
+              filename={parsedOptionalLink.filename}
+              filetype={parsedOptionalLink.filetype}
+              pages={parsedOptionalLink.pages}
+              video={parsedOptionalLink.video}
+              reverse={parsedOptionalLink.reverse}
+              external={parsedOptionalLink.external}
+              label={parsedOptionalLink.label}
+              icon-name={parsedOptionalLink.iconName}
+              icon-size={parsedOptionalLink.iconSize}
+              language={parsedOptionalLink.language}
             ></va-link>
           )}
         </div>

--- a/packages/web-components/src/components/va-service-list-item/va-service-list-item.tsx
+++ b/packages/web-components/src/components/va-service-list-item/va-service-list-item.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 import { Component, Host, h, Prop, Watch, State, Element } from '@stencil/core';
 import { consoleDevError } from '../../utils/utils';
-import { VaLinkProps } from '../va-link/va-link';
+import { Components } from '../../components';
 
 export interface ServiceDetails {
   [key: string]: string;
@@ -10,7 +10,7 @@ export interface ServiceAction {
   href: string;
   text: string;
 }
-export type OptionalLink = VaLinkProps;
+export type OptionalLink = Components.VaLink;
 
 /**
  * @componentName Service List Item
@@ -158,28 +158,7 @@ export class VaServiceListItem {
           <ul class="service-details-list">{serviceDetailsList}</ul>
 
           {parsedOptionalLink?.href && parsedOptionalLink?.text && (
-            <va-link
-              class="optional-link"
-              href={parsedOptionalLink.href}
-              text={parsedOptionalLink.text}
-              abbr-title={parsedOptionalLink.abbrTitle}
-              active={parsedOptionalLink.active}
-              back={parsedOptionalLink.back}
-              calendar={parsedOptionalLink.calendar}
-              channel={parsedOptionalLink.channel}
-              disable-analytics={parsedOptionalLink.disableAnalytics}
-              download={parsedOptionalLink.download}
-              filename={parsedOptionalLink.filename}
-              filetype={parsedOptionalLink.filetype}
-              pages={parsedOptionalLink.pages}
-              video={parsedOptionalLink.video}
-              reverse={parsedOptionalLink.reverse}
-              external={parsedOptionalLink.external}
-              label={parsedOptionalLink.label}
-              icon-name={parsedOptionalLink.iconName}
-              icon-size={parsedOptionalLink.iconSize}
-              language={parsedOptionalLink.language}
-            ></va-link>
+            <va-link class="optional-link" {...parsedOptionalLink}></va-link>
           )}
         </div>
       </Host>

--- a/packages/web-components/src/components/va-service-list-item/va-service-list-item.tsx
+++ b/packages/web-components/src/components/va-service-list-item/va-service-list-item.tsx
@@ -46,7 +46,7 @@ export class VaServiceListItem {
   /** Action associated with the service  */
   @Prop() action?: ServiceAction | string;
 
-  /** An optional link related to the service */
+  /** An optional link related to the service. All props of the va-link component are supported as properties of this object. */
   @Prop() optionalLink?: OptionalLink | string;
 
   @State() parsedServiceDetails: ServiceDetails;


### PR DESCRIPTION
## Chromatic
<!-- This `aedp-aw-342-update-va-servi` is a placeholder for a CI job - it will be updated automatically -->
https://aedp-aw-342-update-va-service-link-op--65a6e2ed2314f7b8f98609d8.chromatic.com/

## Description
Closes https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/342

Adds the ability for the optionalLink of the `va-service-list-item` to use any of the props that are available on the `va-link` component. This was requested via a content update where they mentioned having guidance that matches the va-link as well.

> Format the optional link to express what it will do. For example, if the link is a [download link](https://dev-design.va.gov/3973/components/link/#download), include the standard download icon. If it takes users to an external site, display the standard "(opens in new tab)" text. See additional accessibility guidance in the [Link](https://dev-design.va.gov/3973/components/link/#accessibility-considerations) component.

Now the optionalLink can be an external link, video, download etc and it uses the same interface as is defined by the va-link itself.

Also added a test for this to make sure props are passed through, and a storybook story to show an external link as one usage.

There are corresponding docs also ready for review here: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/3973

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
   - accessibility remains the same if not better now that the link has all props now supported
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![Screenshot 2025-04-11 at 1 45 30 PM](https://github.com/user-attachments/assets/2cb76c25-6ca5-4bc5-82b9-0272f5d24a1e)



## Acceptance criteria
- [x] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue
