### PR TITLE
va-accordion: logic update to fix 2 clicks to collapse bug

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -129,7 +129,8 @@ export class VaAccordion {
         .forEach(item => (item as Element).setAttribute('open', 'false'));
     }
 
-    const prevAttr = clickedItem.getAttribute('open') === 'true' ? true : false;
+    // setAttribute to "true" will only add the attribute name to the DOM, so we need to use "hasAttribute"
+    const prevAttr = clickedItem.getAttribute('open') === 'false' ? false : clickedItem.hasAttribute('open');
 
     if (!this.disableAnalytics) {
       const detail = {


### PR DESCRIPTION
## Chromatic
<!-- This `4010-va-accordion-expand-bug` is a placeholder for a CI job - it will be updated automatically -->
https://4010-va-accordion-expand-bug--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
This fixes an issue where a user needed to click an accordion item twice after using the "Expand all" button to collapse it.
The issue was caused by the logic expecting a "true" value for the "open" attribute. Since setAttribute only adds the attribute name to the DOM if the value is "true" the logic was failing. The fix checks for the value to be false first and then checks if the accordion-item has the attribute open.

Closes [4010](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4010)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ x] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual changes, just improved functionality

## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue
