### PR TITLE
va-input-telephone: update event payload

### DIFF
--- a/packages/storybook/stories/va-input-telephone.stories.tsx
+++ b/packages/storybook/stories/va-input-telephone.stories.tsx
@@ -22,7 +22,8 @@ const defaultArgs = {
   country: null,
   'no-country': false,
   hint: "",
-  error: ""
+  error: "",
+  required: false
 };
 
 const Template = ({
@@ -31,7 +32,8 @@ const Template = ({
   contact,
   country,
   error,
-  header
+  header,
+  required
 }) => {
   return (
     <va-input-telephone
@@ -41,6 +43,7 @@ const Template = ({
       contact={contact}
       no-country={noCountry}
       error={error}
+      required={required}
     />
   );
 };
@@ -85,6 +88,12 @@ export const WithHint = Template.bind(null);
 WithHint.args = {
   ...defaultArgs,
   hint: 'Enter a phone number where you can be reached if we have questions about your application',
+}
+
+export const WithRequired = Template.bind(null);
+WithRequired.args = {
+  ...defaultArgs,
+  required: true
 }
 
 export const WithNoCountry = Template.bind(null);

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -818,6 +818,10 @@ export namespace Components {
           * Whether the country select should be included. Set to true to exclude it.
          */
         "noCountry"?: boolean;
+        /**
+          * Render marker indicating field is required.
+         */
+        "required"?: boolean;
     }
     /**
      * @componentName Language Toggle
@@ -2722,7 +2726,6 @@ declare global {
     };
     interface HTMLVaInputTelephoneElementEventMap {
         "vaContact": any;
-        "vaCountryCode": any;
     }
     /**
      * @componentName Input Telephone
@@ -4409,9 +4412,9 @@ declare namespace LocalJSX {
          */
         "onVaContact"?: (event: VaInputTelephoneCustomEvent<any>) => void;
         /**
-          * The event emitted when the country code changes
+          * Render marker indicating field is required.
          */
-        "onVaCountryCode"?: (event: VaInputTelephoneCustomEvent<any>) => void;
+        "required"?: boolean;
     }
     /**
      * @componentName Language Toggle

--- a/packages/web-components/src/components/va-input-telephone/test/va-input-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-input-telephone/test/va-input-telephone.e2e.ts
@@ -23,7 +23,17 @@ describe('va-input-telephone', () => {
     const input = await page.find('va-input-telephone >>> input#inputField');
     const value = await input.getProperty('value');
     expect(value).toBe('(234) 567-8910')
-  })
+  });
+
+  it('renders an error and shows invalid contact in prefill', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-input-telephone contact="abcdefg" />');
+    const input = await page.find('va-input-telephone >>> input#inputField');
+    const value = await input.getProperty('value');
+    expect(value).toBe('abcdefg')
+    const error = await page.find('va-input-telephone >>> span#error-message');
+    expect(error.innerText).toContain('phone number in a valid format, for example,');
+  });
 
   it('prefills a country', async () => {
     const page = await newE2EPage();
@@ -60,7 +70,7 @@ describe('va-input-telephone', () => {
     await input.click(); 
     await input.press('Tab');
     const error = await page.find('va-input-telephone >>> span#error-message');
-    expect(error.innerText).toContain('Please enter a phone number');
+    expect(error.innerText).toContain('phone number in a valid format, for example,');
   });
 
   it('shows an error message if contact does not match the form required by the selected country', async () => {
@@ -98,17 +108,6 @@ describe('va-input-telephone', () => {
     expect(flagSpan).not.toBeNull();
   })
 
-  it('emits the vaCountryCode event', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<va-input-telephone />');
-    const countrySpy = await page.spyOnEvent('vaCountryCode');
-    const input = await page.find('va-input-telephone >>> va-combo-box');
-    await input.click();
-    await input.press('Tab');
-    await input.press('Tab');
-    expect(countrySpy).toHaveReceivedEventDetail({ code: 'US' });
-  });
-
   it('emits the vaContact event', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-input-telephone contact="2345678910" />');
@@ -116,7 +115,24 @@ describe('va-input-telephone', () => {
     const input = await page.find('va-input-telephone >>> va-text-input >>> input');
     await input.click();
     await input.press('Tab');
-    expect(contactSpy).toHaveReceivedEventDetail({ contact: '(234) 567-8910', isValid: true });
+    expect(contactSpy).toHaveReceivedEventDetail({
+      callingCode: '1',
+      contact: '2345678910',
+      countryCode: 'US',
+      isValid: true
+    });
+  });
+
+  it('renders a required span', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-input-telephone required />',
+    );
+
+    const requiredSpan = await page.find(
+      'va-input-telephone >>> span.usa-label--required',
+    );
+    expect(requiredSpan).not.toBeNull();
   });
 
   it('does not render render country select when no-country is true', async () => {

--- a/packages/web-components/src/components/va-input-telephone/utils.tsx
+++ b/packages/web-components/src/components/va-input-telephone/utils.tsx
@@ -30,7 +30,7 @@ export const DATA_MAP = {
     'AQ': 'NF', //Antarctica
     'BV': 'NO', //Bouvet Island
     'TF': 'RE', //French Southern Territories
-    'HM': 'NF', //Heard Island and McDonald Islands,
+    'HM': 'AU', //Heard Island and McDonald Islands,
     'UM': 'US', //United States Minor Outlying Islands
     'PN': 'NZ', //Pitcairn Island
   }

--- a/packages/web-components/src/components/va-input-telephone/va-input-telephone.tsx
+++ b/packages/web-components/src/components/va-input-telephone/va-input-telephone.tsx
@@ -9,9 +9,19 @@ import {
   Event
 } from '@stencil/core';
 
-import { AsYouType, isPossiblePhoneNumber, CountryCode, getExampleNumber, getCountries, getCountryCallingCode } from 'libphonenumber-js/min'; 
+import {
+  AsYouType,
+  isPossiblePhoneNumber,
+  CountryCode,
+  getExampleNumber,
+  getCountries,
+  getCountryCallingCode,
+  parsePhoneNumber,
+  PhoneNumber
+} from 'libphonenumber-js/min'; 
 import examples from 'libphonenumber-js/examples.mobile.json';
 import classNames from 'classnames';
+import { i18next } from '../..';
 import { DATA_MAP, mapCountry } from './utils';
 
 /**
@@ -27,7 +37,7 @@ import { DATA_MAP, mapCountry } from './utils';
   styleUrl: 'va-input-telephone.scss',
   shadow: true,
 })
-export class VaInternationalTelephone {
+export class VaInputTelephone {
   @Element() el: HTMLElement;
   textInputRef: HTMLVaTextInputElement;
   DEFAULT_COUNTRY: CountryCode = 'US';
@@ -35,13 +45,12 @@ export class VaInternationalTelephone {
   /**
    * The telephone contact information
    */
-  @Prop() contact?: string;
+  @Prop({ reflect: true, mutable: true }) contact?: string = '';
 
   /**
    * The 2 letter ISO country code for a country
    */
   @Prop({ reflect: true, mutable: true }) country?: CountryCode = this.DEFAULT_COUNTRY;
-
 
   /**
    * Header text for the component
@@ -64,14 +73,14 @@ export class VaInternationalTelephone {
   @Prop() noCountry?: boolean = false;
 
   /**
+   * Render marker indicating field is required.
+   */
+  @Prop() required?: boolean = false;
+
+  /**
    * The event emitted when the contact changes
    */
   @Event() vaContact: EventEmitter;
-
-  /**
-   * The event emitted when the country code changes
-   */
-  @Event() vaCountryCode: EventEmitter
 
   /**
    * The contact formatted according to the selected country
@@ -93,6 +102,11 @@ export class VaInternationalTelephone {
    */
   @State() contactError: string = '';
 
+  /**
+   * Is the phone number valid for the selected country
+   */
+  @State() isValid: boolean = false;
+
   resetErrors() {
     this.countryError = '';
     this.contactError = '';
@@ -102,7 +116,8 @@ export class VaInternationalTelephone {
   updateContact(event: InputEvent) {
     const target = event.target as HTMLInputElement;
     const { value } = target;
-    this.formattedContact = value ? this.formatContact(value) : '';
+    this.contact = value;
+    this.formattedContact = this.formatContact(value);
   }
 
   // get an error message for a country that includes the template of a valid phone number for that country
@@ -118,20 +133,39 @@ export class VaInternationalTelephone {
   // validate the contact and emit the contact and validation state
   validateContact() {
     this.resetErrors();
-    let isValid = false;
     if (this.country) {
-      if (this.formattedContact) {
-        const _country = mapCountry(this.country);
-        isValid = isPossiblePhoneNumber(this.formattedContact, _country);
-        this.error = isValid ? '' : this.getErrorMessageForCountry()
-      } else {
-        this.error = 'Please enter a phone number';
-      }
+      const _country = mapCountry(this.country);
+      this.isValid = !!this.contact
+        ? isPossiblePhoneNumber(this.contact, _country)
+        : false;
+      this.error = this.isValid
+        ? ''
+        : this.getErrorMessageForCountry();
       this.contactError = this.error;
     } else {
       this.validateCountry();
     }
-    this.vaContact.emit({ contact: this.formattedContact, isValid });
+    this.handelEmit();
+  }
+
+  handelEmit() {
+    const tryParse = !!this.contact && !!this.country;
+    let phoneNumber: PhoneNumber | null;
+    try {
+      phoneNumber = tryParse
+        ? parsePhoneNumber(this.contact, mapCountry(this.country))
+        : null;
+    } catch {
+      // there was a parse error of some kind due to invalid input, i.e. input like "abc"
+      // not screening contact via regex because it is difficult to handle all possibilities for all countries
+      phoneNumber = null;
+    }
+    this.vaContact.emit({
+      callingCode: (tryParse && phoneNumber !== null) ? phoneNumber.countryCallingCode : undefined,
+      countryCode: this.country,
+      contact: (tryParse && phoneNumber !== null) ? phoneNumber.nationalNumber : this.contact,
+      isValid: this.isValid
+    });
   }
 
   // make sure country has been selected
@@ -140,6 +174,7 @@ export class VaInternationalTelephone {
     if (!this.country) {
       this.error = 'Please choose a country';
       this.countryError = this.error;
+      this.handelEmit();
     } else {
       this.validateContact();
     }
@@ -150,13 +185,14 @@ export class VaInternationalTelephone {
     const { value } = event.detail;
     this.country = value;
     this.validateCountry();
-    this.vaCountryCode.emit({ code: value });
   }
 
   formatContact(value: string) {
     // some territories are formatted / validated as if they were a different, larger country
     const _country = mapCountry(this.country);
-    return new AsYouType(_country).input(value);
+    const _formatted = new AsYouType(_country).input(value);
+    // if input has no numbers return it for sake of error correction
+    return _formatted === '' ? value : _formatted
   }
 
   // get list of country codes alphabetized by name with US in front
@@ -189,15 +225,13 @@ export class VaInternationalTelephone {
   }
 
   componentWillLoad() {
-    if (this.contact) {
-      this.formattedContact = this.formatContact(this.contact);
-    }
     this.countries = this.buildCountryList();
   }
 
   componentDidLoad() {
     // if a contact was provided, check if it's valid for the country
-    if (this.formattedContact) {
+    if (this.contact) {
+      this.formattedContact = this.formatContact(this.contact);
       this.validateContact();
     }
     const comboBox = this.el.shadowRoot.querySelector('va-combo-box');
@@ -232,7 +266,8 @@ export class VaInternationalTelephone {
       country,
       countryError,
       contactError,
-      noCountry
+      noCountry,
+      required
     } = this;
     
     const legendClasses = classNames({
@@ -246,6 +281,12 @@ export class VaInternationalTelephone {
           <fieldset class="usa-form usa-fieldset">
             <legend class={legendClasses}>
               {header}
+              {required && (
+                <span class="usa-label--required">
+                  {' '}
+                  {i18next.t('required')}
+                </span>
+              )}
               {hint && <div class="usa-hint">{hint}</div>}
             </legend>
             {error && <span id="error-message" role="alert">{error}</span>}


### PR DESCRIPTION
## Chromatic
<!-- This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

---
## Description
This PR updates the va-input-telephone component so that it can be incorporated into the forms system by:
* consolidating the `vaCountry` and `vaContact` events into one `vaContact` event and updating its payload so that it includes a phone number's`callingCode`. This is to accommodate the needs of the Profile team.
* add a `required` property and associated markup
* avoid crashing by handling non-numeric input

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
<img width="520" alt="Screenshot 2025-06-02 at 10 42 09 AM" src="https://github.com/user-attachments/assets/55aec714-7efa-4407-bfa4-59ba8d8393de" />


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
