### PR TITLE
va-telephone-input: improve error message accuracy

### DIFF
--- a/packages/web-components/src/components/va-telephone-input/test/va-input-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone-input/test/va-input-telephone.e2e.ts
@@ -34,7 +34,7 @@ describe('va-telephone-input', () => {
     const value = await input.getProperty('value');
     expect(value).toBe('abcdefg')
     const error = await page.find('va-telephone-input >>> span#error-message');
-    expect(error.innerText).toContain('phone number in a valid format, for example,');
+    expect(error.innerText).toContain('Enter a valid United States of America phone number. Use 10 digits.');
   });
 
   it('prefills a country', async () => {
@@ -72,7 +72,7 @@ describe('va-telephone-input', () => {
     await input.click(); 
     await input.press('Tab');
     const error = await page.find('va-telephone-input >>> span#error-message');
-    expect(error.innerText).toContain('phone number in a valid format, for example,');
+    expect(error.innerText).toContain('Enter a valid United States of America phone number. Use 10 digits.');
   });
 
   it('shows an error message if contact does not match the form required by the selected country', async () => {
@@ -82,7 +82,7 @@ describe('va-telephone-input', () => {
     await input.press('2');
     await input.press('Tab');
     const error = await page.find('va-telephone-input >>> span#error-message');
-    expect(error.innerText).toContain('phone number in a valid format, for example,');
+    expect(error.innerText).toContain('Enter a valid United States of America phone number. Use 10 digits.');
   });
 
   it('shows an error message if country is missing', async () => {
@@ -116,7 +116,7 @@ describe('va-telephone-input', () => {
     let input = await page.find('va-telephone-input >>> va-text-input >>> input');
     await input.press('Tab');
     let error = await page.find('va-telephone-input >>> span#error-message');
-    expect(error.innerText).toContain('Enter an Indonesia');
+    expect(error.innerText).toContain('Enter a valid Indonesia phone number. Use 7 to 17 digits.');
   });
 
   it('handles the a/an in error message appropriately for country doesn\'t start with vowel', async () => {
@@ -126,7 +126,7 @@ describe('va-telephone-input', () => {
     const input = await page.find('va-telephone-input >>> va-text-input >>> input');
     await input.press('Tab');
     const error = await page.find('va-telephone-input >>> span#error-message');
-    expect(error.innerText).toContain('Enter a Fiji');
+    expect(error.innerText).toContain('Enter a valid Fiji phone number. Use 7 or 11 digits.');
   });
 
   it('emits the vaContact event', async () => {

--- a/packages/web-components/src/components/va-telephone-input/test/va-telephone-input.unit.spec.ts
+++ b/packages/web-components/src/components/va-telephone-input/test/va-telephone-input.unit.spec.ts
@@ -1,0 +1,28 @@
+import { VaTelephoneInput } from '../va-telephone-input';
+
+describe('getNumberRange', () => {
+  let instance: VaTelephoneInput;
+  beforeEach(() => {
+    instance = new VaTelephoneInput();
+  });
+
+  it('returns empty string for empty array', () => {
+    expect(instance.getNumberRange([])).toBe('');
+  });
+
+  it('returns single value for one number', () => {
+    expect(instance.getNumberRange([7])).toBe('7');
+  });
+
+  it('returns range for consecutive numbers', () => {
+    expect(instance.getNumberRange([7,8,9,10])).toBe('7 to 10');
+  });
+
+  it('returns list for non-consecutive numbers', () => {
+    expect(instance.getNumberRange([7,9,10])).toBe('7, 9 or 10');
+  });
+
+  it('returns mixed ranges and values', () => {
+    expect(instance.getNumberRange([7,8,10,12,13,14])).toBe('7, 8, 10, 12, 13 or 14');
+  });
+});


### PR DESCRIPTION
<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description
This pull request refactors the error handling and messaging for the `va-telephone-input` web component to provide clearer, more country-specific feedback to users. The changes improve both the internal logic for generating error messages and the way errors are displayed in the UI. Additionally, a new utility method for formatting valid phone number length ranges is introduced, with accompanying unit tests.

**Error Handling and Messaging Improvements:**

* The error message shown for invalid US phone numbers is now more explicit: "Enter a valid United States of America phone number. Use 10 digits." This replaces the previous, less specific format guidance in multiple end-to-end tests. [[1]](diffhunk://#diff-7902bfb119feeb235a30907e88da44c46a7800ccbcd66705edfcf93336805e1aL37-R37) [[2]](diffhunk://#diff-7902bfb119feeb235a30907e88da44c46a7800ccbcd66705edfcf93336805e1aL75-R75) [[3]](diffhunk://#diff-7902bfb119feeb235a30907e88da44c46a7800ccbcd66705edfcf93336805e1aL85-R85)
* Error messages for other countries are also updated for clarity and specificity, e.g., "Enter a valid Indonesia phone number. Use 7 to 17 digits." and "Enter a valid Fiji phone number. Use 7 or 11 digits." [[1]](diffhunk://#diff-7902bfb119feeb235a30907e88da44c46a7800ccbcd66705edfcf93336805e1aL119-R119) [[2]](diffhunk://#diff-7902bfb119feeb235a30907e88da44c46a7800ccbcd66705edfcf93336805e1aL129-R129)

**Internal State and Rendering Changes:**

* Introduced a new `visibleError` state property to manage the error message shown in the UI, decoupling it from the `error` prop to prevent unintended side effects and ensure correct rendering. All internal error assignments and UI rendering now use `visibleError`. [[1]](diffhunk://#diff-948c0410058c7a0adfeb3de8a11ced03e7e0fcf7accbebf0458b422bf7d53480R123-R128) [[2]](diffhunk://#diff-948c0410058c7a0adfeb3de8a11ced03e7e0fcf7accbebf0458b422bf7d53480L140-R144) [[3]](diffhunk://#diff-948c0410058c7a0adfeb3de8a11ced03e7e0fcf7accbebf0458b422bf7d53480L185-R209) [[4]](diffhunk://#diff-948c0410058c7a0adfeb3de8a11ced03e7e0fcf7accbebf0458b422bf7d53480L232-R256) [[5]](diffhunk://#diff-948c0410058c7a0adfeb3de8a11ced03e7e0fcf7accbebf0458b422bf7d53480R355) [[6]](diffhunk://#diff-948c0410058c7a0adfeb3de8a11ced03e7e0fcf7accbebf0458b422bf7d53480L355-R379)
* The error prop is no longer mutable, reflecting the shift to using internal state for error display.

**Phone Number Length Formatting Utility:**

* Added a new `getNumberRange` method to generate user-friendly descriptions of valid phone number lengths for a given country (e.g., "7 to 10", "7, 9 or 10"). This is now used in error messages to inform users about valid digit counts.
* Comprehensive unit tests for `getNumberRange` are included to ensure correct formatting for various input scenarios.

**Code Cleanup and Dependency Updates:**

* Refactored imports to remove unused dependencies and streamline the codebase, including removal of the `getArticle` utility and unused example number logic.


## Related tickets and links

<!-- 
Link to any related issues, PRs, Slack conversations, or anything else relevant to documenting the changes.
-->

Closes [4313](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4313)

## Screenshots

Old error:
<img width="520" height="171" alt="Screenshot 2025-08-12 at 1 47 22 PM" src="https://github.com/user-attachments/assets/77add98c-dbdf-45b2-9c7d-60f83b5d3567" />
<img width="519" height="166" alt="Screenshot 2025-08-12 at 1 47 47 PM" src="https://github.com/user-attachments/assets/25f47024-e714-4325-9068-966aec32c262" />
<img width="524" height="168" alt="Screenshot 2025-08-12 at 1 48 06 PM" src="https://github.com/user-attachments/assets/d510f7f5-c764-4635-85a1-268bccd7c7f5" />

New Error:
<img width="508" height="170" alt="Screenshot 2025-08-12 at 1 49 06 PM" src="https://github.com/user-attachments/assets/1121dc17-8842-48c5-b2f8-0baac375fdce" />
<img width="509" height="138" alt="Screenshot 2025-08-12 at 1 49 27 PM" src="https://github.com/user-attachments/assets/47d626e1-f559-4553-a24a-494867dab514" />
<img width="499" height="169" alt="Screenshot 2025-08-12 at 1 49 46 PM" src="https://github.com/user-attachments/assets/9e99312e-9859-49bf-93fe-138f51fb3f97" />


## Testing and review

- Make sure the error message is grammatically correct among a variety of countries

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
