### PR TITLE
added error class to input element

### DIFF
--- a/packages/web-components/src/components/va-combo-box/va-combo-box-library.js
+++ b/packages/web-components/src/components/va-combo-box/va-combo-box-library.js
@@ -22,6 +22,7 @@ const LIST_OPTION_GROUP_OPTION_CLASS = `${LIST_OPTION_CLASS}--group-option`;
 const LIST_OPTION_FOCUSED_CLASS = `${LIST_OPTION_CLASS}--focused`;
 const LIST_OPTION_SELECTED_CLASS = `${LIST_OPTION_CLASS}--selected`;
 const STATUS_CLASS = `${COMBO_BOX_CLASS}__status`;
+const ERROR_CLASS = `usa-input--error`;
 
 const COMBO_BOX = `.${COMBO_BOX_CLASS}`;
 const SELECT = `.${SELECT_CLASS}`;
@@ -253,6 +254,11 @@ const noop = () => {};
         input.setAttribute(key, value);
       }),
     );
+
+    // Check for the error state and add the error class if needed
+    if (comboBoxEl.dataset.error === 'true') {
+      input.classList.add(ERROR_CLASS);
+    }
 
     comboBoxEl.insertAdjacentElement('beforeend', input);
 

--- a/packages/web-components/src/components/va-combo-box/va-combo-box.tsx
+++ b/packages/web-components/src/components/va-combo-box/va-combo-box.tsx
@@ -230,6 +230,7 @@ export class VaComboBox {
           class="usa-combo-box"
           data-default-value={value}
           data-placeholder={placeholder}
+          data-error={!!error}
         >
           <select
             class="usa-select"


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [ ] Link to any related issues in the description so they can be cross-referenced.
- [ ] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes <ticket>

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
