### PR TITLE
va-combo-box: Restore filtering functionality

### DIFF
--- a/packages/web-components/src/components/va-combo-box/test/va-combo-box.e2e.ts
+++ b/packages/web-components/src/components/va-combo-box/test/va-combo-box.e2e.ts
@@ -156,8 +156,8 @@ describe('va-combo-box', () => {
     const changeEvent = await page.spyOnEvent('vaSelect');
 
     await input.click();
-    await page.keyboard.press('ArrowDown'); 
-    await page.keyboard.press('Enter'); 
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
     const vaSelectEvent = changeEvent.events[0];
     expect(vaSelectEvent.detail.value).toEqual('foo');
     expect(vaSelectEvent.type).toEqual('vaSelect');
@@ -179,8 +179,8 @@ describe('va-combo-box', () => {
     const changeEvent = await page.spyOnEvent('vaSelect');
 
     await input.click();
-    await page.keyboard.press('ArrowDown'); 
-    await page.keyboard.press('Enter'); 
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
     const vaSelectEvent = changeEvent.events[0];
     expect(vaSelectEvent.detail.value).toEqual('foo');
     expect(vaSelectEvent.type).toEqual('vaSelect');
@@ -328,7 +328,7 @@ describe('va-combo-box', () => {
 
   it('selects matching option on focusout if user-typed text is identical', async () => {
     const page = await newE2EPage();
-  
+
     // Initialize 2 combo boxes, the first with a value of ""
     await page.setContent(`
           <va-combo-box label="label 1" value="">
@@ -340,16 +340,16 @@ describe('va-combo-box', () => {
             <option value="bar">Bar</option>
           </va-select>
         `);
-  
+
     const firstCombo = await page.find('va-combo-box:first-of-type >>> input');
     const secondCombo = await page.find('va-combo-box:last-of-type >>> input');
-  
+
     // Type into the first combo box
     await firstCombo.type('foo');
-  
+
     // Click into the second combo box to focus away from the first
     await secondCombo.click();
-  
+
     // Verify the value of the first combo box has changed to the value of the typed text
     const firstComboValue = await firstCombo.getProperty('value');
     expect(firstComboValue).toBe('foo');
@@ -369,7 +369,7 @@ describe('va-combo-box', () => {
               <option value="qux">Qux</option>
             </optgroup>
             <option value="quux">Quux</option>
-          </va-select>
+          </va-combo-box>
         `);
 
     const input = await page.find('va-combo-box >>> input');
@@ -380,16 +380,16 @@ describe('va-combo-box', () => {
     const ariaElement = async () => await page.find('va-combo-box >>> .usa-combo-box__status.usa-sr-only');
 
     const element = await ariaElement();
-    expect(element.textContent).toEqualText('2 groups available. 5 results available.');
+    expect(element.textContent).toEqualText('2 groups available. 2 results available.');
 
     await page.keyboard.type('z');
     const updatedElement = await ariaElement();
-    expect(updatedElement.textContent).toEqualText('2 groups available. 5 results available.');
+    expect(updatedElement.textContent).toEqualText('1 group available. 1 result available.');
   });
-  
+
   it('sets value to empty when user-typed text does not match any valid options', async () => {
     const page = await newE2EPage();
-  
+
     // Initialize 2 combo boxes, the first with a value of "foo"
     await page.setContent(`
           <va-combo-box label="label 1" value="foo">
@@ -397,22 +397,22 @@ describe('va-combo-box', () => {
             <option value="bar">Bar</option>
           </va-combo-box>
         `);
-  
+
     // Get the entire first va-combo-box element
     const firstComboBox = await page.find('va-combo-box');
     const initialFirstComboBoxValue = await firstComboBox.getProperty('value');
     expect(initialFirstComboBoxValue).toBe('foo');
-  
+
     // Get the input inside the first va-combo-box
     const firstComboInput = await firstComboBox.find('va-combo-box >>> input');
-  
+
     // Type into the combo box input
     await firstComboInput.type('faa');
-    await page.keyboard.press('Enter'); 
-  
+    await page.keyboard.press('Enter');
+
     await page.waitForChanges();
     // Verify the value of the first combo box has been cleared
     const firstComboValue = await firstComboBox.getProperty('value');
     expect(firstComboValue).toBe('');
-  });  
+  });
 });

--- a/packages/web-components/src/components/va-combo-box/va-combo-box-library.js
+++ b/packages/web-components/src/components/va-combo-box/va-combo-box-library.js
@@ -45,9 +45,10 @@ const noop = () => {};
    * @param {HTMLInputElement|HTMLSelectElement} el The element to update
    * @param {string} value The new value of the element
    */
-const changeElementValue = (el, value = '') => {
+  const changeElementValue = (el, value = '') => {
     const elementToChange = el;
     elementToChange.value = value;
+
     const event = new CustomEvent('change', {
       bubbles: true,
       cancelable: true,
@@ -247,7 +248,6 @@ const changeElementValue = (el, value = '') => {
     input.setAttribute('type', 'text');
     input.setAttribute('role', 'combobox');
     input.onmouseup = handleMouseUp;
-
     additionalAttributes.forEach(attr =>
       Object.keys(attr).forEach(key => {
         const value = Sanitizer.escapeHTML`${attr[key]}`;
@@ -265,7 +265,7 @@ const changeElementValue = (el, value = '') => {
     comboBoxEl.insertAdjacentHTML(
       'beforeend',
       Sanitizer.escapeHTML`
-      <span class="${CLEAR_INPUT_BUTTON_WRAPPER_CLASS}" tabindex="-1">
+    <span class="${CLEAR_INPUT_BUTTON_WRAPPER_CLASS}" tabindex="-1">
         <button type="button" class="${CLEAR_INPUT_BUTTON_CLASS}" aria-label="Clear the select contents">&nbsp;</button>
       </span>
       <span class="${INPUT_BUTTON_SEPARATOR_CLASS}">&nbsp;</span>
@@ -288,6 +288,7 @@ const changeElementValue = (el, value = '') => {
     if (comboBox.isInVaInputTelephone) {
       comboBoxEl.querySelector(`:scope > span.${CLEAR_INPUT_BUTTON_WRAPPER_CLASS}`).remove();
     }
+
 
     if (selectedOption) {
       const { inputEl } = getComboBoxContext(comboBoxEl);
@@ -413,12 +414,13 @@ const changeElementValue = (el, value = '') => {
     const regex = generateDynamicRegExp(filter, inputValue, comboBoxEl.dataset);
 
     const options = [];
+    let parentOptGroupId = '';
     for (let i = 0, len = selectEl.options.length; i < len; i += 1) {
       const optionEl = selectEl.options[i];
       const optionId = `${listOptionBaseId}${options.length}`;
-
       const filterKey = comboBox.isInVaInputTelephone ? 'innerHTML' : 'text';
       const filterValue = optionEl[filterKey];
+
       if (
         optionEl.value &&
         (disableFiltering ||
@@ -433,8 +435,32 @@ const changeElementValue = (el, value = '') => {
         if (disableFiltering && !firstFoundId && regex.test(filterValue)) {
           firstFoundId = optionId;
         }
+
+        // handle filtering when input contains a value
+        if (
+          inputValue &&
+          regex.test(filterValue) &&
+          optionEl.getAttribute('data-optgroup') !== 'true'
+        ) {
+
+          // Check if the option element is not a header optgroup
+          // and has a header optgroup associated with it
+          if (
+            optionEl.getAttribute('data-optgroup-option') === 'true' &&
+            parentOptGroupId !== optionEl.getAttribute('aria-describedby')
+          ) {
+            // Get an associated header optgroup element
+            parentOptGroupId = optionEl.getAttribute('aria-describedby');
+            const parentOptgroupEl = selectEl.querySelector(
+              '#' + parentOptGroupId,
+            );
+            // Add the header optgroup element first
+            options.push(parentOptgroupEl);
+          }
+        }
+        // Add the option element
+        options.push(optionEl);
       }
-      options.push(optionEl);
     }
 
     const numOptions = options.length;
@@ -445,7 +471,7 @@ const changeElementValue = (el, value = '') => {
     const optionHtml = options.map((option, index) => {
       const isOptGroup = isDataOptGroup(option);
       const isOptgroupOption = option.getAttribute('data-optgroup-option') !== null;
-      if (isOptGroup) 
+      if (isOptGroup)
         groupLength += 1;
 
       if (!isOptGroup) {
@@ -487,7 +513,7 @@ const changeElementValue = (el, value = '') => {
       li.setAttribute('tabindex', tabindex);
       li.setAttribute('role', isOptGroup ? 'group' : 'option');
       li.setAttribute('data-value', option.value);
-      
+
       if (comboBox.isInVaInputTelephone) {
         li.innerHTML = Sanitizer.escapeHTML`<div class="flag-wrapper">
         <span class="flag flag-${option.value.toLowerCase()}"></span>
@@ -495,6 +521,7 @@ const changeElementValue = (el, value = '') => {
       } else {
         li.textContent = option.text;
       }
+
       return li;
     });
 
@@ -516,9 +543,9 @@ const changeElementValue = (el, value = '') => {
 
     inputEl.setAttribute('aria-expanded', 'true');
 
-    const getPluralizedMessage = (count, singular, plural) => 
+    const getPluralizedMessage = (count, singular, plural) =>
       count ? `${count} ${count > 1 ? plural : singular} available.` : '';
-  
+
     const groupsStatus = getPluralizedMessage(groupLength, 'group', 'groups');
     const optionsStatus = getPluralizedMessage(optionIndex, 'result', 'results');
 
@@ -606,20 +633,21 @@ const changeElementValue = (el, value = '') => {
    */
 const completeSelection = el => {
     const { comboBoxEl, selectEl, inputEl, statusEl } = getComboBoxContext(el);
+
     statusEl.textContent = '';
-  
+
     const inputValue = (inputEl.value || '').trim().toLowerCase();
-  
+
     if (inputValue) {
       // Find a matching option
-      const matchingFunc = comboBox.isInVaInputTelephone
+    const matchingFunc = comboBox.isInVaInputTelephone
         ? (option => {
           const [name, _] = inputValue.split('...');
           return option.text.toLowerCase().startsWith(name.toLowerCase());
         })
         : (option => option.text.toLowerCase() === inputValue)
       const matchingOption = Array.from(selectEl.options).find(matchingFunc)
-  
+
       if (matchingOption) {
         // If a match is found, update the input and select values
         changeElementValue(selectEl, matchingOption.value);
@@ -629,7 +657,7 @@ const completeSelection = el => {
         return;
       }
     }
-  
+
     // If no match is found or input value is empty,
     // clear the select value but maintain the input value.
     // This allows the user to type a value that doesn't exist in the options
@@ -671,7 +699,7 @@ const completeSelection = el => {
     if (nextOptionEl) {
       if (nextOptionEl.getAttribute('role') === 'group') {
         nextOptionEl = nextOptionEl.nextSibling
-      } 
+      }
       highlightOption(comboBoxEl, nextOptionEl);
     }
 
@@ -708,7 +736,7 @@ const completeSelection = el => {
     if (nextOptionEl) {
       if (nextOptionEl.getAttribute('role') === 'group') {
         nextOptionEl = nextOptionEl.nextSibling
-      } 
+      }
       highlightOption(focusedOptionEl, nextOptionEl);
     }
 
@@ -750,7 +778,7 @@ const completeSelection = el => {
     if (nextOptionEl) {
       if (nextOptionEl.getAttribute('role') === 'group') {
         nextOptionEl = nextOptionEl.previousSibling
-      } 
+      }
       highlightOption(focusedOptionEl, nextOptionEl);
     }
 


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `4226-combo-box-fix-filters` is a placeholder for a CI job - it will be updated automatically -->
https://4226-combo-box-fix-filters--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

**Restored previous filtering functionality to combo box.** The filter should now [match the previous filtering behavior](https://4105-combo-box-bug--65a6e2ed2314f7b8f98609d8.chromatic.com/) (PR #1602) in both `va-combo-box` and `va-input-telephone`.

### History
- This functionality was originally created in https://github.com/department-of-veterans-affairs/component-library/pull/1478
- This functionality was removed in https://github.com/department-of-veterans-affairs/component-library/pull/1595/

### Possible future enhancements
In a future iteration, recommend incorporating the improved sorting of USWDS' combo box introduced in [USWDS v3.10.0](https://github.com/uswds/uswds/releases/tag/v3.10.0). However, there will need to be some discussion about how to adapt the results when optgroups are present.

## Related Tickets and Links

<!-- 
Link to any related issues, PRs, Slack conversations, or anything else relevant to documenting the changes.
-->

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4226



## Testing and review
Confirm that combo box filter behavior matches the [previous filtering functionality](https://github.com/department-of-veterans-affairs/component-library/pull/1602) that existed prior to the [introduction of `va-input-telephone`](https://github.com/department-of-veterans-affairs/component-library/pull/1595/). 

### Combo box
- [ ] When you type "app" into the [default combo box](https://4226-combo-box-fix-filters--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/story/uswds-va-combo-box--default&globals=viewport:small), the component returns filtered search results that start with "Apple", then includes all options that include "ap" in alphabetical order
- [ ] When you type "berry" into the [default combo box](https://4226-combo-box-fix-filters--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/story/uswds-va-combo-box--default&globals=viewport:small), the component returns filtered search results that contain the word "berry"  in alphabetical order
- [ ] When you type "C" into the [Option group combo box](https://4226-combo-box-fix-filters--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/story/uswds-va-combo-box--option-groups&globals=viewport:small), the component returns all results that contain the letter "c", organized inside the appropriate option group. 

### Input telephone
- [ ] When you type "United" into the [input telephone combo box](https://4226-combo-box-fix-filters--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/story/components-va-input-telephone--default&globals=viewport:small), the component returns filtered all options that include the word "United".
- [ ] When you type "+1" into the input telephone combo box, the component returns filtered all options with the "+1" country code.

## Screenshots

<!-- 
If there are any visual changes, screenshots should be added here. 
-->
## Required Approvals Before Merging
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval Groups**
- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA Checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
