### PR TITLE
fix(dashboard-cli): stable CSV column order and 10-10D form number

### DIFF
--- a/packages/design-system-dashboard-cli/src/find-form-apps.js
+++ b/packages/design-system-dashboard-cli/src/find-form-apps.js
@@ -24,7 +24,8 @@ function extractFormNumber(manifest) {
     /\((\d{2}[A-Z]?-\d{4,5})\)/i,                       // In parentheses: (21P-0537)
     /\b(\d{2}-\d{4,5}[A-Z0-9]*)\b/i,                    // Full format: 22-1995, 40-10007, 21-10210
     /\b(\d{2}[A-Z]-\d{4,5}[A-Z0-9]*)\b/i,               // With letter: 21P-0537, 21P-0847
-    /\b(\d{2,3}-\d{2,3}[A-Z]{2,})\b/i,                  // 10-10EZ format
+    /\b(\d{2,3}-\d{2,3}[A-Z]{2,})\b/i,                  // 10-10EZ, 10-10CG format (2+ letter suffix)
+    /\b(\d{2,3}-\d{2,3}[A-Z])\b/i,                      // 10-10D format (single letter suffix)
     /\bform[- ]?(\d{1,3}[A-Z]?-\d{1,5}[A-Z0-9]*)\b/i,  // "form-21-4142" or "form 20-0995"
     /\b(\d{4,5}[A-Z]{2,})\b/,                           // Compact: 1010EZ, 527EZ
     /\b(\d{4,5}[Mm]\d?)\b/,                             // Medallion forms: 1330M, 1330M2

--- a/packages/design-system-dashboard-cli/src/flatten-data.js
+++ b/packages/design-system-dashboard-cli/src/flatten-data.js
@@ -19,13 +19,27 @@ function normalizeNames(data, componentName) {
 /**
  * Takes an object keyed by component name and returns an array containing all
  * the data for each component.
+ *
+ * Column order is explicitly stabilized so the CSV schema is consistent across
+ * runs regardless of filesystem traversal order:
+ *   date, component_name, uswds, <app columns a-z>, total
  */
 function flattenData(data, date) {
   const flattened = Object.keys(data).map(componentName => {
+    const normalized = normalizeNames(data, componentName);
+    const { total, uswds, ...appColumns } = normalized;
+
+    // Sort app columns alphabetically so the header is identical every run.
+    const sortedAppColumns = Object.keys(appColumns)
+      .sort()
+      .reduce((obj, key) => ({ ...obj, [key]: appColumns[key] }), {});
+
     return {
-      date: date,
+      date,
       component_name: componentName,
-      ...normalizeNames(data, componentName),
+      ...(uswds !== undefined ? { uswds } : {}),
+      ...sortedAppColumns,
+      ...(total !== undefined ? { total } : {}),
     };
   });
 

--- a/packages/design-system-dashboard-cli/test/flatten-data.spec.js
+++ b/packages/design-system-dashboard-cli/test/flatten-data.spec.js
@@ -53,5 +53,38 @@ describe('flattenData', () => {
     expect(numeric._100app).toEqual(3)
   });
 
+  it('puts date and component_name first, total last, app columns sorted alphabetically', () => {
+    const flattened = flattenData(dataMock, date)
+
+    const alert = flattened.find(item => item.component_name === 'AlertComponent')
+    const keys = Object.keys(alert)
+
+    expect(keys[0]).toEqual('date')
+    expect(keys[1]).toEqual('component_name')
+    expect(keys[keys.length - 1]).toEqual('total')
+
+    // App columns between component_name and total should be sorted
+    const appKeys = keys.slice(2, keys.length - 1)
+    expect(appKeys).toEqual([...appKeys].sort())
+  });
+
+  it('places uswds immediately after component_name when present', () => {
+    const dataWithUswds = {
+      AlertComponent: {
+        total: 5,
+        'App one': 2,
+        'App two': 3,
+        uswds: 1,
+      },
+    }
+    const flattened = flattenData(dataWithUswds, date)
+    const keys = Object.keys(flattened[0])
+
+    expect(keys[0]).toEqual('date')
+    expect(keys[1]).toEqual('component_name')
+    expect(keys[2]).toEqual('uswds')
+    expect(keys[keys.length - 1]).toEqual('total')
+  });
+
 });
 


### PR DESCRIPTION
## Summary

Two fixes to the `design-system-dashboard-cli` that improve metrics reliability in `vets-design-system-documentation`.

### Fix 1: Stable CSV column order (`flatten-data.js`)

Column order in `ds-components-*.csv` was non-deterministic because `tallyResults` inserts `total` first and app columns in filesystem traversal order. The downstream processing script in `vets-design-system-documentation` used the `uswds` column position to determine where application columns start — so any run where `uswds` drifted past column 2 silently dropped all earlier app columns, causing severe undercounting (reported: 459 total usages vs correct: 7,523).

**New column order:** `date`, `component_name`, `uswds`, app columns sorted A–Z, `total`

App columns are now sorted alphabetically so the CSV schema is identical every run, regardless of filesystem traversal order.

### Fix 2: Single-letter-suffix form numbers (`find-form-apps.js`)

The existing pattern `\d{2,3}-\d{2,3}[A-Z]{2,}` required 2+ letters after the digits, so forms like `10-10D` (single letter suffix) fell through to later patterns and were extracted as `10D` instead of `10-10D`.

Added a dedicated pattern for single-letter-suffix forms.

## Test plan
- [ ] All 16 existing tests pass
- [ ] Two new tests added for column order guarantees in `flatten-data.spec.js`
- [ ] Verify next `yarn report:csv` run produces `date,component_name,uswds,...` as first three columns
- [ ] Verify `10-10D` forms appear with correct form number in `yarn forms --csv` output

## Related
- department-of-veterans-affairs/vets-design-system-documentation#4903
- department-of-veterans-affairs/vets-design-system-documentation#5902