### PR TITLE
va-file-input and va-file-input-multiple: Add link to platform documentation for encrypted PDFs

### DIFF
--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
@@ -440,6 +440,10 @@ const EncryptedTemplate = ({ label, name }) => {
 
   return (
     <>
+      To learn how to check for an encrypted PDF <va-link 
+        text='see platform documentation'
+        href='https://depo-platform-documentation.scrollhelp.site/developer-docs/checking-if-an-uploaded-pdf-is-encrypted' 
+      />.
       <VaFileInputMultiple
         label={label}
         name={name}

--- a/packages/storybook/stories/va-file-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.tsx
@@ -99,8 +99,31 @@ export const Required = Template.bind(null);
 Required.args = { ...defaultArgs, required: true };
 
 
-export const AcceptsFilePassword = Template.bind(null);
-AcceptsFilePassword.args = { ...defaultArgs, encrypted: true, label: 'Password info emitted through the onVaPasswordChange event' };
+const AcceptsFilePasswordTemplate = ({
+  label,
+  name,
+  hint,
+  vaChange,
+  encrypted,
+}) => {
+  return (
+    <>
+      To learn how to check for an encrypted PDF <va-link 
+        text='see platform documentation'
+        href='https://depo-platform-documentation.scrollhelp.site/developer-docs/checking-if-an-uploaded-pdf-is-encrypted' 
+      />.
+      <VaFileInput
+        label={label}
+        name={name}
+        hint={hint}
+        onVaChange={vaChange}
+        encrypted={encrypted}
+      />
+    </>
+  );
+};
+export const AcceptsFilePassword = AcceptsFilePasswordTemplate.bind(null);
+AcceptsFilePassword.args = { ...defaultArgs, encrypted: true, };
 
 export const AcceptsOnlySpecificFileTypes = Template.bind(null);
 AcceptsOnlySpecificFileTypes.args = {


### PR DESCRIPTION
## Chromatic
<!-- This `va-file-input-add-platform-documentation` is a placeholder for a CI job - it will be updated automatically -->
https://va-file-input-add-platform-documentation--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Adds link to "Accept Password Field" stories of `va-file-input` and `va-file-input-multiple`
Closes [Add link to platform documentation for displaying password field on va-file-input in storybook #3980](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3980)

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [X] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
![Screenshot 2025-04-22 at 10 49 06](https://github.com/user-attachments/assets/e5f1db15-0b8f-4170-b40b-199d67a8d3a1)
![Screenshot 2025-04-22 at 10 49 16](https://github.com/user-attachments/assets/65f8f1ff-1abd-4799-91b2-56ad92ed3b86)


## Acceptance criteria
- [x] QA checklist has been completed
- [X] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
