### PR TITLE
Expand story when modal is open

### DIFF
--- a/packages/storybook/.storybook/style.scss
+++ b/packages/storybook/.storybook/style.scss
@@ -21,6 +21,10 @@
   }
 }
 
+.sb-anchor.expand .docs-story > div > div {
+  height: 400px;
+}
+
 .sbdocs-wrapper {
   padding: 2.5rem 20px !important;
 }

--- a/packages/storybook/stories/va-modal-uswds.stories.tsx
+++ b/packages/storybook/stories/va-modal-uswds.stories.tsx
@@ -1,6 +1,11 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { VaModal } from '@department-of-veterans-affairs/web-components/react-bindings';
-import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
+import {
+  getWebComponentDocs,
+  propStructure,
+  StoryDocs,
+  resizeViewPorts,
+} from './wc-helpers';
 
 VaModal.displayName = 'VaModal';
 
@@ -55,10 +60,17 @@ const Template = ({
   forcedModal,
 }) => {
   const [isVisible, setIsVisible] = useState(visible);
-  const onCloseEvent = () => setIsVisible(!isVisible);
-  const openModal = () => setIsVisible(true);
+  const wrapRef = useRef(null);
+  const onCloseEvent = () => {
+    setIsVisible(!isVisible);
+    resizeViewPorts(wrapRef?.current, false);
+  };
+  const openModal = () => {
+    setIsVisible(true);
+    resizeViewPorts(wrapRef?.current, true);
+  };
   return (
-    <div>
+    <div ref={wrapRef}>
       <h1>Testing h1 heading</h1>
       <va-button onClick={openModal} text="Click here to open modal" />
       <VaModal
@@ -95,10 +107,17 @@ const ForcedTemplate = ({
   forcedModal,
 }) => {
   const [isVisible, setIsVisible] = useState(visible);
-  const openModal = () => setIsVisible(true);
-  const closeModal = () => setIsVisible(false);
+  const wrapRef = useRef(null);
+  const openModal = () => {
+    setIsVisible(true);
+    resizeViewPorts(wrapRef?.current, true);
+  };
+  const closeModal = () => {
+    setIsVisible(false);
+    resizeViewPorts(wrapRef?.current, false);
+  };
   return (
-    <div>
+    <div ref={wrapRef}>
       <h1>Testing h1 heading</h1>
       <va-button onClick={openModal} text="Click here to open modal" />
       <VaModal
@@ -194,10 +213,17 @@ export const WithNestedWebComponents = ({
   forcedModal,
 }) => {
   const [isVisible, setIsVisible] = useState(visible);
-  const onCloseEvent = () => setIsVisible(!isVisible);
-  const openModal = () => setIsVisible(true);
+  const wrapRef = useRef(null);
+  const onCloseEvent = () => {
+    setIsVisible(!isVisible);
+    resizeViewPorts(wrapRef?.current, false);
+  };
+  const openModal = () => {
+    setIsVisible(true);
+    resizeViewPorts(wrapRef?.current, true);
+  };
   return (
-    <div>
+    <div ref={wrapRef}>
       <h1>Testing h1 heading</h1>
       <va-button onClick={openModal} text="Click here to open modal" />
       <input id="pre-modal-input" type="checkbox" />

--- a/packages/storybook/stories/wc-helpers.tsx
+++ b/packages/storybook/stories/wc-helpers.tsx
@@ -343,3 +343,17 @@ export function applyFocus(el) {
     el.focus();
   }
 }
+
+/**
+ * This utility will expand the vertical space of the viewport when a web
+ * component is active or expanded (e.g. modal, accordion, etc.)
+ * @param wrap
+ * @param isVisible
+ * @returns
+ */
+export function resizeViewPorts(wrap, isVisible) {
+  if (!wrap) return;
+  const story = wrap.closest('.sb-anchor');
+  story.scrollIntoView();
+  story.classList.toggle('expand', isVisible);
+}


### PR DESCRIPTION
## Chromatic
<!-- This `771-expand-modal-story` is a placeholder for a CI job - it will be updated automatically -->
https://771-expand-modal-story--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

When a modal is opened, the contents aren't completely visible within the storybook story. This PR adds a class to the wrapper to increase the height to `400px` - this makes all current modals completely visible within the storybook page.

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/771

The above ticket was meant for the documentation pages at design.va.gov, so I misunderstood the need; but this is still a good addition :D

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

| Before | After |
|---|---|
| ![modal-before](https://github.com/user-attachments/assets/5c427321-21c7-4e0d-a3f4-bf5be60a6ba3) | ![modal](https://github.com/user-attachments/assets/cc66ed99-64fa-4bdf-9947-0de12f90f03b) |

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
