### PR TITLE
va-alert: fix TypeError for close button aria label

### DIFF
--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -82,6 +82,15 @@ describe('va-alert', () => {
     expect(button.getAttribute('aria-label')).toEqual('Close this notification');
   });
 
+  it('uses generic text for the close button ARIA label, if no custom text is provided and no headline slot exists', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-alert closeable="true"><p>Some alert content</p></va-alert>');
+
+    let button = await page.find('va-alert >>> button');
+
+    expect(button.getAttribute('aria-label')).toEqual('Close this notification');
+  });
+
   it('fires a custom "close" event when the close button is clicked', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -112,9 +112,9 @@ export class VaAlert {
 
     // This is the happy path, meaning the user isn't using IE11
     try { 
-      const headline = this.el.shadowRoot.querySelector('slot').assignedNodes();
+      const children = this.el.shadowRoot.querySelector('slot').assignedNodes();
       // An empty array means that there isn't a node with `slot="headline"`
-      headlineText = headline.length > 0 ? headline[0].textContent : null;
+      headlineText = children.length > 0 ? children[0].textContent : null;
     } catch (e) {
       // This is where we handle the edge case of the user being on IE11
       const children = this.el.shadowRoot.childNodes;

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -107,24 +107,25 @@ export class VaAlert {
     this.closeEvent.emit(e);
   }
 
-  private getHeadlineText(): string {
-    let headlineText = null;
+  private getHeadlineText(): string | null {
+    let headlineText: string | null = null;
 
-    // This is the happy path, meaning the user isn't using IE11
     try { 
-      const children = this.el.shadowRoot.querySelector('slot').assignedNodes();
-      // An empty array means that there isn't a node with `slot="headline"`
-      headlineText = children.length > 0 ? children[0].textContent : null;
+      // This is the happy path, meaning the user isn't using IE11
+    const slot = this.el.shadowRoot?.querySelector('slot');
+    const children = slot ? (slot as HTMLSlotElement).assignedNodes() : [];
+    headlineText = children.length > 0 ? children[0].textContent : null;
     } catch (e) {
       // This is where we handle the edge case of the user being on IE11
-      const children = this.el.shadowRoot.childNodes;
-      const headerList = children.filter((node: any) =>
-        /* eslint-disable-next-line i18next/no-literal-string */
-        ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(
-          node.tagName.toLowerCase(),
+    const children = Array.from(this.el.shadowRoot?.childNodes || []);
+    const headerList = children.filter(
+      (node: Node) =>
+        node.nodeType === Node.ELEMENT_NODE &&
+        ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(
+          (node as HTMLElement).tagName,
         ),
-      );
-      headlineText = headerList.length > 0 ? headerList[0].textContent : null;
+    );
+    headlineText = headerList.length > 0 ? (headerList[0] as HTMLElement).textContent : null;
     } finally {
       return headlineText;
     }

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -107,19 +107,14 @@ export class VaAlert {
     this.closeEvent.emit(e);
   }
 
-  private updateCloseAriaLabelWithHeadlineText(): void {
-    const headline = this.el.shadowRoot.querySelector('slot[name="headline"]');
-    this.closeBtnAriaLabel = `Close ${headline.assignedNodes()[0].textContent} notification`;
-  }
-
-  private handleAlertBodyClick(e: MouseEvent): void {
+  private getHeadlineText(): string {
     let headlineText = null;
 
     // This is the happy path, meaning the user isn't using IE11
-    try {
-      const children = this.el.shadowRoot.querySelector('slot').assignedNodes();
+    try { 
+      const headline = this.el.shadowRoot.querySelector('slot').assignedNodes();
       // An empty array means that there isn't a node with `slot="headline"`
-      headlineText = children.length > 0 ? children[0].textContent : null;
+      headlineText = headline.length > 0 ? headline[0].textContent : null;
     } catch (e) {
       // This is where we handle the edge case of the user being on IE11
       const children = this.el.shadowRoot.childNodes;
@@ -129,9 +124,19 @@ export class VaAlert {
           node.tagName.toLowerCase(),
         ),
       );
-
       headlineText = headerList.length > 0 ? headerList[0].textContent : null;
+    } finally {
+      return headlineText;
     }
+  }
+
+  private updateCloseAriaLabelWithHeadlineText(): void {
+    const headlineText = this.getHeadlineText();
+    this.closeBtnAriaLabel = `Close ${headlineText ?? 'this'} notification`
+  }
+
+  private handleAlertBodyClick(e: MouseEvent): void {
+    const headlineText = this.getHeadlineText();
 
     if (!this.disableAnalytics) {
       const target = e.target as HTMLElement;


### PR DESCRIPTION
## Chromatic
<!-- This `longmd-105037-fix-va-alert-typeerror` is a placeholder for a CI job - it will be updated automatically -->
https://longmd-105037-fix-va-alert-typeerror--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [x] Link to any related issues in the description so they can be cross-referenced.
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
After implementing Datadog logs on the Caregivers application, the a recurring log we notice is emitting from the va-alert web component. The error message is `TypeError: Cannot read properties of undefined (reading 'textContent')` This error is occurring because the component is attempting to find the headline `slot` when not all alerts have headlines.

This PR creates a shared method that attempts to fetch the headline slot for both the `updateCloseAriaLabelWithHeadlineText` method and the `handleAlertBodyClick`. Utilizing this method allows for IE11 support, as was already in the handle click method, and gives a generic fallback for the aria label if no headline exists.

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![image](https://github.com/user-attachments/assets/eb009114-8bc6-4508-a252-49fc41807730)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
