### PR TITLE
va-alert: add the slim prop if no headline is provided

### DIFF
--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -37,7 +37,7 @@ describe('va-alert', () => {
     const element = await page.find('va-alert');
 
     expect(element).toEqualHtml(`
-      <va-alert class="hydrated" visible="false" status="info">
+      <va-alert class="hydrated" slim="" visible="false" status="info">
         <mock:shadow-root>
           <div aria-live="polite"></div>
         </mock:shadow-root>
@@ -252,17 +252,25 @@ describe('va-alert', () => {
     await axeCheck(page);
   });
 
-  it('applies the slim class when a headline is not provided', async () => {
+  it('applies the slim class and attribute when a headline is not provided', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-alert></va-alert>');
+
+    const alert = await page.find('va-alert');
     const element = await page.find('va-alert >>> .usa-alert');
+
     expect(element.classList.contains('usa-alert--slim')).toBeTruthy();
+    expect(alert).toHaveAttribute('slim');
   });
 
-  it('does not apply the slim class when a headline is provided', async () => {
+  it('does not apply the slim class and attribute when a headline is provided', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-alert><h4 slot="headline">This is an alert</h4></va-alert>');
+
+    const alert = await page.find('va-alert');
     const element = await page.find('va-alert >>> .usa-alert');
+
     expect(element.classList.contains('usa-alert--slim')).toBeFalsy();
+    expect(alert).not.toHaveAttribute('slim');
   }); 
 });

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -259,7 +259,7 @@ describe('va-alert', () => {
     expect(element.classList.contains('usa-alert--slim')).toBeTruthy();
   });
 
-  it('does not apply the slim class when aheadline is provided', async () => {
+  it('does not apply the slim class when a headline is provided', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-alert><h4 slot="headline">This is an alert</h4></va-alert>');
     const element = await page.find('va-alert >>> .usa-alert');

--- a/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
+++ b/packages/web-components/src/components/va-alert/test/va-alert.e2e.ts
@@ -5,7 +5,7 @@ describe('va-alert', () => {
   it('renders', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<va-alert></va-alert>');
+    await page.setContent('<va-alert><h4 slot="headline">This is an alert</h4><div>This is the alert content</div></va-alert>');
     const element = await page.find('va-alert');
 
     expect(element).toEqualHtml(`
@@ -20,6 +20,12 @@ describe('va-alert', () => {
             </div>
           </div>
         </mock:shadow-root>
+        <h4 slot="headline">
+          This is an alert
+        </h4>
+        <div>
+          This is the alert content
+        </div>
       </va-alert>
     `);
   });
@@ -245,4 +251,18 @@ describe('va-alert', () => {
 
     await axeCheck(page);
   });
+
+  it('applies the slim class when a headline is not provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-alert></va-alert>');
+    const element = await page.find('va-alert >>> .usa-alert');
+    expect(element.classList.contains('usa-alert--slim')).toBeTruthy();
+  });
+
+  it('does not apply the slim class when aheadline is provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-alert><h4 slot="headline">This is an alert</h4></va-alert>');
+    const element = await page.find('va-alert >>> .usa-alert');
+    expect(element.classList.contains('usa-alert--slim')).toBeFalsy();
+  }); 
 });

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -169,9 +169,12 @@ export class VaAlert {
       this.updateCloseAriaLabelWithHeadlineText();
     }
 
-    const headlineText = this.getHeadlineText();
-    if (!headlineText) {
-      this.slim = true;
+    const isBannerAlert = this.el.id === 'va-banner-alert';
+
+    // Apply the slim property if there is no headline text and this alert is not used by va-banner
+    if (!isBannerAlert) {
+      const headlineText = this.getHeadlineText();
+      this.slim = !headlineText;
     }
   }
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -69,7 +69,7 @@ export class VaAlert {
   /**
    * Displays the slim variation.
    */
-  @Prop() slim?: boolean = false;
+  @Prop({ mutable: true }) slim?: boolean = false;
 
   /**
    * Fires when the component has successfully finished rendering for the first
@@ -112,9 +112,11 @@ export class VaAlert {
 
     try { 
       // This is the happy path, meaning the user isn't using IE11
-    const slot = this.el.shadowRoot?.querySelector('slot');
-    const children = slot ? (slot as HTMLSlotElement).assignedNodes() : [];
-    headlineText = children.length > 0 ? children[0].textContent : null;
+      const headlineSlot = this.el.shadowRoot?.querySelector('slot[name="headline"]');
+      if (headlineSlot) {
+        const children = (headlineSlot as HTMLSlotElement).assignedNodes();
+        headlineText = children.length > 0 ? children[0].textContent : null;
+      }
     } catch (e) {
       // This is where we handle the edge case of the user being on IE11
     const children = Array.from(this.el.shadowRoot?.childNodes || []);
@@ -165,6 +167,11 @@ export class VaAlert {
   componentDidRender() {
     if (!this.closeBtnAriaLabel) {
       this.updateCloseAriaLabelWithHeadlineText();
+    }
+
+    const headlineText = this.getHeadlineText();
+    if (!headlineText) {
+      this.slim = true;
     }
   }
 

--- a/packages/web-components/src/components/va-alert/va-alert.tsx
+++ b/packages/web-components/src/components/va-alert/va-alert.tsx
@@ -69,7 +69,7 @@ export class VaAlert {
   /**
    * Displays the slim variation.
    */
-  @Prop({ mutable: true }) slim?: boolean = false;
+  @Prop({ mutable: true, reflect: true }) slim?: boolean = false;
 
   /**
    * Fires when the component has successfully finished rendering for the first

--- a/packages/web-components/src/components/va-banner/test/va-banner.e2e.ts
+++ b/packages/web-components/src/components/va-banner/test/va-banner.e2e.ts
@@ -11,7 +11,7 @@ describe('va-banner', () => {
     expect(element).toEqualHtml(`
      <va-banner class="hydrated">
        <mock:shadow-root>
-         <va-alert class="hydrated" data-label="Info banner" data-role="region" full-width="" status="info">
+         <va-alert id="va-banner-alert" class="hydrated" data-label="Info banner" data-role="region" full-width="" status="info">
            <h3 slot="headline"></h3>
            <slot></slot>
          </va-alert>

--- a/packages/web-components/src/components/va-banner/va-banner.tsx
+++ b/packages/web-components/src/components/va-banner/va-banner.tsx
@@ -186,6 +186,7 @@ export class VaBanner {
     return (
       <Host>
         <va-alert
+          id="va-banner-alert"
           visible
           full-width
           closeable={this.showClose}


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `3119-alert-header` is a placeholder for a CI job - it will be updated automatically -->
https://3119-alert-header--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

<!-- 
Describe the change and context.
Consider:
    - What is relevant to code reviewer(s)?
    - What context may be relevant to a future dev or you in 6 months about this PR?
    - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 -->

## Related tickets and links

The `va-alert` component has a variation "slim" that is intended to be used without a headline. But when a standard alert was being used without a headline and the `slim` prop wasn't also set, there was an unsightly gap at the top where the header should go. This PR will automatically set the `slim` prop if there's no `headline` slot content.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3119

## Screenshots

When the `headline` slot is not populated:

**Before**

<img width="1025" height="244" alt="Screenshot 2025-08-05 at 8 40 01 AM" src="https://github.com/user-attachments/assets/134948bc-d414-43e9-a792-8b2734c829c9" />

**After**

<img width="1031" height="208" alt="Screenshot 2025-08-05 at 8 40 27 AM" src="https://github.com/user-attachments/assets/35265817-cc17-4603-b6c8-037cd08dcb3a" />

## Testing and review

<!--
Provide any testing instructions or review steps as needed.
-->

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
