### PR TITLE
va-text-input: Add password type variation / va-file-input: Use new password variation to mask file password.

### DIFF
--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
@@ -430,7 +430,7 @@ CustomValidation.args = {
 const EncryptedTemplate = ({ label, name }) => {
   const [encryptedList, setEncryptedList] = useState([]);
 
-  function setEncrpytedForEachFile(event) {
+  function setEncryptedForEachFile(event) {
     const fileEntries = event.detail.state;
     const pdfFiles = fileEntries.map((file) => {
       return file.file.type === 'application/pdf'
@@ -449,13 +449,13 @@ const EncryptedTemplate = ({ label, name }) => {
         name={name}
         hint={"This example shows a password field when a .pdf file is uploaded."}
         encrypted={encryptedList}
-        onVaMultipleChange={setEncrpytedForEachFile}
+        onVaMultipleChange={setEncryptedForEachFile}
       />
       <hr />
       <div>
         <p>
           Parent components are responsible for managing if a password
-          needs to be requested for the file through a dedicated encryted
+          needs to be requested for the file through a dedicated encrypted
           array. Each index in this array corresponds to a file input, 
           with the value at each index being true if a password should
           be requested for that specific file, or false if no password is
@@ -468,22 +468,25 @@ const EncryptedTemplate = ({ label, name }) => {
       <div className="vads-u-margin-top--2">
         <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
           <code>
-            {`const [encryptedList, setEncryptedList] = useState([]);
+            {`
+              const [encryptedList, setEncryptedList] = useState([]);
 
-  function setEncrpytedForEachFile(event) {
-    const fileEntries = event.detail.state;
-    const pdfFiles = fileEntries.map((file, index) => {
-      return file.file.type === 'application/pdf'
-    });
-    setEncryptedList(pdfFiles);
-  }
+              function setEncryptedForEachFile(event) {
+                const fileEntries = event.detail.state;
+                const pdfFiles = fileEntries.map((file, index) => {
+                  return file.file.type === 'application/pdf'
+                });
+                setEncryptedList(pdfFiles);
+              }
 
-  return (
-    <VaFileInputMultiple
-      ...
-      encrypted={encryptedList}
-      onVaMultipleChange={setEncrpytedForEachFile}
-    />`}
+              return (
+                <VaFileInputMultiple
+                  ...
+                  encrypted={encryptedList}
+                  onVaMultipleChange={setEncryptedForEachFile}
+                />
+              );
+            `}
           </code>
         </pre>
         <a

--- a/packages/storybook/stories/va-file-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.tsx
@@ -290,33 +290,35 @@ const CustomValidationTemplate = ({
       <div className="vads-u-margin-top--2">
         <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
           <code>
-            {`const [errorVal, setErrorVal] = useState(error);
+            {`
+                const [errorVal, setErrorVal] = useState(error);
 
-function validateFileContents(event) {
-  setErrorVal(null);
-  if (event.detail.files && event.detail.files.length) {
-    const file = event.detail.files[0];
+                function validateFileContents(event) {
+                  setErrorVal(null);
+                  if (event.detail.files && event.detail.files.length) {
+                    const file = event.detail.files[0];
 
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const contents = reader.result;
-      const hasX = contents.includes('X');
+                    const reader = new FileReader();
+                    reader.onloadend = () => {
+                      const contents = reader.result;
+                      const hasX = contents.includes('X');
 
-      if (hasX)
-        setErrorVal('File contains an \\'X\\' character');
-    };
+                      if (hasX)
+                        setErrorVal('File contains an \\'X\\' character');
+                    };
 
-    reader.readAsText(file);
-  }
-}
+                    reader.readAsText(file);
+                  }
+                }
 
-return (
-  <VaFileInput
-    ...
-    error={errorVal}
-    onVaChange={validateFileContents}
-  />
-)`}
+                return (
+                  <VaFileInput
+                    ...
+                    error={errorVal}
+                    onVaChange={validateFileContents}
+                  />
+                )
+              `}
           </code>
         </pre>
         <a

--- a/packages/storybook/stories/va-text-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.tsx
@@ -40,7 +40,7 @@ export default {
     type: {
       control: {
         type: 'select',
-        options: ['email', 'number', 'search', 'tel', 'text', 'url'],
+        options: ['email', 'number', 'password', 'search', 'tel', 'text', 'url'],
       },
     },
     'hide-required-text': {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -2217,7 +2217,7 @@ export namespace Components {
         /**
           * The type attribute.
          */
-        "type"?: 'email' | 'number' | 'search' | 'tel' | 'text' | 'url';
+        "type"?: 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
         /**
           * Enabling this will add a heading and description for integrating into the forms pattern. Accepts `single` or `multiple` to indicate if the form is a single input or will have multiple inputs.
          */
@@ -6352,7 +6352,7 @@ declare namespace LocalJSX {
         /**
           * The type attribute.
          */
-        "type"?: 'email' | 'number' | 'search' | 'tel' | 'text' | 'url';
+        "type"?: 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
         /**
           * Enabling this will add a heading and description for integrating into the forms pattern. Accepts `single` or `multiple` to indicate if the form is a single input or will have multiple inputs.
          */

--- a/packages/web-components/src/components/va-file-input/va-file-input.tsx
+++ b/packages/web-components/src/components/va-file-input/va-file-input.tsx
@@ -189,7 +189,7 @@ export class VaFileInput {
         this.resetState();
       }
   }
-  
+
   /**
    * Return to initial visual state of component to display error and
    * allow user to try to add file again.
@@ -660,7 +660,7 @@ export class VaFileInput {
                 {(file || value || uploadedFile) && (
                   <div>
                     {this.showSeparator && <hr class="separator" />}
-                    {!readOnly && showProgBar && 
+                    {!readOnly && showProgBar &&
                       (
                         <Fragment>
                             <va-progress-bar percent={percentUploaded} />
@@ -671,14 +671,20 @@ export class VaFileInput {
                     {!showProgBar && (
                       <Fragment>
                         {encrypted && (
-                          <va-text-input onInput={(e) =>{this.handlePasswordChange(e)}} label="File password" required error={passwordError} />
+                          <va-text-input
+                            type="password"
+                            onInput={(e) =>{this.handlePasswordChange(e)}}
+                            label="File password"
+                            required
+                            error={passwordError}
+                          />
                         )}
                         <div class="additional-info-slot">
                           <slot></slot>
                         </div>
                       </Fragment>
                     )}
-                    {!readOnly && !showProgBar && 
+                    {!readOnly && !showProgBar &&
                       (
                         <Fragment>
                           <div class="file-button-section">

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -24,7 +24,7 @@ describe('va-text-input', () => {
         </mock:shadow-root>
       </va-text-input>
     `);
-  });
+  })
 
   it('renders an error message', async () => {
     const page = await newE2EPage();
@@ -371,6 +371,7 @@ describe('va-text-input', () => {
       'email',
       'none',
       'numeric',
+      'password',
       'search',
       'tel',
       'text',

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -54,7 +54,7 @@ export class VaTextInput {
    * Input types we will allow to be specified with the "type" prop.
    */
   /* eslint-disable-next-line i18next/no-literal-string */
-  allowedInputTypes = ['email', 'number', 'search', 'tel', 'text', 'url'];
+  allowedInputTypes = ['email', 'number', 'password', 'search', 'tel', 'text', 'url'];
 
   /**
    * The label for the text input.
@@ -114,7 +114,7 @@ export class VaTextInput {
   /**
    * The type attribute.
    */
-  @Prop() type?: 'email' | 'number' | 'search' | 'tel' | 'text' | 'url' =
+  @Prop() type?: 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url' =
     'text';
 
   /**


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `4706-file-input-password` is a placeholder for a CI job - it will be updated automatically -->
https://4706-file-input-password--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This resolves an issue flagged for `va-file-input` where the passwords for encrypted files were shown as plain text as opposed to being masked. Rather than using JS/CSS to mask the input value, I added a password variation for the `type` prop of `va-text-input` to simplify things and utilize the web standard as best practice.

File changes also include fixing some typos and cleaning up indentation in the story files for `va-file-input` and `va-file-input-multiple`.

<!-- 
Describe the change and context.
Consider:
    - What is relevant to code reviewer(s)?
    - What context may be relevant to a future dev or you in 6 months about this PR?
    - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 -->

## Related tickets and links

<!-- 
Link to any related issues, PRs, Slack conversations, or anything else relevant to documenting the changes.
-->

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4706

## Screenshots

### Before:
<img width="544" height="466" alt="Monosnap Components : File input multiple USWDS - Accepts File Password ⋅ Storybook 2025-09-17 16-50-09" src="https://github.com/user-attachments/assets/7ed89e98-746a-426b-8ada-e71a6394669c" />

### After:
<img width="531" height="426" alt="Monosnap Components : File input multiple USWDS - Accepts File Password ⋅ Storybook 2025-09-17 16-50-00" src="https://github.com/user-attachments/assets/686c75c3-4842-47f8-8552-96b7d99f242f" />

<!-- 
If there are any visual changes, screenshots should be added here. 
-->

## Testing and review

<!--
Provide any testing instructions or review steps as needed.
-->


1. Navigate to "Accespts File Password" story for either [`<va-file-input>`](https://4706-file-input-password--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/story/uswds-va-file-input--accepts-file-password) or [`<va-file-input-multiple>`](https://4706-file-input-password--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/story/uswds-va-file-input-multiple--accepts-file-password) 
2. Upload an encrypted PDF file (included a sample one below this list for convenience with password of "test-pdf").
3. Observe the password input field that appears
4. Type a password into the field
5. Note that the password is visible is masked.

[sample-local-pdf.pdf](https://github.com/user-attachments/files/22394556/sample-local-pdf.pdf)


## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
