### PR TITLE
va-button, va-button-icon: fix for focus outline getting covered up

### DIFF
--- a/packages/web-components/src/components/va-button-icon/va-button-icon.scss
+++ b/packages/web-components/src/components/va-button-icon/va-button-icon.scss
@@ -10,14 +10,20 @@
 }
 
 // Styles for "regular" buttons
+// add position relative and z-index to make focus outline appear above sibling elements
 :host .usa-button {
   background: var(--vads-button-color-background-secondary-on-light, #FFFFFF);
   color: var(--vads-color-link);
   text-transform: uppercase;
+  position: relative;
 
   &:hover, &:focus, &:active {
     color: var(--vads-color-primary-dark);
     background: var(--vads-color-primary-lighter);
+  }
+
+  &:focus {
+    z-index: 1;
   }
 }
 

--- a/packages/web-components/src/components/va-button/va-button.scss
+++ b/packages/web-components/src/components/va-button/va-button.scss
@@ -23,12 +23,18 @@
   }
 
   // override USWDS to solve issue with multi-line decenders touching (increase line-height and decrease padding top/bottom)
+  // add position relative and z-index to make focus outline appear above sibling elements
   .usa-button {
     line-height: var(--vads-font-line-height-2);
     padding: .60rem 1.25rem;
+    position: relative;
 
     &--big {
       padding: .8rem 1.5rem;
+    }
+
+    &:focus {
+      z-index: 1;
     }
   }
 


### PR DESCRIPTION
## Chromatic
<!-- DO NOT REMOVE - This `3086-file-input-button-focus` is a placeholder for a CI job - it will be updated automatically -->
https://3086-file-input-button-focus--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
The button focus outline was getting covered up by sibling elements. This change updates the button to have a `position:relative` and a z-index on focus. The primary example of the overflow happening was in the file upload component on small screens where the buttons wrapped.

## Related tickets and links
Closes [3086](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3086)

## Screenshots

Before: 

![Brian-77552-5](https://github.com/user-attachments/assets/bda35d06-630c-4602-aff8-f9789b382919)


After:

![Screenshot 2025-07-07 at 9 46 47 AM](https://github.com/user-attachments/assets/396763b2-688a-4aac-8a69-86912a711483)



## Testing and review

Testing can be done using the va-file-input component.

-  Add a file 
- Shrink the window so that the buttons wrap
- Bring focus to the Change file button
- The focus outline should be completely visible

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
