### PR TITLE
va-input-telephone: improve grammar of error message

### DIFF
--- a/packages/web-components/src/components/va-input-telephone/test/va-input-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-input-telephone/test/va-input-telephone.e2e.ts
@@ -106,7 +106,26 @@ describe('va-input-telephone', () => {
     await page.waitForChanges();
     const flagSpan = await page.find('va-input-telephone >>> va-combo-box >>> span.flag-af');
     expect(flagSpan).not.toBeNull();
-  })
+  });
+
+  it('handles the a/an in error message appropriately for country starts with a vowel', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-input-telephone country="ID" />');
+    let input = await page.find('va-input-telephone >>> va-text-input >>> input');
+    await input.press('Tab');
+    let error = await page.find('va-input-telephone >>> span#error-message');
+    expect(error.innerText).toContain('Enter an Indonesia');
+  });
+
+  it('handles the a/an in error message appropriately for country doesn\'t start with vowel', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-input-telephone country="FJ" />');
+    await page.waitForChanges();
+    const input = await page.find('va-input-telephone >>> va-text-input >>> input');
+    await input.press('Tab');
+    const error = await page.find('va-input-telephone >>> span#error-message');
+    expect(error.innerText).toContain('Enter a Fiji');
+  });
 
   it('emits the vaContact event', async () => {
     const page = await newE2EPage();

--- a/packages/web-components/src/components/va-input-telephone/va-input-telephone.tsx
+++ b/packages/web-components/src/components/va-input-telephone/va-input-telephone.tsx
@@ -127,7 +127,12 @@ export class VaInputTelephone {
     const asYouType = new AsYouType(_country);
     asYouType.input(example);
     const msg = asYouType.getTemplate();
-    return `Enter a ${this.getCountryName(_country)} phone number in a valid format, for example, [${msg}]`;
+    const countryName = this.getCountryName(_country);
+    const article =
+      ['a', 'e', 'i', 'o'].includes(countryName.charAt(0).toLowerCase())
+      ? 'an'
+      : 'a';
+    return `Enter ${article} ${countryName} phone number in a valid format, for example, [${msg}]`;
   }
 
   // validate the contact and emit the contact and validation state

--- a/packages/web-components/src/components/va-input-telephone/va-input-telephone.tsx
+++ b/packages/web-components/src/components/va-input-telephone/va-input-telephone.tsx
@@ -23,6 +23,7 @@ import examples from 'libphonenumber-js/examples.mobile.json';
 import classNames from 'classnames';
 import { i18next } from '../..';
 import { DATA_MAP, mapCountry } from './utils';
+import { getArticle } from '../../utils/utils';
 
 /**
  * @componentName Input Telephone
@@ -128,10 +129,7 @@ export class VaInputTelephone {
     asYouType.input(example);
     const msg = asYouType.getTemplate();
     const countryName = this.getCountryName(_country);
-    const article =
-      ['a', 'e', 'i', 'o'].includes(countryName.charAt(0).toLowerCase())
-      ? 'an'
-      : 'a';
+    const article = getArticle(countryName, false);
     return `Enter ${article} ${countryName} phone number in a valid format, for example, [${msg}]`;
   }
 

--- a/packages/web-components/src/utils/utils.spec.ts
+++ b/packages/web-components/src/utils/utils.spec.ts
@@ -5,7 +5,8 @@ import {
   isInteractiveLinkOrButton,
   isMessageSet,
   deepEquals,
-  truncate
+  truncate,
+  getArticle
 } from './utils';
 
 describe('format', () => {
@@ -335,5 +336,19 @@ describe('truncate()', () => {
     const startingText = 'This text is short';
     const truncatedText = truncate(startingText, 200, FONT);
     expect(truncatedText).toEqual(startingText);
+  })
+
+  it('it gets the right article for a string', () => {
+    const appleArticle = getArticle('apple');
+    expect(appleArticle).toEqual('an');
+
+    const dogArticle = getArticle('dog');
+    expect(dogArticle).toEqual('a');
+
+    const universityArticle = getArticle('university', false);
+    expect(universityArticle).toEqual('a');
+
+    const umbrellaArticle = getArticle('umbrella');
+    expect(umbrellaArticle).toEqual('an');
   })
 })

--- a/packages/web-components/src/utils/utils.ts
+++ b/packages/web-components/src/utils/utils.ts
@@ -332,3 +332,24 @@ export function truncate(text: string, maxWidth: number, fontStyle: string): str
 
   return text.substring(0, best).trim() + ellipsis;
 }
+
+/**
+ * Gets the proper article for a word, either "a" or "an"
+ * based upon first letter of the word
+ * 
+ * @param string - The string that needs an article
+ * @param useUe - Whether to treat a word that starts with "u" as starting with a vowel
+ * @returns Either "a" or "an"
+ */
+export function getArticle(string: string, useU=true): 'a' | 'an' {
+  const vowels = ['a', 'i', 'e', 'o', ];
+
+  // there are cases when we know we will have words that start with "u"
+  // that don't get "an" as an article, e.g. "university"
+  if (useU) {
+    vowels.push('u');
+  }
+
+  const testLetter = string.charAt(0).toLowerCase();
+  return vowels.includes(testLetter) ? 'an' : 'a';
+}


### PR DESCRIPTION
## Chromatic
<!-- This `va-input-tel-grammar` is a placeholder for a CI job - it will be updated automatically -->
https://va-input-tel-grammar--65a6e2ed2314f7b8f98609d8.chromatic.com

---

## Description
This PR improves the grammar of the error message when a phone number is missing such that the article before the country name is a/an as needed.

## QA Checklist
- [ ] Component maintains 1:1 parity with design mocks
- [ ] Text is consistent with what's been provided in the mocks
- [ ] Component behaves as expected across breakpoints
- [ ] Accessibility expert has signed off on code changes (if applicable. If not applicable provide reason why)
- [ ] Designer has signed off on changes (if applicable. If not applicable provide reason why)
- [ ] Tab order and focus state work as expected
- [ ] Changes have been tested against screen readers (if applicable. If not applicable provide reason why)
- [ ] New components are covered by e2e tests; updates to existing components are covered by existing test suite
- [ ] Changes have been tested in vets-website using Verdaccio (if applicable. If not applicable provide reason why)

## Screenshots
Before:
<img width="561" alt="Screenshot 2025-06-03 at 7 46 36 AM" src="https://github.com/user-attachments/assets/3a03d353-3bc8-46e2-9972-83aa727ddad6" />

After: 
<img width="528" alt="Screenshot 2025-06-03 at 7 45 43 AM" src="https://github.com/user-attachments/assets/c4ccbd42-027e-428a-a300-f9e10d1735f9" />


## Acceptance criteria
- [ ] QA checklist has been completed
- [ ] Screenshots have been attached that cover desktop and mobile screens

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue
