### PR TITLE
va-text-input & va-statement-of-truth: add prop for adding Datadog privacy class on error message

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1862,7 +1862,7 @@ export namespace Components {
          */
         "error"?: string;
         /**
-          * Add Datadog privacy class to error for va-statement-of-truth because it includes sensitive information.
+          * Adds a Datadog privacy class to the error message for cases when sensitive information is included, such as in va-statement-of-truth.
          */
         "errorHasPii"?: boolean;
         /**
@@ -5549,7 +5549,7 @@ declare namespace LocalJSX {
          */
         "error"?: string;
         /**
-          * Add Datadog privacy class to error for va-statement-of-truth because it includes sensitive information.
+          * Adds a Datadog privacy class to the error message for cases when sensitive information is included, such as in va-statement-of-truth.
          */
         "errorHasPii"?: boolean;
         /**

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1862,6 +1862,10 @@ export namespace Components {
          */
         "error"?: string;
         /**
+          * Add Datadog privacy class to error for va-statement-of-truth because it includes sensitive information.
+         */
+        "errorHasPii"?: boolean;
+        /**
           * The content of the heading if `useFormsPattern` is true.
          */
         "formHeading"?: string;
@@ -5544,6 +5548,10 @@ declare namespace LocalJSX {
           * The error message to render.
          */
         "error"?: string;
+        /**
+          * Add Datadog privacy class to error for va-statement-of-truth because it includes sensitive information.
+         */
+        "errorHasPii"?: boolean;
         /**
           * The content of the heading if `useFormsPattern` is true.
          */

--- a/packages/web-components/src/components/va-statement-of-truth/test/va-statement-of-truth.e2e.ts
+++ b/packages/web-components/src/components/va-statement-of-truth/test/va-statement-of-truth.e2e.ts
@@ -1,5 +1,5 @@
-import { newE2EPage } from "@stencil/core/testing";
-import { axeCheck } from "../../../testing/test-helpers";
+import { newE2EPage } from '@stencil/core/testing';
+import { axeCheck } from '../../../testing/test-helpers';
 
 describe('va-statement-of-truth', () => {
   it('renders', async () => {
@@ -17,23 +17,40 @@ describe('va-statement-of-truth', () => {
 
   it('correctly sets the error props as attributes', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-statement-of-truth input-error="Please enter your full name" checkbox-error="Please certify"/>');
-    const inputElem = await page.find('va-statement-of-truth >>> va-text-input');
-    const checkboxElem = await page.find('va-statement-of-truth >>> va-checkbox');
-    expect(inputElem.getAttribute('error')).toEqual('Please enter your full name');
+    await page.setContent(
+      '<va-statement-of-truth input-error="Please enter your full name" checkbox-error="Please certify"/>',
+    );
+    const inputElem = await page.find(
+      'va-statement-of-truth >>> va-text-input',
+    );
+    const checkboxElem = await page.find(
+      'va-statement-of-truth >>> va-checkbox',
+    );
+    expect(inputElem.getAttribute('error')).toEqual(
+      'Please enter your full name',
+    );
+    expect(inputElem).toHaveAttribute('error-has-pii');
     expect(checkboxElem.getAttribute('error')).toEqual('Please certify');
   });
 
   it('renders errors when error props set', async () => {
     const page = await newE2EPage();
-    await page.setContent('<va-statement-of-truth input-error="Please enter your full name" checkbox-error="Please certify"/>');
+    await page.setContent(
+      '<va-statement-of-truth input-error="Please enter your full name" checkbox-error="Please certify"/>',
+    );
 
     const inputSpanEl = await page.$('pierce/span#input-error-message');
-    const inputErrorText = await page.evaluate(element => element.textContent, inputSpanEl);
+    const inputErrorText = await page.evaluate(
+      element => element.textContent,
+      inputSpanEl,
+    );
     expect(inputErrorText).toContain('Please enter your full name');
 
     const checkboxSpanEl = await page.$('pierce/span#checkbox-error-message');
-    const checkboxErrorText = await page.evaluate(element => element.textContent, checkboxSpanEl);
+    const checkboxErrorText = await page.evaluate(
+      element => element.textContent,
+      checkboxSpanEl,
+    );
     expect(checkboxErrorText).toContain('Please certify');
   });
 
@@ -41,7 +58,9 @@ describe('va-statement-of-truth', () => {
     const page = await newE2EPage();
     await page.setContent('<va-statement-of-truth />');
     const vaInputBlurSpy = await page.spyOnEvent('vaInputBlur');
-    const inputEl = await page.find('va-statement-of-truth >>> va-text-input >>> input');
+    const inputEl = await page.find(
+      'va-statement-of-truth >>> va-text-input >>> input',
+    );
     await inputEl.click();
     await page.keyboard.press('Tab');
     expect(vaInputBlurSpy).toHaveReceivedEvent();
@@ -124,4 +143,4 @@ describe('va-statement-of-truth', () => {
     const checkboxLabel = await checkboxEl.getProperty('label');
     expect(checkboxLabel).toBe('test label');
   });
-})
+});

--- a/packages/web-components/src/components/va-statement-of-truth/va-statement-of-truth.tsx
+++ b/packages/web-components/src/components/va-statement-of-truth/va-statement-of-truth.tsx
@@ -5,7 +5,7 @@ import {
   h,
   Element,
   Event,
-  EventEmitter
+  EventEmitter,
 } from '@stencil/core';
 
 /**
@@ -94,7 +94,7 @@ export class VaStatementOfTruth {
   @Element() el: HTMLElement;
 
   private handleInputChange = (event: InputEvent) => {
-    const { value } = event.currentTarget as HTMLInputElement
+    const { value } = event.currentTarget as HTMLInputElement;
     this.vaInputChange.emit({ value });
   };
 
@@ -103,7 +103,7 @@ export class VaStatementOfTruth {
   };
 
   private handleCheckboxChange = (event: Event) => {
-    const { checked } = event.currentTarget as HTMLInputElement
+    const { checked } = event.currentTarget as HTMLInputElement;
     this.vaCheckboxChange.emit({ checked });
   };
 
@@ -143,6 +143,7 @@ export class VaStatementOfTruth {
             error={inputError}
             onInput={this.handleInputChange}
             onBlur={this.handleInputBlur}
+            error-has-pii
           />
           <va-checkbox
             id="veteran-certify"

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -43,6 +43,19 @@ describe('va-text-input', () => {
     expect(errorMessage).not.toHaveClass('usa-sr-only');
   });
 
+  it('renders an error message with a Datadog privacy class ', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-text-input error="This is a mistake" error-has-pii />',
+    );
+
+    // Render the error message text
+    const error = await page.find('va-text-input >>> .usa-error-message');
+    expect(error.innerText).toContain('This is a mistake');
+    expect(error).toHaveClass('dd-privacy-hidden');
+    expect(error).toHaveAttribute('data-dd-action-name');
+  });
+
   it('renders an with a hidden error message when showInputError is false', async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -216,6 +216,12 @@ export class VaTextInput {
    */
   @Prop() max?: number | string;
 
+  /**
+   * Add Datadog privacy class to error for va-statement-of-truth because it
+   * includes sensitive information.
+   */
+  @Prop() errorHasPii?: boolean = false;
+
   @State() paddingLeftValue: string = '0';
   @State() paddingRightValue: string = '0';
 
@@ -391,6 +397,7 @@ export class VaTextInput {
       inputIconPrefix,
       inputSuffix,
       inputIconSuffix,
+      errorHasPii = false,
     } = this;
     const type = this.getInputType();
     const maxlength = this.getMaxlength();
@@ -449,6 +456,11 @@ export class VaTextInput {
       'usa-sr-only': !showInputError,
     });
 
+    const errorMessageClass = classnames({
+      'usa-error-message': true,
+      'dd-privacy-hidden': errorHasPii,
+    });
+
     const isFormsPattern =
       useFormsPattern === 'single' || useFormsPattern === 'multiple'
         ? true
@@ -496,7 +508,12 @@ export class VaTextInput {
             {error && (
               <Fragment>
                 <span class="usa-sr-only">{i18next.t('error')}</span>
-                <span class="usa-error-message">{error}</span>
+                <span
+                  class={errorMessageClass}
+                  data-dd-action-name="input error"
+                >
+                  {error}
+                </span>
               </Fragment>
             )}
           </span>

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -217,8 +217,8 @@ export class VaTextInput {
   @Prop() max?: number | string;
 
   /**
-   * Add Datadog privacy class to error for va-statement-of-truth because it
-   * includes sensitive information.
+   * Adds a Datadog privacy class to the error message for cases when sensitive
+   * information is included, such as in va-statement-of-truth.
    */
   @Prop() errorHasPii?: boolean = false;
 
@@ -510,7 +510,7 @@ export class VaTextInput {
                 <span class="usa-sr-only">{i18next.t('error')}</span>
                 <span
                   class={errorMessageClass}
-                  data-dd-action-name="input error"
+                  data-dd-action-name={errorHasPii ? 'input error' : undefined}
                 >
                   {error}
                 </span>


### PR DESCRIPTION
## Chromatic
<!-- This `107935-sot-privacy` is a placeholder for a CI job - it will be updated automatically -->
https://107935-sot-privacy--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Adds `error-has-pii` property to `va-text-input` which is then used by the `va-statement-of-truth` component when rendering an error. The span containing the error would then have a `dd-privacy-hidden` class and a `data-dd-action-name` attribute applied to prevent PII exposure within Datadog Real User Monitoring sessions.

- Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/107935
- [Slack discussion about implementation](https://dsva.slack.com/archives/C01DBGX4P45/p1746631663473989?thread_ts=1746631613.935949&cid=C01DBGX4P45)

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

| | |
|----|---|
| Before | <img width="971" alt="before changes showing error span with no treatment" src="https://github.com/user-attachments/assets/efd5feb3-2a72-46bb-b691-08d2b516e90a" /> |
| After | <img width="974" alt="after changes showing error span with 'dd-privacy-hidden' class and 'data-dd-action-name' attribute applied" src="https://github.com/user-attachments/assets/a5e70c0d-0b3f-42ab-aa4e-62735fb11b89" /> |

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
