### PR TITLE
va-accordion: Create separate buttons for "expand all" and "collapse all"

### DIFF
--- a/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
+++ b/packages/web-components/src/components/va-accordion/va-accordion.e2e.ts
@@ -14,9 +14,18 @@ describe('va-accordion', () => {
       <va-accordion class="hydrated">
         <mock:shadow-root>
           <div class="usa-accordion">
-            <button aria-expanded="false" aria-label="expand-all-aria-label" class="va-accordion__button" data-testid="expand-all-accordions">
-              expand-all +
-            </button>
+            <ul class="expand-collapse-list">
+              <li>
+                <button aria-pressed="false" aria-label="expand-all-aria-label" class="va-accordion__button" data-testid="expand-all-accordions">
+                  expand-all
+                </button>
+              </li>
+              <li>
+                <button aria-pressed="false" aria-label="collapse-all-aria-label" class="va-accordion__button" data-testid="collapse-all-accordions">
+                  collapse-all
+                </button>
+              </li>
+            </ul>
             <slot></slot>
           </div>
         </mock:shadow-root>
@@ -77,7 +86,7 @@ describe('va-accordion', () => {
     expect(buttons[0].getAttribute('aria-expanded')).toEqual('false');
     expect(buttons[1].getAttribute('aria-expanded')).toEqual('true');
   });
-  
+
   it('can open nested open-single item', async () => {
     const page = await newE2EPage();
     await page.setContent(`
@@ -134,7 +143,7 @@ describe('va-accordion', () => {
     expect(buttons[1].getAttribute('aria-expanded')).toEqual('true');
   });
 
-  it('expands all items when `Expand all +` button is triggered', async () => {
+  it('expands all items when `Expand all` button is triggered', async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-accordion>
@@ -142,16 +151,35 @@ describe('va-accordion', () => {
         <va-accordion-item header="Second item">A bit more</va-accordion-item>
       </va-accordion>`);
 
-    const expandButton = await page.find('va-accordion >>> button');
+    const expandButton = await page.find('va-accordion >>> button[data-testid="expand-all-accordions"]');
     const accordionItems = await page.findAll('va-accordion-item >>> button');
     // Click to trigger expand of all accordion items collectively
     await expandButton.click();
 
     expect(accordionItems[0].getAttribute('aria-expanded')).toEqual('true');
     expect(accordionItems[1].getAttribute('aria-expanded')).toEqual('true');
+    expect(expandButton).toEqualAttribute('aria-pressed', 'true');
   });
 
-  it('fires accordionExpandCollapseAll event when `Expand all +` button is triggered', async () => {
+  it('collapses all items when `Collapse all` button is triggered', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <va-accordion>
+        <va-accordion-item header="First item">Some content</va-accordion-item>
+        <va-accordion-item header="Second item">A bit more</va-accordion-item>
+      </va-accordion>`);
+
+    const collapseButton = await page.find('va-accordion >>> button[data-testid="collapse-all-accordions"]');
+    const accordionItems = await page.findAll('va-accordion-item >>> button');
+    // Click to trigger expand of all accordion items collectively
+    await collapseButton.click();
+
+    expect(accordionItems[0].getAttribute('aria-expanded')).toEqual('false');
+    expect(accordionItems[1].getAttribute('aria-expanded')).toEqual('false');
+    expect(collapseButton).toEqualAttribute('aria-pressed', 'true');
+  });
+
+  it('fires accordionExpandCollapseAll event when `Expand all` button is triggered', async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-accordion>
@@ -160,10 +188,10 @@ describe('va-accordion', () => {
       </va-accordion>`);
 
     const analyticsSpy = await page.spyOnEvent('accordionExpandCollapseAll');
-    const expandCollapseButton = await page.find('va-accordion >>> button');
+    const expandButton = await page.find('va-accordion >>> button[data-testid="expand-all-accordions"]');
 
     // Click to trigger expand of all accordion items collectively
-    await expandCollapseButton.click();
+    await expandButton.click();
 
     expect(analyticsSpy).toHaveReceivedEventTimes(1);
   });
@@ -177,10 +205,10 @@ describe('va-accordion', () => {
       </va-accordion>`);
 
     const analyticsSpy = await page.spyOnEvent('accordionExpandCollapseAll');
-    const expandCollapseButton = await page.find('va-accordion >>> button');
+    const expandButton = await page.find('va-accordion >>> button[data-testid="expand-all-accordions"]');
 
     // Click to trigger expand of all accordion items collectively
-    await expandCollapseButton.click(); // open all
+    await expandButton.click(); // open all
 ;
     expect(analyticsSpy).toHaveReceivedEventDetail({
       status: 'allOpen',
@@ -196,38 +224,16 @@ describe('va-accordion', () => {
       </va-accordion>`);
 
     const analyticsSpy = await page.spyOnEvent('accordionExpandCollapseAll');
-    const expandCollapseButton = await page.find('va-accordion >>> button');
+    const collapseButton = await page.find('va-accordion >>> button[data-testid="collapse-all-accordions"]');
 
-    // Click to trigger expand of all accordion items collectively
-    await expandCollapseButton.click(); // open all
-    await expandCollapseButton.click(); // close all
+    await collapseButton.click(); // close all
 
     expect(analyticsSpy).toHaveReceivedEventDetail({
       status: 'allClosed',
     });
   });
 
-  it('collapses all items when `Collapse All -` button is triggered', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-accordion>
-        <va-accordion-item header="First item">Some content</va-accordion-item>
-        <va-accordion-item header="Second item">A bit more</va-accordion-item>
-      </va-accordion>`);
-
-    const expandButton = await page.find('va-accordion >>> button');
-    const accordionItems = await page.findAll('va-accordion-item >>> button');
-    // Click to expand both accordion items manually
-    await accordionItems[0].click();
-    await accordionItems[1].click();
-    // Click to trigger collapse of all accordion items collectively
-    await expandButton.click();
-
-    expect(accordionItems[0].getAttribute('aria-expanded')).toEqual('false');
-    expect(accordionItems[1].getAttribute('aria-expanded')).toEqual('false');
-  });
-
-  it('fires accordionExpandCollapseAll event when `Collapse All -` button is clicked', async () => {
+  it('fires accordionExpandCollapseAll event when `Collapse All` button is clicked', async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-accordion>
@@ -236,18 +242,18 @@ describe('va-accordion', () => {
       </va-accordion>`);
 
     const analyticsSpy = await page.spyOnEvent('accordionExpandCollapseAll');
-    const expandCollapseButton = await page.find('va-accordion >>> button');
+    const collapseButton = await page.find('va-accordion >>> button[data-testid="collapse-all-accordions"]');
     const accordionItems = await page.findAll('va-accordion-item >>> button');
     // Click to expand both accordion items manually
     await accordionItems[0].click();
     await accordionItems[1].click();
     // Click to trigger collapse of all accordion items collectively
-    await expandCollapseButton.click();
+    await collapseButton.click();
 
     expect(analyticsSpy).toHaveReceivedEventTimes(1);
   });
 
