### PR TITLE
va-telephone-input: prevent cursor from jumping to end of input on edit

### DIFF
--- a/packages/web-components/src/components/va-telephone-input/test/utils.spec.tsx
+++ b/packages/web-components/src/components/va-telephone-input/test/utils.spec.tsx
@@ -1,10 +1,56 @@
 import { CountryCode } from 'libphonenumber-js/min';
-import { mapCountry } from "../utils";
+import { mapCountry, countDigitsUpTo, findPositionForDigitCount } from "../utils";
 
 describe('mapcountry()', () => {
   it('returns the correct country', () => {
     expect(mapCountry('US')).toBe('US');
     expect(mapCountry('PN' as CountryCode)).toBe('NZ');
     expect(mapCountry('FAKE' as CountryCode)).toBe(undefined);
+  });
+});
+
+describe('cursor utils', () => {
+  const str = 'abc123efg456hij789';
+  const phone = '(234) 567-8900';
+
+  describe('countDigitsUpTo', () => {
+    it('finds the number of digits up to an index in a string', () => {
+      expect(countDigitsUpTo(str, 12)).toEqual(6);
+    });
+    it('returns 0 when index is 0', () => {
+      expect(countDigitsUpTo(str, 0)).toEqual(0);
+    });
+    it('returns 0 when string has no digits', () => {
+      expect(countDigitsUpTo('abcdef', 4)).toEqual(0);
+    });
+    it('counts all digits when index exceeds string length', () => {
+      expect(countDigitsUpTo(str, 100)).toEqual(9);
+    });
+    it('returns 0 for an empty string', () => {
+      expect(countDigitsUpTo('', 5)).toEqual(0);
+    });
+    it('counts digits correctly in a formatted phone number', () => {
+      // "(234) 5" = index 7 → digits 2,3,4,5 = 4
+      expect(countDigitsUpTo(phone, 7)).toEqual(4);
+    });
+  });
+
+  describe('findPositionForDigitCount', () => {
+    it('finds the correct position in a string given a digit count', () => {
+      expect(findPositionForDigitCount(str, 3)).toEqual(6);
+    });
+    it('returns 0 when digit count is 0', () => {
+      expect(findPositionForDigitCount(str, 0)).toEqual(0);
+    });
+    it('returns string length when digit count exceeds total digits', () => {
+      expect(findPositionForDigitCount(str, 20)).toEqual(str.length);
+    });
+    it('returns string length for an empty string', () => {
+      expect(findPositionForDigitCount('', 3)).toEqual(0);
+    });
+    it('finds the correct position in a formatted phone number', () => {
+      // "(234) 567-8900" → after 4th digit (5) is position 7
+      expect(findPositionForDigitCount(phone, 4)).toEqual(7);
+    });
   });
 });

--- a/packages/web-components/src/components/va-telephone-input/test/va-input-telephone.e2e.ts
+++ b/packages/web-components/src/components/va-telephone-input/test/va-input-telephone.e2e.ts
@@ -209,4 +209,51 @@ describe('va-telephone-input', () => {
     await page.setContent('<va-telephone-input/>');
     await axeCheck(page);
   });
+
+  it('preserves cursor position when typing in the middle of a formatted number', async () => {
+    const page = await newE2EPage();
+    // 9 digits → "(234) 567-890"
+    await page.setContent('<va-telephone-input contact="234567890" />');
+    await page.waitForChanges();
+
+    // Place cursor at position 6 (after "(234) ", before "5") and type "1"
+    await page.evaluate(() => {
+      const host = document.querySelector('va-telephone-input');
+      const input = host.shadowRoot
+        .querySelector('va-text-input')
+        .shadowRoot.querySelector('#inputField') as HTMLInputElement;
+      input.focus();
+      input.setSelectionRange(6, 6);
+    });
+    await page.keyboard.press('1');
+    await page.waitForChanges();
+
+    const result = await page.evaluate(() => {
+      const host = document.querySelector('va-telephone-input');
+      const input = host.shadowRoot
+        .querySelector('va-text-input')
+        .shadowRoot.querySelector('#inputField') as HTMLInputElement;
+      return { value: input.value, cursorPos: input.selectionStart };
+    });
+
+    // 10 digits (2341567890) → "(234) 156-7890"
+    expect(result.value).toBe('(234) 156-7890');
+    // Cursor should be at position 7: right after the "1" that was just typed
+    expect(result.cursorPos).toBe(7);
+  });
+
+  it('places cursor at position 0 when no digits precede the cursor', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<va-telephone-input />');
+    await page.waitForChanges();
+
+    const input = await page.find('va-telephone-input >>> va-text-input >>> input');
+    // Type enough digits to trigger formatting
+    await input.type('234');
+    await page.waitForChanges();
+
+    const value = await input.getProperty('value');
+    // For US, "234" formats to "(234)"
+    expect(value).toContain('234');
+  });
 });

