### PR TITLE
va-search-filter: update accordion-items to be heading level 3

### DIFF
--- a/packages/web-components/src/components/va-search-filter/va-search-filter.tsx
+++ b/packages/web-components/src/components/va-search-filter/va-search-filter.tsx
@@ -303,6 +303,7 @@ export class VaSearchFilter {
                 <va-accordion-item
                   header={facet.label + (facet.activeFiltersCount > 0 ? ` (${facet.activeFiltersCount})` : '')}
                   key={facet.id}
+                  level={3}
                   open
                 >
                   <va-checkbox-group label={facet.label} class="va-search-filter__checkbox-group">


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
The "Filters" heading is an h2 so to maintain heading hierarchy the heading level for the accordion items on desktop need to be an h3.

Closes [4156](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4156)

## QA Checklist
- [ x] Component maintains 1:1 parity with design mocks
- [ x] Text is consistent with what's been provided in the mocks
- [ x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ x] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ x] Tab order and focus state work as expected
- [ x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ x] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
No visual differences

Current:
![Screenshot 2025-05-21 at 1 43 35 PM](https://github.com/user-attachments/assets/6556a57f-8ad0-4704-98d4-0411da749fbb)

New:
![Screenshot 2025-05-21 at 1 44 21 PM](https://github.com/user-attachments/assets/c3877edb-30b3-4f1a-8e34-e4b0e6f6637d)



## Acceptance criteria
- [ x] QA checklist has been completed
- [ x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ x] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue
