### PR TITLE
Storybook: Disable unused chromatic snapshots

### DIFF
--- a/packages/storybook/stories/Modal.stories.tsx
+++ b/packages/storybook/stories/Modal.stories.tsx
@@ -6,6 +6,9 @@ export default {
   title: 'Deprecated/Modal - React',
   component: Modal,
   parameters: {
+    // Snapshots disabled because visual difference is only apparent after interaction.
+    // TODO: Enable snapshots after integrating Storybook play function
+    chromatic: { disableSnapshot: true },
     componentSubtitle: 'Modal React component',
     docs: {
       page: () => <StoryDocs storyDefault={Default} componentName="Modal - React" />,
@@ -173,4 +176,7 @@ CrisisLineModal.args = {
       </div>
     </div>
   ),
+};
+CrisisLineModal.parameters = {
+  chromatic: { disableSnapshot: false },
 };

--- a/packages/storybook/stories/action-link.stories.js
+++ b/packages/storybook/stories/action-link.stories.js
@@ -1,6 +1,9 @@
 export default {
   title: 'Deprecated/Link - Action',
   id: 'components/action-link',
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export const Primary = {

--- a/packages/storybook/stories/pattern-prefill/va-card.stories.jsx
+++ b/packages/storybook/stories/pattern-prefill/va-card.stories.jsx
@@ -8,6 +8,7 @@ export default {
   title: 'Patterns/Prefill/Components/Card',
   id: 'patterns/components/card',
   parameters: {
+    chromatic: { disableSnapshot: true },
     componentSubtitle: 'Prefill card variations',
     docs: {
       page: () => <StoryDocs storyDefault={Editable} data={cardDocs} />,

--- a/packages/storybook/stories/pattern-prefill/va-prefill-alert.stories.jsx
+++ b/packages/storybook/stories/pattern-prefill/va-prefill-alert.stories.jsx
@@ -25,6 +25,7 @@ export default {
     },
   },
   parameters: {
+    chromatic: { disableSnapshot: true },
     componentSubtitle: 'va prefill alert',
     docs: {
       page: () => (

--- a/packages/storybook/stories/pattern-prefill/va-prefill-signed-in.stories.jsx
+++ b/packages/storybook/stories/pattern-prefill/va-prefill-signed-in.stories.jsx
@@ -6,6 +6,7 @@ export default {
   title: 'Patterns/Prefill/Usage Examples/Signed In Prefill Alert',
   id: 'patterns/va-prefill-signed-in',
   parameters: {
+    chromatic: { disableSnapshot: true },
     componentSubtitle: 'va prefill pattern signed in',
   },
 };

--- a/packages/storybook/stories/pattern-prefill/va-prefilled-info-with-editable-card.stories.jsx
+++ b/packages/storybook/stories/pattern-prefill/va-prefilled-info-with-editable-card.stories.jsx
@@ -6,6 +6,7 @@ export default {
   title: 'Patterns/Prefill/Usage Examples/Prefilled info with editable card',
   id: 'patterns/Editable-card',
   parameters: {
+    chromatic: { disableSnapshot: true },
     componentSubtitle: 'va prefilled info with editable card',
   },
 };

--- a/packages/storybook/stories/pattern-prefill/va-prefilled-info-with-uneditable-card.stories.jsx
+++ b/packages/storybook/stories/pattern-prefill/va-prefilled-info-with-uneditable-card.stories.jsx
@@ -5,6 +5,7 @@ export default {
   title: 'Patterns/Prefill/Usage Examples/Prefilled info with uneditable card',
   id: 'patterns/va-prefilled-info-with-uneditable-card',
   parameters: {
+    chromatic: { disableSnapshot: true },
     componentSubtitle: 'va prefilled info with uneditable card',
   },
 };

--- a/packages/storybook/stories/va-accordion-uswds.stories.tsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.tsx
@@ -207,6 +207,11 @@ CustomHeaderLevel.args = {
 
 export const Internationalization = I18nTemplate.bind(null);
 Internationalization.args = {};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Internationalization.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const ManyAccordions = Template.bind(null);
 ManyAccordions.args = {

--- a/packages/storybook/stories/va-accordion-uswds.stories.tsx
+++ b/packages/storybook/stories/va-accordion-uswds.stories.tsx
@@ -256,6 +256,9 @@ ManyAccordions.args = {
     },
   ],
 };
+ManyAccordions.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 // todo: after upgrading to storybook 8 we can hide this story from the sidebar: https://storybook.js.org/docs/writing-stories/tags
 export const PrintAccordion = Template.bind(null);
@@ -278,5 +281,6 @@ PrintAccordion.args = {
 PrintAccordion.parameters = {
   chromatic: {
     media: 'print',
+    disableSnapshot: true,
   },
 };

--- a/packages/storybook/stories/va-additional-info-uswds.stories.tsx
+++ b/packages/storybook/stories/va-additional-info-uswds.stories.tsx
@@ -59,3 +59,8 @@ NoBorder.args = {
   ...defaultArgs,
   'disable-border': true,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+NoBorder.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-alert-uswds.stories.tsx
+++ b/packages/storybook/stories/va-alert-uswds.stories.tsx
@@ -220,7 +220,7 @@ Default.argTypes = {
   ...propStructure(alertDocs),
    'status': {
     description: 'Determines the icon and background color. `info`, `error`, `success`, or `warning`',
-    table: { 
+    table: {
       category: 'Properties',
       defaultValue: { summary: 'info' },
     },
@@ -303,6 +303,9 @@ NotVisible.args = {
 export const WithARIARole = WithARIARoleTemplate.bind(null);
 WithARIARole.args = {
   ...defaultArgs,
+};
+WithARIARole.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 export const FullWidthSiteAlert = Template.bind(null);

--- a/packages/storybook/stories/va-back-to-top.stories.tsx
+++ b/packages/storybook/stories/va-back-to-top.stories.tsx
@@ -67,4 +67,6 @@ ShortExample.args = {
   ...defaultArgs,
   displayAmount: 2,
 };
-Default.argTypes = propStructure(bttDocs);
+ShortExample.parameters = {
+  chromatic: {disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-banner.stories.tsx
+++ b/packages/storybook/stories/va-banner.stories.tsx
@@ -80,3 +80,6 @@ DismissibleWithSpecificBannerId.args = {
   'show-close': true,
   'dismissed-banner-id': 'specific-banner-id',
 };
+DismissibleWithSpecificBannerId.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-breadcrumbs-uswds.stories.tsx
+++ b/packages/storybook/stories/va-breadcrumbs-uswds.stories.tsx
@@ -15,10 +15,10 @@ export default {
     },
   },
 };
-const Template = ({ 
-  label, 
-  'disable-analytics': disableAnalytics, 
-  'current-page-redirect': currentPageRedirect, 
+const Template = ({
+  label,
+  'disable-analytics': disableAnalytics,
+  'current-page-redirect': currentPageRedirect,
   'breadcrumb-list': breadcrumbList,
   'home-veterans-affairs': homeVeteransAffairs = true
 }) => (
@@ -261,17 +261,26 @@ WrappingState.args = { ...defaultArgs, wrapping: true };
 
 export const MultipleLanguages = MultipleLanguagesTemplate.bind(null);
 MultipleLanguages.args = { ...defaultArgs };
+MultipleLanguages.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const WithRouterLinkSupport = WithRouterTemplate.bind(null);
 WithRouterLinkSupport.args = { ...defaultArgs };
+WithRouterLinkSupport.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const CurrentPageRedirect = Template.bind(null);
-CurrentPageRedirect.args = { 
-  ...defaultArgs, 
-  'current-page-redirect': true, 
+CurrentPageRedirect.args = {
+  ...defaultArgs,
+  'current-page-redirect': true,
   'breadcrumb-list': [
-    { "label": "VA.gov home", "href": "/" }, 
-    { "label": "Last Page", "href": "/example-last-page" }, 
+    { "label": "VA.gov home", "href": "/" },
+    { "label": "Last Page", "href": "/example-last-page" },
     { "label": "Current Page", "href": "/introduction" }
-  ] 
+  ]
+};
+CurrentPageRedirect.parameters = {
+  chromatic: { disableSnapshot: true },
 };

--- a/packages/storybook/stories/va-breadcrumbs-uswds.stories.tsx
+++ b/packages/storybook/stories/va-breadcrumbs-uswds.stories.tsx
@@ -255,6 +255,11 @@ Default.argTypes = propStructure(breadcrumbsDocs);
 
 export const RerenderState = DynamicCrumbsTemplate.bind(null);
 RerenderState.args = { ...defaultArgs };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+RerenderState.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const WrappingState = WrappingCrumbsTemplate.bind(null);
 WrappingState.args = { ...defaultArgs, wrapping: true };

--- a/packages/storybook/stories/va-button-icon.stories.tsx
+++ b/packages/storybook/stories/va-button-icon.stories.tsx
@@ -58,3 +58,6 @@ DisableAnalytics.args = {
   ...defaultArgs,
   'disable-analytics': true,
 };
+DisableAnalytics.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-button-uswds.stories.tsx
+++ b/packages/storybook/stories/va-button-uswds.stories.tsx
@@ -131,6 +131,11 @@ Loading.args = {
     }, 5000);
   },
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Loading.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const FullWidth = Template.bind(null);
 FullWidth.args = {
@@ -191,4 +196,9 @@ Submitted.args = {
   },
   submit: 'prevent',
   text: 'Submit',
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Submitted.parameters = {
+  chromatic: { disableSnapshot: true },
 };

--- a/packages/storybook/stories/va-checkbox-group-uswds.stories.tsx
+++ b/packages/storybook/stories/va-checkbox-group-uswds.stories.tsx
@@ -385,6 +385,9 @@ TileWithHint.args = {
   label: 'Select any historical figure',
   hint: 'This is example hint text',
 };
+TileWithHint.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const TileWithError = USWDSTiled.bind(null);
 TileWithError.args = {
@@ -392,6 +395,9 @@ TileWithError.args = {
   tile: true,
   label: 'Select any historical figure',
   error: 'There has been a problem',
+};
+TileWithError.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 export const TileWithHintAndError = USWDSTiled.bind(null);
@@ -408,6 +414,10 @@ withDescriptionMessage.args = {
   ...defaultArgs,
   'message-aria-describedby': 'some additional info',
 };
+withDescriptionMessage.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
 
 export const Internationalization = I18nTemplate.bind(null);
 Internationalization.args = {

--- a/packages/storybook/stories/va-checkbox-uswds.stories.tsx
+++ b/packages/storybook/stories/va-checkbox-uswds.stories.tsx
@@ -344,6 +344,11 @@ Internationalization.args = {
   error: 'There has been a problem',
   required: true,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Internationalization.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const Indeterminate = IndeterminateTemplate.bind(null);
 Indeterminate.args = { ...defaultArgs };

--- a/packages/storybook/stories/va-checkbox-uswds.stories.tsx
+++ b/packages/storybook/stories/va-checkbox-uswds.stories.tsx
@@ -332,6 +332,9 @@ Required.args = { ...defaultArgs, required: true };
 
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
+WithAnalytics.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const Internationalization = I18nTemplate.bind(null);
 Internationalization.args = {

--- a/packages/storybook/stories/va-combo-box-uswds.stories.tsx
+++ b/packages/storybook/stories/va-combo-box-uswds.stories.tsx
@@ -173,3 +173,9 @@ export const OptionGroups = Template.bind({});
 OptionGroups.args = {
   ...optGroupArgs,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+OptionGroups.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+

--- a/packages/storybook/stories/va-combo-box-uswds.stories.tsx
+++ b/packages/storybook/stories/va-combo-box-uswds.stories.tsx
@@ -139,6 +139,10 @@ WithMessageAriaDescribedBy.args = {
   ...defaultArgs,
   messageAriaDescribedby: 'This is example aria message',
 };
+WithMessageAriaDescribedBy.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
 
 const optGroupArgs = {
   ...defaultArgs,

--- a/packages/storybook/stories/va-date.stories.tsx
+++ b/packages/storybook/stories/va-date.stories.tsx
@@ -179,6 +179,9 @@ WithHintTextError.args = {
   ...defaultArgs,
   error: 'Error Message Example',
 };
+WithHintTextError.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const MonthYear = Template.bind({});
 MonthYear.args = { ...defaultArgs, 'month-year-only': true };
@@ -199,3 +202,6 @@ CustomValidation.args = {
 
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
+WithAnalytics.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-date.stories.tsx
+++ b/packages/storybook/stories/va-date.stories.tsx
@@ -173,6 +173,11 @@ CustomRequiredMessage.args = {
   ...defaultArgs,
   required: true,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+CustomRequiredMessage.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const WithHintTextError = WithHintTextTemplate.bind(null);
 WithHintTextError.args = {
@@ -192,12 +197,22 @@ MonthOptional.args = {
   'month-year-only': true,
   'month-optional': true,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+    // TODO: Enable snapshots after integrating Storybook play function
+MonthOptional.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const CustomValidation = CustomValidationTemplate.bind(null);
 CustomValidation.args = {
   ...defaultArgs,
   required: true,
   value: '2022-04-19',
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+    // TODO: Enable snapshots after integrating Storybook play function
+CustomValidation.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 export const WithAnalytics = Template.bind(null);

--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
@@ -84,6 +84,11 @@ Accept.args = {
   hint: 'All files in this list must be PDFs',
   accept: '.pdf',
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Accept.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const HeaderSize = Template.bind(null);
 HeaderSize.args = {
@@ -182,6 +187,11 @@ AdditionalFormInputs.args = {
   label: 'Additional Form Inputs',
   children: additionalFormInputsContent,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+AdditionalFormInputs.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 const AdditionalFormInputsOnSpecificFieldsContentTemplate = ({
   label,
@@ -248,6 +258,11 @@ AdditionalFormInputsOnSpecificFields.args = {
   label: 'Additional Form Inputs On Specific Inputs',
   children: additionalFormInputsContent,
   slotFieldIndexes: '[1,3]',
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+AdditionalFormInputsOnSpecificFields.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 const ErrorsTemplate = ({ label, name, hint }) => {
@@ -322,6 +337,11 @@ export const Errors = ErrorsTemplate.bind(null);
 Errors.args = {
   ...defaultArgs,
   label: 'Label Header',
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Errors.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 const CustomValidationTemplate = ({ label, name, accept, hint }) => {
@@ -426,6 +446,11 @@ CustomValidation.args = {
   label: 'Upload files which are smaller than 2 MB',
   hint: 'Select any file type',
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+CustomValidation.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 const EncryptedTemplate = ({ label, name }) => {
   const [encryptedList, setEncryptedList] = useState([]);
@@ -440,9 +465,9 @@ const EncryptedTemplate = ({ label, name }) => {
 
   return (
     <>
-      To learn how to check for an encrypted PDF <va-link 
+      To learn how to check for an encrypted PDF <va-link
         text='see platform documentation'
-        href='https://depo-platform-documentation.scrollhelp.site/developer-docs/checking-if-an-uploaded-pdf-is-encrypted' 
+        href='https://depo-platform-documentation.scrollhelp.site/developer-docs/checking-if-an-uploaded-pdf-is-encrypted'
       />.
       <VaFileInputMultiple
         label={label}
@@ -456,7 +481,7 @@ const EncryptedTemplate = ({ label, name }) => {
         <p>
           Parent components are responsible for managing if a password
           needs to be requested for the file through a dedicated encryted
-          array. Each index in this array corresponds to a file input, 
+          array. Each index in this array corresponds to a file input,
           with the value at each index being true if a password should
           be requested for that specific file, or false if no password is
           needed. By default, no password field will be displayed. This
@@ -499,6 +524,11 @@ const EncryptedTemplate = ({ label, name }) => {
 
 export const AcceptsFilePassword = EncryptedTemplate.bind(null);
 AcceptsFilePassword.args = {...defaultArgs};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+AcceptsFilePassword.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 const FilesUploadedTemplate = args => {
   const [mockFiles, setMockFiles] = useState(null);

--- a/packages/storybook/stories/va-file-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.tsx
@@ -343,6 +343,9 @@ WithAnalytics.args = {
   ...defaultArgs,
   'enable-analytics': true,
 };
+WithAnalytics.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const UploadedFile = Template.bind(null);
 UploadedFile.args = {
@@ -391,6 +394,9 @@ UploadStatus.args = {
 
 export const FileUploaded = FileUploadedTemplate.bind(null);
 FileUploaded.args = { ...defaultArgs, vaChange: event => event };
+FileUploaded.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const ReadOnly = FileUploadedTemplate.bind(null);
 ReadOnly.args = { ...defaultArgs, vaChange: event => event, readOnly: true };

--- a/packages/storybook/stories/va-file-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.tsx
@@ -160,9 +160,19 @@ const AcceptsFilePasswordTemplate = ({
 };
 export const AcceptsFilePassword = AcceptsFilePasswordTemplate.bind(null);
 AcceptsFilePassword.args = { ...defaultArgs, encrypted: true, };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+AcceptsFilePassword.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const WithFilePasswordError = AcceptsFilePasswordTemplate.bind(null);
 WithFilePasswordError.args = { ...defaultArgs, encrypted: true, passwordError: 'Encrypted file requires a password.' };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+WithFilePasswordError.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const AcceptsOnlySpecificFileTypes = Template.bind(null);
 AcceptsOnlySpecificFileTypes.args = {
@@ -171,6 +181,12 @@ AcceptsOnlySpecificFileTypes.args = {
   hint: 'You can upload a .pdf or .txt file',
   accept: '.pdf,.txt',
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+AcceptsOnlySpecificFileTypes.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
 
 export const AcceptsAnyKindOfImage = Template.bind(null);
 AcceptsAnyKindOfImage.args = {
@@ -179,6 +195,12 @@ AcceptsAnyKindOfImage.args = {
   hint: 'Select any type of image format',
   accept: 'image/*',
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+AcceptsAnyKindOfImage.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
 
 export const ErrorMessage = Template.bind(null);
 ErrorMessage.args = {
@@ -195,6 +217,11 @@ WithMaxFileSize.args = {
   hint: 'An error will be thrown if the selected file is greater than 1 KB',
   maxFileSize: 1024,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+WithMaxFileSize.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const WithMinFileSize = Template.bind(null);
 WithMinFileSize.args = {
@@ -203,6 +230,11 @@ WithMinFileSize.args = {
   hint: 'An error will be thrown if the selected file is less than 1 MB',
   minFileSize: 1024*1024,
 }
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+WithMinFileSize.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const HeaderLabel = Template.bind(null);
 HeaderLabel.args = {
@@ -236,6 +268,12 @@ AdditionalFormInputs.args = {
   label: 'Additional Form Inputs',
   children: additionalFormInputsContent,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+AdditionalFormInputs.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
 
 const CustomValidationTemplate = ({
   label,
@@ -336,6 +374,11 @@ CustomValidation.args = {
   label: "Upload a file which does not contain the character 'X'",
   hint: 'Select a .txt file',
   accept: '.txt',
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+CustomValidation.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 export const WithAnalytics = Template.bind(null);
@@ -453,6 +496,11 @@ const PercentUploadedTemplate = args => {
 
 export const WithPercentUploaded = PercentUploadedTemplate.bind(null);
 WithPercentUploaded.args = { ...defaultArgs };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+WithPercentUploaded.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 const VisualStateResetTemplate = args => {
   const [reset, setReset] = useState(false);
@@ -491,3 +539,8 @@ const VisualStateResetTemplate = args => {
 
 export const WithVisualStateReset = VisualStateResetTemplate.bind(null);
 WithVisualStateReset.args = { ...defaultArgs };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+WithVisualStateReset.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-icon-uswds.stories.tsx
+++ b/packages/storybook/stories/va-icon-uswds.stories.tsx
@@ -137,6 +137,7 @@ globalThis.setVaIconSpriteLocation('[custom sprite path]');
 }
 export const GlobalSpritePathConfiguration = iconPathConfigurationDocs.bind(null);
 GlobalSpritePathConfiguration.parameters = {
+  chromatic: { disableSnapshot: true },
   docs: {
     canvas: {
       sourceState: 'none',

--- a/packages/storybook/stories/va-link.stories.tsx
+++ b/packages/storybook/stories/va-link.stories.tsx
@@ -380,3 +380,6 @@ WithRouterLinkSupport.args = {
   href: 'https://va.gov/',
   text: 'example router link',
 };
+WithRouterLinkSupport.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-loading-indicator.stories.tsx
+++ b/packages/storybook/stories/va-loading-indicator.stories.tsx
@@ -61,6 +61,12 @@ Default.argTypes = propStructure(loadingIndicatorDocs);
 
 export const SetFocus = Template.bind(null);
 SetFocus.args = { ...defaultArgs, 'set-focus': true };
+SetFocus.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const EnableAnalytics = Template.bind(null);
 EnableAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
+EnableAnalytics.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-modal-uswds.stories.tsx
+++ b/packages/storybook/stories/va-modal-uswds.stories.tsx
@@ -240,6 +240,11 @@ ClickOutsideToClose.args = {
   ...defaultArgs,
   'click-to-close': true,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+ClickOutsideToClose.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const WithoutButtons = Template.bind(null);
 WithoutButtons.args = {

--- a/packages/storybook/stories/va-modal-uswds.stories.tsx
+++ b/packages/storybook/stories/va-modal-uswds.stories.tsx
@@ -22,20 +22,20 @@ export default {
         useEffect(() => {
           // Function to scroll to top
           const scrollToTop = () => window.scrollTo(0, 0);
-          
+
           // Immediate scroll
           scrollToTop();
-          
+
           // Schedule multiple scroll attempts with increasing delays
           // This helps ensure scrolling works even if Storybook does additional rendering
-          const timers = [50, 100, 300, 500, 1000].map(delay => 
+          const timers = [50, 100, 300, 500, 1000].map(delay =>
             setTimeout(scrollToTop, delay)
           );
-          
+
           // Clean up timers on unmount
           return () => timers.forEach(clearTimeout);
         }, []);
-        
+
         return (
           <>
             <style>
@@ -262,6 +262,9 @@ WithoutTitleAndWithLabel.args = {
   ...defaultArgs,
   'modal-title': undefined,
   'label': 'A test modal',
+};
+WithoutTitleAndWithLabel.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 export const WithInitialFocusSelector = Template.bind(null);

--- a/packages/storybook/stories/va-notification.stories.tsx
+++ b/packages/storybook/stories/va-notification.stories.tsx
@@ -13,6 +13,7 @@ export default {
     },
   },
   parameters: {
+    chromatic: { disableSnapshot: true },
     componentSubtitle: 'va-notification web component',
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={notificationDocs} />,

--- a/packages/storybook/stories/va-omb-info.stories.tsx
+++ b/packages/storybook/stories/va-omb-info.stories.tsx
@@ -97,3 +97,8 @@ Children.args = {
   ...defaultArgs,
   'benefit-type': undefined,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Children.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-on-this-page.stories.tsx
+++ b/packages/storybook/stories/va-on-this-page.stories.tsx
@@ -82,6 +82,11 @@ const I18nTemplate = args => {
 export const Default = Template.bind(null);
 
 export const Internationalization = I18nTemplate.bind(null);
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Internationalization.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const CustomHeaderLevel = Template.bind(null);
 CustomHeaderLevel.args = {

--- a/packages/storybook/stories/va-pagination-uswds.stories.tsx
+++ b/packages/storybook/stories/va-pagination-uswds.stories.tsx
@@ -118,3 +118,8 @@ export const Internationalization = () => {
     </div>
   );
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Internationalization.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-privacy-agreement-uswds.stories.tsx
+++ b/packages/storybook/stories/va-privacy-agreement-uswds.stories.tsx
@@ -56,3 +56,6 @@ WithError.args = { ...defaultArgs, 'show-error': true };
 
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
+WithAnalytics.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-promo-banner.stories.tsx
+++ b/packages/storybook/stories/va-promo-banner.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: 'Deprecated/Banner - Promo',
   id: 'components/va-promo-banner',
   parameters: {
+    chromatic: { disableSnapshot: true },
     componentSubtitle: 'va-promo-banner web component',
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={promoBannerDocs} />,

--- a/packages/storybook/stories/va-radio-uswds.stories.tsx
+++ b/packages/storybook/stories/va-radio-uswds.stories.tsx
@@ -507,6 +507,9 @@ export const ReactWithCustomEvent = ReactBindingExample.bind(null);
 ReactWithCustomEvent.args = {
   ...defaultArgs,
 };
+ReactWithCustomEvent.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const Error = USWDSTiledError.bind(null);
 Error.args = {

--- a/packages/storybook/stories/va-radio-uswds.stories.tsx
+++ b/packages/storybook/stories/va-radio-uswds.stories.tsx
@@ -522,6 +522,11 @@ IDUsage.args = {
   ...defaultArgs,
   required: true,
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+IDUsage.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const withDescriptionMessage = withDescriptionMessageTemplate.bind(null);
 withDescriptionMessage.args = {
@@ -533,6 +538,11 @@ Internationalization.args = {
   ...defaultArgs,
   name: 'i18n-example',
   required: true,
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Internationalization.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 export const FormsPatternSingle = FormsPatternSingleTemplate.bind(null);

--- a/packages/storybook/stories/va-search-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-search-input-uswds.stories.tsx
@@ -132,3 +132,8 @@ WithTypeahead.args = {
   value: '',
   suggestions: [],
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+WithTypeahead.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-segmented-progress-bar-uswds.stories.tsx
+++ b/packages/storybook/stories/va-segmented-progress-bar-uswds.stories.tsx
@@ -176,6 +176,9 @@ CustomProgressTerm.args = {
   headerLevel: 2,
   progressTerm: 'Chapter',
 };
+CustomProgressTerm.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const LongHeaderCausingWrap = Template.bind(null);
 LongHeaderCausingWrap.args = {

--- a/packages/storybook/stories/va-select-uswds.stories.tsx
+++ b/packages/storybook/stories/va-select-uswds.stories.tsx
@@ -185,6 +185,11 @@ ErrorMessage.args = { ...defaultArgs, error: 'There was a problem' };
 
 export const DynamicOptions = Template.bind(null);
 DynamicOptions.args = { ...defaultArgs, 'use-add-button': true };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+DynamicOptions.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const OptGroups = Template.bind(null);
 OptGroups.args = {
@@ -202,6 +207,11 @@ OptGroups.args = {
     </optgroup>,
   ],
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+OptGroups.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const OptGroupsWithOptions = Template.bind(null);
 OptGroupsWithOptions.args = {
@@ -218,6 +228,11 @@ OptGroupsWithOptions.args = {
       Other
     </option>,
   ],
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+OptGroupsWithOptions.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 export const ReadOnly = InertTemplate.bind(null);
@@ -242,6 +257,11 @@ const I18nTemplate = args => {
 
 export const Internationalization = I18nTemplate.bind(null);
 Internationalization.args = { ...defaultArgs, required: true };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Internationalization.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 const WidthsTemplate = ({
   label,

--- a/packages/storybook/stories/va-sidenav.stories.tsx
+++ b/packages/storybook/stories/va-sidenav.stories.tsx
@@ -27,10 +27,10 @@ export default {
   parameters: {
     componentSubtitle: 'va-sidenav web component',
     docs: {
-      page: () => <StoryDocs 
-        storyDefault={Default} 
-        data={sidenavDocs} 
-        componentName="va-sidenav" 
+      page: () => <StoryDocs
+        storyDefault={Default}
+        data={sidenavDocs}
+        componentName="va-sidenav"
       />,
     },
     chromatic: {
@@ -67,33 +67,33 @@ const Template = (args) => {
   }
 
   return (
-    <va-sidenav 
+    <va-sidenav
       id={args.id}
       header={args.header}
       icon-name={args['icon-name']}
       icon-background-color={args['icon-background-color']}>
-      {sideNav.map((item, index) => 
+      {sideNav.map((item, index) =>
         item.submenu ? (
-          <va-sidenav-submenu 
-            {...withKey(`item-${index}`)} 
-            label={item.label} 
-            href={item.href} 
+          <va-sidenav-submenu
+            {...withKey(`item-${index}`)}
+            label={item.label}
+            href={item.href}
             onClick={ (e) => handleClick(e)}>
-            {item.submenu.map((submenuItem, submenuIndex) => 
-              <va-sidenav-item 
-                {...withKey(`item-${index}-${submenuIndex}`)} 
-                href={submenuItem.href} 
-                label={submenuItem.label} 
+            {item.submenu.map((submenuItem, submenuIndex) =>
+              <va-sidenav-item
+                {...withKey(`item-${index}-${submenuIndex}`)}
+                href={submenuItem.href}
+                label={submenuItem.label}
                 onClick={ (e) => handleClick(e)}>
               </va-sidenav-item>
             )}
           </va-sidenav-submenu>
         ) : (
-          <va-sidenav-item 
-            {...withKey(`item-${index}`)} 
-            current-page={item['current-page']} 
-            href={item.href} 
-            label={item.label} 
+          <va-sidenav-item
+            {...withKey(`item-${index}`)}
+            current-page={item['current-page']}
+            href={item.href}
+            label={item.label}
             onClick={ (e) => handleClick(e)}
           ></va-sidenav-item>
         )
@@ -120,9 +120,9 @@ const WithRouterTemplate = (args) => {
       <p>
         The navigation items in this example have a{' '}
         <code>router-link</code> property. When the corresponding anchor
-        tag is clicked, these links emit a <code>VaRouteChange</code> event that 
-        contains the href of the clicked link. This event can be handled in a 
-        React component where utilities provided by React Router can be used to 
+        tag is clicked, these links emit a <code>VaRouteChange</code> event that
+        contains the href of the clicked link. This event can be handled in a
+        React component where utilities provided by React Router can be used to
         change the page under view, as in the example below:
       </p>
       <pre className="vads-u-font-size--sm vads-u-background-color--gray-lightest vads-u-padding--2">
@@ -176,31 +176,31 @@ const WithRouterTemplate = (args) => {
       <p id="route-change-message"></p>
 
       <va-sidenav
-        id="router-sidenav" 
+        id="router-sidenav"
         header={args.header}
         icon-name={args['icon-name']}
         icon-background-color={args['icon-background-color']}>
         <VaSidenavItem
-          href="/contact-info" 
+          href="/contact-info"
           label="Contact information"
           router-link={true}
           onClick={(e) => handleClick(e)}
           onVaRouteChange={handleRouteChange}></VaSidenavItem>
         <VaSidenavItem
-          href="/personal-info" 
-          label="Personal information" 
+          href="/personal-info"
+          label="Personal information"
           router-link={true}
           onClick={(e) => handleClick(e)}
           onVaRouteChange={handleRouteChange}></VaSidenavItem>
         <VaSidenavItem
-          href="/military-service" 
-          label="Military service" 
+          href="/military-service"
+          label="Military service"
           router-link={true}
           onClick={(e) => handleClick(e)}
           onVaRouteChange={handleRouteChange}></VaSidenavItem>
       </va-sidenav>
     </div>
-  ) 
+  )
 }
 
 function sideNavBaseline() {
@@ -334,3 +334,6 @@ WithRouterLinkSupport.args = {
   id: 'router-link-sidenav',
 };
 WithRouterLinkSupport.argTypes = propStructure(sidenavDocs);
+WithRouterLinkSupport.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/storybook/stories/va-tabs.stories.tsx
+++ b/packages/storybook/stories/va-tabs.stories.tsx
@@ -245,7 +245,9 @@ WithHeadingNotMatchingTab.decorators = [(Story) => (
     <Story />
   </>
 )];
-
+WithHeadingNotMatchingTab.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const WithAdditionalTabItem = Template.bind(null);
 WithAdditionalTabItem.args = {
@@ -264,7 +266,7 @@ WithAdditionalTabItem.argTypes = propStructure(tabsDocs);
 WithAdditionalTabItem.decorators = [(Story) => (
   <>
     {internalTestingAlert(
-      'how the component behaves when an additional tab item is added. At this point, only three tabs are recommended', 
+      'how the component behaves when an additional tab item is added. At this point, only three tabs are recommended',
       true
     )}
     <Story />

--- a/packages/storybook/stories/va-telephone.stories.tsx
+++ b/packages/storybook/stories/va-telephone.stories.tsx
@@ -156,6 +156,9 @@ AriaDescribedBy.args = {
   ...defaultArgs,
   'message-aria-describedby': 'Main number to facility',
 };
+AriaDescribedBy.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const VanityNumber = Template.bind(null);
 VanityNumber.args = {

--- a/packages/storybook/stories/va-text-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.tsx
@@ -424,9 +424,15 @@ Autocomplete.args = {
   autocomplete: 'email',
   label: 'This va-text-input is configured for email autocompletion',
 };
+Autocomplete.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
+WithAnalytics.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const WithHintText = Template.bind(null);
 WithHintText.args = { ...defaultArgs, hint: 'This is hint text' };
@@ -451,6 +457,9 @@ const WithInlineHintTextTemplate = ({ name, label }) => {
 
 export const WithInlineHintText = WithInlineHintTextTemplate.bind(null);
 WithInlineHintText.args = { ...defaultArgs, label: 'My input (with hint)' };
+WithInlineHintText.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 const WithAdditionalInfoTemplate = ({ name, label }) => {
   return (

--- a/packages/storybook/stories/va-text-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.tsx
@@ -347,12 +347,22 @@ Internationalization.args = {
   required: true,
   maxlength: '6',
 };
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Internationalization.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const Pattern = Template.bind(null);
 Pattern.args = {
   ...defaultArgs,
   label: 'Must be 4 digits',
   pattern: '[0-9]{4}',
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+Pattern.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 export const ValidRange = Template.bind(null);
@@ -362,6 +372,11 @@ ValidRange.args = {
   min: 0,
   max: 4,
   hint: 'The valid range is 0 to 4',
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+ValidRange.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 export const Autocomplete = ({ name, label, autocomplete }) => {
@@ -444,6 +459,11 @@ WithStep.args = {
   inputmode: 'decimal',
   step: '.2',
   hint: 'step=".2" (only even values in tenth position valid)',
+};
+// Snapshots disabled because visual difference is only apparent after interaction.
+// TODO: Enable snapshots after integrating Storybook play function
+WithStep.parameters = {
+  chromatic: { disableSnapshot: true },
 };
 
 const WithInlineHintTextTemplate = ({ name, label }) => {

--- a/packages/storybook/stories/va-textarea-uswds.stories.tsx
+++ b/packages/storybook/stories/va-textarea-uswds.stories.tsx
@@ -306,6 +306,9 @@ WithHintTextAndHeaderLevel.args = {
 
 export const WithAnalytics = Template.bind(null);
 WithAnalytics.args = { ...defaultArgs, 'enable-analytics': true };
+WithAnalytics.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const ResizableControl = ResizableTemplate.bind(null);
 ResizableControl.args = { ...defaultArgs };


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `4744-disable-chromatic-snapshots` is a placeholder for a CI job - it will be updated automatically -->
https://4744-disable-chromatic-snapshots--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

**Disabled Chromatic snapshots on stories that do not provide useful visual regression test data.** This PR disables 105 stories, which is a 25% reduction in our snapshot count. I've added comments to these stories so that we can easily find and return to them later. 

> [!note]
> Approximately half of these disabled tests (52 tests) should have their snapshots re-enabled once we can test visual display after interaction via the [Storybook play function](https://storybook.js.org/docs/writing-stories/play-function). I've opened https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4858 to explore integrating the play function and Chromatic interaction tests. 

### Details

We disabled stories according to the following criteria (More details in the [Storybook standards doc](https://docs.google.com/document/d/1TVqq2RobJhYb0PeO0UUK58Iix6B-viDIihINfU-kzBw/edit?tab=t.q8gj9n90sk4e)):

> Enable UI snapshots for stories that show:
> 
> * Each visual variant or state of a component  
> * Common visual customizations in the component  
> * Content that tests the visual limits of the component, such as long text strings
> 
> Disable UI snapshots for stories that show:
> 
> * Deprecated components, patterns, or variants  
> * Redundant stories that duplicate visual coverage already provided by other stories, including:  
>   * Compositions of other stories or components  
> * Behavior or interaction differences that do not affect the visual display   
>   * Note: some stories show a visual difference only after interaction. These snapshots do not provide value *at this time* but the play function should enable us to programmatically interact with the component before Chromatic takes its snapshot.  
> * Screen reader-only features, such as changes to aria or lang attributes, screen reader-only updates, or focus management


#### Related links
- [Component stories spreadsheet with notes about disabling stories](https://docs.google.com/spreadsheets/u/1/d/1R5OE8xGfoO5cfIvLkg3yJoH3pGby6FVjDAQGq51iIxk/edit?ouid=113413942593090391882&usp=sheets_home&ths=true) (Google sheets :lock:)
- [Storybook standards doc](https://docs.google.com/document/d/1TVqq2RobJhYb0PeO0UUK58Iix6B-viDIihINfU-kzBw/edit?tab=t.q8gj9n90sk4e) (Google Docs :lock:)

### Impact


| Header | Total test/snapshot count | [Total turbosnap count](https://www.chromatic.com/docs/turbosnap/#pricing) |
|--------|--------|--------|
| Before | [430](https://www.chromatic.com/build?appId=65a6e2ed2314f7b8f98609d8&number=3782) | 86 |
| After | [324](https://www.chromatic.com/build?appId=65a6e2ed2314f7b8f98609d8&number=3788) | 65 |

<img width="1012" height="854" alt="image" src="https://github.com/user-attachments/assets/08555106-703d-43b3-954e-162507e2b9da" />



## Related tickets and links

<!-- 
Link to any related issues, PRs, Slack conversations, or anything else relevant to documenting the changes.
-->

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4744

## Screenshots

N/A

## Testing and review
- Confirm that disabling the snapshots worked, and the Chromatic snapshot count is lower
- Confirm that we do not need visual regression testing on the disabled stories
- Confirm that all the items marked as "No" in the story spreadsheet have been disabled

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
