### PR TITLE
va-alert-sign-in: Update storybook button examples

### DIFF
--- a/packages/storybook/stories/va-alert-sign-in.stories.tsx
+++ b/packages/storybook/stories/va-alert-sign-in.stories.tsx
@@ -26,9 +26,9 @@ const IdMeLogo = () => (
     fill="none"
     viewBox="0 0 30 12"
     style={svgStyles}
-    aria-labelledby="service-name"
+    aria-labelledby="idme-title"
   >
-    <title id="service-name">ID.me</title>
+    <title id="idme-title">ID.me</title>
     <path
       fill="#FFF"
       d="M1.5 0H1C.3 0 0 .2 0 .7v10c0 .5.3.7 1 .7h.5c.6 0 1-.2 1-.6V.7c0-.5-.4-.7-1-.7m6.2 9.1H6V2.3h1.6c1.9 0 2.3 1.9 2.3 3.4s-.4 3.4-2.3 3.4zm2.9 1c0-1.2.7-2.2 1.7-2.5l.2-1.9c0-3.6-1.7-5.7-4.8-5.7H4.4c-.5 0-.7.3-.7.8v9.9c0 .5.2.7.7.7h3.3c1.2 0 2.1-.3 2.9-.9v-.3z"
@@ -50,9 +50,9 @@ const LoginGovLogo = () => (
     fill="none"
     viewBox="0 0 114 15"
     style={svgStyles}
-    aria-labelledby="service-name"
+    aria-labelledby="logingov-title"
   >
-    <title id="service-name">Login.gov</title>
+    <title id="logingov-title">Login.gov</title>
     <g fill="#fff" clipPath="url(#a)">
       <path d="M10.4 0H1.7C.7 0 0 .7 0 1.6v8.1a1 1 0 0 0 .1.5c.4.7 1.8 3 6 4.8 4-1.8 5.5-4.1 5.9-4.8a1 1 0 0 0 0-.5v-8c0-.5-.1-1-.4-1.2a1.7 1.7 0 0 0-1.2-.5ZM7.7 9.6a9.8 9.8 0 0 1-3.3 0L5 6.5a1.6 1.6 0 0 1-.7-1.3 1.7 1.7 0 0 1 1.3-1.7 1.7 1.7 0 0 1 2 1 1.6 1.6 0 0 1-.5 2l.6 3.1Z" />
       <path

--- a/packages/storybook/stories/va-alert-sign-in.stories.tsx
+++ b/packages/storybook/stories/va-alert-sign-in.stories.tsx
@@ -12,7 +12,7 @@ const buttonStyles = {
 };
 
 const fixedButtonStyles = {
-  maxWidth: 165,
+  maxWidth: 258,
   width: '100%',
 };
 
@@ -32,7 +32,7 @@ const IdMeLogo = () => (
       d="M1.5 0H1C.3 0 0 .2 0 .7v10c0 .5.3.7 1 .7h.5c.6 0 1-.2 1-.6V.7c0-.5-.4-.7-1-.7m6.2 9.1H6V2.3h1.6c1.9 0 2.3 1.9 2.3 3.4s-.4 3.4-2.3 3.4zm2.9 1c0-1.2.7-2.2 1.7-2.5l.2-1.9c0-3.6-1.7-5.7-4.8-5.7H4.4c-.5 0-.7.3-.7.8v9.9c0 .5.2.7.7.7h3.3c1.2 0 2.1-.3 2.9-.9v-.3z"
     />
     <path
-      fill="#2EC777"
+      fill="#fff"
       d="M14.2 10.2c0 .6-.5 1.2-1.1 1.2-.6 0-1.2-.6-1.2-1.2 0-.7.6-1.3 1.2-1.3s1.1.6 1.1 1.3"
     />
     <path
@@ -107,12 +107,12 @@ const SignInButton = () => <va-button text="Sign in or create an account" />;
 const IdMeSignInButton = () => (
   <button
     style={{
-      ...buttonStyles as React.CSSProperties,
+      ...(buttonStyles as React.CSSProperties),
       ...fixedButtonStyles,
-      backgroundColor: 'var(--vads-color-success-dark)',
+      backgroundColor: '#08833D',
     }}
   >
-    <IdMeLogo />
+    Sign in with <IdMeLogo />
   </button>
 );
 const IdMeVerifyButton = () => (
@@ -127,12 +127,12 @@ const IdMeVerifyButton = () => (
 const LoginGovSignInButton = () => (
   <button
     style={{
-      ...buttonStyles as React.CSSProperties,
+      ...(buttonStyles as React.CSSProperties),
       ...fixedButtonStyles,
       backgroundColor: 'var(--vads-color-secondary)',
     }}
   >
-    <LoginGovLogo />
+    Sign in with <LoginGovLogo />
   </button>
 );
 const LoginGovVerifyButton = () => (

--- a/packages/storybook/stories/va-alert-sign-in.stories.tsx
+++ b/packages/storybook/stories/va-alert-sign-in.stories.tsx
@@ -26,7 +26,9 @@ const IdMeLogo = () => (
     fill="none"
     viewBox="0 0 30 12"
     style={svgStyles}
+    aria-labelledby="service-name"
   >
+    <title id="service-name">ID.me</title>
     <path
       fill="#FFF"
       d="M1.5 0H1C.3 0 0 .2 0 .7v10c0 .5.3.7 1 .7h.5c.6 0 1-.2 1-.6V.7c0-.5-.4-.7-1-.7m6.2 9.1H6V2.3h1.6c1.9 0 2.3 1.9 2.3 3.4s-.4 3.4-2.3 3.4zm2.9 1c0-1.2.7-2.2 1.7-2.5l.2-1.9c0-3.6-1.7-5.7-4.8-5.7H4.4c-.5 0-.7.3-.7.8v9.9c0 .5.2.7.7.7h3.3c1.2 0 2.1-.3 2.9-.9v-.3z"
@@ -48,7 +50,9 @@ const LoginGovLogo = () => (
     fill="none"
     viewBox="0 0 114 15"
     style={svgStyles}
+    aria-labelledby="service-name"
   >
+    <title id="service-name">Login.gov</title>
     <g fill="#fff" clipPath="url(#a)">
       <path d="M10.4 0H1.7C.7 0 0 .7 0 1.6v8.1a1 1 0 0 0 .1.5c.4.7 1.8 3 6 4.8 4-1.8 5.5-4.1 5.9-4.8a1 1 0 0 0 0-.5v-8c0-.5-.1-1-.4-1.2a1.7 1.7 0 0 0-1.2-.5ZM7.7 9.6a9.8 9.8 0 0 1-3.3 0L5 6.5a1.6 1.6 0 0 1-.7-1.3 1.7 1.7 0 0 1 1.3-1.7 1.7 1.7 0 0 1 2 1 1.6 1.6 0 0 1-.5 2l.6 3.1Z" />
       <path


### PR DESCRIPTION
## Chromatic
<!-- DO NOT REMOVE - This `db-udpate-example-buttons-3993` is a placeholder for a CI job - it will be updated automatically -->
https://db-udpate-example-buttons-3993--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Align the example button color and text in storybook to current [ID.me branding standards](https://developers.id.me/brand-assets).

## Related tickets and links

Closes [#3993](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3993)

## Screenshots

Before:
<img width="951" alt="image" src="https://github.com/user-attachments/assets/7869ef8b-e039-465e-a74d-c40fa59e5023" />

After:
<img width="951" alt="image" src="https://github.com/user-attachments/assets/9bb85692-384e-4a7e-b182-e014a5864ad8" />

## Testing and review

<!--
Provide any testing instructions or review steps as needed.
-->

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>
