### PR TITLE
va-sidenav: enhance current-page handling for truthy and false values 

### DIFF
--- a/packages/web-components/src/components/va-sidenav/test/va-sidenav-item.e2e.ts
+++ b/packages/web-components/src/components/va-sidenav/test/va-sidenav-item.e2e.ts
@@ -103,6 +103,7 @@ describe('va-sidenav-item handles different formats of current-page attribute', 
     const page = await newE2EPage();
     await page.setContent(`
       <va-sidenav>
+        <va-sidenav-item href="#" label="Neutral link"></va-sidenav-item>
         <va-sidenav-item id="explicit-true" current-page="true" href="#" label="Explicit true"></va-sidenav-item>
       </va-sidenav>
     `);
@@ -126,6 +127,7 @@ describe('va-sidenav-item handles different formats of current-page attribute', 
     const page = await newE2EPage();
     await page.setContent(`
       <va-sidenav>
+        <va-sidenav-item href="#" label="Neutral link"></va-sidenav-item>
         <va-sidenav-item id="empty-string" current-page="" href="#" label="Empty string"></va-sidenav-item>
       </va-sidenav>
     `);
@@ -150,6 +152,7 @@ describe('va-sidenav-item handles different formats of current-page attribute', 
     const page = await newE2EPage();
     await page.setContent(`
       <va-sidenav>
+        <va-sidenav-item href="#" label="Neutral link"></va-sidenav-item>
         <va-sidenav-item id="no-value" current-page href="#" label="No value"></va-sidenav-item>
       </va-sidenav>
     `);
@@ -174,6 +177,7 @@ describe('va-sidenav-item handles different formats of current-page attribute', 
     const page = await newE2EPage();
     await page.setContent(`
       <va-sidenav>
+        <va-sidenav-item href="#" label="Neutral link"></va-sidenav-item>
         <va-sidenav-item id="true" current-page="TRUE" href="#" label="True"></va-sidenav-item>
       </va-sidenav>
     `);
@@ -198,6 +202,7 @@ describe('va-sidenav-item handles different formats of current-page attribute', 
     const page = await newE2EPage();
     await page.setContent(`
       <va-sidenav>
+        <va-sidenav-item href="#" label="Neutral link"></va-sidenav-item>
         <va-sidenav-item id="false" current-page="false" href="#" label="False"></va-sidenav-item>
       </va-sidenav>
     `);

--- a/packages/web-components/src/components/va-sidenav/test/va-sidenav-item.e2e.ts
+++ b/packages/web-components/src/components/va-sidenav/test/va-sidenav-item.e2e.ts
@@ -97,3 +97,120 @@ describe('va-sidenav-item', () => {
     await page.close();
   });
 });
+
+describe('va-sidenav-item handles different formats of current-page attribute', () => {
+  it('handles explict "true" on the current-page attribute', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-sidenav>
+        <va-sidenav-item id="explicit-true" current-page="true" href="#" label="Explicit true"></va-sidenav-item>
+      </va-sidenav>
+    `);
+
+    await page.waitForChanges();
+    
+    const explicitTrue = await page.find('#explicit-true');
+    expect(await explicitTrue.getAttribute('current-page')).not.toBeNull();
+
+    const hasCurrentIndicator = await page.evaluate(() => {
+      const explicitTrue = document.querySelector('#explicit-true');
+      return !!explicitTrue.shadowRoot.querySelector('.va-sidenav-item__current');
+    });
+    
+    expect(hasCurrentIndicator).toBe(true);
+    
+    await page.close();
+  });
+
+  it('handles an empty string for the current-page attribute', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-sidenav>
+        <va-sidenav-item id="empty-string" current-page="" href="#" label="Empty string"></va-sidenav-item>
+      </va-sidenav>
+    `);
+
+    await page.waitForChanges();
+    
+    const emptyString = await page.find('#empty-string');
+    
+    expect(await emptyString.getAttribute('current-page')).not.toBeNull();
+
+    const hasCurrentIndicator = await page.evaluate(() => {
+      const emptyString = document.querySelector('#empty-string');
+      return !!emptyString.shadowRoot.querySelector('.va-sidenav-item__current');
+    });
+    
+    expect(hasCurrentIndicator).toBe(true);
+    
+    await page.close();
+  });
+
+  it('handles just the attribute current-page (no value)', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-sidenav>
+        <va-sidenav-item id="no-value" current-page href="#" label="No value"></va-sidenav-item>
+      </va-sidenav>
+    `);
+
+    await page.waitForChanges();
+    
+    const noValue = await page.find('#no-value');
+    
+    expect(await noValue.getAttribute('current-page')).not.toBeNull();
+
+    const hasCurrentIndicator = await page.evaluate(() => {
+      const noValue = document.querySelector('#no-value');
+      return !!noValue.shadowRoot.querySelector('.va-sidenav-item__current');
+    });
+    
+    expect(hasCurrentIndicator).toBe(true);
+    
+    await page.close();
+  });
+
+  it('handles "TRUE" on the current-page attribute', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-sidenav>
+        <va-sidenav-item id="true" current-page="TRUE" href="#" label="True"></va-sidenav-item>
+      </va-sidenav>
+    `);
+
+    await page.waitForChanges();
+    
+    const trueItem = await page.find('#true');
+    
+    expect(await trueItem.getAttribute('current-page')).not.toBeNull();
+
+    const hasCurrentIndicator = await page.evaluate(() => {
+      const trueItem = document.querySelector('#true');
+      return !!trueItem.shadowRoot.querySelector('.va-sidenav-item__current');
+    });
+    
+    expect(hasCurrentIndicator).toBe(true);
+    
+    await page.close();
+  });
+
+  it('does not show current page indicator when current-page="false"', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-sidenav>
+        <va-sidenav-item id="false" current-page="false" href="#" label="False"></va-sidenav-item>
+      </va-sidenav>
+    `);
+
+    await page.waitForChanges();
+    
+    const hasCurrentIndicator = await page.evaluate(() => {
+      const falseItem = document.querySelector('#false');
+      return !!falseItem.shadowRoot.querySelector('.va-sidenav-item__current');
+    });
+    
+    expect(hasCurrentIndicator).toBe(false);
+    
+    await page.close();
+  });
+});

--- a/packages/web-components/src/components/va-sidenav/test/va-sidenav.e2e.ts
+++ b/packages/web-components/src/components/va-sidenav/test/va-sidenav.e2e.ts
@@ -231,4 +231,50 @@ describe('va-sidenav', () => {
     
     await page.close();
   });
+
+  it('programatically set the current-page attribute on multiple elements', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-sidenav><va-sidenav-item id="item-0"></va-sidenav-item><va-sidenav-item id="item-1" current-page></va-sidenav-item><va-sidenav-item id="item-2"></va-sidenav-item></va-sidenav>');
+    
+    function hasCurrentStyle(item: any) {
+      return !!item.shadowRoot.querySelector('.va-sidenav-item__current');
+    }
+
+    let currentPageElements = await page.findAll('va-sidenav-item');
+
+    // expect only the second item to have the current-page attribute on initial load
+    expect(currentPageElements[0].getAttribute('current-page')).toBeNull();
+    expect(currentPageElements[1].getAttribute('current-page')).not.toBeNull();
+    expect(currentPageElements[2].getAttribute('current-page')).toBeNull();
+
+    // The second item has the current-page styling
+    expect(hasCurrentStyle(currentPageElements[1] as any)).toBe(true);
+
+    // The others do not have the current-page styling
+    expect(hasCurrentStyle(currentPageElements[0] as any)).toBe(false);
+    expect(hasCurrentStyle(currentPageElements[2] as any)).toBe(false); 
+
+    // update all of the current-page attributes to "false" except the third element
+    currentPageElements.forEach((el) => {
+      el.setAttribute('current-page', el.id === 'item-2' ? '' : 'false');
+    });
+
+    await page.waitForChanges();
+
+    currentPageElements = await page.findAll('va-sidenav-item');
+
+    // expect only the third item to have the current-page attribute
+    expect(currentPageElements[0].getAttribute('current-page')).toBeNull();
+    expect(currentPageElements[1].getAttribute('current-page')).toBeNull();
+    expect(currentPageElements[2].getAttribute('current-page')).not.toBeNull();
+
+    // The third item has the current-page styling
+    expect(hasCurrentStyle(currentPageElements[2] as any)).toBe(true);
+
+    // The others do not
+    expect(hasCurrentStyle(currentPageElements[0] as any)).toBe(false);
+    expect(hasCurrentStyle(currentPageElements[1] as any)).toBe(false); 
+    
+    await page.close();
+  });
 });

--- a/packages/web-components/src/components/va-sidenav/va-sidenav.tsx
+++ b/packages/web-components/src/components/va-sidenav/va-sidenav.tsx
@@ -52,7 +52,7 @@ export class VaSidenav {
     const currentPageElements = this.el.querySelectorAll('va-sidenav-item[current-page], va-sidenav-submenu[current-page]');
     currentPageElements.forEach((el, index) => {
       if (index > 0) {
-        el.setAttribute('current-page', 'false');
+        el.removeAttribute('current-page');
       }
     });
   }

--- a/packages/web-components/src/components/va-sidenav/va-sidenav.tsx
+++ b/packages/web-components/src/components/va-sidenav/va-sidenav.tsx
@@ -74,13 +74,14 @@ export class VaSidenav {
       if (currentPageMutations.length > 0) {
         // Get the element that triggered the mutation
         const changedElement = currentPageMutations[0].target as Element;
-        const isCurrentPage = changedElement.getAttribute('current-page') === 'true';
+        const attrValue = changedElement.getAttribute('current-page');
+        const isCurrentPage = attrValue !== null && attrValue !== 'false';
 
         if (isCurrentPage) {
           // Get all elements with current-page attribute
           const allElements = this.el.querySelectorAll('va-sidenav-item[current-page], va-sidenav-submenu[current-page]');
           
-          // Set current-page="false" for all elements except the one that triggered the mutation
+          // Remove the current-page attribute for all elements except the one that triggered the mutation
           allElements.forEach(el => {
             if (el !== changedElement) {
               // Remove the attribute completely

--- a/packages/web-components/src/components/va-sidenav/va-sidenav.tsx
+++ b/packages/web-components/src/components/va-sidenav/va-sidenav.tsx
@@ -60,8 +60,8 @@ export class VaSidenav {
   /**
    * Watch for changes to the current-page attribute on any va-sidenav-item or va-sidenav-submenu element.
    * With those changed current-page attributes, check if the attribute value is not null and not "false".
-   * If it is not null and not "false", allow the first element found to hav a truthy current-page value 
-   * to be marked as the current-page. Otherwise, remove the current-page attribute from all elements. 
+   * If it is not null and not "false", allow the first element found to have a truthy current-page value 
+   * to be marked as the current-page. Otherwise, remove the current-page attribute from all other elements. 
    * Only one element should be the current-page.
    */
   setupCurrentPageObserver() {


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `va-sidenav-current-page` is a placeholder for a CI job - it will be updated automatically -->
https://va-sidenav-current-page--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

<!-- 
Describe the change and context.
Consider:
    - What is relevant to code reviewer(s)?
    - What context may be relevant to a future dev or you in 6 months about this PR?
    - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 -->

This will update the `va-sidenav` component to better handle truthy values for `current-page` and if the prop is not set with a truthy value, the attribute will be removed (instead of set to "false"). Examples of truthy values:

- Explicit true: `current-page="true"`
- Empty string: `current-page=""`
- Just attribute (no value): `current-page`
- Different case: `current-page="TRUE"`

The `current-page` is considered "false" in the following scenarios but we are no longer explicitly setting "false" internally. This was causing issues with identifying the active page. Falsy scenarios are 

- Explicit false: `current-page="false"`
- No attribute: (attribute not present)

## Related tickets and links

<!-- 
Link to any related issues, PRs, Slack conversations, or anything else relevant to documenting the changes.
-->

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4614

## Screenshots

There should be no visual changes. A single current page should still be styled with left border and bold text.

<img width="407" height="400" alt="Screenshot 2025-08-06 at 3 04 19 PM" src="https://github.com/user-attachments/assets/85605be2-b970-4fa1-9d62-9bb052bd48ec" />


<!-- 
If there are any visual changes, screenshots should be added here. 
-->

## Testing and review

<!--
Provide any testing instructions or review steps as needed.
-->

- Click individual navigation items and observe that there is only one `current-page` at any given time with associated styling

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