-  it('tracks which accordions are opened', async () => {
+  it('applies aria-pressed="true" to expand button when all accordions are opened', async () => {
     const page = await newE2EPage();
     await page.setContent(`
       <va-accordion>
@@ -257,17 +263,17 @@ describe('va-accordion', () => {
     const accordionItemsButtons = await page.findAll(
       'va-accordion-item >>> button',
     );
-    const expandButton = await page.find('va-accordion >>> button');
+    const expandButton = await page.find('va-accordion >>> button[data-testid="expand-all-accordions"]');
     // Click to expand single accordion item manually
     await accordionItemsButtons[0].click();
     // Check if all accordions opened conditions are met
     // This is a translation key for i18next
-    expect(expandButton).toEqualText('expand-all +');
+    expect(expandButton).toEqualAttribute('aria-pressed', 'false');
     // Click to expand single accordion item manually
     await accordionItemsButtons[1].click();
     // Check if all accordions opened conditions are met
     // This is a translation key for i18next
-    expect(expandButton).toEqualText('collapse-all -');
+    expect(expandButton).toEqualAttribute('aria-pressed', 'true');
   });
 
   it('fires an analytics event when expanded', async () => {
@@ -391,30 +397,5 @@ describe('va-accordion', () => {
         subheader: null,
       },
     });
-  });
-
-  it('shows "Collapse all -" if all accordion-items are open on load', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-accordion section-heading="The Section Heading">
-        <va-accordion-item header="First item" open="true">Some content</va-accordion-item>
-      </va-accordion>`);
-
-    const button = await page.find('va-accordion >>> button');
-
-    expect(button.innerText).toEqual('collapse-all -');
-  });
-
-  it('shows "Collapse all -" if some of accordion-items are open on load', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <va-accordion section-heading="The Section Heading">
-        <va-accordion-item header="First item" open="true">Some content</va-accordion-item>
-        <va-accordion-item header="Second item">Some content</va-accordion-item>
-      </va-accordion>`);
-
-    const button = await page.find('va-accordion >>> button');
-
-    expect(button.innerText).toEqual('collapse-all -');
   });
 });

--- a/packages/web-components/src/components/va-accordion/va-accordion.scss
+++ b/packages/web-components/src/components/va-accordion/va-accordion.scss
@@ -4,6 +4,19 @@
 
 @import '../../mixins/focusable.css';
 
+.expand-collapse-list {
+  display: flex;
+  justify-content: flex-end;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  li:first-child::after {
+    content: '|';
+    font-size: 0.875rem;
+  }
+}
+
 button.va-accordion__button {
   border: none;
   color: var(--vads-color-link);
@@ -12,7 +25,6 @@ button.va-accordion__button {
   cursor: pointer;
   font-family: inherit;
   font-weight: bold;
-  float: right;
 }
 
 @media print {

--- a/packages/web-components/src/components/va-accordion/va-accordion.scss
+++ b/packages/web-components/src/components/va-accordion/va-accordion.scss
@@ -12,7 +12,8 @@
   padding: 0;
 
   li:first-child::after {
-    content: '|';
+    // empty second value prevents pseudo-element from being read by screen readers
+    content: '|' / '';
     font-size: 0.875rem;
   }
 }

--- a/packages/web-components/src/components/va-accordion/va-accordion.tsx
+++ b/packages/web-components/src/components/va-accordion/va-accordion.tsx
@@ -58,6 +58,7 @@ export class VaAccordion {
   expandCollapseBtn!: HTMLButtonElement;
 
   @State() expanded = false;
+  @State() collapsed = true;
 
   /**
    * True if only a single item can be opened at once
@@ -175,13 +176,22 @@ export class VaAccordion {
     }
 
     if (accordionItems[method](allClosed)) {
-      return (this.expanded = false);
+      return (
+        this.expanded = false,
+        this.collapsed = true
+      );
     }
+
+    return (
+      this.expanded = false,
+      this.collapsed = false
+    );
   }
 
   // Expand or Collapse All Function for Button Click
   private expandCollapseAll = (expanded: boolean) => {
     this.expanded = expanded;
+    this.collapsed = !expanded;
 
     const value = expanded ? 'allOpen' : 'allClosed';
     this.accordionExpandCollapseAll.emit({ status: value });
@@ -217,6 +227,8 @@ export class VaAccordion {
   // if one or more accordion-items are open on load, then we should put component in state to "Collapse all"
   componentWillLoad() {
     this.accordionsOpened('some');
+    this.expanded = false;
+    this.collapsed = false;
   }
 
   render() {
@@ -236,22 +248,32 @@ export class VaAccordion {
           }
         >
           {(!openSingle && !isInsideSearchFilter) ? (
-            <button
-              aria-expanded={`${this.expanded}`}
-              class="va-accordion__button"
-              data-testid="expand-all-accordions"
-              ref={el => (this.expandCollapseBtn = el as HTMLButtonElement)}
-              onClick={() => this.expandCollapseAll(!this.expanded)}
-              aria-label={
-                this.expanded
-                  ? i18next.t('collapse-all-aria-label')
-                  : i18next.t('expand-all-aria-label')
-              }
-            >
-              {this.expanded
-                ? `${i18next.t('collapse-all')} -`
-                : `${i18next.t('expand-all')} +`}
-            </button>
+            <ul class="expand-collapse-list">
+              <li>
+                <button
+                  class="va-accordion__button"
+                  data-testid="expand-all-accordions"
+                  ref={el => (this.expandCollapseBtn = el as HTMLButtonElement)}
+                  onClick={() => this.expandCollapseAll(true)}
+                  aria-pressed={this.expanded ? 'true' : 'false'}
+                  aria-label={i18next.t('expand-all-aria-label')}
+                >
+                  {i18next.t('expand-all')}
+                </button>
+              </li>
+              <li>
+                <button
+                  class="va-accordion__button"
+                  data-testid="collapse-all-accordions"
+                  ref={el => (this.expandCollapseBtn = el as HTMLButtonElement)}
+                  onClick={() => this.expandCollapseAll(false)}
+                  aria-pressed={this.collapsed ? 'true' : 'false'}
+                  aria-label={i18next.t('collapse-all-aria-label')}
+                >
+                  {i18next.t('collapse-all')}
+                </button>
+              </li>
+            </ul>
           ) : null}
           <slot></slot>
         </div>


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `4531-expand-collapse-buttons` is a placeholder for a CI job - it will be updated automatically -->
https://4531-expand-collapse-buttons--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

Separated the current "Expand/collapse all" button into two separate buttons. This has two main benefits:
1. It adds more direct control over the expanded and collapsed states of the component 
2. It provides a more accurate state readout to screen reader users

### References
This approach was at least partially informed by the following articles:
- https://inclusive-components.design/toggle-button/
    > As a rule of thumb, you should never change pressed state and label together. If the label changes, the button has already changed state in a sense, just not via explicit WAI-ARIA state management.”
- https://inclusive-components.design/collapsible-sections/
    > It's tempting to implement 'expand/collapse all' as a single toggle button. But we don't know how many sections will initially be in either state. Nor do we know, at any given time, how many sections the user has opened or closed manually. Instead, we should group two alternative controls.”

## Related tickets and links

<!-- 
Link to any related issues, PRs, Slack conversations, or anything else relevant to documenting the changes.
-->

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4531

## Screenshots

### Before
<img width="932" height="236" alt="image" src="https://github.com/user-attachments/assets/96fe6321-6427-493d-8584-5c5f3ef6cdc0" />


### After
<img width="932" height="229" alt="image" src="https://github.com/user-attachments/assets/40828074-aaf0-402f-ae93-9f3e7db187ea" />


## Testing and review

### Designers
- Confirm the updated visual presentation meets standards

### Developers
- Confirm that the code updates meet standards
- Confirm the tests are comprehensive
- Confirm no regressions

### Accessibility
- Confirm this is the two button approach is the best solution for accessibiltiy
- Confirm that aria-pressed is the correct attribute and works as expected across screen readers

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
