### PR TITLE
Storybook: update va-file-input-multiple slot example with file name on va-select

### DIFF
--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
@@ -150,6 +150,13 @@ const additionalFormInputsContent = (
   </div>
 );
 
+interface FileState {
+  file?: File | null;
+  key?: number;
+  content?: any;
+  hasError?: boolean;
+}
+
 const AdditionalFormInputsContentTemplate = ({
   label,
   name,
@@ -164,19 +171,21 @@ const AdditionalFormInputsContentTemplate = ({
 }) => {
   const componentRef = useRef(null);
 
-  // Update aria-describedby-message on va-select elements after files change
-  const handleFileData = (e: CustomEvent) => {
-    const { state } = e.detail;
+  /**
+   * Update to va-select slot elements with filenames
+   * Using mutation observer to wait for va-select elements to be available
+   * @param state - Array of file state objects
+   */
+  const syncFilenamesToSlotSelects = (state: FileState[]) => {
+    if (!componentRef.current?.shadowRoot) return;
     
-    // Wait for DOM to update, then sync all va-select elements with current state
-    setTimeout(() => {
-      if (!componentRef.current) return;
+    const observer = new MutationObserver(() => {
+      const fileInputs = componentRef.current.shadowRoot.querySelectorAll('va-file-input');
       
-      const fileInputs = Array.from(
-        componentRef.current.shadowRoot?.querySelectorAll('va-file-input') || []
-      );
+      // Count how many files should have slotted content
+      const expectedSlots = state.filter(fileData => fileData?.file).length;
+      let foundSlots = 0;
       
-      // Update each file input's va-select with the corresponding filename
       fileInputs.forEach((fileInput: HTMLElement, index: number) => {
         const vaSelect = fileInput.querySelector('va-select');
         const fileData = state[index];
@@ -184,12 +193,28 @@ const AdditionalFormInputsContentTemplate = ({
         if (vaSelect) {
           if (fileData?.file) {
             vaSelect.setAttribute('message-aria-describedby', fileData.file.name);
+            foundSlots++;
           } else {
             vaSelect.removeAttribute('message-aria-describedby');
           }
         }
       });
-    }, 100);
+      
+      // Only disconnect when all expected slotted content has been found and updated
+      if (foundSlots >= expectedSlots && expectedSlots > 0) {
+        observer.disconnect();
+      }
+    });
+    
+    observer.observe(componentRef.current.shadowRoot, {
+      childList: true,
+      subtree: true
+    });
+  };
+
+  const handleFileChange = (e: CustomEvent) => {
+    const { state } = e.detail;
+    syncFilenamesToSlotSelects(state);
   };
 
   return (
@@ -203,7 +228,7 @@ const AdditionalFormInputsContentTemplate = ({
         errors={errors}
         hint={hint}
         enable-analytics={enableAnalytics}
-        onVaMultipleChange={handleFileData}
+        onVaMultipleChange={handleFileChange}
         slot-field-indexes={slotFieldIndexes}
         header-size={headerSize}
       >

--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
@@ -150,12 +150,6 @@ const additionalFormInputsContent = (
   </div>
 );
 
-interface FileState {
-  file?: File | null;
-  changed?: boolean;
-  hasError?: boolean;
-}
-
 const AdditionalFormInputsContentTemplate = ({
   label,
   name,
@@ -170,26 +164,24 @@ const AdditionalFormInputsContentTemplate = ({
 }) => {
   const componentRef = useRef(null);
 
-  /**
-   * Add filenames as aria-describedby to va-select elements in the shadow DOM.
-   * Using mutation observer to watch for slotted content to load.
-   * @param state - Array of file state objects
-   */
-  const syncFilenamesToSelects = (state: FileState[]) => {
-    if (!componentRef.current?.shadowRoot) return;
+  // Update aria-describedby-message on va-select elements after files change
+  const handleFileData = (e: CustomEvent) => {
+    const { state } = e.detail;
     
-    const observer = new MutationObserver(() => {
-      const fileInputs = componentRef.current.shadowRoot.querySelectorAll('va-file-input');
+    // Wait for DOM to update, then sync all va-select elements with current state
+    setTimeout(() => {
+      if (!componentRef.current) return;
       
-      // Check if slotted content has loaded by looking for va-select elements
-      let hasSlottedContent = false;
+      const fileInputs = Array.from(
+        componentRef.current.shadowRoot?.querySelectorAll('va-file-input') || []
+      );
       
+      // Update each file input's va-select with the corresponding filename
       fileInputs.forEach((fileInput: HTMLElement, index: number) => {
         const vaSelect = fileInput.querySelector('va-select');
         const fileData = state[index];
         
         if (vaSelect) {
-          hasSlottedContent = true;
           if (fileData?.file) {
             vaSelect.setAttribute('message-aria-describedby', fileData.file.name);
           } else {
@@ -197,22 +189,7 @@ const AdditionalFormInputsContentTemplate = ({
           }
         }
       });
-      
-      // Only disconnect if we found and updated slotted content
-      if (hasSlottedContent) {
-        observer.disconnect();
-      }
-    });
-    
-    observer.observe(componentRef.current.shadowRoot, {
-      childList: true,
-      subtree: true
-    });
-  };
-
-  const handleFileChange = (e: CustomEvent) => {
-    const { state } = e.detail;
-    syncFilenamesToSelects(state);
+    }, 100);
   };
 
   return (
@@ -226,7 +203,7 @@ const AdditionalFormInputsContentTemplate = ({
         errors={errors}
         hint={hint}
         enable-analytics={enableAnalytics}
-        onVaMultipleChange={handleFileChange}
+        onVaMultipleChange={handleFileData}
         slot-field-indexes={slotFieldIndexes}
         header-size={headerSize}
       >

--- a/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
+++ b/packages/storybook/stories/va-file-input-multiple-uswds.stories.tsx
@@ -150,6 +150,12 @@ const additionalFormInputsContent = (
   </div>
 );
 
+interface FileState {
+  file?: File | null;
+  changed?: boolean;
+  hasError?: boolean;
+}
+
 const AdditionalFormInputsContentTemplate = ({
   label,
   name,
@@ -158,14 +164,61 @@ const AdditionalFormInputsContentTemplate = ({
   required,
   hint,
   'enable-analytics': enableAnalytics,
-  vaMultipleChange,
   headerSize,
   slotFieldIndexes,
   children,
 }) => {
+  const componentRef = useRef(null);
+
+  /**
+   * Add filenames as aria-describedby to va-select elements in the shadow DOM.
+   * Using mutation observer to watch for slotted content to load.
+   * @param state - Array of file state objects
+   */
+  const syncFilenamesToSelects = (state: FileState[]) => {
+    if (!componentRef.current?.shadowRoot) return;
+    
+    const observer = new MutationObserver(() => {
+      const fileInputs = componentRef.current.shadowRoot.querySelectorAll('va-file-input');
+      
+      // Check if slotted content has loaded by looking for va-select elements
+      let hasSlottedContent = false;
+      
+      fileInputs.forEach((fileInput: HTMLElement, index: number) => {
+        const vaSelect = fileInput.querySelector('va-select');
+        const fileData = state[index];
+        
+        if (vaSelect) {
+          hasSlottedContent = true;
+          if (fileData?.file) {
+            vaSelect.setAttribute('message-aria-describedby', fileData.file.name);
+          } else {
+            vaSelect.removeAttribute('message-aria-describedby');
+          }
+        }
+      });
+      
+      // Only disconnect if we found and updated slotted content
+      if (hasSlottedContent) {
+        observer.disconnect();
+      }
+    });
+    
+    observer.observe(componentRef.current.shadowRoot, {
+      childList: true,
+      subtree: true
+    });
+  };
+
+  const handleFileChange = (e: CustomEvent) => {
+    const { state } = e.detail;
+    syncFilenamesToSelects(state);
+  };
+
   return (
     <>
       <VaFileInputMultiple
+        ref={componentRef}
         label={label}
         name={name}
         accept={accept}
@@ -173,7 +226,7 @@ const AdditionalFormInputsContentTemplate = ({
         errors={errors}
         hint={hint}
         enable-analytics={enableAnalytics}
-        onVaMultipleChange={vaMultipleChange}
+        onVaMultipleChange={handleFileChange}
         slot-field-indexes={slotFieldIndexes}
         header-size={headerSize}
       >


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `5963-file-input-slot-select` is a placeholder for a CI job - it will be updated automatically -->
https://5963-file-input-slot-select--65a6e2ed2314f7b8f98609d8.chromatic.com


# Summary

**Updated the slotted Storybook example with file name info.** The Additional Form Inputs Storybook example has been updated to demonstrate how to add the file name of an uploaded file to a slotted component like va-select. 

<!--
A successful summary is written in the past tense and includes:
**A benefit statement.** A description of the update.
See [component-library release notes](https://github.com/department-of-veterans-affairs/component-library/releases) for examples.
-->

## Description

This will add an example of how to add file information like the file name to a slotted component in`va-file-input-multiple`. I think this is better provided as an example in Storybook rather than built into the component itself because:

1. Slotted content is for the consumer to leverage and we may not be able to always anticipate how they are using the slot
2. Depending on the scenario, teams might need to adjust how additional context is being applied to the slotted element and managing it themselves will allow that flexibility.

<!-- 
Consider:
    - What is relevant to code reviewer(s)?
    - What context may be relevant to a future dev or you in 6 months about this PR?
    - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 -->

## Related tickets and links

<!-- 
Leverage supported Github keywords like "closed", "fixes", or "resolves". When a github ticket is added directly after 
one of those keywords, it will trigger auto-closure of the issue upon merging.
 -->

related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5963

## Screenshots

<img width="647" height="468" alt="Screenshot 2026-04-07 at 3 06 48 PM" src="https://github.com/user-attachments/assets/4cf4ba02-2ff2-43e8-acc7-4eadb91d3d07" />


## Testing and review

**Adding a file**
1. Navigate to the [Additional Form Inputs story](https://5963-file-input-slot-select--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/story/uswds-va-file-input-multiple--additional-form-inputs).
2. Add a file (add multiple files too)
3. Using a screenreader (ie VoiceOver), tab/focus the va-select component
4. Observe that the uploaded file name is read as part of the label

**Delete/Change a file**
1. Navigate to the [Additional Form Inputs story](https://5963-file-input-slot-select--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/story/uswds-va-file-input-multiple--additional-form-inputs).
2. Add at least three files to the va-file-input-multiple componet
3. Delete/Change the second file.
4. Using a screenreader (ie VoiceOver), tab/focus the va-select component
5. Observe that the correct uploaded file name is read as part of the label

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
