### PR TITLE
va-file-input: remove duplicate aria-labels caused by defining both the label and aria-label on the va-icon-buttons

### DIFF
--- a/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
+++ b/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
@@ -119,7 +119,7 @@ describe('va-file-input', () => {
       '.file-button-section va-button-icon',
     );
     const buttonLabel = await fileChangeButton.getProperty('label');
-    expect(buttonLabel).toBe('change file 1x1.png');
+    expect(buttonLabel).toBe('Change file');
   });
 
   it('does not render a "Change File" button if read-only', async () => {

--- a/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
+++ b/packages/web-components/src/components/va-file-input/test/va-file-input.e2e.ts
@@ -110,7 +110,7 @@ describe('va-file-input', () => {
       '.file-button-section va-button-icon',
     );
     const buttonLabel = await fileChangeButton.getProperty('label');
-    expect(buttonLabel).toBe('Change file');
+    expect(buttonLabel).toBe('change file 1x1.png');
   });
 
   it('does not render a "Change File" button if read-only', async () => {

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -607,14 +607,12 @@ export class VaFileInput {
                             <va-button-icon
                               buttonType="change-file"
                               onClick={this.changeFile}
-                              label="Change file"
-                              aria-label={`change file ${file ? file.name : uploadedFile.name}`}
+                              label={`change file ${file ? file.name : uploadedFile.name}`}
                             ></va-button-icon>
                             <va-button-icon
                               buttonType="delete"
                               onClick={this.openModal}
-                              aria-label={`delete file ${file ? file.name : uploadedFile.name}`}
-                              label="Delete"
+                              label={`delete file ${file ? file.name : uploadedFile.name}`}
                             ></va-button-icon>
                           </div>
                           <va-modal

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -611,12 +611,14 @@ export class VaFileInput {
                             <va-button-icon
                               buttonType="change-file"
                               onClick={this.changeFile}
-                              label={`change file ${file ? file.name : uploadedFile.name}`}
+                              title={`change file ${file ? file.name : uploadedFile.name}`}
+                              label={`Change file`}
                             ></va-button-icon>
                             <va-button-icon
                               buttonType="delete"
                               onClick={this.openModal}
-                              label={`delete file ${file ? file.name : uploadedFile.name}`}
+                              title={`delete file ${file ? file.name : uploadedFile.name}`}
+                              label={`Delete`}
                             ></va-button-icon>
                           </div>
                           <va-modal


### PR DESCRIPTION
## Chromatic
<!-- This `4106-file-input-buttons-dictation` is a placeholder for a CI job - it will be updated automatically -->
https://4106-file-input-buttons-dictation--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
When using Voice Command on windows 11, the change and delete buttons on the va-file-input presented as a button with 2 options. @amyleadem found that this was caused by defining both a label (which sets the aria-label on va-button-icon) and aria-label properties set on the buttons. This change removes the aria-label and sets the label to the old value of the aria-label.

Closes [4106](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4106)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes

## Acceptance criteria
- [ ] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue
