### PR TITLE
va-button-segmented: Update styles for two/three buttons

### DIFF
--- a/packages/storybook/stories/va-button-segmented.stories.tsx
+++ b/packages/storybook/stories/va-button-segmented.stories.tsx
@@ -55,3 +55,22 @@ SelectedItem.args = {
   ...defaultArgs,
   selected: 1,
 };
+
+export const ThreeButtons = Template.bind(null);
+ThreeButtons.args = {
+  ...defaultArgs,
+  buttons: [
+    { label: 'All', value: 'all' },
+    { label: 'Active', value: 'active' },
+    { label: 'Archived', value: 'archived' }
+  ],
+};
+
+export const TwoButtons = Template.bind(null);
+TwoButtons.args = {
+  ...defaultArgs,
+  buttons: [
+    { label: 'Upcoming', value: 'upcoming' },
+    { label: 'Past', value: 'past' },
+  ],
+};

--- a/packages/web-components/src/components/va-button-segmented/test/va-button-segmented.e2e.ts
+++ b/packages/web-components/src/components/va-button-segmented/test/va-button-segmented.e2e.ts
@@ -57,7 +57,7 @@ describe('va-button-segmented', () => {
     );
 
     expect(shadowContent.trim()).toEqualHtml(`
-      <ul aria-label="Segmented Button Example." class="usa-button-group va-segmented-button">
+      <ul aria-label="Segmented Button Example." class="usa-button-group va-segmented-button" data-count="3">
         <li class="usa-button-group__item">
           <button class="va-segmented-button__button" aria-pressed="true" data-label="Segment 1" type="button">
             Segment 1
@@ -108,7 +108,7 @@ describe('va-button-segmented', () => {
     );
 
     expect(shadowContent).toEqualHtml(`
-      <ul aria-label="Segmented Button Example." class="usa-button-group va-segmented-button">
+      <ul aria-label="Segmented Button Example." class="usa-button-group va-segmented-button" data-count="3">
         <li class="usa-button-group__item">
           <button class="va-segmented-button__button" aria-pressed="false" data-label="Segment 1" type="button">
             Segment 1
@@ -146,7 +146,7 @@ describe('va-button-segmented', () => {
     );
 
     expect(shadowContent).toEqualHtml(`
-      <ul aria-label="Segmented Button Example." class="usa-button-group va-segmented-button">
+      <ul aria-label="Segmented Button Example." class="usa-button-group va-segmented-button" data-count="3">
         <li class="usa-button-group__item">
           <button class="va-segmented-button__button" aria-pressed="true" data-label="Segment 1" type="button">
             Segment 1
@@ -218,7 +218,7 @@ describe('va-button-segmented', () => {
     );
 
     expect(shadowContent).toEqualHtml(`
-      <ul aria-label="Segmented Button Example." class="usa-button-group va-segmented-button">
+      <ul aria-label="Segmented Button Example." class="usa-button-group va-segmented-button" data-count="4">
         <li class="usa-button-group__item">
           <button class="va-segmented-button__button" aria-pressed="true" data-label="Segment 1" type="button">
             Segment 1

--- a/packages/web-components/src/components/va-button-segmented/va-button-segmented.scss
+++ b/packages/web-components/src/components/va-button-segmented/va-button-segmented.scss
@@ -45,7 +45,6 @@
 
 .va-segmented-button__button {
   width: 100%;
-  // max-width: 160px;
   height: 100%;
   min-height: 44px;
   background-color: var(--vads-color-base-lighter);

--- a/packages/web-components/src/components/va-button-segmented/va-button-segmented.scss
+++ b/packages/web-components/src/components/va-button-segmented/va-button-segmented.scss
@@ -19,9 +19,25 @@
   margin-left: 0;
   margin-right: 0;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
   gap: 8px;
 }
+
+.va-segmented-button[data-count='4'] {
+  grid-template-columns: repeat(4, 1fr);
+
+  .va-segmented-button__button {
+    max-width: 160px;
+  }
+}
+
+.va-segmented-button[data-count='3'] {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.va-segmented-button[data-count='2'] {
+  grid-template-columns: repeat(2, 1fr);
+}
+
 
 .usa-button-group__item {
   margin: 0;
@@ -29,7 +45,7 @@
 
 .va-segmented-button__button {
   width: 100%;
-  max-width: 160px;
+  // max-width: 160px;
   height: 100%;
   min-height: 44px;
   background-color: var(--vads-color-base-lighter);
@@ -52,6 +68,10 @@
 }
 
 @media screen and (min-width: $tablet) {
+  .va-segmented-button[data-count='2'], .va-segmented-button[data-count='3'] {
+    display: flex;
+  }
+
   .va-segmented-button__button {
     max-width: 160px;
     padding: var(--vads-spacing-1p5) var(--vads-spacing-2p5) var(--vads-spacing-1p5) var(--vads-spacing-2p5);

--- a/packages/web-components/src/components/va-button-segmented/va-button-segmented.tsx
+++ b/packages/web-components/src/components/va-button-segmented/va-button-segmented.tsx
@@ -139,7 +139,7 @@ export class VaButtonSegmented {
 
     return (
       <Host>
-        <ul class={containerClass} aria-label={this.label}>
+        <ul class={containerClass} aria-label={this.label} data-count={this.buttons.length}>
           {this.buttons.map((buttonItem: ButtonItem, index: number) => (
             <li class="usa-button-group__item">
               <button


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `4777-seg-button-2-or-3-bug` is a placeholder for a CI job - it will be updated automatically -->
https://4777-seg-button-2-or-3-bug--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This PR updates the `<va-button-segmented>` component to fix a bug where the styles of the child `<ul>` element were not responsive when two or three buttons were used instead of four.

The updates make it so that: 
- On mobile resolutions, the buttons will each span an equal number of grid columns (where the number of columns equals the number of buttons), while the `<ul>` will continue to fill its parent container.
- On tablet and desktop resolutions, the buttons will have an automatic width, taking up only as much space as needed for their text and padding. The parent `<ul>` will also have an automatic width to accommodate the buttons.

I have also added two stories for <va-segmented-button>, showcasing each of the button counts addressed in this update.

**Resource:** Design specs on component-specific branch of Figma: https://www.figma.com/design/afurtw4iqQe6y4gXfNfkkk/branch/zpbF7Kh203mlfpZE1thN54/VADS-Component-Library?node-id=28629-138&p=f&t=ObFGGDEGaCUi9PTQ-0

<!-- 
Describe the change and context.
Consider:
    - What is relevant to code reviewer(s)?
    - What context may be relevant to a future dev or you in 6 months about this PR?
    - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 -->

## Related tickets and links

<!-- 
Link to any related issues, PRs, Slack conversations, or anything else relevant to documenting the changes.
-->

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4777

## Screenshots

<!-- 
If there are any visual changes, screenshots should be added here. 
-->

|      | Before     | After     |
|--------------|--------------|--------------|
| Two Buttons - Small screen | <img width="772" height="229" alt="two-small-screen-before" src="https://github.com/user-attachments/assets/5042218d-126c-46b3-be8c-eb6afd55ffe7" /> | <img width="811" height="223" alt="two-small-screen-after" src="https://github.com/user-attachments/assets/fb4091a5-5793-4813-8957-d2c4f3ff323d" /> |
| Two Buttons - Medium Screen/Tablet | <img width="888" height="233" alt="two-tablet-before" src="https://github.com/user-attachments/assets/41182721-8e02-49c5-8bac-f2864bb78f0f" /> | <img width="871" height="227" alt="two-tablet-after" src="https://github.com/user-attachments/assets/01adfb70-b131-41ba-8820-d1313016f70e" /> |
| Three Buttons - Small screen | <img width="746" height="181" alt="three-small-screen-before" src="https://github.com/user-attachments/assets/67a9255a-c2b4-4e82-b9cc-4e8b5b94136d" /> | <img width="745" height="198" alt="three-small-screen-after" src="https://github.com/user-attachments/assets/c2f6a7f3-7bc6-4889-a7d8-945fd2de6d62" /> |
| Three Buttons - Medium Screen/Tablet | <img width="855" height="243" alt="three-tablet-before" src="https://github.com/user-attachments/assets/36a32f0f-f7dc-43a9-8b99-44a04937e5c5" /> | <img width="850" height="251" alt="three-tablet-after" src="https://github.com/user-attachments/assets/441e718e-f11b-4a65-91cc-3c75f61d942b" /> |


## Testing and review
- Open the Chromatic deploy above and observe that the variations for the segmented button stories match what is on [Figma](https://www.figma.com/design/afurtw4iqQe6y4gXfNfkkk/branch/zpbF7Kh203mlfpZE1thN54/VADS-Component-Library?node-id=28629-138&p=f&t=ObFGGDEGaCUi9PTQ-0).

<!--
Provide any testing instructions or review steps as needed.
-->

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
