### PR TITLE
va-table: prevent table slot attributes from being added to nested spans

### DIFF
--- a/packages/web-components/src/components/va-table/test/va-table.e2e.ts
+++ b/packages/web-components/src/components/va-table/test/va-table.e2e.ts
@@ -21,7 +21,7 @@ function getTableMarkup(props = {}): string {
       Declaration of Independence
     </span>
     <span>
-      Statement adopted by the Continental Congress declaring independence from the British Empire
+      Statement adopted by the Continental Congress declaring independence from the <span id="embedded-span">British Empire</span>
     </span>
     <span>
       1776
@@ -94,5 +94,16 @@ describe('va-table', () => {
     const element = await page.find('va-table-inner >>> table');
 
     expect(element).toHaveClass('usa-table--stacked');
+  });
+
+  it('only adds va-table-slot-* to top-level spans in va-table-row', async () => {
+    const page = await newE2EPage();
+    await page.setContent(getTableMarkup());
+
+    // Only top-level spans should have the slot attribute
+    const firstRow = await (await page.findAll('va-table-row')).at(1);
+    const nested = await firstRow.find('#embedded-span');
+
+    expect(nested.getAttribute('slot')).toBeNull();
   });
 });

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -88,10 +88,7 @@ export class VaTable {
    */
   getCellsInRow(row: Element): HTMLSpanElement[] {
     // Only select top-level span children, not nested spans
-    const children = Array.from(row.children).filter(
-      (el) => el.tagName === 'SPAN'
-    ) as HTMLSpanElement[];
-    const cells = children;
+    const cells = Array.from(row.querySelectorAll(':scope > span')) as HTMLSpanElement[];
     if (!this.cols) {
       this.cols = cells.length;
     }

--- a/packages/web-components/src/components/va-table/va-table.tsx
+++ b/packages/web-components/src/components/va-table/va-table.tsx
@@ -87,8 +87,11 @@ export class VaTable {
    * a particular va-table-row element
    */
   getCellsInRow(row: Element): HTMLSpanElement[] {
-    const children = row.querySelectorAll('span');
-    const cells = Array.from(children);
+    // Only select top-level span children, not nested spans
+    const children = Array.from(row.children).filter(
+      (el) => el.tagName === 'SPAN'
+    ) as HTMLSpanElement[];
+    const cells = children;
     if (!this.cols) {
       this.cols = cells.length;
     }


### PR DESCRIPTION
## Chromatic
<!-- DO NOT REMOVE - This `4064-va-table-nested-span` is a placeholder for a CI job - it will be updated automatically -->
https://4064-va-table-nested-span--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
The va-table getCellsInRow function was selecting all spans within a row element and the component was adding va-table-slot to them. This change is to only select the top level/children of the row instead of both children and further embedded spans.

## Related tickets and links

Closes [4064](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4064)

## Screenshots
![Screenshot 2025-07-03 at 3 31 31 PM](https://github.com/user-attachments/assets/ab0410cb-a843-4492-949d-bd415cd79910)
![Screenshot 2025-07-03 at 3 32 19 PM](https://github.com/user-attachments/assets/dc781967-e69c-494f-a61a-20584792c5e9)



## Testing and review

The table story was not updated to include an example with an embedded span as I don't know if that should be encouraged, manual verification is required.

A test has also been added

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
