### PR TITLE
va-on-this-page: Convert title list item to a header element

### DIFF
--- a/packages/storybook/stories/va-on-this-page.stories.tsx
+++ b/packages/storybook/stories/va-on-this-page.stories.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect } from 'react';
-import { getWebComponentDocs, StoryDocs } from './wc-helpers';
+import { getWebComponentDocs, propStructure, StoryDocs } from './wc-helpers';
 
 const otpDocs = getWebComponentDocs('va-on-this-page');
+
+const defaultArgs = {
+  'header-level': undefined,
+};
 
 export default {
   title: 'Components/On this page',
@@ -12,11 +16,16 @@ export default {
       page: () => <StoryDocs storyDefault={Default} data={otpDocs} />,
     },
   },
+  args: defaultArgs,
+  argTypes: propStructure(otpDocs),
 };
 
-const articleJSX = (
-  <article>
-    <va-on-this-page></va-on-this-page>
+const Template = ({
+  'header-level': headerLevel
+}) => {
+  return (
+<article>
+    <va-on-this-page header-level={headerLevel}/>
     <h2 id="if-im-a-veteran">
       If I’m a Veteran, can I get VR&amp;E benefits and services?
     </h2>
@@ -49,11 +58,8 @@ const articleJSX = (
       <li>Gamma</li>
     </ol>
   </article>
-);
-
-const Template = () => {
-  return articleJSX;
-};
+  )
+}
 
 const I18nTemplate = args => {
   const { headline, level, ...rest } = args;
@@ -69,7 +75,7 @@ const I18nTemplate = args => {
       <button onClick={e => setLang('en')}>English</button>
       <button onClick={e => setLang('tl')}>Tagalog</button>
 
-      {articleJSX}
+      {Template}
     </div>
   );
 };
@@ -77,3 +83,9 @@ const I18nTemplate = args => {
 export const Default = Template.bind(null);
 
 export const Internationalization = I18nTemplate.bind(null);
+
+export const CustomHeaderLevel = Template.bind(null);
+CustomHeaderLevel.args = {
+  ...defaultArgs,
+  'header-level': 3,
+};

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1321,6 +1321,10 @@ export namespace Components {
           * If true, analytics event will not be fired
          */
         "disableAnalytics"?: boolean;
+        /**
+          * Header level. Must be between 1 and 6
+         */
+        "headerLevel"?: number;
     }
     /**
      * @componentName Pagination
@@ -5308,6 +5312,10 @@ declare namespace LocalJSX {
           * If true, analytics event will not be fired
          */
         "disableAnalytics"?: boolean;
+        /**
+          * Header level. Must be between 1 and 6
+         */
+        "headerLevel"?: number;
         /**
           * The event used to track usage of the component. This is emitted when the user clicks on a link and enableAnalytics is true.
          */

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.css
@@ -18,6 +18,7 @@
 #on-this-page {
   font-family: var(--font-serif);
   font-size: 1.25rem;
+  font-weight: var(--font-weight-normal);
   margin: 0.4em 0em;
 }
 
@@ -29,7 +30,8 @@ ul {
   padding-left: 0;
 }
 
-li {
+li,
+#on-this-page {
   padding: 0.5em;
   max-width: var(--vads-size-line-length-4);
 }

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
@@ -9,7 +9,7 @@ import {
 } from '@stencil/core';
 import { i18next } from '../..';
 import { Build } from '@stencil/core';
-import { consoleDevError } from '../../utils/utils';
+import { consoleDevError, getHeaderLevel } from '../../utils/utils';
 
 if (Build.isTesting) {
   // Make i18next.t() return the key instead of the value
@@ -47,6 +47,11 @@ export class VaOnThisPage {
     bubbles: true,
   })
   componentLibraryAnalytics: EventEmitter;
+
+  /**
+   * Header level. Must be between 1 and 6
+   */
+  @Prop() headerLevel?: number = 2;
 
   /**
    * If true, analytics event will not be fired
@@ -111,6 +116,8 @@ export class VaOnThisPage {
 
   render() {
     const { handleOnClick } = this;
+    // eslint-disable-next-line i18next/no-literal-string
+    const HeaderLevel = getHeaderLevel(this.headerLevel) || 'h2';
 
     const h2s = Array.from(document.querySelectorAll('article h2')).filter(
       heading => {
@@ -123,8 +130,8 @@ export class VaOnThisPage {
 
     return (
       <nav aria-labelledby="on-this-page">
+        <HeaderLevel id="on-this-page">{i18next.t('on-this-page')}</HeaderLevel>
         <ul>
-          <li id="on-this-page">{i18next.t('on-this-page')}</li>
           {h2s.map(heading => (
             <li>
               <a href={`#${heading.id}`} onClick={handleOnClick}>


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Changed "#on-this-page" title element from a list item to a header element. This is more semantically appropriate and will remove the unintended hover styles from the title. 

> [!warning]
> This change might cause some heading order accessibility issues.

## Related tickets and links

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4595

## Screenshots

N/A

## Testing and review
- Confirm that a heading element is appropriate for the component title
- Confirm the new `header-level` prop works as expected

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
