### PR TITLE
va-card-status: wrapped long content to prevent overflow outside card container

### DIFF
--- a/packages/web-components/src/components/va-card-status/test/va-card-status.e2e.ts
+++ b/packages/web-components/src/components/va-card-status/test/va-card-status.e2e.ts
@@ -151,4 +151,32 @@ describe('<va-card-status />', () => {
     const cardStatus = await page.find('va-card-status >>> .va-card-status__wrapper');
     expect(cardStatus).toBeNull();
   });
+
+  it('wraps long unbroken slotted content within the card', async () => {
+    const page = await newE2EPage();
+    const longText = 'x'.repeat(200);
+    await page.setContent(`
+      <va-card-status
+        header-text="Title"
+        link-href="/test"
+        link-text="Next">
+        <p id="long-content">${longText}</p>
+      </va-card-status>
+    `);
+    await page.waitForChanges();
+
+    const overflows = await page.$eval('va-card-status', el => {
+      const root = el.shadowRoot;
+      const card = root?.querySelector('va-card');
+      const paragraph = el.querySelector('#long-content') as HTMLElement | null;
+
+      if (!card || !paragraph) return true;
+
+      const cardRect = card.getBoundingClientRect();
+      const paragraphRect = paragraph.getBoundingClientRect();
+      return paragraphRect.right > cardRect.right + 1;
+    });
+
+    expect(overflows).toBe(false);
+  });
 });

--- a/packages/web-components/src/components/va-card-status/va-card-status.scss
+++ b/packages/web-components/src/components/va-card-status/va-card-status.scss
@@ -4,6 +4,10 @@
 @import '../../mixins/hint-text.css';
 
 :host {
+  /* Prevent long unbroken values from spilling outside the card. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
+
   .va-card-status__header {
     margin: var(--units-1) 0 var(--units-1) 0;
     font-size: var(--font-size-h3);
@@ -11,6 +15,8 @@
     .va-card-status_card-title {
       font-family: var(--font-serif);
       font-weight: var(--font-weight-bold);
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
   }
 
@@ -25,6 +31,11 @@
     font-size: var(--font-size-h4);
     font-family: var(--font-sans-serif);
   } 
+}
+
+::slotted(*) {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 :host([error]:not([error=''])) .va-card-status__wrapper {


### PR DESCRIPTION
## PR Title
`va-card-status: wrapped long content to prevent overflow outside card container`

## PR Body

## Chromatic
https://content-doesnt-stay-within-the-card-c--65a6e2ed2314f7b8f98609d8.chromatic.com/

# Summary

Updated `va-card-status` to wrap long unbroken content so text stays inside the card container. Added an e2e regression test to verify long slotted content no longer overflows card bounds.

## Description

This update addresses a staging finding where long contact content could visually extend outside of card boundaries.

Changes made:
- Added overflow protection to `va-card-status` styles using `overflow-wrap` / `word-break` for host/title/slotted content.
- Added an e2e test case that renders long unbroken slotted text and verifies it remains within the card's rendered bounds.

Implementation details:
- `packages/web-components/src/components/va-card-status/va-card-status.scss`
- `packages/web-components/src/components/va-card-status/test/va-card-status.e2e.ts`

## Related tickets and links

- Staging finding issue: [department-of-veterans-affairs/va.gov-team#135211](https://github.com/department-of-veterans-affairs/va.gov-team/issues/135211)
- DST tracking issue: [department-of-veterans-affairs/vets-design-system-documentation#5853](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5853)

Closes department-of-veterans-affairs/vets-design-system-documentation#5853  
Closes department-of-veterans-affairs/va.gov-team#135211

## Testing and review

Local testing performed:
- `corepack yarn workspace @department-of-veterans-affairs/web-components test src/components/va-card-status/test/va-card-status.e2e.ts`

Expected reviewer validation:
- Confirm long unbroken content in `va-card-status` wraps and remains inside the card at supported breakpoints.
- Confirm no regressions to header, tag, error, and link rendering.
- Review Chromatic snapshots for visual changes.

## Approvals

**Approval groups**
- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklist

- [x] The PR has the `patch` label
- [x] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [x] Any markup changes are evaluated for impact on vets-website
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Engineering has approved the PR