### PR TITLE
va-text-input / va-memorable-date: more support for label headers

### DIFF
--- a/packages/storybook/stories/va-text-input-uswds.stories.tsx
+++ b/packages/storybook/stories/va-text-input-uswds.stories.tsx
@@ -94,6 +94,7 @@ const defaultArgs = {
   'showToggleFocusButton': false,
   'focusEl': null,
   'width': undefined,
+  'label-header-level': undefined
 };
 
 const Template = ({
@@ -123,7 +124,8 @@ const Template = ({
   'show-input-error': showInputError,
   showToggleFocusButton,
   focusEl,
-  width
+  width,
+  'label-header-level': labelHeaderLevel
 }) => {
 
   const { errorMsg, handleClick } = useErrorToggle(error, focusEl);
@@ -161,6 +163,7 @@ const Template = ({
         show-input-error={showInputError}
         id={showToggleFocusButton ? 'error-demo-wrapper' : undefined}
         width={width}
+        label-header-level={labelHeaderLevel}
       />
       {showToggleFocusButton && (
           <va-button
@@ -606,4 +609,12 @@ FormsPatternSingleError.args = {
 export const FormsPatternMultiple = FormsPatternMultipleTemplate.bind(null);
 FormsPatternMultiple.args = {
   ...defaultArgs,
+};
+
+
+export const WithLabelHeaderLevel = Template.bind(null);
+WithLabelHeaderLevel.args = {
+  ...defaultArgs,
+  label: 'My input',
+  'label-header-level': 3
 };

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -2406,6 +2406,10 @@ export namespace Components {
          */
         "label"?: string;
         /**
+          * Insert a header with defined level inside the label (legend)
+         */
+        "labelHeaderLevel"?: string;
+        /**
           * The max attribute specifies the maximum value for an input element if the inputmode is numeric.
          */
         "max"?: number | string;
@@ -6903,6 +6907,10 @@ declare namespace LocalJSX {
           * The label for the text input.
          */
         "label"?: string;
+        /**
+          * Insert a header with defined level inside the label (legend)
+         */
+        "labelHeaderLevel"?: string;
         /**
           * The max attribute specifies the maximum value for an input element if the inputmode is numeric.
          */

--- a/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
+++ b/packages/web-components/src/components/va-memorable-date/va-memorable-date.tsx
@@ -497,6 +497,7 @@ export class VaMemorableDate {
               {label && HeaderLevel ? (
                   <HeaderLevel
                     aria-describedby={headerAriaDescribedbyId}
+                    part="header"
                   >
                     {InnerLabelPart}
                   </HeaderLevel>

--- a/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
+++ b/packages/web-components/src/components/va-text-input/test/va-text-input.e2e.ts
@@ -652,4 +652,14 @@ describe('va-text-input', () => {
     const inputEl = await page.find('va-text-input >>> input');
     expect(inputEl.getAttribute('step')).toEqual('any');
   });
+
+  it('it wraps the label in an appropriate heading if label-header-level is set', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<va-text-input label="This is the label" label-header-level="3" />'
+    );
+    const h3El = await page.find('va-text-input >>> h3');
+    expect(h3El).toBeTruthy();
+    expect(h3El.getAttribute('part')).toEqual('header');
+  })
 });

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -232,6 +232,11 @@ export class VaTextInput {
    */
   @Prop() errorHasPii?: boolean = false;
 
+  /**
+   * Insert a header with defined level inside the label (legend)
+   */
+  @Prop() labelHeaderLevel?: string;
+
   @State() paddingLeftValue: string = '0';
   @State() paddingRightValue: string = '0';
 
@@ -397,9 +402,17 @@ export class VaTextInput {
     return this.step ? this.step : undefined;
   }
 
+  // get label content based on label string and possible labelHeaderLevel
+  private getLabelContent(label: string, labelHeaderLevel: string): string | HTMLHeadingElement {
+    if (!labelHeaderLevel) return label;
+    const Header = getHeaderLevel(labelHeaderLevel);
+    return <Header part="header">{label}</Header>
+  }
+
   render() {
     const {
       label,
+      labelHeaderLevel,
       error,
       reflectInputError,
       showInputError,
@@ -522,7 +535,7 @@ export class VaTextInput {
               class={labelClass}
               part="label"
             >
-              {label}
+              {this.getLabelContent(label, labelHeaderLevel)}
               {required && !hideRequiredText && (
                 <span class="usa-label--required">
                   {' '}

--- a/packages/web-components/src/components/va-text-input/va-text-input.tsx
+++ b/packages/web-components/src/components/va-text-input/va-text-input.tsx
@@ -404,8 +404,8 @@ export class VaTextInput {
 
   // get label content based on label string and possible labelHeaderLevel
   private getLabelContent(label: string, labelHeaderLevel: string): string | HTMLHeadingElement {
-    if (!labelHeaderLevel) return label;
     const Header = getHeaderLevel(labelHeaderLevel);
+    if (!Header) return label;
     return <Header part="header">{label}</Header>
   }
 


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `more-label-header-level-support` is a placeholder for a CI job - it will be updated automatically -->
https://more-label-header-level-support--65a6e2ed2314f7b8f98609d8.chromatic.com


# Summary

This PR does two things:
1. adds support to `va-text-input` for the `label-header-level` prop
2. adds a `part="header"` attribute to a header rendered in `va-memorable-date` for form-system styling

These are in response to a request made to the forms-system.

<!--
A successful summary is written in the past tense and includes:
**A benefit statement.** A description of the update.
See [component-library release notes](https://github.com/department-of-veterans-affairs/component-library/releases) for examples.
-->

## Description

_Describe the change and context._

<!-- 
Consider:
    - What is relevant to code reviewer(s)?
    - What context may be relevant to a future dev or you in 6 months about this PR?
    - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 -->

## Related tickets and links

[5178](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5178)

<!-- 
Leverage supported Github keywords like "closed", "fixes", or "resolves". When a github ticket is added directly after 
one of those keywords, it will trigger auto-closure of the issue upon merging.
 -->

Closes #_[issue_no]_

## Screenshots

_If there are any visual changes, screenshots should be added here._

**va-text-input**
<img width="754" height="359" alt="Screenshot 2026-04-10 at 4 57 24 PM" src="https://github.com/user-attachments/assets/ed1181e4-a473-4d76-affb-0ae26f4e2e9d" />

**va-memorable-date**
<img width="563" height="351" alt="Screenshot 2026-04-10 at 4 58 16 PM" src="https://github.com/user-attachments/assets/eb44677d-5858-479d-b079-f50918639770" />

## Testing and review

local testing

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
