### PR TITLE
Add react-bindings build step to script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,7 @@ sleep .5
 echo "Building web-components"
 cd packages/web-components
 yarn build
+yarn build-bindings
 sleep .5
 
 echo "Building core package"


### PR DESCRIPTION
## Chromatic
<!-- This `add-react-bindings-command-dev-script` is a placeholder for a CI job - it will be updated automatically -->
https://add-react-bindings-command-dev-script--65a6e2ed2314f7b8f98609d8.chromatic.com


## Description

Sometimes we need the build to regenerate the react bindings so this will add it to the setup script that runs with `yarn run dev`

Reference full list of build steps here:
https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#running-build-via-storybook


## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
