### PR TITLE
va-link | Fix external link text wrapping

### DIFF
--- a/packages/storybook/stories/va-link.stories.tsx
+++ b/packages/storybook/stories/va-link.stories.tsx
@@ -43,6 +43,7 @@ const Template = ({
   channel,
   'disable-analytics': disableAnalytics,
   download,
+  external,
   href,
   filename,
   filetype,
@@ -64,6 +65,7 @@ const Template = ({
         channel={channel}
         disable-analytics={disableAnalytics}
         download={download}
+        external={external}
         href={href}
         filename={filename}
         filetype={filetype}

--- a/packages/web-components/src/components/va-link/test/va-link.e2e.ts
+++ b/packages/web-components/src/components/va-link/test/va-link.e2e.ts
@@ -184,7 +184,7 @@ describe('va-link', () => {
     expect(element).toEqualHtml(`
     <va-link class="hydrated" external="" href="https://www.va.gov" text="Veteran's Affairs">
       <mock:shadow-root>
-        <a href="https://www.va.gov" rel="noreferrer" class="link--center" target="_blank">
+        <a href="https://www.va.gov" rel="noreferrer" target="_blank">
           Veteran's Affairs
           <span class="screen-only">
             (opens in a new tab)

--- a/packages/web-components/src/components/va-link/va-link.scss
+++ b/packages/web-components/src/components/va-link/va-link.scss
@@ -65,7 +65,7 @@
 }
 
 .link--center {
-  display: inline;
+  display: inline-flex;
   align-items: center;
 }
 

--- a/packages/web-components/src/components/va-link/va-link.scss
+++ b/packages/web-components/src/components/va-link/va-link.scss
@@ -65,7 +65,7 @@
 }
 
 .link--center {
-  display: inline-flex;
+  display: inline;
   align-items: center;
 }
 

--- a/packages/web-components/src/components/va-link/va-link.tsx
+++ b/packages/web-components/src/components/va-link/va-link.tsx
@@ -165,7 +165,7 @@ export class VaLink {
 
     const linkClass = classNames({
       'va-link--reverse': reverse,
-      'link--center': iconName || external,
+      'link--center': iconName,
     });
 
     // Active link variant


### PR DESCRIPTION
## Chromatic
<!-- This `4025-link-wrap` is a placeholder for a CI job - it will be updated automatically -->
https://4025-link-wrap--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Fixed the wrapping of the "(opens in a new tab)" text that is included when the `external` property is included.

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4025
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107923

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots

| Before | After |
|---|---|
| <img width="577" alt="Image" src="https://github.com/user-attachments/assets/590f7d0a-0e2b-42e9-8dc1-a27c87e827d2" /> | <img width="575" alt="Screenshot 2025-06-02 at 4 00 41 PM" src="https://github.com/user-attachments/assets/813bc875-515c-46cc-8d56-f38077c81041" /> |

## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
