### PR TITLE
va-combo-box: populate options when loading

### DIFF
--- a/packages/web-components/src/components/va-combo-box/test/va-combo-box.e2e.ts
+++ b/packages/web-components/src/components/va-combo-box/test/va-combo-box.e2e.ts
@@ -63,6 +63,9 @@ describe('va-combo-box', () => {
     await page.find('va-combo-box >>> input');
     const combobox = await page.find('va-combo-box >>> .usa-combo-box');
     expect(combobox).toEqualAttribute('data-default-value', 'bar');
+    const input = await page.find('va-combo-box >>> input');
+    const value = await input.getProperty('value');
+    expect(value).toBe('Bar');
   });
 
   it('renders opt groups', async () => {

--- a/packages/web-components/src/components/va-combo-box/va-combo-box.tsx
+++ b/packages/web-components/src/components/va-combo-box/va-combo-box.tsx
@@ -86,6 +86,10 @@ export class VaComboBox {
    */
   @Event() vaSelect: EventEmitter;
 
+  componentWillLoad() {
+    this.populateOptions();
+  }
+
   connectedCallback() {
     i18next.on('languageChanged', () => {
       forceUpdate(this.el);


### PR DESCRIPTION
## Chromatic
<!-- This `mhv-71475-combo-box-default-value-fix` is a placeholder for a CI job - it will be updated automatically -->
https://mhv-71475-combo-box-default-value-fix--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Configuring this pull request
- [x] Link to any related issues in the description so they can be cross-referenced.
- [x] Add the appropriate version patch label (`major`, `minor`, `patch`, or `ignore-for-release`).
    - See [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library#how-to-choose-a-version-number) for guidance.
    - Use `ignore-for-release` if files haven't been changed in a component library package. (ie. only Storybook files)
- [ ] DST Only: Increment the `/packages/core` version number if this will be the last PR merged before a release.
- [ ] Complete all sections below.
- [ ] Delete this section once complete

## Description
Closes [MHV-71475](https://jira.devops.va.gov/browse/MHV-71475) - Combo Box - bug - fix default value not populating

We noticed a bug in the combo box after a recent update.  It was not being populated with the default value if one was provided.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
