### PR TITLE
[ComboBox]: In React Updates Text When value Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ yarn-error.log*
 *.tsbuildinfo
 .npm
 .eslintcache
+.tool-versions
 
 .yarn/*
 !.yarn/patches

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@department-of-veterans-affairs/component-library",
   "description": "VA.gov component library. Includes React and web components.",
-  "version": "56.1.0",
+  "version": "56.2.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/web-components",
-  "version": "24.1.0",
+  "version": "24.2.0",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/web-components/src/components/va-combo-box/va-combo-box.tsx
+++ b/packages/web-components/src/components/va-combo-box/va-combo-box.tsx
@@ -9,7 +9,7 @@ import {
   h,
   State,
   Fragment,
-  Watch, 
+  Watch,
   Listen
 } from '@stencil/core';
 import classnames from 'classnames';
@@ -86,9 +86,8 @@ export class VaComboBox {
    */
   @Prop() messageAriaDescribedby?: string;
 
-
   /**
-   * Whether to show error message text 
+   * Whether to show error message text
    */
   @Prop() showInputError?: boolean = true;
 
@@ -99,9 +98,33 @@ export class VaComboBox {
       if (newValue) {
         input.classList.add('usa-input--error');
       } else {
-        input.classList.remove('usa-input--error')
+        input.classList.remove('usa-input--error');
       }
     }