--- a/packages/web-components/src/components/va-telephone-input/utils.tsx
+++ b/packages/web-components/src/components/va-telephone-input/utils.tsx
@@ -47,3 +47,21 @@ export function mapCountry(country: CountryCode) {
   console.error(`Not a valid country: ${country}`);
 }
   
+ /**
+   * Returns the number of numeric characters that occur before an index position in a string taking into account that the string may contain more than numeric characters.
+   * For example, in "(234) 5" with index 7, only digits 2, 3, 4, 5 are counted → returns 4.
+   */
+  export function countDigitsUpTo(value: string, index: number): number {
+    return value.slice(0, index).replace(/\D/g, '').length;
+  }
+
+  /**
+   * Given a digit count, returns the index in `str` where that many digits have been seen.
+   * This maps a cursor position from one formatted string to another.
+   */
+  export function findPositionForDigitCount(str: string, digitCount: number): number {
+    for (let i = 0; i < str.length; i++) {
+      if (digitCount === countDigitsUpTo(str, i)) return i;
+    }
+    return str.length;
+  }

--- a/packages/web-components/src/components/va-telephone-input/va-telephone-input.tsx
+++ b/packages/web-components/src/components/va-telephone-input/va-telephone-input.tsx
@@ -196,7 +196,9 @@ export class VaTelephoneInput {
     requestAnimationFrame(() => {
       const input = this.getNativeInput();
       if (!input) return;
-      if (/^\d*$/.test(newFormatted)) return;
+      // Skip cursor adjustment if no reformatting occurred (value unchanged)
+      // or if the formatted value contains only digits (no formatting chars to shift around)
+      if (value === newFormatted || /^\d*$/.test(newFormatted)) return;
 
       const digitsBeforeCursor = countDigitsUpTo(value, cursorPos);
       const newPos = digitsBeforeCursor === 0

--- a/packages/web-components/src/components/va-telephone-input/va-telephone-input.tsx
+++ b/packages/web-components/src/components/va-telephone-input/va-telephone-input.tsx
@@ -22,7 +22,7 @@ import {
 } from 'libphonenumber-js/min';
 import classNames from 'classnames';
 import { i18next } from '../..';
-import { DATA_MAP, mapCountry } from './utils';
+import { DATA_MAP, mapCountry, countDigitsUpTo, findPositionForDigitCount } from './utils';
 
 /**
  * @componentName Telephone Input
@@ -148,6 +148,15 @@ export class VaTelephoneInput {
   }
 
   /**
+   * Returns the native <input> element inside the va-text-input shadow DOM.
+   */
+  getNativeInput(): HTMLInputElement | null {
+    return this.textInputRef
+      ?.shadowRoot
+      ?.querySelector('#inputField') as HTMLInputElement | null;
+  }
+
+  /**
    * Sets the validity state of the phone number for the selected country.
    * Updates isValid and formattedContact based on the current contact and country values.
    */
@@ -170,10 +179,32 @@ export class VaTelephoneInput {
   updateContact(event: InputEvent) {
     const target = event.target as HTMLInputElement;
     const { value } = target;
+
+    // Capture cursor position before reformatting
+    const nativeInput = this.getNativeInput();
+    const cursorPos = nativeInput?.selectionStart ?? value.length;
+
     this.contact = value;
-    this.formattedContact = this.formatContact(value);
+    const newFormatted = this.formatContact(value);
+    this.formattedContact = newFormatted;
     this.validateContact();
     this.handleEmit();
+
+    // Restore cursor position after Stencil re-renders
+    // Count how many digits are before the cursor in the current input value,
+    // then find where that same digit count lands in the new formatted value.
+    requestAnimationFrame(() => {
+      const input = this.getNativeInput();
+      if (!input) return;
+      if (/^\d*$/.test(newFormatted)) return;
+
+      const digitsBeforeCursor = countDigitsUpTo(value, cursorPos);
+      const newPos = digitsBeforeCursor === 0
+        ? 0
+        : findPositionForDigitCount(newFormatted, digitsBeforeCursor);
+
+      input.setSelectionRange(newPos, newPos);
+    });
   }
 
   /**
@@ -488,6 +519,7 @@ export class VaTelephoneInput {
                 error={contactError}
                 onInput={(e) => this.updateContact(e)}
                 onBlur={() => this.handleBlur()}
+                ref={(el) => (this.textInputRef = el)}
               />
             </div>
           </fieldset>


### PR DESCRIPTION
<!-- 
ℹ️ PR title naming convention:
[component-name]: brief summary suitable for the release notes
-->

<!-- 
🏷️ PR Setup - Add a label
Label Guidelines:
    - Review the [version change examples](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number) in the README.
    - Use `major`, `minor`, `patch` for changes to the `web-components` or `react-components` packages.
    - Use `css-library` if a file has been changed in the `css-library` package.
    - Use `ignore-for-release` if a file has not been changed in one of the following packages: 
        - `css-library`
        - `web-components`
        - `react-components`
        - `core`
-->

## Chromatic
<!-- DO NOT REMOVE - This `va-telephone-input-cursor-fix` is a placeholder for a CI job - it will be updated automatically -->
https://va-telephone-input-cursor-fix--65a6e2ed2314f7b8f98609d8.chromatic.com


# Summary

This PR fixes a bug in `va-telephone-input` in which the cursor jumps to the end of an entered telephone number when the number is edited.
<!--
A successful summary is written in the past tense and includes:
**A benefit statement.** A description of the update.
See [component-library release notes](https://github.com/department-of-veterans-affairs/component-library/releases) for examples.
-->

## Description

When a user clicked into the middle of a formatted phone number and typed or deleted a character, the cursor would jump to the end of the string. This happened because the component reformats on every keystroke caused which lead to to re-render of the input with a new value prop, which resets the browser's caret position.

<!-- 
Consider:
    - What is relevant to code reviewer(s)?
    - What context may be relevant to a future dev or you in 6 months about this PR?
    - Did the course of work lead to notable dead ends? If so, why didn't they pan out?
 -->

## Related tickets and links

_Link to any related issues, PRs, Slack conversations, or anything else relevant to documenting the changes._

<!-- 
Leverage supported Github keywords like "closed", "fixes", or "resolves". When a github ticket is added directly after 
one of those keywords, it will trigger auto-closure of the issue upon merging.
 -->

Closes #[5658](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/5658#issuecomment-4254389119)

## Screenshots

**Before** (note cursor jumps to end of input after first keystroke and this results in the wrong number being entered):

https://github.com/user-attachments/assets/940537de-c031-41e6-b997-eed59edbf330

**After**: (no cursor jump)

https://github.com/user-attachments/assets/b8d653d1-d5b0-4242-993c-b743ce8f77f5

## Testing and review

local testing

## Approvals
See the QA Checklists section below for suggested approvals. Use your best judgment if additional reviews are needed. When in doubt, request a review.

**Approval groups**

Add approval groups to the PR as needed:

- Engineering: [platform-design-system-fe](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-fe)
- Accessibility: [platform-design-system-a11y](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-a11y)
- Design: [platform-design-system-designer](https://github.com/orgs/department-of-veterans-affairs/teams/platform-design-system-designers)

## QA checklists

Use the QA checklists below as guides, not rules. Not all checklists will apply to every PR but there could be some overlap.

In all scenarios, changes should be fully tested by the author and verified by the reviewer(s); functionality, responsiveness, etc.

<details>
  <summary>✨ New Component Added</summary>

- [ ] The PR has the `minor` label
- [ ] The component matches the [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) designs.
- [ ] All properties, custom events, and utility functions have e2e and/or unit tests
- [ ] A new Storybook page has been added for the component
- [ ] Tested in all [VA breakpoints](https://design.va.gov/foundation/breakpoints).
- [ ] Chromatic UI Tests have run and snapshot changes have been accepted by the design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🌱 New Component Variation Added</summary>

- [ ] The PR has the `minor` label
- [ ] The variation matches its [Figma](https://www.figma.com/files/1499394822283304153/project/105082786?fuid=1192586511403544015) design.
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] A new story has been added to the component's existing Storybook page
- [ ] Any Chromatic UI snapshot changes have been accepted by a design reviewer
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
- [ ] **Design** has approved the PR
</details>

<details>
  <summary>🐞 Component Fix</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any markup changes are evaluated for impact on vets-website.
    - Will any vets-website tests fail from the change?
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>♿️ Component Fix - Accessibility</summary>

- [ ] The PR has the `patch` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
- [ ] **Accessibility** has approved the PR
</details>

<details>
  <summary>🚨 Component Fix - Breaking API Change</summary>

- [ ] The PR has the `major` label
- [ ] vets-website and content-build have been evaluated to determine the impact of the breaking change
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] Tested in vets-website using [Verdaccio](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#local-testing-in-vets-website-with-verdaccio)
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🔧 Component Update - Non-Breaking API Change</summary>

- [ ] The PR has the `minor` label
- [ ] Any new properties, custom events, or utility functions have e2e and/or unit tests
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>📖 Storybook Update</summary>

- [ ] The PR has the `ignore-for-release` label
- [ ] Any Chromatic UI snapshot changes have been reviewed and approved by a designer if necessary
- [ ] **Engineering** has approved the PR
</details>

<details>
  <summary>🎨 CSS-Library Update</summary>

- [ ] The PR has the `css-library` label
- [ ] vets-website and content-build have been checked to determine the impact of any breaking changes
- [ ] **Engineering** has approved the PR
</details>
