### PR TITLE
Set va-modal visual to true by default in Storybook

### DIFF
--- a/packages/storybook/stories/va-modal-uswds.stories.tsx
+++ b/packages/storybook/stories/va-modal-uswds.stories.tsx
@@ -28,7 +28,7 @@ export default {
           
           // Schedule multiple scroll attempts with increasing delays
           // This helps ensure scrolling works even if Storybook does additional rendering
-          const timers = [50, 100, 300, 500].map(delay => 
+          const timers = [50, 100, 300, 500, 1000].map(delay => 
             setTimeout(scrollToTop, delay)
           );
           

--- a/packages/storybook/stories/va-modal-uswds.stories.tsx
+++ b/packages/storybook/stories/va-modal-uswds.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { VaModal } from '@department-of-veterans-affairs/web-components/react-bindings';
 import {
   getWebComponentDocs,
@@ -17,8 +17,50 @@ export default {
   parameters: {
     componentSubtitle: 'va-modal web component',
     docs: {
-      page: () => <StoryDocs storyDefault={Default} data={modalDocs} />,
+      page: () => {
+        // Use effect to control scroll position
+        useEffect(() => {
+          // Function to scroll to top
+          const scrollToTop = () => window.scrollTo(0, 0);
+          
+          // Immediate scroll
+          scrollToTop();
+          
+          // Schedule multiple scroll attempts with increasing delays
+          // This helps ensure scrolling works even if Storybook does additional rendering
+          const timers = [50, 100, 300, 500].map(delay => 
+            setTimeout(scrollToTop, delay)
+          );
+          
+          // Clean up timers on unmount
+          return () => timers.forEach(clearTimeout);
+        }, []);
+        
+        return (
+          <>
+            <style>
+              {`
+                body {
+                  overflow: auto !important;
+                  position: static !important;
+                }
+                body.modal-open {
+                  overflow: auto !important;
+                  position: static !important;
+                  height: auto !important;
+                  padding-right: 0 !important;
+                }
+              `}
+            </style>
+            <StoryDocs storyDefault={Default} data={modalDocs} />
+          </>
+        );
+      },
     },
+    // This tells Storybook to scroll to the top when this story loads
+    viewport: {
+      scrollTop: 0
+    }
   },
   argTypes: {
     status: {
@@ -37,7 +79,7 @@ const defaultArgs = {
   'modal-title': 'Title',
   'initial-focus-selector': undefined,
   'status': undefined,
-  'visible': false,
+  'visible': true,
   'primaryButtonClick': () => window.alert('Primary button clicked!'),
   'primary-button-text': 'Primary',
   'secondaryButtonClick': () => window.alert('Secondary button clicked!'),
@@ -69,6 +111,11 @@ const Template = ({
     setIsVisible(true);
     resizeViewPorts(wrapRef?.current, true);
   };
+
+  useEffect(() => {
+    resizeViewPorts(wrapRef?.current, isVisible);
+  }, [isVisible]);
+
   return (
     <div ref={wrapRef}>
       <h1>Testing h1 heading</h1>
@@ -116,6 +163,11 @@ const ForcedTemplate = ({
     setIsVisible(false);
     resizeViewPorts(wrapRef?.current, false);
   };
+
+  useEffect(() => {
+    resizeViewPorts(wrapRef?.current, isVisible);
+  }, [isVisible]);
+
   return (
     <div ref={wrapRef}>
       <h1>Testing h1 heading</h1>
@@ -222,6 +274,10 @@ export const WithNestedWebComponents = ({
     setIsVisible(true);
     resizeViewPorts(wrapRef?.current, true);
   };
+
+  useEffect(() => {
+    resizeViewPorts(wrapRef?.current, isVisible);
+  }, [isVisible]);
   return (
     <div ref={wrapRef}>
       <h1>Testing h1 heading</h1>
@@ -247,10 +303,6 @@ export const WithNestedWebComponents = ({
           A modal may pass any React nodes as children to be displayed within
           it.
         </p>
-        <blockquote>
-          <input id="plain-checkbox" type="checkbox" />
-          <label htmlFor="plain-checkbox">Plain checkbox</label>
-        </blockquote>
         <va-checkbox label="va-checkbox" />
       </VaModal>
       <input id="post-modal-input" type="checkbox" />

--- a/packages/storybook/stories/wc-helpers.tsx
+++ b/packages/storybook/stories/wc-helpers.tsx
@@ -354,6 +354,5 @@ export function applyFocus(el) {
 export function resizeViewPorts(wrap, isVisible) {
   if (!wrap) return;
   const story = wrap.closest('.sb-anchor');
-  story.scrollIntoView();
-  story.classList.toggle('expand', isVisible);
+  story?.classList.toggle('expand', isVisible);
 }


### PR DESCRIPTION
## Chromatic
<!-- This `chromatic-modal-visual-regression` is a placeholder for a CI job - it will be updated automatically -->
https://chromatic-modal-visual-regression--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/docs/uswds-va-modal--docs

## Description

We have not been able to track visual changes to va-modal in Storybook with Chromatic because it required a button to be clicked before the modal would display. 

This PR will set the modals `visual` prop to true but it also deals with some unwanted scrolling behavior in Storybook that is built into the component itself when the modals are set to open.

With the modals now defaulting to open, we have some baseline Chromatic snapshots to start diffing against. 🎉

No issue to reference but this is in response to a Slack conversation here: https://dsva.slack.com/archives/C01DBGX4P45/p1747081203050729

![Screenshot 2025-05-13 at 9 28 09 AM](https://github.com/user-attachments/assets/37c0ff6f-1381-4e78-8425-ecfab79a83dd)

I also checked the documentation site locally and it appears to be working there too:

![Screenshot 2025-05-13 at 10 15 20 AM](https://github.com/user-attachments/assets/e0f12b19-8fbb-4330-99e0-4658cefa256c)


## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
