### PR TITLE
va-on-this-page: Filter sr-only text from h2 link content

### DIFF
--- a/packages/storybook/stories/va-on-this-page.stories.tsx
+++ b/packages/storybook/stories/va-on-this-page.stories.tsx
@@ -50,7 +50,7 @@ const Template = ({
     </ul>
     <h2 id="telephone-contacts">Telephone Contacts</h2>
     <p>Here is a table of phone numbers</p>
-    <h2 id="some-additional-info"><span className="usa-sr-only">SR only placeholder</span>Some additional information</h2>
+    <h2 id="some-additional-info">Some additional information</h2>
     <p>Placeholder for additional content.</p>
     <ol>
       <li>Alpha</li>

--- a/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
+++ b/packages/web-components/src/components/va-on-this-page/va-on-this-page.tsx
@@ -52,6 +52,17 @@ export class VaOnThisPage {
   };
 
   /**
+   * Determines whether an element is visible to the user.
+   */
+  private isVisibleElement = (node: HTMLElement): boolean => {
+    return !node.classList?.contains('usa-sr-only') &&
+           !node.classList?.contains('sr-only') &&
+            node.style?.visibility !== 'hidden' &&
+            node.style?.display !== 'none' &&
+            node.checkVisibility();
+  };
+
+  /**
    * Creates the link label text from an h2.
    *
    * This filters out common screen-reader-only classes and invisible elements
@@ -64,11 +75,7 @@ export class VaOnThisPage {
           return node.textContent;
         }
         const elementNode = node as HTMLElement;
-        return elementNode.classList?.contains('usa-sr-only') ||
-          elementNode.classList?.contains('sr-only') ||
-                elementNode.style?.visibility === 'hidden' ||
-                elementNode.style?.display === 'none' ||
-                !elementNode.checkVisibility() ? '' : elementNode.textContent;
+        return this.isVisibleElement(elementNode) ? (elementNode.textContent || '') : '';
       }).join(' ');
   };
 


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `5897-on-this-page-sr-only` is a placeholder for a CI job - it will be updated automatically -->
https://5897-on-this-page-sr-only--65a6e2ed2314f7b8f98609d8.chromatic.com


# Summary

Filters out sr-only content from the generated link text

## Description

Updated logic to filter out sr-only text from h2 elements that are used to generate the "On this page" links.

## Related tickets and links

_Link to any related issues, PRs, Slack conversations, or anything else relevant to documenting the changes._

<!-- 
Leverage supported Github keywords like "closed", "fixes", or "resolves". When a github ticket is added directly after 
one of those keywords, it will trigger auto-closure of the issue upon merging.
 -->

Closes #[5897](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5897)

## Screenshots
Before:
<img width="522" height="223" alt="Screenshot 2026-03-12 at 3 09 48 PM" src="https://github.com/user-attachments/assets/dd979bef-15f5-4ed4-bd0c-dc9d5f0da4e9" />

After:
<img width="442" height="184" alt="Screenshot 2026-03-12 at 3 08 27 PM" src="https://github.com/user-attachments/assets/a8ec4456-7bfc-402f-a0d3-7cdfebcb09c8" />

_If there are any visual changes, screenshots should be added here._

## Testing and review

_Provide any testing instructions or review steps as needed._

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
