### PR TITLE
va-modal: Fix TypeError on render

### DIFF
--- a/packages/web-components/src/components/va-modal/test/va-modal.e2e.ts
+++ b/packages/web-components/src/components/va-modal/test/va-modal.e2e.ts
@@ -235,4 +235,26 @@ describe('va-modal', () => {
       },
     });
   });
+
+  it('should handle empty focusableChildren array gracefully when no focusable content exists', async () => {
+    const page = await newE2EPage();
+  
+    // the `forced-modal` removes the close button
+    await page.setContent(`
+      <va-modal modal-title="No Focusable Content" forced-modal visible>
+        <div aria-hidden="true">Non-focusable content</div>
+      </va-modal>
+    `);
+  
+    await page.waitForChanges();
+  
+    // Try to find any focused element inside the modal
+    const activeTagName = await page.evaluate(() => {
+      const modal = document.querySelector('va-modal');
+      return modal.shadowRoot.activeElement?.tagName || modal.shadowRoot.querySelector(':focus')?.tagName;
+    });
+  
+    // Expect that nothing is focused
+    expect(activeTagName).toBeFalsy();
+  });
 });

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -207,7 +207,7 @@ export class VaModal {
   handleLastElementFocus(e: KeyboardEvent) {
     if (this.visible) {
       // The focus is outside the modal
-      if (e.key === "Tab" && !this.shifted) {
+      if (e.key === 'Tab' && !this.shifted) {
         e.preventDefault();
         const focusIndex = 0;
         this.focusableChildren[focusIndex]?.focus();
@@ -219,9 +219,9 @@ export class VaModal {
   handleFirstElementFocus(e: KeyboardEvent) {
     if (this.visible) {
       // The focus is outside the modal
-      if (e.key === "Tab" && this.shifted) {
+      if (e.key === 'Tab' && this.shifted) {
         e.preventDefault();
-        const focusIndex =  this.focusableChildren.length - 1;
+        const focusIndex = this.focusableChildren.length - 1;
         this.focusableChildren[focusIndex]?.focus();
       }
     }
@@ -236,7 +236,11 @@ export class VaModal {
   }
 
   componentDidLoad() {
-    if (this.visible) this.setupModal();
+    if (this.visible) {
+      requestAnimationFrame
+        ? requestAnimationFrame(() => this.setupModal())
+        : setTimeout(() => this.setupModal(), 0);
+    }
   }
 
   // Stencil's componentDidUpdate doesn't provide us with previous props to compare
@@ -248,7 +252,9 @@ export class VaModal {
 
     this.isVisibleDirty = false;
     if (this.visible) {
-      this.setupModal();
+      requestAnimationFrame
+        ? requestAnimationFrame(() => this.setupModal())
+        : setTimeout(() => this.setupModal(), 0);
     } else {
       this.teardownModal();
     }
@@ -354,21 +360,25 @@ export class VaModal {
 
     // find first focusable item so that focus can be redirected there when needed
     const firstFocusChild = this.focusableChildren[0];
-    firstFocusChild.classList.add('first-focusable-child');
-    firstFocusChild.onkeydown = (e)=> this.handleFirstElementFocus(e);
+    if (firstFocusChild) {
+      firstFocusChild.classList.add('first-focusable-child');
+      firstFocusChild.onkeydown = e => this.handleFirstElementFocus(e);
+    }
 
     // find last focusable item so that focus can be redirected there when needed
     const lastFocusChild =
       this.focusableChildren[this.focusableChildren.length - 1];
-    lastFocusChild.classList.add('last-focusable-child');
-    lastFocusChild.onkeydown = (e)=> this.handleLastElementFocus(e);
+    if (lastFocusChild) {
+      lastFocusChild.classList.add('last-focusable-child');
+      lastFocusChild.onkeydown = e => this.handleLastElementFocus(e);
+    }
 
     // If an initialFocusSelector is provided, the element will be focused on modal open
     // if it exists. You are able to focus elements in both light and shadow DOM.
     const initialFocus = (this.el.querySelector(this.initialFocusSelector) ||
-      this.el.shadowRoot.querySelector(this.initialFocusSelector) ||
+      this.el.shadowRoot?.querySelector(this.initialFocusSelector) ||
       this.closeButton) as HTMLElement;
-    initialFocus.focus();
+    initialFocus?.focus();
 
     // Prevents scrolling outside modal
     disableBodyScroll(this.el);
@@ -438,7 +448,7 @@ export class VaModal {
     const contentClass = classnames({
       'usa-modal__content': true,
       'usa-modal-alert': status,
-      'va-modal__content': true
+      'va-modal__content': true,
     });
     const bodyClass = classnames({
       'usa-modal__main': true,

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -237,9 +237,7 @@ export class VaModal {
 
   componentDidLoad() {
     if (this.visible) {
-      requestAnimationFrame
-        ? requestAnimationFrame(() => this.setupModal())
-        : setTimeout(() => this.setupModal(), 0);
+      requestAnimationFrame(() => this.setupModal());
     }
   }
 
@@ -252,9 +250,7 @@ export class VaModal {
 
     this.isVisibleDirty = false;
     if (this.visible) {
-      requestAnimationFrame
-        ? requestAnimationFrame(() => this.setupModal())
-        : setTimeout(() => this.setupModal(), 0);
+      requestAnimationFrame(() => this.setupModal());
     } else {
       this.teardownModal();
     }


### PR DESCRIPTION
## Chromatic
<!-- This `longmd--108748-fix-va-modal-typeerror` is a placeholder for a CI job - it will be updated automatically -->
https://longmd--108748-fix-va-modal-typeerror--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [x] Link to any related issues in the description so they can be cross-referenced.
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
After implementing Datadog logs on the multiple applications, there a consistent log emitting from the `va-modal` web component. The error messages are `TypeError: Cannot read properties of undefined (reading 'classList')` & `TypeError: undefined is not an object (evaluating 'e.classList')`. These errors occur on initial render where an attempt to apply focus to an internal element is made before the shadow DOM (or shadow DOMs of internal content) is fully hydrated.

This PR defers execution of the setup method to ensure the method runs after the browser has completed rendering and the shadow DOM is hydrated. Additionally, there is a check added to ensure focusable content is available before attempting to perform the focus.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/108748

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

**Variation 1:**

![Screenshot 2025-04-30 at 17 03 20](https://github.com/user-attachments/assets/5537c846-5a5a-42a7-8f8e-84d44f283af1)

**Variation 2:**

![Screenshot 2025-04-30 at 17 12 44](https://github.com/user-attachments/assets/ae899349-4e25-45c9-9c5c-0b23acc00294)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
