### PR TITLE
VA-button: Feedback variant

### DIFF
--- a/packages/storybook/stories/va-button-uswds.stories.tsx
+++ b/packages/storybook/stories/va-button-uswds.stories.tsx
@@ -24,6 +24,7 @@ const defaultArgs = {
   'secondary': undefined,
   'primary-alternate': undefined,
   'submit': undefined,
+  'feedback': undefined,
   'message-aria-describedby': 'Optional description text for screen readers',
   'onClick': e => console.log(e),
 };
@@ -39,6 +40,7 @@ const Template = ({
   label,
   secondary,
   primaryAlternate,
+  feedback,
   submit,
   text,
   messageAriaDescribedby,
@@ -56,6 +58,7 @@ const Template = ({
       label={label}
       secondary={secondary}
       primary-alternate={primaryAlternate}
+      feedback={feedback}
       submit={submit}
       text={!loading && !text ? null : text}
       onClick={onClick}
@@ -111,6 +114,12 @@ Back.args = {
   back: true,
 };
 
+export const Feedback = Template.bind(null);
+Feedback.args = {
+  ...defaultArgs,
+  feedback: true,
+};
+
 export const Disabled = Template.bind(null);
 Disabled.args = {
   ...defaultArgs,
@@ -148,6 +157,7 @@ const TemplateWithForm = ({
   label,
   secondary,
   primaryAlternate,
+  feedback,
   submit,
   text,
   messageAriaDescribedby,
@@ -169,6 +179,7 @@ const TemplateWithForm = ({
         label={label}
         secondary={secondary}
         primary-alternate={primaryAlternate}
+        feedback={feedback}
         submit={submit}
         text={text}
         onClick={e => handleClick(e)}

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -282,6 +282,10 @@ export namespace Components {
          */
         "disabled"?: boolean;
         /**
+          * If `true`, the button will use `Feedback` as its text and use the secondary variant.
+         */
+        "feedback": boolean;
+        /**
           * If `true`, the button will expand to the full available width of its container.
          */
         "fullWidth"?: boolean;
@@ -4018,6 +4022,10 @@ declare namespace LocalJSX {
           * If `true`, the click event will not fire.
          */
         "disabled"?: boolean;
+        /**
+          * If `true`, the button will use `Feedback` as its text and use the secondary variant.
+         */
+        "feedback"?: boolean;
         /**
           * If `true`, the button will expand to the full available width of its container.
          */

--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -49,6 +49,22 @@ describe('va-button', () => {
     `);
   });
 
+  it('renders Feedback button variant', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-button feedback></va-button>');
+    const element = await page.find('va-button');
+    expect(element).toEqualHtml(`
+    <va-button feedback="" class="hydrated">
+      <mock:shadow-root>
+        <span class="loading-message" role="status"></span>
+        <button class="usa-button usa-button--outline" type="button" part="button">
+          Feedback
+        </button>
+      </mock:shadow-root>
+    </va-button>
+    `);
+  });
+
   it('renders an icon after the button text when continue is true', async () => {
     const page = await newE2EPage();
     await page.setContent('<va-button continue></va-button>');

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -111,6 +111,11 @@ export class VaButton {
   @Prop() messageAriaDescribedby?: string;
 
   /**
+   * If `true`, the button will use `Feedback` as its text and use the secondary variant.
+   */
+  @Prop({ reflect: true }) feedback: boolean = false;
+
+  /**
    * The event used to track usage of the component.
    */
   @Event({
@@ -140,6 +145,7 @@ export class VaButton {
     if (this.continue) return 'Continue';
     if (this.back) return 'Back';
     if (this.loading && !this.text) return 'Loading...';
+    if (this.feedback) return 'Feedback';
     return;
   };
 
@@ -212,6 +218,7 @@ export class VaButton {
       big,
       messageAriaDescribedby,
       fullWidth,
+      feedback
     } = this;
 
     const ariaDescribedbyIds =
@@ -225,7 +232,7 @@ export class VaButton {
     const buttonClass = classnames({
       'usa-button': true,
       'usa-button--big': big,
-      'usa-button--outline': back || secondary,
+      'usa-button--outline': back || secondary || feedback,
       'va-button-primary--alternate': primaryAlternate,
       'va-button--full-width': fullWidth,
     });


### PR DESCRIPTION
## Chromatic
<!-- DO NOT REMOVE - This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Adding variant to `va-button`. This adds a `feedback` prop to `va-button` for the new feedback button variant in the secondary style. This was added to replace the custom feedback button in the footer in `next-build`.

## Related tickets and links


Closes [3099](https://github.com/orgs/department-of-veterans-affairs/projects/1643/views/6?sliceBy%5Bvalue%5D=ediiotero&pane=issue&itemId=106634475&issue=department-of-veterans-affairs%7Cvets-design-system-documentation%7C3099)

## Screenshots

<img width="1080" height="244" alt="Screenshot 2025-08-15 at 9 39 25 AM" src="https://github.com/user-attachments/assets/73645809-170e-49ee-ada0-244094255d43" />
<img width="1065" height="340" alt="Screenshot 2025-08-15 at 9 39 42 AM" src="https://github.com/user-attachments/assets/d0b4b4d9-5fb5-459d-8361-97d714d2731e" />


## Testing and review

Use `va-button` with feedback prop

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [X] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [X] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
