### PR TITLE
va-telephone - Update `messageAriaDescribedby` value for "Aria Described By" story

### DIFF
--- a/packages/storybook/stories/va-telephone.stories.tsx
+++ b/packages/storybook/stories/va-telephone.stories.tsx
@@ -155,7 +155,7 @@ SMS.args = {
 export const AriaDescribedBy = Template.bind(null);
 AriaDescribedBy.args = {
   ...defaultArgs,
-  'message-aria-describedby': 'Main number to facility',
+  'message-aria-describedby': 'Call to schedule',
 };
 AriaDescribedBy.parameters = {
   chromatic: { disableSnapshot: true },

--- a/packages/storybook/stories/va-telephone.stories.tsx
+++ b/packages/storybook/stories/va-telephone.stories.tsx
@@ -70,7 +70,7 @@ const Template = ({
   return (
     <div>
       {messageAriaDescribedBy && messageAriaDescribedBy !== 'false' && (
-        <span>Main number to facility </span>
+        <span>Call to schedule an appointment: </span>
       )}
       <va-telephone
         contact={contact}
@@ -155,7 +155,7 @@ SMS.args = {
 export const AriaDescribedBy = Template.bind(null);
 AriaDescribedBy.args = {
   ...defaultArgs,
-  'message-aria-describedby': 'Call to schedule',
+  'message-aria-describedby': 'Main number to facility',
 };
 AriaDescribedBy.parameters = {
   chromatic: { disableSnapshot: true },


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `6099-va-telephone-messageAria-story` is a placeholder for a CI job - it will be updated automatically -->
https://6099-va-telephone-messageAria-story--65a6e2ed2314f7b8f98609d8.chromatic.com


# Summary

Updates the value passed to `messageAriaDescribedby` prop for the "Aria Described By" story of `va-telephone` so that it is not the same text of the contextual sibling element.

<!--
A successful summary is written in the past tense and includes:
**A benefit statement.** A description of the update.
See [component-library release notes](https://github.com/department-of-veterans-affairs/component-library/releases) for examples.
-->

## Description

Updates the value passed to the `messageAriaDescribedby` prop in the "Aria Described By" story of `va-telephone `so it no longer matches the text content of the sibling `<span>` element that serves as a label for the component.

This aligns the Storybook example with new accessibility guidance added to the component's docs. The underlying motivation for both changes is the same: duplicate `aria-describedby` values can cause screen readers to announce the label multiple times.

<!-- 
Consider:
    - What is relevant to code reviewer(s)?
    - What context may be relevant to a future dev or you in 6 months about this PR?
    - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 -->

## Related tickets and links

<!-- 
Leverage supported Github keywords like "closed", "fixes", or "resolves". When a github ticket is added directly after 
one of those keywords, it will trigger auto-closure of the issue upon merging.
 -->

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/6099

## Screenshots

### Before
<img width="993" height="913" alt="va-telephone-before" src="https://github.com/user-attachments/assets/27199c76-e05e-4eed-ad44-4bd509fa5512" />

### After
<img width="1018" height="827" alt="va-telephone-after" src="https://github.com/user-attachments/assets/12828730-459f-46fe-b2db-0436f746f077" />

## Testing and review

1. Navigate to [the updated story](https://6099-va-telephone-messagearia-story--65a6e2ed2314f7b8f98609d8.chromatic.com/?path=/story/components-va-telephone--aria-described-by)
2. Turn on VoiceOver
3. Set VO cursor on component and note that the updated value is read after phone number.

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
