### PR TITLE
Storybook: set .9rem left padding for error borders

### DIFF
--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -135,11 +135,11 @@ export const initialGlobals = {
 export const decorators = [
   (Story, { parameters }) => 
   {
-    const pageLayout = parameters.layoutName;
+    const pageLayout = parameters.storyType;
     switch (pageLayout) {
       case 'form':
         return (
-          <div className='sb-layout--form'>
+          <div className='sb-type--form'>
             <Story />
           </div>
         );

--- a/packages/storybook/.storybook/style.scss
+++ b/packages/storybook/.storybook/style.scss
@@ -69,7 +69,7 @@ button {
 /**
 * Applies left margin for form element stories to allow the error border-left to be visible.
 */
-.sb-layout--form {
+.sb-type--form {
   @include media($small-desktop-screen) {
     margin-left: .9rem;
   }

--- a/packages/storybook/stories/va-checkbox-group-uswds.stories.tsx
+++ b/packages/storybook/stories/va-checkbox-group-uswds.stories.tsx
@@ -24,7 +24,7 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={checkBoxGroupDocs} />,
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
   argTypes: {
     ...propStructure(checkBoxGroupDocs),

--- a/packages/storybook/stories/va-checkbox-uswds.stories.tsx
+++ b/packages/storybook/stories/va-checkbox-uswds.stories.tsx
@@ -17,7 +17,7 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={checkboxDocs} />,
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
 };
 

--- a/packages/storybook/stories/va-combo-box-uswds.stories.tsx
+++ b/packages/storybook/stories/va-combo-box-uswds.stories.tsx
@@ -16,7 +16,7 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={comboBoxDocs} />,
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
   argTypes: {
     ...propStructure(comboBoxDocs),

--- a/packages/storybook/stories/va-date.stories.tsx
+++ b/packages/storybook/stories/va-date.stories.tsx
@@ -14,7 +14,7 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={dateDocs} />,
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
 };
 

--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
@@ -17,7 +17,7 @@ export default {
         <StoryDocs storyDefault={Default} data={fileInputMultipleDocs} />
       ),
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
 };
 

--- a/packages/storybook/stories/va-file-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-uswds.stories.tsx
@@ -22,7 +22,7 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={fileInputDocs} />,
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
   argTypes: {
     ...propStructure(fileInputDocs),

--- a/packages/storybook/stories/va-memorable-date-uswds.stories.tsx
+++ b/packages/storybook/stories/va-memorable-date-uswds.stories.tsx
@@ -21,7 +21,7 @@ export default {
         <StoryDocs storyDefault={Default} data={memorableDateInputDocs} />
       ),
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
 };
 

--- a/packages/storybook/stories/va-radio-uswds.stories.tsx
+++ b/packages/storybook/stories/va-radio-uswds.stories.tsx
@@ -31,7 +31,7 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={radioDocs} />,
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
   argTypes: {
       ...propStructure(radioDocs),

--- a/packages/storybook/stories/va-select-uswds.stories.tsx
+++ b/packages/storybook/stories/va-select-uswds.stories.tsx
@@ -18,7 +18,7 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={selectDocs} />,
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
   argTypes: {
     ...propStructure(selectDocs),

--- a/packages/storybook/stories/va-telephone-input.stories.tsx
+++ b/packages/storybook/stories/va-telephone-input.stories.tsx
@@ -17,7 +17,7 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={inputTelephoneDocs} />,
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
 };
 

--- a/packages/storybook/stories/va-text-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.tsx
@@ -16,7 +16,7 @@ export default {
   id: 'uswds/va-text-input',
   parameters: {
     componentSubtitle: 'va-text-input web component',
-    layoutName: 'form',
+    storyType: 'form',
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={textInputDocs} />,
     },

--- a/packages/storybook/stories/va-textarea-uswds.stories.tsx
+++ b/packages/storybook/stories/va-textarea-uswds.stories.tsx
@@ -18,7 +18,7 @@ export default {
     docs: {
       page: () => <StoryDocs storyDefault={Default} data={textareaDocs} />,
     },
-    layoutName: 'form',
+    storyType: 'form',
   },
   argTypes: {
     ...propStructure(textareaDocs),


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `4645-sb-error-state-border` is a placeholder for a CI job - it will be updated automatically -->
https://4645-sb-error-state-border--65a6e2ed2314f7b8f98609d8.chromatic.com

## Description

This pull request updates the Storybook configuration and several component stories to support a new "form" layout option. The most significant change is the addition of a conditional decorator in `preview.js` that applies specific padding and margin styles when the "form" layout is requested. Additionally, the "form" layout parameter is added to multiple component stories to ensure consistent styling across form-related components.

**Storybook configuration improvements:**

* The `decorators` array in `packages/storybook/.storybook/preview.js` now checks the `layout` parameter and applies custom padding and margin for stories using the "form" layout, improving visual consistency for form components.

**Component story updates for "form" layout:**

* Added `layout: 'form'` to the `parameters` of the following stories to enable the new layout:
  - `va-checkbox-group-uswds.stories.tsx`
  - `va-checkbox-uswds.stories.tsx`
  - `va-combo-box-uswds.stories.tsx`
  - `va-date.stories.tsx`
  - `va-file-input-multiple-uswds.stories.tsx`
  - `va-file-input-uswds.stories.tsx`
  - `va-memorable-date-uswds.stories.tsx`
  - `va-radio-uswds.stories.tsx`
  - `va-select-uswds.stories.tsx`
  - `va-telephone-input.stories.tsx`
  - `va-text-input-uswds.stories.tsx`
  - `va-textarea-uswds.stories.tsx`

## Related tickets and links

Closes [4645](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4645)

## Screenshots

Before: 
<img width="513" height="514" alt="Screenshot 2025-12-01 at 11 23 55 AM" src="https://github.com/user-attachments/assets/f0102ebe-c7be-49a4-aee7-9854546ec285" />

After:
<img width="540" height="501" alt="Screenshot 2025-12-01 at 11 23 03 AM" src="https://github.com/user-attachments/assets/c2e9b006-558b-4a08-96b3-6d3bc3900c77" />



## Testing and review

The left border should be visible on any form component with an left border error state (text input, text area, date input, etc)

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
