### PR TITLE
dashboard-cli: add support for web-components/react-bindings import path

### DIFF
--- a/packages/design-system-dashboard-cli/src/find-ds-components.js
+++ b/packages/design-system-dashboard-cli/src/find-ds-components.js
@@ -205,6 +205,13 @@ function findComponents(searchStrings) {
     usedBindingsRegex
   );
 
+  const usedWebComponentsBindingsRegex =
+    /import {\s*([^;]+)\s*}\s*from '@department-of-veterans-affairs\/web-components\/react-bindings'/gms;
+  const usedWebComponentsBindings = findUsedReactComponents(
+    vwModules,
+    usedWebComponentsBindingsRegex
+  );
+
   const wcTagRegex = /<(va-[^\s>]+)/gms;
   // Excludes uswds="false" (explicit opt-out) == only matches true if V3, else not V3
   const wcUswds3Regex =
@@ -226,6 +233,7 @@ function findComponents(searchStrings) {
       ...usedReactComponents,
       ...vwWebComponents,
       ...usedReactBindings,
+      ...usedWebComponentsBindings,
     ];
   }
 


### PR DESCRIPTION
- Added regex pattern to capture imports from @department-of-veterans-affairs/web-components/react-bindings
- Updated component tallying to include newer React components using the updated import path
- Fixes missing component reporting for newer components like VaComboBox, VaSearchFilter, VaLanguageToggle, VaSidenav
- Resolves issue where dashboard CLI was only tracking the legacy component-library/dist/react-bindings import path


## Chromatic
<!-- DO NOT REMOVE - This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Fixes an issue in reporting whereby our reporting scripts were not picking up a new import path for components and thus we were not counting usage correctly for newer components.

## Testing and review

Generate a report manually that verified the behavior.
