### PR TITLE
va-button: Revert PR #1946 "VaButton submit fire order"

### DIFF
--- a/packages/web-components/src/components/va-button/test/va-button.e2e.ts
+++ b/packages/web-components/src/components/va-button/test/va-button.e2e.ts
@@ -1,12 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 import { axeCheck } from '../../../testing/test-helpers';
 
-declare global {
-  interface Window {
-    eventOrder: string[];
-  }
-}
-
 describe('va-button', () => {
   it('renders a button with text Edit', async () => {
     const page = await newE2EPage();
@@ -320,63 +314,15 @@ describe('va-button', () => {
     `);
   });
 
-  it('submit is not triggered when submit=skip is set', async () => {
+  it('submits form when clicked', async () => {
     const page = await newE2EPage();
-    await page.setContent('<form><va-button submit="skip" continue></va-button></form>');
+    await page.setContent(
+      '<form onsubmit="e=>{e.preventDefault();}"><va-button submit text="Submit"></va-button></form>',
+    );
     const submitSpy = await page.spyOnEvent('submit');
-    const button = await page.find('va-button[continue]');
-    await button.click();
-    await page.waitForChanges();
-    expect(submitSpy).toHaveReceivedEventTimes(0);
-  });
-
-  it('submit is triggered when submit=prevent is set', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<form onsubmit="e=>{e.preventDefault();}"><va-button submit="prevent" continue></va-button></form>');
-    const submitSpy = await page.spyOnEvent('submit');
-    const button = await page.find('va-button[continue]');
+    const button = await page.find('va-button >>> button');
     await button.click();
     await page.waitForChanges();
     expect(submitSpy).toHaveReceivedEventTimes(1);
   });
-
-  it('fires consumer onClick before onSubmit when submit=prevent', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(`
-      <script>
-        window.eventOrder = [];
-
-        function handleClick() {
-          window.eventOrder.push('click');
-        }
-
-        function handleSubmit() {
-          window.eventOrder.push('submit');
-        }
-      </script>
-
-      <form onsubmit="handleSubmit()">
-        <va-button
-          submit="prevent"
-          continue
-          onclick="handleClick()"
-          >
-        </va-button>
-      </form>
-    `);
-
-    const submitSpy = await page.spyOnEvent('submit');
-    const button = await page.find('va-button[continue]');
-
-    await button.click();
-    await page.waitForChanges();
-
-    expect(submitSpy).toHaveReceivedEventTimes(1);
-
-    // Assert ordering
-    const order = await page.evaluate(() => window.eventOrder);
-    expect(order).toEqual(['click', 'submit']);
-  });
-
 });

--- a/packages/web-components/src/components/va-button/va-button.tsx
+++ b/packages/web-components/src/components/va-button/va-button.tsx
@@ -173,16 +173,11 @@ export class VaButton {
       cancelable: true,
       composed: true,
     });
-
     if (this.submit !== 'skip') {
-      setTimeout(() => {
-        formElement.dispatchEvent(submitEvent);
-      }, 100);
+      formElement.dispatchEvent(submitEvent);
     }
     if (this.submit !== 'prevent') {
-      setTimeout(() => {
-        formElement.submit();
-      }, 200);
+      formElement.submit();
     }
   }
 


### PR DESCRIPTION
## Summary

Reverted department-of-veterans-affairs/component-library#1946

When we ran this update through the full test suite on vets-website, we discovered a failure that indicated a potential issue in the approach to this fix. Setting a timeout on the submit action is likely unexpected for downstream teams and could result in unintended behavior. Reverting this change will allow us to figure out the best path forward for synchronizing submit events. 

## Related links
- [Summary of test failures on vets-website for v54.6.0](https://github.com/department-of-veterans-affairs/vets-website/pull/41995#issuecomment-3842639981)