+  }
+
+  @Watch('value')
+  updateInputValueOnValueChange(newValue: string) {
+    const inputElement = this.el.shadowRoot.querySelector('input');
+    if (inputElement) inputElement.value = newValue;
+  }
+
+  /**
+   * When options are updated, and the property value set does not match the input el value,
+   * but the option does exist now:
+   * update the input el value to match the property value
+   */
+  @Watch('options')
+  updateInputValueOnOptionsChange() {
+    const inputElement = this.el.shadowRoot.querySelector('input');
+    const allNodes = this.el.querySelectorAll('option') as Array<HTMLOptionElement>;
+    const nodes = Array.from(allNodes);
+    if (
+      inputElement &&
+      inputElement.value !== this.value &&
+      nodes.some(option => option.value === this.value)
+    )
+      inputElement.value = this.value;
   }
 
   /**
@@ -110,7 +133,9 @@ export class VaComboBox {
   @Event() vaSelect: EventEmitter;
 
   componentWillLoad() {
-    this.isInVaInputTelephone = this.el.parentElement?.classList.contains('va-input-telephone-wrapper');
+    this.isInVaInputTelephone = this.el.parentElement?.classList.contains(
+      'va-input-telephone-wrapper',
+    );
     this.populateOptions();
   }
 
@@ -128,10 +153,14 @@ export class VaComboBox {
       const comboBoxEl = this.el.shadowRoot.querySelector('div.usa-combo-box');
       const flagSpan = document.createElement('span');
       this.value = !!this.value ? this.value : 'US';
-      flagSpan.classList.add('flag', `flag-${this.value.toLowerCase()}`, 'dynamic-flag');
+      flagSpan.classList.add(
+        'flag',
+        `flag-${this.value.toLowerCase()}`,
+        'dynamic-flag',
+      );
       comboBoxEl.appendChild(flagSpan);
     }
-    
+
     if (comboBoxElement) {
       comboBox.init(comboBoxElement, labelElement, this.value);
       comboBox.on(comboBoxElement);
@@ -171,51 +200,53 @@ export class VaComboBox {
     const allNodes = this.el.querySelectorAll('option, optgroup');
 
     const nodes = Array.from(allNodes);
-    this.options = nodes.map((node: HTMLOptionElement | HTMLOptGroupElement, index) => {
-      if (node.nodeName.toLowerCase() === 'optgroup') {
-        return (
-          <Fragment>
-            {/* adding data-optgroup attribute to identify this element as an optgroup header
-             * assigning unique id to reference in va-combo-box-library.js while transforming options to <li> elements
-             */}
-            <option data-optgroup="true" id={'optgroup-' + index}>
-              {node.label}
-            </option>
+    this.options = nodes.map(
+      (node: HTMLOptionElement | HTMLOptGroupElement, index) => {
+        if (node.nodeName.toLowerCase() === 'optgroup') {
+          return (
+            <Fragment>
+              {/* adding data-optgroup attribute to identify this element as an optgroup header
+               * assigning unique id to reference in va-combo-box-library.js while transforming options to <li> elements
+               */}
+              <option data-optgroup="true" id={'optgroup-' + index}>
+                {node.label}
+              </option>
 
-            {/* iterate through all children <option> elements within an <optgroup>
-             * assign specific attributes
-             * add aria-described bto associate <option> with an <optgroup> for SR */}
-            {Array.from(node.children).map((child: HTMLOptionElement) => {
-              return (
-                <option
-                  value={child.value}
-                  selected={value === child.value}
-                  data-optgroup-option="true"
-                  aria-describedby={'optgroup-' + index}
-                >
-                  {child.text}
-                </option>
-              );
-            })}
-          </Fragment>
-        );
-      } else if (
-        node.nodeName.toLowerCase() === 'option' &&
-        node.parentElement.nodeName.toLowerCase() !== 'optgroup'
-      ) {
-        {
-          /* handling <option> elements that are not nested within <optgroup> element */
+              {/* iterate through all children <option> elements within an <optgroup>
+               * assign specific attributes
+               * add aria-described bto associate <option> with an <optgroup> for SR */}
+              {Array.from(node.children).map((child: HTMLOptionElement) => {
+                return (
+                  <option
+                    value={child.value}
+                    selected={value === child.value}
+                    data-optgroup-option="true"
+                    aria-describedby={'optgroup-' + index}
+                  >
+                    {child.text}
+                  </option>
+                );
+              })}
+            </Fragment>
+          );
+        } else if (
+          node.nodeName.toLowerCase() === 'option' &&
+          node.parentElement.nodeName.toLowerCase() !== 'optgroup'
+        ) {
+          {
+            /* handling <option> elements that are not nested within <optgroup> element */
+          }
+          return (
+            <option
+              value={(node as HTMLOptionElement).value}
+              selected={value === (node as HTMLOptionElement).value}
+            >
+              {node.textContent}
+            </option>
+          );
         }
-        return (
-          <option
-            value={(node as HTMLOptionElement).value}
-            selected={value === (node as HTMLOptionElement).value}
-          >
-            {node.textContent}
-          </option>
-        );
-      }
-    });
+      },
+    );
   }
 
   private handleChange(e: Event) {
@@ -249,7 +280,7 @@ export class VaComboBox {
       hint,
       messageAriaDescribedby,
       showInputError,
-      isInVaInputTelephone
+      isInVaInputTelephone,
     } = this;
     const labelClass = classnames({
       'usa-label': true,
@@ -257,11 +288,16 @@ export class VaComboBox {
     });
     const comboBoxContainerClass = classnames({
       'usa-combo-box': true,
-      'input-telephone-wrapper': isInVaInputTelephone
-    })
+      'input-telephone-wrapper': isInVaInputTelephone,
+    });
     return (
       <Host>
-        <label htmlFor="options" class={labelClass} id="options-label" part="label">
+        <label
+          htmlFor="options"
+          class={labelClass}
+          id="options-label"
+          part="label"
+        >
           {label}
           {required && (
             <span class="usa-label--required"> {i18next.t('required')}</span>


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `{{head.ref}}` is a placeholder for a CI job - it will be updated automatically -->
https://{{head.ref}}--65a6e2ed2314f7b8f98609d8.chromatic.com


# Summary
Fix how component works in React to align with expected results
<!--
A successful summary is written in the past tense and includes:
**A benefit statement.** A description of the update.
See [component-library release notes](https://github.com/department-of-veterans-affairs/component-library/releases) for examples.
-->

## Description

- If value is set but options is empty because of an asynchronous load, this now causes the value to be set in the text field if the options loads with that text as a valid option.
- This also allows upstream changes to value to update the input text regardless of options
- Also added .gitignore line for asdf versioning of packages as an alternative to nvm
- Also my IDE automatically ran eslint on the file so there are a lot of syntax changes I didn't personally write

<!-- 
Consider:
    - What is relevant to code reviewer(s)?
    - What context may be relevant to a future dev or you in 6 months about this PR?
    - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 -->

## Related tickets and links
https://dsva.slack.com/archives/C01DBGX4P45/p1772646306360519
https://dsva.slack.com/archives/C01DBGX4P45/p1773330473480909

<!-- 
Leverage supported Github keywords like "closed", "fixes", or "resolves". When a github ticket is added directly after 
one of those keywords, it will trigger auto-closure of the issue upon merging.
 -->

Closes #_[issue_no]_

## Screenshots
There are no changes to styling or other direct visual elements, this merely changes logic of the component, adding text into the box programmatically rather than just through user interaction

## Testing and review
* When using this component in React, have an initial value set that is a possible option but have the options be an empty array
* After load, asynchronously update options to be filled with values
* The text should now fill with the selected option

For other watch function:
* Any changes upstream to value after initial load
  * For the specific usecase this is fixing, we are setting the value to null/empty string to clear it

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
