### PR TITLE
Add password events to file input

### DIFF
--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
@@ -427,12 +427,12 @@ CustomValidation.args = {
   hint: 'Select any file type',
 };
 
-const EncryptedTemplate = ({ label, name, hint }) => {
+const EncryptedTemplate = ({ label, name }) => {
   const [encryptedList, setEncryptedList] = useState([]);
 
   function setEncrpytedForEachFile(event) {
     const fileEntries = event.detail.state;
-    const pdfFiles = fileEntries.map((file, index) => {
+    const pdfFiles = fileEntries.map((file) => {
       return file.file.type === 'application/pdf'
     });
     setEncryptedList(pdfFiles);
@@ -457,7 +457,8 @@ const EncryptedTemplate = ({ label, name, hint }) => {
           be requested for that specific file, or false if no password is
           needed. By default, no password field will be displayed. This
           setup allows for the dynamic display of a password field based
-          on real-time validation of each file as it is processed.
+          on real-time validation of each file as it is processed. Passwords
+          are passed through the <code>onVaMultipleChange</code> event.
         </p>
       </div>
       <div className="vads-u-margin-top--2">

--- a/packages/storybook/stories/va-file-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.tsx
@@ -37,6 +37,7 @@ const defaultArgs = {
   'hint': 'You can upload a .pdf, .gif, .jpg, .bmp, or .txt file.',
   'vaChange': event =>
     alert(`File change event received: ${event?.detail?.files[0]?.name}`),
+  'vaPasswordChange': null,
   'uswds': true,
   'header-size': null,
   'children': null,
@@ -57,6 +58,7 @@ const Template = ({
   hint,
   enableAnalytics,
   vaChange,
+  vaPasswordChange,
   headerSize,
   readOnly,
   encrypted,
@@ -76,6 +78,7 @@ const Template = ({
       hint={hint}
       enable-analytics={enableAnalytics}
       onVaChange={vaChange}
+      onVaPasswordChange={vaPasswordChange}
       header-size={headerSize}
       readOnly={readOnly}
       encrypted={encrypted}
@@ -97,7 +100,7 @@ Required.args = { ...defaultArgs, required: true };
 
 
 export const AcceptsFilePassword = Template.bind(null);
-AcceptsFilePassword.args = { ...defaultArgs, encrypted: true };
+AcceptsFilePassword.args = { ...defaultArgs, encrypted: true, label: 'Password info emitted through the onVaPasswordChange event' };
 
 export const AcceptsOnlySpecificFileTypes = Template.bind(null);
 AcceptsOnlySpecificFileTypes.args = {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -2581,6 +2581,7 @@ declare global {
     };
     interface HTMLVaFileInputElementEventMap {
         "vaChange": any;
+        "vaPasswordChange": any;
         "component-library-analytics": any;
     }
     /**
@@ -4120,6 +4121,10 @@ declare namespace LocalJSX {
           * The event emitted when the file input value changes.
          */
         "onVaChange"?: (event: VaFileInputCustomEvent<any>) => void;
+        /**
+          * The event emitted when the file input password value changes.
+         */
+        "onVaPasswordChange"?: (event: VaFileInputCustomEvent<any>) => void;
         /**
           * Percent upload completed. For use with va-progress-bar component
          */

--- a/packages/web-components/src/components/va-file-input-multiple/FileDetails.ts
+++ b/packages/web-components/src/components/va-file-input-multiple/FileDetails.ts
@@ -9,5 +9,6 @@
 
 export interface FileDetails {
   file: File,
-  changed: Boolean
+  changed: Boolean,
+  password?: string
 }

--- a/packages/web-components/src/components/va-file-input-multiple/FileIndex.ts
+++ b/packages/web-components/src/components/va-file-input-multiple/FileIndex.ts
@@ -13,4 +13,5 @@ export interface FileIndex {
   file: File | null;
   key: number;
   content: Node[];
+  password?: string;
 }

--- a/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.spec.ts
+++ b/packages/web-components/src/components/va-file-input-multiple/test/va-file-input-multiple.spec.ts
@@ -1,17 +1,21 @@
 import { VaFileInputMultiple } from '../va-file-input-multiple';
 import { FileDetails } from "../FileDetails";
+import { FileIndex } from '../FileIndex';
 
 describe('checking buildFilesArray output', ()=> {
-  const fileArray = [new File(["foo"], "foo.txt"), new File(["bar"], "bar.txt")];
+  const fileArray:FileIndex[] = [
+    {file:new File(["foo"], "foo.txt"), key: 0, content:null},
+    {file:new File(["bar"], "bar.txt"), key: 1, content:null}
+  ];
   it('should mark the first file as changed', async () => {
     const component = new VaFileInputMultiple();
     let filesArray = component.buildFilesArray(fileArray, false, 0);
     let expectedOutput:FileDetails[] = [ {
-      file: fileArray[0],
+      file: fileArray[0].file,
       changed: true
     },
     {
-      file: fileArray[1],
+      file: fileArray[1].file,
       changed: false
     }];
     expect(filesArray).toEqual(expectedOutput);
@@ -21,11 +25,11 @@ describe('checking buildFilesArray output', ()=> {
     const component = new VaFileInputMultiple();
     let filesArray = component.buildFilesArray(fileArray, false, 1);
     let expectedOutput:FileDetails[] = [ {
-      file: fileArray[0],
+      file: fileArray[0].file,
       changed: false
     },
     {
-      file: fileArray[1],
+      file: fileArray[1].file,
       changed: true
     }];
     expect(filesArray).toEqual(expectedOutput);
@@ -35,11 +39,11 @@ describe('checking buildFilesArray output', ()=> {
     const component = new VaFileInputMultiple();
     let filesArray = component.buildFilesArray(fileArray, true, 0);
     let expectedOutput:FileDetails[] = [ {
-      file: fileArray[0],
+      file: fileArray[0].file,
       changed: false
     },
     {
-      file: fileArray[1],
+      file: fileArray[1].file,
       changed: false
     }];
     expect(filesArray).toEqual(expectedOutput);
@@ -47,13 +51,13 @@ describe('checking buildFilesArray output', ()=> {
 
   it('should filter out null files', async () => {
     const component = new VaFileInputMultiple();
-    let filesArray = component.buildFilesArray([...fileArray, null], true, 0);
+    let filesArray = component.buildFilesArray([...fileArray, {file:null, key: 2, content:null}], true, 0);
     let expectedOutput:FileDetails[] = [ {
-      file: fileArray[0],
+      file: fileArray[0].file,
       changed: false
     },
     {
-      file: fileArray[1],
+      file: fileArray[1].file,
       changed: false
     }];
     expect(filesArray).toEqual(expectedOutput);
@@ -63,11 +67,11 @@ describe('checking buildFilesArray output', ()=> {
     const component = new VaFileInputMultiple();
     let filesArray = component.buildFilesArray(fileArray, false, -1);
     let expectedOutput:FileDetails[] = [ {
-      file: fileArray[0],
+      file: fileArray[0].file,
       changed: false
     },
     {
-      file: fileArray[1],
+      file: fileArray[1].file,
       changed: false
     }];
     expect(filesArray).toEqual(expectedOutput);
@@ -77,12 +81,34 @@ describe('checking buildFilesArray output', ()=> {
     const component = new VaFileInputMultiple();
     let filesArray = component.buildFilesArray(fileArray, false, 10)
     let expectedOutput:FileDetails[] = [ {
-      file: fileArray[0],
+      file: fileArray[0].file,
       changed: false
     },
     {
-      file: fileArray[1],
+      file: fileArray[1].file,
       changed: false
+    }];
+    expect(filesArray).toEqual(expectedOutput);
+  });
+
+  it('should return password info', async () => {
+    const component = new VaFileInputMultiple();
+    const newFile = new File(["bat"], "bat.txt")
+    let filesArray = component.buildFilesArray([...fileArray, {file:newFile, key: 2, content:null, password: 'password123'}], false, 0);
+    let expectedOutput:FileDetails[] = [ {
+      file: fileArray[0].file,
+      changed: true,
+      password: undefined
+    },
+    {
+      file: fileArray[1].file,
+      changed: false,
+      password: undefined
+    },
+    {
+      file: newFile,
+      changed: false,
+      password: 'password123'
     }];
     expect(filesArray).toEqual(expectedOutput);
   });

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -140,6 +140,11 @@ export class VaFileInput {
   @Event() vaChange: EventEmitter;
 
   /**
+   * The event emitted when the file input password value changes.
+   */
+  @Event() vaPasswordChange: EventEmitter;
+
+  /**
    * The event used to track usage of the component. This is emitted when the
    * file input changes and enableAnalytics is true.
    */
@@ -407,6 +412,10 @@ export class VaFileInput {
     )
   }
 
+  private handlePasswordChange(e) {
+    this.vaPasswordChange.emit( {password: e.target.value} );
+  }
+
   render() {
     const {
       label,
@@ -582,7 +591,7 @@ export class VaFileInput {
                   <div>
                     {this.showSeparator && <hr class="separator" />}
                     {encrypted && (
-                      <va-text-input label="File password" required />
+                      <va-text-input onInput={(e) =>{this.handlePasswordChange(e)}} label="File password" required />
                     )}
                     <div class="additional-info-slot">
                       <slot></slot>


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes [Add event emitter for password field in va-file-input #3981](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3981)

Adds `vaPasswordChange` to `va-file-input` which sends the current value of the password field.
Adds `PASSWORD_CHANGE` event to `vaMultipleChange` in `va-file-input-multiple` and and adds `password` to the emitted event.


## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
