### PR TITLE
va-file-input: add aria-label to input for dictation

### DIFF
--- a/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
+++ b/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
@@ -42,6 +42,15 @@ describe('va-file-input', () => {
     expect(hintTextElement.innerText).toContain('This is hint text');
   });
 
+  it('renders an aria-label', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-file-input label="Select a file to upload"/>');
+
+    const fileInput = await page.find('va-file-input >>> input');
+    const ariaLabel = await fileInput.getAttribute('aria-label');
+    expect(ariaLabel).toBe('Select a file to upload. Drag a file here or choose from folder');
+  });
+
   it('renders a required span', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -524,7 +524,7 @@ export class VaFileInput {
           <input
             id="fileInputField"
             class="file-input"
-            aria-label={fileInputString}
+            aria-label={`Select a file to upload. Drag file here or ${fileInputString}`}
             style={{
               visibility: (this.uploadStatus === 'success' || uploadedFile) ? 'hidden' : 'unset',
             }}

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -34,7 +34,7 @@ export class VaFileInput {
   private uploadStatus: 'idle' | 'success' = 'idle';
   private fileType?: string;
   private chooseFileString: string ='choose from folder';
-  private dragFileString: string = 'Drag file here or ';
+  private dragFileString: string = 'Drag a file here or ';
 
   @Element() el: HTMLElement;
   @State() file?: File;

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -33,7 +33,8 @@ export class VaFileInput {
   private fileInputRef!: HTMLInputElement;
   private uploadStatus: 'idle' | 'success' = 'idle';
   private fileType?: string;
-  private fileInputString: string ='choose from folder';
+  private chooseFileString: string ='choose from folder';
+  private dragFileString: string = 'Drag file here or ';
 
   @Element() el: HTMLElement;
   @State() file?: File;
@@ -403,11 +404,11 @@ export class VaFileInput {
   disconnectedCallback() {
     this.el.removeEventListener('change', this.handleChange);
   }
-  private getDefaultUploadMessage(fileInputString: string) {
+  private getDefaultUploadMessage(chooseFileString: string) {
     return (
       <span>
-        Drag a file here or{' '}
-        <span class="file-input-choose-text">{fileInputString}</span>
+        {this.dragFileString}
+        <span class="file-input-choose-text">{chooseFileString}</span>
       </span>
     )
   }
@@ -426,7 +427,8 @@ export class VaFileInput {
       hint,
       file,
       uploadStatus,
-      fileInputString,
+      dragFileString,
+      chooseFileString,
       uploadMessage,
       headerSize,
       fileContents,
@@ -524,7 +526,7 @@ export class VaFileInput {
           <input
             id="fileInputField"
             class="file-input"
-            aria-label={`Select a file to upload. Drag file here or ${fileInputString}`}
+            aria-label={`${label}. ${dragFileString}${chooseFileString}`}
             style={{
               visibility: (this.uploadStatus === 'success' || uploadedFile) ? 'hidden' : 'unset',
             }}
@@ -553,7 +555,7 @@ export class VaFileInput {
               <div class={fileInputTargetClasses}>
                 <div class="file-input-box"></div>
                 <div class="file-input-instructions">
-                  {!!uploadMessage ? uploadMessage : this.getDefaultUploadMessage(fileInputString)}
+                  {!!uploadMessage ? uploadMessage : this.getDefaultUploadMessage(chooseFileString)}
                 </div>
               </div>
             </div>

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -33,6 +33,7 @@ export class VaFileInput {
   private fileInputRef!: HTMLInputElement;
   private uploadStatus: 'idle' | 'success' = 'idle';
   private fileType?: string;
+  private fileInputString: string ='choose from folder';
 
   @Element() el: HTMLElement;
   @State() file?: File;
@@ -402,12 +403,11 @@ export class VaFileInput {
   disconnectedCallback() {
     this.el.removeEventListener('change', this.handleChange);
   }
-
-  private getDefaultUploadMessage() {
+  private getDefaultUploadMessage(fileInputString: string) {
     return (
       <span>
         Drag a file here or{' '}
-        <span class="file-input-choose-text">choose from folder</span>
+        <span class="file-input-choose-text">{fileInputString}</span>
       </span>
     )
   }
@@ -426,6 +426,7 @@ export class VaFileInput {
       hint,
       file,
       uploadStatus,
+      fileInputString,
       uploadMessage,
       headerSize,
       fileContents,
@@ -523,6 +524,7 @@ export class VaFileInput {
           <input
             id="fileInputField"
             class="file-input"
+            aria-label={fileInputString}
             style={{
               visibility: (this.uploadStatus === 'success' || uploadedFile) ? 'hidden' : 'unset',
             }}
@@ -551,7 +553,7 @@ export class VaFileInput {
               <div class={fileInputTargetClasses}>
                 <div class="file-input-box"></div>
                 <div class="file-input-instructions">
-                  {!!uploadMessage ? uploadMessage : this.getDefaultUploadMessage()}
+                  {!!uploadMessage ? uploadMessage : this.getDefaultUploadMessage(fileInputString)}
                 </div>
               </div>
             </div>

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -404,11 +404,11 @@ export class VaFileInput {
   disconnectedCallback() {
     this.el.removeEventListener('change', this.handleChange);
   }
-  private getDefaultUploadMessage(chooseFileString: string) {
+  private getDefaultUploadMessage() {
     return (
       <span>
         {this.dragFileString}
-        <span class="file-input-choose-text">{chooseFileString}</span>
+        <span class="file-input-choose-text">{this.chooseFileString}</span>
       </span>
     )
   }
@@ -526,7 +526,7 @@ export class VaFileInput {
           <input
             id="fileInputField"
             class="file-input"
-            aria-label={`${label}. ${dragFileString}${chooseFileString}`}
+            aria-label={`${label}${required ? ' ' + i18next.t('required') : ''}. ${dragFileString}${chooseFileString}`}
             style={{
               visibility: (this.uploadStatus === 'success' || uploadedFile) ? 'hidden' : 'unset',
             }}
@@ -555,7 +555,7 @@ export class VaFileInput {
               <div class={fileInputTargetClasses}>
                 <div class="file-input-box"></div>
                 <div class="file-input-instructions">
-                  {!!uploadMessage ? uploadMessage : this.getDefaultUploadMessage(chooseFileString)}
+                  {!!uploadMessage ? uploadMessage : this.getDefaultUploadMessage()}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Chromatic
<!-- This `108718-va-file-input-dictation` is a placeholder for a CI job - it will be updated automatically -->
https://108718-va-file-input-dictation--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
It was reported that you could not use dictation to click on the file input and select a file. This PR adds an aria-label so that the field becomes actionable with dictation.

Closes [108718](https://github.com/department-of-veterans-affairs/va.gov-team/issues/108718)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes

## Acceptance criteria
- [x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue
