### PR TITLE
va-table: add data-sort-value attribute for raw number value sorting

### DIFF
--- a/packages/storybook/stories/va-table-uswds.stories.tsx
+++ b/packages/storybook/stories/va-table-uswds.stories.tsx
@@ -285,68 +285,67 @@ const Pagination = args => {
         onPageSelect={e => onPageChange(e.detail.page)}
         page={currentPage}
         pages={numPages}
-        maxPageListLength={MAX_PAGE_LIST_LENGTH}
-        showLastPage
       />
     </main>
   );
 };
 
-const missingData = [
-  ['A document', '', ''],
-  [
-    'Bill of Rights',
-    'The first ten ammendements of the U.S. Constitution guaranteeing rights and freedoms',
-    '1791',
-  ],
-];
-
-export const Default = Template.bind(null);
-Default.args = {
-  'table-title': 'This is a borderless table.',
-  'rows': data,
-  'columns': defaultColumns,
-};
-Default.argTypes = propStructure(vaTableDocs);
-
-export const Bordered = Template.bind(null);
-Bordered.args = {
-  'table-title': 'This is a stacked bordered table.',
-  'table-type': 'bordered',
-  'rows': data,
-  'columns': defaultColumns,
-};
-Bordered.argTypes = propStructure(vaTableDocs);
-
-export const NonStacked = Template.bind(null);
-NonStacked.args = {
-  'table-title':
-    'This table is not stacked. It will not change on a mobile screen.',
-  'stacked': false,
-  'rows': data,
-  'columns': defaultColumns,
-};
-NonStacked.argTypes = propStructure(vaTableDocs);
-
-export const WithCustomMarkup = CustomComponentsTemplate.bind(null);
-WithCustomMarkup.args = {
-  'table-title': 'This table has custom markup in some of its cells.',
-  'rows': data,
-  'columns': defaultColumns,
-};
-
-export const WithPagination = Pagination.bind(null);
-WithPagination.args = {
-  'table-title': 'This table uses pagination.',
-  'rows': paginationData,
-  'scrollable': true,
-};
-
-export const WithMissingData = Template.bind(null);
-WithMissingData.args = {
-  'table-title': 'This table has some cells without data',
-  'rows': missingData,
-  'columns': defaultColumns,
+const SortWithDataAttributeTemplate = args => {
+  const { 'table-title': tableTitle } = args;
+  return (
+    <va-table table-title={tableTitle} sortable scrollable>
+      <va-table-row>
+        <span>Integer/Float</span>
+        <span>Percent</span>
+        <span>Currency</span>
+        <span>Ordinal mixed</span>
+        <span>Ordinal</span>
+        <span>Month only</span>
+        <span>Full date</span>
+        <span>Alphabetical</span>
+      </va-table-row>
+      <va-table-row>
+        <span data-sort-value="3">3</span>
+        <span data-sort-value="60">60%</span>
+        <span data-sort-value="2500"><strong>$2,500</strong></span>
+        <span data-sort-value="4">4th</span>
+        <span data-sort-value="9">Ninth</span>
+        <span data-sort-value="8">August</span>
+        <span data-sort-value="19030603">June 3, 1903</span>
+        <span>Lorem ipsum dolor sit,</span>
+      </va-table-row>
+      <va-table-row>
+        <span data-sort-value="8.9">8.9</span>
+        <span data-sort-value="1">1%</span>
+        <span data-sort-value="17000">$17,000</span>
+        <span data-sort-value="3">3rd</span>
+        <span data-sort-value="2">Second</span>
+        <span data-sort-value="2">February</span>
+        <span data-sort-value="14151025">October 25, 1415</span>
+        <span>amet consectetur adipisicing elit.</span>
+      </va-table-row>
+      <va-table-row>
+        <span data-sort-value="-5">-5</span>
+        <span data-sort-value="60.01">60.01%</span>
+        <span data-sort-value="100000">$100,000</span>
+        <span data-sort-value="8">8th</span>
+        <span data-sort-value="5">Fifth</span>
+        <span data-sort-value="11">November</span>
+        <span data-sort-value="16211210">December 10, 1621</span>
+        <span>Alias nam eum minima</span>
+      </va-table-row>
+      <va-table-row>
+        <span data-sort-value="99">99</span>
+        <span data-sort-value="100">100%</span>
+        <span data-sort-value="0">$0</span>
+        <span data-sort-value="1">1st</span>
+        <span data-sort-value="10">Tenth</span>
+        <span data-sort-value="6">June</span>
+        <span data-sort-value="17890714">July 14, 1789</span>
+        <span>Beatae, eum.</span>
+      </va-table-row>
+    </va-table>
+  );
 };
 
 const sortColumns = [
@@ -403,6 +402,61 @@ const sortData = [
   ],
 ];
 
+export const Default = Template.bind(null);
+Default.args = {
+  'table-title': 'This is a borderless table.',
+  'rows': data,
+  'columns': defaultColumns,
+};
+Default.argTypes = propStructure(vaTableDocs);
+
+export const Bordered = Template.bind(null);
+Bordered.args = {
+  'table-title': 'This is a stacked bordered table.',
+  'table-type': 'bordered',
+  'rows': data,
+  'columns': defaultColumns,
+};
+Bordered.argTypes = propStructure(vaTableDocs);
+
+export const NonStacked = Template.bind(null);
+NonStacked.args = {
+  'table-title':
+    'This table is not stacked. It will not change on a mobile screen.',
+  'stacked': false,
+  'rows': data,
+  'columns': defaultColumns,
+};
+NonStacked.argTypes = propStructure(vaTableDocs);
+
+export const WithCustomMarkup = CustomComponentsTemplate.bind(null);
+WithCustomMarkup.args = {
+  'table-title': 'This table has custom markup in some of its cells.',
+  'rows': data,
+  'columns': defaultColumns,
+};
+
+export const WithPagination = Pagination.bind(null);
+WithPagination.args = {
+  'table-title': 'This table uses pagination.',
+  'rows': paginationData,
+  'scrollable': true,
+};
+
+export const WithMissingData = Template.bind(null);
+WithMissingData.args = {
+  'table-title': 'This table has some cells without data',
+  'rows': [
+    ['A document', '', ''],
+    [
+      'Bill of Rights',
+      'The first ten ammendements of the U.S. Constitution guaranteeing rights and freedoms',
+      '1791',
+    ],
+  ],
+  'columns': defaultColumns,
+};
+
 export const Sortable = Template.bind(null);
 Sortable.args = {
   'table-title': 'This is a sortable table',
@@ -410,6 +464,11 @@ Sortable.args = {
   'columns': sortColumns,
   'sortable': true,
   'scrollable': true,
+};
+
+export const SortWithDataAttribute = SortWithDataAttributeTemplate.bind(null);
+SortWithDataAttribute.args = {
+  'table-title': 'This is a sortable table using data-sort-value',
 };
 
 export const Striped = Template.bind(null);

--- a/packages/storybook/stories/va-table-uswds.stories.tsx
+++ b/packages/storybook/stories/va-table-uswds.stories.tsx
@@ -307,7 +307,7 @@ const SortWithDataAttributeTemplate = args => {
       <va-table-row>
         <span data-sort-value="3">3</span>
         <span data-sort-value="60">60%</span>
-        <span data-sort-value="2500"><strong>$2,500</strong></span>
+        <span data-sort-value="2500">$2,500</span>
         <span data-sort-value="4">4th</span>
         <span data-sort-value="9">Ninth</span>
         <span data-sort-value="8">August</span>

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1720,7 +1720,7 @@ export namespace Components {
          */
         "scrollable"?: boolean;
         /**
-          * Is the table sortable
+          * If true, the table is sortable. To use a raw sort value for a cell, add a data-sort-value attribute to the span element.
          */
         "sortable"?: boolean;
         /**
@@ -1764,7 +1764,7 @@ export namespace Components {
          */
         "scrollable"?: boolean;
         /**
-          * Is this a sortable table
+          * If true, the table is sortable. To use a raw sort value for a cell, add a data-sort-value attribute to the span element.
          */
         "sortable"?: boolean;
         /**
@@ -5395,7 +5395,7 @@ declare namespace LocalJSX {
          */
         "scrollable"?: boolean;
         /**
-          * Is the table sortable
+          * If true, the table is sortable. To use a raw sort value for a cell, add a data-sort-value attribute to the span element.
          */
         "sortable"?: boolean;
         /**
@@ -5443,7 +5443,7 @@ declare namespace LocalJSX {
          */
         "scrollable"?: boolean;
         /**
-          * Is this a sortable table
+          * If true, the table is sortable. To use a raw sort value for a cell, add a data-sort-value attribute to the span element.
          */
         "sortable"?: boolean;
         /**

--- a/packages/web-components/src/components/va-table/sort/utils.tsx
+++ b/packages/web-components/src/components/va-table/sort/utils.tsx
@@ -26,7 +26,17 @@ export function _getCompareFunc(a: string, sortdir: string) {
 // if all values are empty strings, return null to signify do not sort 
 export function getCompareFunc(rows: Element[], index: number, sortdir: string): CompareFuncReturn | null {
   for (const row of rows) {
-    const cellContents = row.children[index].innerHTML.trim();
+    const cell = row.children[index];
+    // First check for data-sort-value attribute
+    const dataSortValue = cell.getAttribute('data-sort-value');
+    
+    if (dataSortValue !== null) {
+      // If data-sort-value exists, use it to determine the sort function
+      return _getCompareFunc.bind(this)(dataSortValue, sortdir);
+    }
+    
+    // Fall back to innerHTML if no data-sort-value
+    const cellContents = cell.innerHTML.trim();
     if (cellContents !== '') {
       return _getCompareFunc.bind(this)(cellContents, sortdir);
     }

--- a/packages/web-components/src/components/va-table/va-table-inner/test/va-table-inner.e2e.ts
+++ b/packages/web-components/src/components/va-table/va-table-inner/test/va-table-inner.e2e.ts
@@ -452,7 +452,7 @@ describe('sorted va-table ', () => {
     expect(rowOrder).toEqual(['row1', 'row2', 'row3']);
     
     // Click the header to sort
-    const button = await page.find('va-table-inner >>> thead >>> th >>> button');
+    let button = await page.find('va-table-inner >>> thead >>> th >>> button');
     await button.click();
     await page.waitForChanges();
     
@@ -463,7 +463,8 @@ describe('sorted va-table ', () => {
     });
     expect(rowOrder).toEqual(['row2', 'row3', 'row1']);
     
-    // Click the header again to sort in descending order
+    // Re-fetch the button and click again to sort in descending order
+    button = await page.find('va-table-inner >>> thead >>> th >>> button');
     await button.click();
     await page.waitForChanges();
     
@@ -476,6 +477,7 @@ describe('sorted va-table ', () => {
   });
 
   it('correctly handles mixed data-sort-value and innerHTML for sorting', async () => {
+    // Create a test table with clearer numeric values to avoid parsing issues
     const mixedSortTableMarkup = `<va-table sortable="true" table-title="Mixed sort values">
       <va-table-row>
         <span>Numbers</span>
@@ -484,13 +486,13 @@ describe('sorted va-table ', () => {
         <span data-sort-value="30">30 (with attribute)</span>
       </va-table-row>
       <va-table-row id="row2">
-        <span>20 (no attribute)</span>
+        <span>20</span>
       </va-table-row>
       <va-table-row id="row3">
         <span data-sort-value="10">10 (with attribute)</span>
       </va-table-row>
       <va-table-row id="row4">
-        <span>40 (no attribute)</span>
+        <span>40</span>
       </va-table-row>
     </va-table>`;
     
@@ -506,7 +508,7 @@ describe('sorted va-table ', () => {
     expect(rowOrder).toEqual(['row1', 'row2', 'row3', 'row4']);
     
     // Click the header to sort
-    const button = await page.find('va-table-inner >>> thead >>> th >>> button');
+    let button = await page.find('va-table-inner >>> thead >>> th >>> button');
     await button.click();
     await page.waitForChanges();
     
@@ -515,10 +517,12 @@ describe('sorted va-table ', () => {
       const rows = Array.from(document.querySelectorAll('va-table-row')).slice(1);
       return rows.map(row => row.id);
     });
-    // Expected order: row3 (10), row2 (20), row1 (30), row4 (40)
+    
+    // Expected ascending order: 10, 20, 30, 40
     expect(rowOrder).toEqual(['row3', 'row2', 'row1', 'row4']);
     
-    // Click the header again to sort in descending order
+    // Re-fetch the button and click again to sort in descending order
+    button = await page.find('va-table-inner >>> thead >>> th >>> button');
     await button.click();
     await page.waitForChanges();
     
@@ -527,7 +531,8 @@ describe('sorted va-table ', () => {
       const rows = Array.from(document.querySelectorAll('va-table-row')).slice(1);
       return rows.map(row => row.id);
     });
-    // Expected order: row4 (40), row1 (30), row2 (20), row3 (10)
+    
+    // Expected descending order: 40, 30, 20, 10
     expect(rowOrder).toEqual(['row4', 'row1', 'row2', 'row3']);
   });
 });

--- a/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
+++ b/packages/web-components/src/components/va-table/va-table-inner/va-table-inner.tsx
@@ -56,7 +56,7 @@ export class VaTableInner {
   @Prop() stacked?: boolean = false;
 
   /**
-   * Is this a sortable table
+   * If true, the table is sortable. To use a raw sort value for a cell, add a data-sort-value attribute to the span element.
    */
   @Prop() sortable?: boolean = false;
 

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -248,8 +248,22 @@ export class VaTable {
     // only do sort if sortable data in column
     if (compareFunc !== null) {
       rows.sort((a: Element, b: Element) => {
-        const _a = a.children[index].innerHTML.trim();
-        const _b = b.children[index].innerHTML.trim();
+        const cellA = a.children[index];
+        const cellB = b.children[index];
+        
+        // Check for data-sort-value attribute first
+        const sortValueA = cellA.getAttribute('data-sort-value');
+        const sortValueB = cellB.getAttribute('data-sort-value');
+        
+        // If both cells have data-sort-value attributes, use those
+        if (sortValueA !== null && sortValueB !== null) {
+          return compareFunc(sortValueA, sortValueB);
+        }
+        
+        // If only one cell has data-sort-value, or neither has it, fall back to innerHTML
+        const _a = sortValueA !== null ? sortValueA : cellA.innerHTML.trim();
+        const _b = sortValueB !== null ? sortValueB : cellB.innerHTML.trim();
+        
         return compareFunc(_a, _b);
       });
       const sortedDataRows = [header, ...rows];

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -51,7 +51,7 @@ export class VaTable {
   @Prop() scrollable?: boolean = false;
 
   /**
-   * Is the table sortable
+   * If true, the table is sortable. To use a raw sort value for a cell, add a data-sort-value attribute to the span element.
    */
   @Prop() sortable?: boolean = false;
 


### PR DESCRIPTION
## Chromatic
<!-- This `4056-table-data-sort-attribute` is a placeholder for a CI job - it will be updated automatically -->
https://4056-table-data-sort-attribute--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

The `data-sort-value` attribute can be added to the cell `span` for sorting based on a raw value instead of a formatted cell value.

This is based on the [USWDS guidelines](https://designsystem.digital.gov/components/table/#using-the-table-component): 

> Provide raw values for cells with formatted number content. If you have formatted your cell content for display (such as using percent, currency, or comma formatting) or if your cell content is non-numeric but should be sorted in a numeric order (such as months, days of the week, or dates), provide a numeric-sortable value in a data-sort-value attribute on each table cell. 

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4056

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

![Screenshot 2025-05-19 at 9 33 10 AM](https://github.com/user-attachments/assets/b2088225-279e-460e-bd73-658663931aaf)

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
