### PR TITLE
va-modal: fix aria-hidden race condition from rAF timing

### DIFF
--- a/packages/web-components/src/components/va-modal/test/va-modal.e2e.ts
+++ b/packages/web-components/src/components/va-modal/test/va-modal.e2e.ts
@@ -792,6 +792,51 @@ describe('va-modal', () => {
         const section2Closed = await page.find('va-accordion-item[header="Section 2"]');
         expect(section2Closed.getAttribute('aria-hidden')).toBeNull();
       });
+
+      it('should not leave orphaned aria-hidden after open/close cycle', async () => {
+        // This test verifies no orphaned aria-hidden attributes remain after
+        // an open/close cycle. The production fix in teardownModal (canceling
+        // pending rAFs) prevents a race condition where React's binding rapidly
+        // sets visible=true then visible=false across two render passes,
+        // causing setupModal's rAF to fire after teardownModal. That exact
+        // timing interleave cannot be reliably reproduced in Stencil e2e tests
+        // since waitForChanges() lets the rAF complete before proceeding.
+        const page = await newE2EPage();
+        await page.setContent(`
+          <div id="sibling-content">
+            <va-link href="#" text="A link"></va-link>
+          </div>
+          <va-modal modal-title="Race Condition Modal">
+            <p>Modal content</p>
+          </va-modal>
+        `);
+
+        // Open the modal and wait for the full setup (including rAF) to complete
+        const modal = await page.find('va-modal');
+        await modal.setProperty('visible', true);
+        await page.waitForChanges();
+
+        // Confirm aria-hidden was correctly applied to sibling
+        const siblingWhileOpen = await page.find('#sibling-content');
+        expect(siblingWhileOpen.getAttribute('aria-hidden')).toBe('true');
+
+        // Close the modal - teardownModal should undo aria-hidden
+        await modal.setProperty('visible', false);
+        await page.waitForChanges();
+
+        // Verify no orphaned aria-hidden attributes remain on siblings
+        const siblingAfterClose = await page.find('#sibling-content');
+        expect(siblingAfterClose.getAttribute('aria-hidden')).toBeNull();
+        expect(siblingAfterClose.getAttribute('data-aria-hidden')).toBeNull();
+
+        // Additionally verify no elements in the document have orphaned attributes
+        const orphanedCount = await page.evaluate(() => {
+          return document.querySelectorAll(
+            '[aria-hidden="true"], [data-aria-hidden="true"]',
+          ).length;
+        });
+        expect(orphanedCount).toBe(0);
+      });
     });
   });
 });

--- a/packages/web-components/src/components/va-modal/va-modal.tsx
+++ b/packages/web-components/src/components/va-modal/va-modal.tsx
@@ -43,6 +43,9 @@ export class VaModal {
   // Track cleanup handlers returned by hideOthers so we can restore DOM state on close.
   undoAriaHidden: Undo[] = [];
 
+  // Track the requestAnimationFrame ID so we can cancel a pending setupModal call.
+  private setupModalRafId?: number;
+
   // This stores reference to previously focused element
   savedFocus: HTMLElement;
 
@@ -174,7 +177,7 @@ export class VaModal {
 
   componentDidLoad() {
     if (this.isVisible()) {
-      requestAnimationFrame(() => this.setupModal());
+      this.setupModalRafId = requestAnimationFrame(() => this.setupModal());
     }
   }
 
@@ -187,13 +190,17 @@ export class VaModal {
 
     this.isVisibleDirty = false;
     if (this.isVisible()) {
-      requestAnimationFrame(() => this.setupModal());
+      this.setupModalRafId = requestAnimationFrame(() => this.setupModal());
     } else {
       this.teardownModal();
     }
   }
 
   disconnectedCallback() {
+    if (this.setupModalRafId) {
+      cancelAnimationFrame(this.setupModalRafId);
+      this.setupModalRafId = undefined;
+    }
     this.teardownModal();
   }
 
@@ -454,6 +461,10 @@ export class VaModal {
   // This method removes the focus trap, re-enables scrolling and
   // removes aria-hidden="true" from external elements.
   private teardownModal() {
+    if (this.setupModalRafId) {
+      cancelAnimationFrame(this.setupModalRafId);
+      this.setupModalRafId = undefined;
+    }
     clearAllBodyScrollLocks();
     this.undoAriaHidden.forEach(undo => undo?.());
     this.undoAriaHidden = [];


### PR DESCRIPTION
## Chromatic
https://fix-va-modal-aria-hidden-raf-race--65a6e2ed2314f7b8f98609d8.chromatic.com

# Summary

**Fixed orphaned `aria-hidden` attributes after modal close.** Cancels pending `requestAnimationFrame` in `teardownModal` to prevent a race condition where `setupModal` fires after teardown, permanently leaving `aria-hidden="true"` / `data-aria-hidden="true"` on DOM elements.

## Description

When React rapidly toggles `visible=true` then `visible=false` across two render passes (e.g., opening a modal with a checkbox click then immediately pressing Escape), `componentDidUpdate` schedules `setupModal` via `requestAnimationFrame` on the first pass, then `teardownModal` runs synchronously on the second pass while the rAF is still pending.

The stale rAF then fires `setupModal` after teardown, calling `applyAriaHidden()` which resets `this.undoAriaHidden = []` and pushes new undo functions from `hideOthers()`. Since `teardownModal` already ran, nobody will ever invoke those undo functions — leaving `aria-hidden="true"` and `data-aria-hidden="true"` permanently on DOM elements outside the modal.

This causes `aria-hidden-focus` axe violations on focusable elements like `va-link`, `va-accordion-item`, `va-text-input`, etc.

**The fix:**
- Store the `requestAnimationFrame` ID in `setupModalRafId`
- Cancel it in `teardownModal()` using `cancelAnimationFrame()`
- Also cancel in `disconnectedCallback()` for safety

**Why this is React-specific:** The React binding (`@stencil/react-output-target`) uses `attachProps` which sets `node.visible = value` as a **property** (synchronous), triggering Stencil's `@Watch` immediately. Two rapid React renders produce two separate Stencil render cycles with the rAF from the first still pending when the second fires teardown. Vanilla JS attribute changes get batched by Stencil into a single render.

**Root cause timeline:**
- PR #1587 (May 2025) introduced the `requestAnimationFrame` wrapper in `componentDidLoad`/`componentDidUpdate` to fix a TypeError
- PR #1867 (Nov 2025) changed `undoAriaHidden` from a single `Undo` to `Undo[]`, making the race consequence more severe
- PR #1977 (Feb 2026, v54.6.2) expanded `applyAriaHidden()` to cover shadow roots and light DOM containers, increasing the number of affected elements

## Related tickets and links

This fixes `aria-hidden-focus` axe violations seen in vets-website CI:
- Webpack build (PR #43349, main branch): Cypress E2E runner 4 — secure-messaging specs
- Esbuild build (PR #42806): appeals and secure-messaging specs

## Screenshots

N/A — no visual changes.

## Testing and review

- All 80 existing va-modal e2e test suites pass (1137 tests)
- New e2e test verifies no orphaned `aria-hidden` attributes remain after open/close cycle
- The exact rAF race timing cannot be reproduced in Stencil e2e tests (see test comment) — the fix is verified by code inspection and the production axe violations it resolves

## Approvals

**Applicable checklist:** Component Fix

- [x] The PR has the `patch` label
- [x] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [x] Any markup changes are evaluated for impact on vets-website — this fix resolves existing CI failures
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
