### PR TITLE
Update copilot instructions with GitHub CLI usage guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -124,6 +124,12 @@ The repository includes automated weekly reporting via GitHub Actions:
 - Code review process for all changes
 - **Branch Protection Rules**: The repository requires all changes to be made through pull requests - direct pushes to main are not allowed
 
+### GitHub CLI Usage
+- When using `gh` commands to view issues or PRs, use the `--json` flag and pipe to `cat` to avoid output being caught in the less pager
+- **Example**: `gh pr view 1234 --json | cat` instead of `gh pr view 1234`
+- **Example**: `gh issue list --json | cat` instead of `gh issue list`
+- This prevents terminal paging issues and ensures clean output for AI processing
+
 ### Documentation
 - Comprehensive JSDoc for all public APIs
 - Storybook stories with controls and examples


### PR DESCRIPTION
## Overview

This PR adds GitHub CLI usage guidelines to the copilot instructions to prevent terminal paging issues when AI tools use gh commands.

## Changes

- Added new section "GitHub CLI Usage" with best practices
- Includes guidance to use `--json` flag and pipe to `cat` 
- Provides examples for viewing PRs and issues
- Helps ensure clean output for AI processing

## Context

This addresses paging issues that can occur when AI assistants use GitHub CLI commands like `gh pr view` or `gh issue list`, which can get caught in the less pager and cause problems with terminal interaction.