### PR TITLE
va-alert-sign-in: replace straight apostrophes with curly ones

### DIFF
--- a/packages/storybook/stories/va-alert-sign-in.stories.tsx
+++ b/packages/storybook/stories/va-alert-sign-in.stories.tsx
@@ -107,7 +107,7 @@ const SignInButton = () => <va-button text="Sign in or create an account" />;
 const IdMeSignInButton = () => (
   <button
     style={{
-      ...buttonStyles,
+      ...buttonStyles as React.CSSProperties,
       ...fixedButtonStyles,
       backgroundColor: 'var(--vads-color-success-dark)',
     }}
@@ -127,7 +127,7 @@ const IdMeVerifyButton = () => (
 const LoginGovSignInButton = () => (
   <button
     style={{
-      ...buttonStyles,
+      ...buttonStyles as React.CSSProperties,
       ...fixedButtonStyles,
       backgroundColor: 'var(--vads-color-secondary)',
     }}
@@ -138,7 +138,7 @@ const LoginGovSignInButton = () => (
 const LoginGovVerifyButton = () => (
   <button
     style={{
-      ...buttonStyles,
+      ...buttonStyles as React.CSSProperties,
       backgroundColor: 'var(--vads-color-secondary)',
     }}
   >

--- a/packages/web-components/src/components/va-alert-sign-in/test/va-alert-sign-in.e2e.ts
+++ b/packages/web-components/src/components/va-alert-sign-in/test/va-alert-sign-in.e2e.ts
@@ -21,11 +21,11 @@ describe('va-alert-sign-in', () => {
                     Sign in with a verified account
                   </h2>
                    <p>
-                     You'll need to sign in with an identity-verified account through one of our account providers. Identity verification helps us protect all Veterans' information and prevent scammers from stealing your benefits.
+                     You’ll need to sign in with an identity-verified account through one of our account providers. Identity verification helps us protect all Veterans’ information and prevent scammers from stealing your benefits.
                    </p>
                    <p>
                      <strong>
-                       Don't yet have a verified account?
+                       Don’t yet have a verified account?
                      </strong>
                      Create a
                      <strong>
@@ -35,13 +35,13 @@ describe('va-alert-sign-in', () => {
                      <strong>
                        ID.me
                      </strong>
-                     account. We'll help you verify your identity for your account now.
+                     account. We’ll help you verify your identity for your account now.
                    </p>
                    <p>
                      <strong>
                        Not sure if your account is verified?
                      </strong>
-                     Sign in here. If you still need to verify your identity, we'll help you do that now.
+                     Sign in here. If you still need to verify your identity, we’ll help you do that now.
                    </p>
                    <p>
                      <slot name="SignInButton"></slot>

--- a/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
+++ b/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
@@ -79,19 +79,18 @@ export class VaAlertSignIn {
           Sign in with a verified account
         </HeaderLevel>
         <p>
-          You'll need to sign in with an identity-verified account through one
+          You’ll need to sign in with an identity-verified account through one
           of our account providers. Identity verification helps us protect all
-          Veterans' information and prevent scammers from stealing your
           benefits.
         </p>
         <p>
-          <strong>Don't yet have a verified account?</strong> Create a{' '}
-          <strong>Login.gov</strong> or <strong>ID.me</strong> account. We'll
+          <strong>Don’t yet have a verified account?</strong> Create a{' '}
+          <strong>Login.gov</strong> or <strong>ID.me</strong> account. We’ll
           help you verify your identity for your account now.
         </p>
         <p>
           <strong>Not sure if your account is verified?</strong> Sign in here.
-          If you still need to verify your identity, we'll help you do that now.
+          If you still need to verify your identity, we’ll help you do that now.
         </p>
         <p>
           <slot name="SignInButton"></slot>
@@ -112,29 +111,29 @@ export class VaAlertSignIn {
           Sign in with a verified account
         </HeaderLevel>
         <p>
-          Here's how signing in with an identity-verified account helps you:
+          Here’s how signing in with an identity-verified account helps you:
         </p>
         <ul>
           <li>
             We can fill in some of your information for you to save you time.
           </li>
           <li>
-            You can save your work in progress. You'll have {this.timeLimit}{' '}
+            You can save your work in progress. You’ll have {this.timeLimit}{' '}
             from when you start or make changes to submit your form.
           </li>
         </ul>
         <p>
-          <strong>Don't yet have a verified account?</strong> Create a{' '}
-          <strong>Login.gov</strong> or <strong>ID.me</strong> account. We'll
+          <strong>Don’t yet have a verified account?</strong> Create a{' '}
+          <strong>Login.gov</strong> or <strong>ID.me</strong> account. We’ll
           help you verify your identity for your account now.
         </p>
         <p>
           <strong>Not sure if your account is verified?</strong> Sign in here.
-          If you still need to verify your identity, we'll help you do that now.
+          If you still need to verify your identity, we’ll help you do that now.
         </p>
         <p>
           <strong>Note:</strong> You can sign in after you start filling out
-          your form. But you'll lose any information you already filled in.
+          your form. But you’ll lose any information you already filled in.
         </p>
         <p>
           <slot name="SignInButton"></slot>
@@ -158,21 +157,21 @@ export class VaAlertSignIn {
         </HeaderLevel>
         <p>
           When you sign in with an identity-verified account, you can save your
-          work in progress. You'll have 60 days from when you start or make
+          work in progress. You’ll have 60 days from when you start or make
           changes to submit your form.
         </p>
         <p>
-          <strong>Don't yet have a verified account?</strong> Create a{' '}
-          <strong>Login.gov</strong> or <strong>ID.me</strong> account. We'll
+          <strong>Don’t yet have a verified account?</strong> Create a{' '}
+          <strong>Login.gov</strong> or <strong>ID.me</strong> account. We’ll
           help you verify your identity for your account now.
         </p>
         <p>
           <strong>Not sure if your account is verified?</strong> Sign in here.
-          If you still need to verify your identity, we'll help you do that now.
+          If you still need to verify your identity, we’ll help you do that now.
         </p>
         <p>
           <strong>Note:</strong> You can sign in after you start filling out
-          your form. But you'll lose any information you already filled in.
+          your form. But you’ll lose any information you already filled in.
         </p>
         <p>
           <slot name="SignInButton"></slot>
@@ -194,11 +193,11 @@ export class VaAlertSignIn {
         <HeaderLevel class="headline">Verify your identity</HeaderLevel>
         <p>
           We need you to verify your identity for your <strong>ID.me</strong>{' '}
-          account. This step helps us protect all Veterans' information and
+          account. This step helps us protect all Veterans’ information and
           prevent scammers from stealing your benefits.
         </p>
         <p>
-          This one-time process often takes about 10 minutes. You'll need to
+          This one-time process often takes about 10 minutes. You’ll need to
           provide certain personal information and identification.
         </p>
         <p>
@@ -220,11 +219,11 @@ export class VaAlertSignIn {
         <p>
           We need you to verify your identity for your{' '}
           <strong>Login.gov</strong> account. This step helps us protect all
-          Veterans' information and prevent scammers from stealing your
+          Veterans’ information and prevent scammers from stealing your
           benefits.
         </p>
         <p>
-          This one-time process often takes about 10 minutes. You'll need to
+          This one-time process often takes about 10 minutes. You’ll need to
           provide certain personal information and identification.
         </p>
         <p>
@@ -247,7 +246,7 @@ export class VaAlertSignIn {
         </HeaderLevel>
         <p>
           We need you to sign in with an identity-verified account. This helps
-          us protect all Veterans' information and prevent scammers from
+          us protect all Veterans’ information and prevent scammers from
           stealing your benefits. You have 2 options: a verified{' '}
           <strong>Login.gov</strong> or a verified <strong>ID.me</strong>{' '}
           account.
@@ -255,11 +254,11 @@ export class VaAlertSignIn {
         <p>
           <strong>If you already have a Login.gov or ID.me account,</strong>{' '}
           sign in with that account. If you still need to verify your identity
-          for your account, we'll help you do that now.
+          for your account, we’ll help you do that now.
         </p>
         <p>
-          <strong>If you don't have a Login.gov or ID.me account,</strong>{' '}
-          create one now. We'll help you verify your identity.
+          <strong>If you don’t have a Login.gov or ID.me account,</strong>{' '}
+          create one now. We’ll help you verify your identity.
         </p>
         <p>
           <slot name="LoginGovSignInButton"></slot>

--- a/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
+++ b/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
@@ -81,7 +81,7 @@ export class VaAlertSignIn {
         <p>
           You’ll need to sign in with an identity-verified account through one
           of our account providers. Identity verification helps us protect all
-          benefits.
+          Veterans’ information and prevent scammers from stealing your benefits.
         </p>
         <p>
           <strong>Don’t yet have a verified account?</strong> Create a{' '}

--- a/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
+++ b/packages/web-components/src/components/va-alert-sign-in/va-alert-sign-in.tsx
@@ -35,6 +35,7 @@ export class VaAlertSignIn {
   /**
    * For the 'optional' variant, how long the respondent has to submit their form
    */
+  // eslint-disable-next-line i18next/no-literal-string
   @Prop() timeLimit?: string = '15 minutes';
 
   /**


### PR DESCRIPTION
## Chromatic
<!-- This `3690-sign-in-apostrophes` is a placeholder for a CI job - it will be updated automatically -->
https://3690-sign-in-apostrophes--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
Closes [#3960](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3960)

Replaces straight apostrophes (i.e. `'`) with curly apostrophes (i.e. `’`) in `va-alert-sign-in` to match style guide.

## QA Checklist
- [x] Component maintains 1:1 parity with design mocks
- [x] Text is consistent with what's been provided in the mocks
- [x] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
  - Content change only
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
  - Content change only _Not sure if this applies here?_
- [ ] Tab order and focus state work as expected
  - Content change only _Not sure if this applies here?_
- [x] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [x] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)
  - Content change only

## Screenshots
Old (mobile):
![Monosnap Components : Alert - Sign-in - Default ⋅ Storybook 2025-05-23 15-52-33](https://github.com/user-attachments/assets/835f100b-83d1-454d-89a8-6f4255d7d621)

New (mobile):
![Monosnap Components : Alert - Sign-in - Default ⋅ Storybook 2025-05-23 15-52-09](https://github.com/user-attachments/assets/31945e73-a21d-4fdc-ace5-a8205fab19c2)

Old (desktop):
![Monosnap Components : Alert - Sign-in - Docs ⋅ Storybook 2025-05-23 15-00-13](https://github.com/user-attachments/assets/93f3b3c2-6ed2-4ea0-aedf-b26daf6478c5)

New (desktop):
![Monosnap Components : Alert - Sign-in - Docs ⋅ Storybook 2025-05-23 15-04-11](https://github.com/user-attachments/assets/2caa87c0-2aaf-4b0b-b3b7-1f0b8a7ab1c2)


## Acceptance criteria
- [ ] QA checklist has been completed
- [x] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue
